### PR TITLE
Added: automatic filetype detection for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install -r requirements.txt
 ```
 $ python ileapp.py --help
 
-Usage: ileapp.py [-h] -o {fs,tar,zip} pathtodir  
+Usage: ileapp.py [-h] pathtodir
 iLEAPP: iOS Logs, Events, and Preferences Parser.  
 
 positional arguments:  
@@ -45,7 +45,6 @@ positional arguments:
 
 optional arguments:
   -h, --help   show this help message and exit  
-  -o {fs,tar}  Directory path or TAR filename and path(required).
 ```
 
 ### GUI

--- a/ileapp.py
+++ b/ileapp.py
@@ -7,20 +7,14 @@ from extraction import *
 parser = argparse.ArgumentParser(
     description="iLEAPP: iOS Logs, Events, and Preferences Parser."
 )
-parser.add_argument(
-    "-o",
-    choices=["fs", "tar", "zip"],
-    required=True,
-    action="store",
-    help="Directory path, TAR, or ZIP filename and path(required).",
-)
 parser.add_argument("pathtodir", help="Path to directory")
 
 args = parser.parse_args()
 pathto = args.pathtodir
-extracttype = args.o
 
 start = process_time()
 log = pre_extraction(pathto)
+
+extracttype = get_filetype(pathto)
 extract_and_process(pathto, extracttype, tosearch, log)
 running_time = post_extraction(start, extracttype, pathto)

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -38,11 +38,6 @@ layout = [
         )
     ],  # added font type and font size
     [
-        sg.Radio(".Tar", "rad1", default=True, font=("Helvetica", 14)),
-        sg.Radio("Directory", "rad1", font=("Helvetica", 14)),
-        sg.Radio(".Zip", "rad1", font=("Helvetica", 14)),
-    ],  # added font type and font size
-    [
         sg.Text("File:", size=(8, 1), font=("Helvetica", 14)),
         sg.Input(),
         sg.FileBrowse(font=("Helvetica", 12)),
@@ -70,52 +65,22 @@ layout = [
 
 # Create the Window
 window = sg.Window("iLEAPP", layout)
+
 # Event Loop to process "events" and get the "values" of the inputs
 while True:
     event, values = window.read()
     if event in (None, "Close"):  # if user closes window or clicks cancel
         break
 
-    if values[0] == True:
-        extracttype = "tar"
-        pathto = values[3]
-        # logfunc(pathto)
-        if pathto.endswith(".tar"):
-            pass
-        else:
-            sg.PopupError(
-                "No file or no .tar extension selected. Run the program again."
-            )
-            sys.exit()
+    pathto = values['Browse'] or values['Browse0']
 
-    elif values[1] == True:
-        extracttype = "fs"
-        pathto = values[4]
-        if os.path.isdir(pathto):
-            pass
-        else:
-            sg.PopupError(
-                "No path or the one selected is invalid. Run the program again.", pathto
-            )
-            sys.exit()
-
-    elif values[2] == True:
-        extracttype = "zip"
-        pathto = values[3]
-        if pathto.endswith(".zip"):
-            pass
-        else:
-            sg.PopupError(
-                "No file or no .zip extension selected. Run the program again.", pathto
-            )
-            sys.exit()
-
+    extracttype = get_filetype(pathto)
     start = process_time()
     log = pre_extraction(pathto, gui_window=window)
     extract_and_process(pathto, extracttype, tosearch, log, gui_window=window)
     running_time = post_extraction(start, extracttype, pathto)
 
-    if values[5] == True:
+    if values[2] == True:
         start = process_time()
         window.refresh()
         logfunc("")
@@ -123,7 +88,7 @@ while True:
         window.refresh()
         html2csv(report_folder_base)
 
-    if values[5] == True:
+    if values[2] == True:
         end = process_time()
         time = start - end
         logfunc("CSV processing time in secs: " + str(abs(time)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs==19.3.0
 beautifulsoup4==4.8.2
 black==19.10b0
 Click==7.0
+filetype==1.0.5
 importanize==0.7.0
 Jinja2==2.10.3
 packaging==20.1


### PR DESCRIPTION
Tested for tar files. Needs testing for others.

New command:

```
# removed the -o option!
$ python ileapp.py test_images/_iOS12.tar
```

TODO before merge:

 - [x] test tar
 - [x] test zip
 - [x] test fs
 - [x] port GUI code if all other tests above work
 - [x] test any from GUI

Also tested that it doesn't allow png files to go through, but detects them.

```
$ python ileapp.py <redacted>/kubernetes.png
...
...
Traceback (most recent call last):
  File "ileapp.py", line 18, in <module>
    extracttype = get_filetype(pathto)
  File "<redacted>/extraction.py", line 92, in get_filetype
    f"Detected file type {extension} for file {fpath} not supported"
extraction.UnsupportedFileType: Detected file type png for file <redacted>/kubernetes.png not supported by iLEAPP.
File types supported are: ['fs', 'zip', 'tar']
````