### PR TITLE
Jinja2: Enhanced HTML reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 format:
 	black ilapfuncs.py contrib/
 	importanize ilapfuncs.py contrib/
+
+clean:
+	rm -rf ILEAPP_Reports*

--- a/contrib/aggregated_dictionary/html/passcode_type.html
+++ b/contrib/aggregated_dictionary/html/passcode_type.html
@@ -31,11 +31,8 @@
   <table class="table sticky">
 
     <tr>
-      <th>Timestamp</th>
-      <th>Key</th>
-      <th>Value</th>
-      {% for col in additional_cols %}
-      <th> {{ col }} </th>
+      {% for header in report_table_columns %}
+      <th>{{ header }}</th>
       {% endfor %}
     </tr>
 

--- a/contrib/aggregated_dictionary/html/passcode_type.html
+++ b/contrib/aggregated_dictionary/html/passcode_type.html
@@ -1,0 +1,53 @@
+<html>
+<style>
+  table,
+  td {
+    border: 1px solid black;
+    border-collapse: collapse;
+  }
+
+  tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+
+  .table th {
+    background: #888888;
+    color: #ffffff
+  }
+
+  .table.sticky th {
+    position: sticky;
+    top: 0;
+  }
+</style>
+
+<body>
+  <h2> {{ category }} report</h2>
+
+  {{ category }} entries: {{ rows | length }}<br>
+  {{ category }} located at: {{ db_path }}<br>
+  <br />
+
+  <table class="table sticky">
+
+    <tr>
+      <th>Timestamp</th>
+      <th>Key</th>
+      <th>Value</th>
+      {% for col in additional_cols %}
+      <th> {{ col }} </th>
+      {% endfor %}
+    </tr>
+
+    {% for row in rows %}
+    <tr>
+      {% for row_item in row %}
+      <td>{{ row_item }}</td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+
+  </table>
+</body>
+
+</html>

--- a/contrib/aggregated_dictionary/html/trial.html
+++ b/contrib/aggregated_dictionary/html/trial.html
@@ -1,6 +1,0 @@
-<title>{% block title %}{% endblock %}</title>
-<ul>
-{% for row in rows %}
-  <li><a href="{{ row }}">{{ row }}</a></li>
-{% endfor %}
-</ul>

--- a/contrib/aggregated_dictionary/html/trial.html
+++ b/contrib/aggregated_dictionary/html/trial.html
@@ -1,0 +1,6 @@
+<title>{% block title %}{% endblock %}</title>
+<ul>
+{% for row in rows %}
+  <li><a href="{{ row }}">{{ row }}</a></li>
+{% endfor %}
+</ul>

--- a/contrib/aggregated_dictionary/main.py
+++ b/contrib/aggregated_dictionary/main.py
@@ -26,7 +26,7 @@ def fetch_and_write_data(
 ):
     logfunc(f"Aggregated dictionary {category} function executing")
 
-    rows = get_sql_output(passcode_type_query, db_path)
+    rows = get_sql_output(query, db_path)
     if not rows:
         logfunc(f"No Aggregated dictionary {category} data available")
         return

--- a/contrib/aggregated_dictionary/main.py
+++ b/contrib/aggregated_dictionary/main.py
@@ -7,6 +7,9 @@ from contrib.utils import get_sql_output, write_html_to_file
 from settings import *
 
 from .sql import *
+from jinja2 import Environment, FileSystemLoader
+
+template_env = Environment(loader=FileSystemLoader('./contrib/aggregated_dictionary/html/'))
 
 
 AGGREGATED_DICT_DIR_NAME = "Aggregated Dict/"
@@ -14,6 +17,11 @@ AGGREGATED_DICT_DIR_NAME = "Aggregated Dict/"
 
 def fetch_and_write_data(query, db_path, category, additional_cols=None):
     rows = get_sql_output(passcode_type_query, db_path)
+    import ipdb; ipdb.set_trace()
+
+    template = template_env.get_template('trial.html')
+    print(template.render(rows=rows))
+
     if not rows:
         logfunc(f"No Aggregated dictionary {category} data available")
         return

--- a/contrib/utils.py
+++ b/contrib/utils.py
@@ -1,4 +1,27 @@
+import logging
+import os
 import sqlite3
+from functools import wraps
+
+from common import logfunc
+
+
+def silence_and_log(log_template):
+    def outer_wrapper(function):
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            ret = None
+            try:
+                ret = function(*args, **kwargs)
+            except Exception as e:
+                if os.environ.get("DEBUG"):
+                    logging.exception("Exception in processing:")
+                logfunc(log_template.format(**kwargs))
+            return ret
+
+        return wrapper
+
+    return outer_wrapper
 
 
 def get_sql_output(query, db_path):
@@ -14,44 +37,3 @@ def get_sql_output(query, db_path):
     cursor.execute(query)
     rows = cursor.fetchall()
     return rows
-
-
-def write_html_to_file(file_path, rows, db_path, category, additional_cols=None):
-    """
-    """
-    with open(file_path, "w", encoding="utf8") as f:
-        f.write("<html><body>")
-        f.write(f"<h2> {category} report</h2>")
-        f.write(f"{category} entries: {len(rows)}<br>")
-        f.write(f"{category} located at: {db_path}<br>")
-        f.write(
-            "<style> table, td {border: 1px solid black; border-collapse: collapse;}tr:nth-child(even) {background-color: #f2f2f2;} .table th { background: #888888; color: #ffffff}.table.sticky th{ position:sticky; top: 0; }</style>"
-        )
-        f.write("<br/>")
-        f.write("")
-        f.write(f'<table class="table sticky">')
-
-        base_table_header_template = f"<tr><th>Timestamp</th><th>Key</th><th>Value</th>"
-        template = base_table_header_template
-
-        if additional_cols:
-            for col in additional_cols:
-                template = f"{template}<th>{col}</th>"
-
-        template = f"{template}</tr>"
-        f.write(f"{template}")
-
-        for row in rows:
-            base_table_row_template = (
-                f"<tr><td>{row[0]}</td><td>{row[1]}</td><td>{row[2]}</td>"
-            )
-            if not additional_cols:
-                f.write(f"{base_table_row_template}</tr>")
-            else:
-                template = base_table_row_template
-                for ind in range(len(additional_cols)):
-                    template = f"{template}<td>{row[(3 + ind)]}</td>"
-                f.write(f"{template}</tr>")
-
-        f.write(f"</table></body></html>")
-    return

--- a/ileapp.py
+++ b/ileapp.py
@@ -11,13 +11,11 @@ from report import *
 from zipfile import ZipFile
 from tarfile import TarFile
 
+from jinja2 import Environment
+
 parser = argparse.ArgumentParser(description='iLEAPP: iOS Logs, Events, and Preferences Parser.')
 parser.add_argument('-o', choices=['fs','tar', 'zip'], required=True, action="store",help="Directory path, TAR, or ZIP filename and path(required).")
 parser.add_argument('pathtodir',help='Path to directory')
-
-# if len(sys.argv[1:])==0:
-# 	parser.logfunc_help()
-# 	parser.exit()
 
 start = process_time()
 	
@@ -26,6 +24,7 @@ args = parser.parse_args()
 pathto = args.pathtodir
 extracttype = args.o
 start = process_time()
+
 
 tosearch = {'mib':'*mobile_installation.log.*',
 			'iconstate':'*SpringBoard/IconState.plist',

--- a/ileapp.py
+++ b/ileapp.py
@@ -66,8 +66,6 @@ tosearch = {'mib':'*mobile_installation.log.*',
 			'redditchats':'*Data/Application/*/Documents/*/accountData/*/chat/*/chat.sqlite',
 			'interactionc':'*interactionC.db'}
 
-tosearch = {'aggdict':'*AggregateDictionary/ADDataStore.sqlitedb'}
-
 os.makedirs(reportfolderbase)
 os.makedirs(reportfolderbase+'Script Logs')
 

--- a/ileapp.py
+++ b/ileapp.py
@@ -11,8 +11,6 @@ from report import *
 from zipfile import ZipFile
 from tarfile import TarFile
 
-from jinja2 import Environment
-
 parser = argparse.ArgumentParser(description='iLEAPP: iOS Logs, Events, and Preferences Parser.')
 parser.add_argument('-o', choices=['fs','tar', 'zip'], required=True, action="store",help="Directory path, TAR, or ZIP filename and path(required).")
 parser.add_argument('pathtodir',help='Path to directory')
@@ -68,11 +66,7 @@ tosearch = {'mib':'*mobile_installation.log.*',
 			'redditchats':'*Data/Application/*/Documents/*/accountData/*/chat/*/chat.sqlite',
 			'interactionc':'*interactionC.db'}
 
-'''
-tosearch = {'redditusers':'*Data/Application/*/Documents/*/accounts/*',
-			'redditchats':'*Data/Application/*/Documents/*/accountData/*/chat/*/chat.sqlite'}
-'''
-	
+
 os.makedirs(reportfolderbase)
 os.makedirs(reportfolderbase+'Script Logs')
 

--- a/ileapp.py
+++ b/ileapp.py
@@ -66,6 +66,7 @@ tosearch = {'mib':'*mobile_installation.log.*',
 			'redditchats':'*Data/Application/*/Documents/*/accountData/*/chat/*/chat.sqlite',
 			'interactionc':'*interactionC.db'}
 
+tosearch = {'aggdict':'*AggregateDictionary/ADDataStore.sqlitedb'}
 
 os.makedirs(reportfolderbase)
 os.makedirs(reportfolderbase+'Script Logs')

--- a/settings.py
+++ b/settings.py
@@ -12,3 +12,9 @@ temp = reportfolderbase + "temp/"
 
 # aliases for new code to use
 report_folder_base = reportfolderbase
+
+# templates
+from jinja2 import Environment, FileSystemLoader
+
+import ipdb; ipdb.set_trace()
+env = Environment(FileSystemLoader('contrib/*/html'))

--- a/settings.py
+++ b/settings.py
@@ -12,9 +12,3 @@ temp = reportfolderbase + "temp/"
 
 # aliases for new code to use
 report_folder_base = reportfolderbase
-
-# templates
-from jinja2 import Environment, FileSystemLoader
-
-import ipdb; ipdb.set_trace()
-env = Environment(FileSystemLoader('contrib/*/html'))


### PR DESCRIPTION
This PR introduces the [Jinja2](https://palletsprojects.com/p/jinja/) templating engine to use with our HTML templates. It allows you to store your HTML as template files which can be populated with variables based on what you are doing. There are also other advantages like code reuse etc etc.

I took the HTML files as is and made a template out of it. The variables are no longer format string vars but are jinja2 variables.

In the process, we also get rid of the temporary `distribution_key_logic` function, so the main.py in aggregated dictionary module is much cleaner.

Also added a way to debug errors in these specific functions by adding:
1. `silence_and_log` decorator
2. log exceptions when using that decorator by using `DEBUG=True` before running the command you need to.

So,
```
DEBUG=True python ileapp.py etc etc etc
```

Lastly, a bug was introduced in the `fetch_and_write_data` which is now fixed. It was essentially a typo, which means we should figure out a testing strategy at some point in the near future.