### PR TITLE
Tile App geololocation coordinates from log files

### DIFF
--- a/scripts/artifacts/tileApp.py
+++ b/scripts/artifacts/tileApp.py
@@ -1,0 +1,55 @@
+import gzip
+import re
+import os
+import scripts.artifacts.artGlobals
+
+from packaging import version
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, logdevinfo, timeline, tsv, is_platform_windows 
+
+
+def get_tileApp(files_found, report_folder, seeker):
+    data_list = []
+    
+    for file_found in files_found:
+        file_found = str(file_found)
+        
+        if file_found.endswith('gz'):
+            x=gzip.open
+        elif file_found.endswith('log'):
+            x=open
+        
+        counter = 0
+        with x(file_found,'rt',) as f:
+            for line in f:
+                regexdate = r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}"
+                datestamp = re.search(regexdate, line)  
+                counter +=1
+                if datestamp != None:
+                    datestamp = datestamp.group(0)
+                    regexlatlong = r"<[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)>"
+                    latlong = re.search(regexlatlong, line)
+                    if latlong != None:
+                        latlong = latlong.group(0)
+                        latlong = latlong.strip('<')
+                        latlong = latlong.strip('>')
+                        lat, longi = latlong.split(',')
+                        head_tail = os.path.split(file_found) 
+                        data_list.append((datestamp, lat.lstrip(), longi.lstrip(), counter, head_tail[1]))
+
+    if len(data_list) > 0:
+        description = 'Tile app recorded langitude and longitude coordinates.'
+        report = ArtifactHtmlReport('Locations')
+        report.start_artifact_report(report_folder, 'Tile App Geolocation', description)
+        report.add_script()
+        data_headers = ('Timestamp', 'Latitude', 'Longitude', 'Row Number', 'Source File' )     
+        report.write_artifact_data_table(data_headers, data_list, head_tail[0])
+        report.end_artifact_report()
+        
+        tsvname = 'Tile App Lat Long'
+        tsv(report_folder, data_headers, data_list, tsvname)
+        
+        tlactivity = 'Tile App Lat Long'
+        timeline(report_folder, tlactivity, data_list)
+    
+        

--- a/scripts/artifacts/tileApp.py
+++ b/scripts/artifacts/tileApp.py
@@ -38,9 +38,9 @@ def get_tileApp(files_found, report_folder, seeker):
                         data_list.append((datestamp, lat.lstrip(), longi.lstrip(), counter, head_tail[1]))
 
     if len(data_list) > 0:
-        description = 'Tile app recorded langitude and longitude coordinates.'
+        description = 'Tile app log recorded langitude and longitude coordinates.'
         report = ArtifactHtmlReport('Locations')
-        report.start_artifact_report(report_folder, 'Tile App Geolocation', description)
+        report.start_artifact_report(report_folder, 'Tile App Geolocation Logs', description)
         report.add_script()
         data_headers = ('Timestamp', 'Latitude', 'Longitude', 'Row Number', 'Source File' )     
         report.write_artifact_data_table(data_headers, data_list, head_tail[0])

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -134,6 +134,7 @@ from scripts.artifacts.mediaLibrary import get_mediaLibrary
 from scripts.artifacts.geodMapTiles import get_geodMapTiles
 from scripts.artifacts.geodPDPlaceCache import get_geodPDPlaceCache
 from scripts.artifacts.geodApplications import get_geodApplications
+from scripts.artifacts.tileApp import get_tileApp
 
 from scripts.ilapfuncs import *
 
@@ -205,7 +206,8 @@ tosearch = {'lastBuild':('IOS Build', '*LastBuildInfo.plist'),
             'mediaLibrary':('Media Library', '**/Medialibrary.sqlitedb'),
             'geodMapTiles': ('Geolocation', '**/MapTiles.sqlitedb'),
             'geodPDPlaceCache': ('Geolocation', '**/PDPlaceCache.db'),
-            'geodApplications': ('Geolocation', '**/AP.db')
+            'geodApplications': ('Geolocation', '**/AP.db'),
+            'tileApp': ('Locations', '*private/var/mobile/Containers/Data/Application/*/Library/log/com.thetileapp.tile*')
             }
 
 '''

--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -1,4 +1,4 @@
-aleapp_version = '1.5'
+aleapp_version = '1.5.1'
 
 # Contributors List
 # Format = [ Name, Blog-url, Twitter-handle, Github-url]
@@ -23,6 +23,7 @@ aleapp_contributors = [
     [ 'Douglas Kein', '', '@DouglasKein', ''],
     [ 'Claudia Meda', '', '@KlodiaMaida', 'https://github.com/KlodiaMaida'],
     [ 'Silvia Spallarossa', '', '@SilviaSpallaro1', 'https://github.com/spatimbs'],
-    [ 'Francesca Maestri', '', '@franc3sca_m', 'https://github.com/francyM']
+    [ 'Francesca Maestri', '', '@franc3sca_m', 'https://github.com/francyM'],
+    [ 'Christopher Vance', 'https://blog.d204n6.com/', '@cScottVance', 'https://github.com/cScottVance']
 
 ]


### PR DESCRIPTION
Artifact that extract longitude and latitude values from the Tile app log files.
These logs are in plain text and GZ compressed format.

iLEAPP version updated to 1.5.1