### PR TITLE
App Group Listing

### DIFF
--- a/scripts/artifacts/appGrouplisting.py
+++ b/scripts/artifacts/appGrouplisting.py
@@ -1,0 +1,37 @@
+import biplist
+import pathlib
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+
+
+def get_appGrouplisting(files_found, report_folder, seeker):
+    data_list = []       
+    for file_found in files_found:
+        file_found = str(file_found)
+
+        plist = biplist.readPlist(file_found)
+        bundleid = plist['MCMMetadataIdentifier']
+        
+        p = pathlib.Path(file_found)
+        appgroupid = p.parent.name
+        
+        data_list.append((bundleid, appgroupid))
+        fileloc = str(p.parents[1])
+
+    if len(data_list) > 0:
+        
+        description = 'List can included once installed but not present apps. Each file is named .com.apple.mobile_container_manager.metadata.plist'
+        report = ArtifactHtmlReport('Bundle ID - AppGroup ID')
+        report.start_artifact_report(report_folder, 'Bundle ID - AppGroup ID', description)
+        report.add_script()
+        data_headers = ('Bundle ID','AppGroup')     
+        report.write_artifact_data_table(data_headers, data_list, fileloc)
+        report.end_artifact_report()
+        
+        tsvname = 'Bundle ID - AppGroup ID'
+        tsv(report_folder, data_headers, data_list, tsvname)
+    else:
+        logfunc('Bundle ID - AppGroup ID')
+
+    

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -147,6 +147,7 @@ from scripts.artifacts.filesAppsm import get_filesAppsm
 from scripts.artifacts.filesAppsdb import get_filesAppsdb
 from scripts.artifacts.filesAppsclient import get_filesAppsclient
 from scripts.artifacts.icloudSharedalbums import get_icloudSharedalbums
+from scripts.artifacts.appGrouplisting import get_appGrouplisting
 
 from scripts.ilapfuncs import *
 
@@ -232,7 +233,7 @@ tosearch = {'lastBuild':('IOS Build', '*LastBuildInfo.plist'),
             'filesAppsdb': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/server.db*'),
             'filesAppsclient': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/client.db*'),
             'icloudSharedalbums': ('iCloud Shared Albums', '*/private/var/mobile/Media/PhotoData/PhotoCloudSharingData/*'),
-            
+            'appGrouplisting': ('Installed Apps', '*/private/var/mobile/Containers/Shared/AppGroup/*/*.metadata.plist'),
             }
 
 '''


### PR DESCRIPTION
Artifact parses each .com.apple.mobile_container_manager.metadata.plist file and extracts the corresponding bundle ID & app group GUID.

It is of note that a deleted app can leave behind the app group directory with possibly relevant data. The plist identifies the app that was related to it even after the app has been deleted. 