### PR TITLE
Added: os.path.join back for zip archives

### DIFF
--- a/search_files.py
+++ b/search_files.py
@@ -35,9 +35,10 @@ def search_archive(archive_obj, search_path):
 
     for member_name in member_names:
         if fnmatch.fnmatch(member_name, search_path):
+            member_path = member_name.lstrip('/')
             try:
                 archive_obj.extract(member_name, path=temp)
-                paths.append(temp+member_name)
+                paths.append(os.path.join(temp, member_path))
             except Exception:
                 logfunc("Could not write file to filesystem")
     return paths


### PR DESCRIPTION
Previously, os.path.join would discard the base path on some archives
if the path they returned were absolute paths.

This workaround allows for such paths and keeps it platform-agnostic.

Please test, although I have run a test on the latest zip I have.