### PR TITLE
Webclip fix

### DIFF
--- a/ilapfuncs.py
+++ b/ilapfuncs.py
@@ -24,7 +24,7 @@ reportfolderbase = './ILEAPP_Reports_'+currenttime+'/'
 base = '/ILEAPP_Reports_'+currenttime+'/'
 temp = reportfolderbase+'temp/'
 
-def logfunc(message):
+def logfunc(message=""):
 	if pathlib.Path(reportfolderbase+'Script Logs/Screen Output.html').is_file():
 		with open(reportfolderbase+'Script Logs/Screen Output.html', 'a', encoding='utf8') as a:
 			print(message)

--- a/ilapfuncs.py
+++ b/ilapfuncs.py
@@ -2909,7 +2909,7 @@ def webclips(filefound):
 		webclip_data = {}
 		for path_val in filefound:
 			# Extract the unique identifier
-			pathstr = str(path_val)
+			pathstr = str(path_val).replace("\\", "/")
 
 			unique_id = pathstr.split("/WebClips/")[1].split(".webclip/")[0]
 			if unique_id != '' and unique_id not in webclip_data:
@@ -2957,8 +2957,8 @@ def webclips(filefound):
 			g.write('</tr>')
 		g.write("</table></html>")
 		g.close()
-	except:
-		logfunc('Error on Webclips function.')	
+	except Exception:
+		logfunc('Error on Webclips function.')
 	logfunc('Webclips function completed')
 	
 def healthdb(filefound):


### PR DESCRIPTION
Converted slashes to normalise how the webclip path is parsed on both Windows and Mac/Linux machines.
Also made a tiny change to logfunc() as it was complaining about calling it with no message on my machine.