### PR TITLE
Info.plist parsing for itunes backup

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -82,6 +82,18 @@ def crunch_artifacts(search_list, extracttype, input_path, out_params, ratio):
     log.write(f'Extraction/Path selected: {input_path}<br><br>')
     
     categories_searched = 0
+    # Special processing for iTunesBackup Info.plist as it is a seperate entity, not part of the Manifest.db. Seeker won't find it
+    if extracttype == 'itunes':
+        info_plist_path = os.path.join(input_path, 'Info.plist')
+        if os.path.exists(info_plist_path):
+            process_artifact([info_plist_path], 'iTunesBackupInfo', 'Device Info', seeker, out_params.report_folder_base)
+            del search_list['lastBuild'] # removing lastBuild as this takes its place
+        else:
+            logfunc('Info.plist not found for iTunes Backup!')
+            log.write('Info.plist not found for iTunes Backup!')
+        categories_searched += 1
+        GuiWindow.SetProgressBar(categories_searched * ratio)
+
     # Search for the files per the arguments
     for key, val in search_list.items():
         search_regexes = []
@@ -107,7 +119,7 @@ def crunch_artifacts(search_list, extracttype, input_path, out_params, ratio):
                     pathh = pathh[4:]
                 log.write(f'Files for {artifact_search_regex} located at {pathh}<br><br>')
         categories_searched += 1
-        GuiWindow.SetProgressBar(categories_searched*ratio)
+        GuiWindow.SetProgressBar(categories_searched * ratio)
     log.close()
 
     logfunc('')

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -140,7 +140,7 @@ while True:
                     key = window[x].metadata
                     if (key in tosearch) and (key != 'lastBuild'):
                         search_list[key] = tosearch[key]
-                        s_items = s_items + 1 #for progress bar
+                    s_items = s_items + 1 # for progress bar
                 
                 # no more selections allowed
                 window[x].Update(disabled = True)

--- a/scripts/artifacts/lastBuild.py
+++ b/scripts/artifacts/lastBuild.py
@@ -1,6 +1,6 @@
+import datetime
 import os
 import plistlib
-import sqlite3
 import scripts.artifacts.artGlobals 
 
 from scripts.artifact_report import ArtifactHtmlReport
@@ -38,3 +38,28 @@ def get_lastBuild(files_found, report_folder, seeker):
     tsvname = 'Last Build'
     tsv(report_folder, data_headers, data_list, tsvname)
             
+def get_iTunesBackupInfo(files_found, report_folder, seeker):
+    versionnum = 0
+    data_list = []
+    file_found = str(files_found[0])
+    with open(file_found, "rb") as fp:
+        pl = plistlib.load(fp)
+        for key, val in pl.items():
+            if isinstance(val, str) or isinstance(val, int) or isinstance(val, datetime.datetime):
+                data_list.append((key, val))
+                if key in ('Build Version', 'Device Name', 'ICCID', 'IMEI', 'Last Backup Date', 
+                            'MEID', 'Phone Number', 'Product Name', 'Product Type',
+                            'Product Version', 'Serial Number'):
+                    logdevinfo(f"{key}: {val}")
+            elif key == "Installed Applications":
+                data_list.append((key, ', '.join(val)))
+  
+    report = ArtifactHtmlReport('iTunes Backup')
+    report.start_artifact_report(report_folder, 'iTunes Backup Information')
+    report.add_script()
+    data_headers = ('Key','Values')
+    report.write_artifact_data_table(data_headers, data_list, file_found)
+    report.end_artifact_report()
+    
+    tsvname = 'iTunes Backup'
+    tsv(report_folder, data_headers, data_list, tsvname)

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -19,7 +19,7 @@ from scripts.artifacts.dataUsageB import get_dataUsageB
 from scripts.artifacts.dataUsageProcessB import get_dataUsageProcessB
 from scripts.artifacts.mobileInstall import get_mobileInstall
 from scripts.artifacts.sms import get_sms
-from scripts.artifacts.lastBuild import get_lastBuild
+from scripts.artifacts.lastBuild import get_lastBuild, get_iTunesBackupInfo
 from scripts.artifacts.dataArk import get_dataArk
 from scripts.artifacts.iconsScreen import get_iconsScreen
 from scripts.artifacts.webClips import get_webClips


### PR DESCRIPTION
Hacked in reading of the Info.plist file, to get device and backup information. I will look into refactoring this later, since it is metadata, not part of the data inside the backup, it had to be hacked in this way.. Take a look.

![image](https://user-images.githubusercontent.com/13247440/93927746-54e28e00-fce7-11ea-9929-2f80cac7f734.png)

Also pulling device info from there.

![image](https://user-images.githubusercontent.com/13247440/93928022-ae4abd00-fce7-11ea-83d2-b61eff8a146f.png)

