### PR TITLE
iOS device activator data file parser + quick mobile installation logs fix (reboots)

### DIFF
--- a/scripts/artifacts/deviceActivator.py
+++ b/scripts/artifacts/deviceActivator.py
@@ -1,0 +1,64 @@
+import re
+import base64
+import os
+from itertools import compress 
+import xml.etree.ElementTree as ET
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
+
+def get_deviceActivator(files_found, report_folder, seeker):
+    data_list = []
+    alllines = ''    
+    file_found = str(files_found[0])
+
+    with open(file_found, 'r') as f_in:
+        for line in f_in:
+            line = line.strip()
+            alllines = alllines + line
+
+    found = re.findall('<key>ActivationInfoXML</key><data>(.*)</data><key>RKCertification</key><data>', alllines)
+    base64_message= found[0]
+
+    data = base64.b64decode(base64_message)
+    
+    outpath = os.path.join(report_folder, "results.xml")
+    with open(outpath, 'wb') as f_out:
+        f_out.write(data)
+    
+    xmlfile = outpath
+    tree = ET.parse(xmlfile)
+    root = tree.getroot()
+
+    for elem in root:
+        for elemx in elem:
+            for elemz in elemx:
+                data_list.append(str(elemz.text).strip())
+
+    it = iter(data_list)     
+    results = list(zip(it, it))
+    
+    for x in results:
+        if x[0] == 'EthernetMacAddress':
+            logdevinfo(f"Ethernet Mac Address: {x[1]}")
+        if x[0] == 'BluetoothAddress':
+            logdevinfo(f"Bluetooth Address: {x[1]}")
+        if x[0] == 'WifiAddress':
+            logdevinfo(f"Wifi Address: {x[1]}") 
+        if x[0] == 'ModelNumber':
+            logdevinfo(f"Model Number: {x[1]}")
+            
+    if len(results) > 0:
+        report = ArtifactHtmlReport('iOS Device Activator Data')
+        report.start_artifact_report(report_folder, 'iOS Device Activator Data')
+        report.add_script()
+        data_headers = ('Key','Values')     
+        report.write_artifact_data_table(data_headers, results, file_found)
+        report.end_artifact_report()
+        
+        tsvname = 'iOS Device Activator Data'
+        tsv(report_folder, data_headers, results, tsvname)
+    else:
+        logfunc('No iOS Device Activator Data')
+
+    

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -534,8 +534,12 @@ def get_mobileInstall(files_found, report_folder, seeker):
     report.start_artifact_report(report_folder, 'Apps - Historical', description)
     report.add_script()
     data_headers = ('Bundle ID', 'Report Link')
+    tsv_data_headers = ('Bundle ID', 'Report Link')
     report.write_artifact_data_table(data_headers, data_list, location, html_escape=False)
     report.end_artifact_report()
+    
+    tsvname = 'Mobile Installation Logs - History'
+    tsv(report_folder, tsv_data_headers, tsv_tml_data_list, tsvname)
 
     # Query to create system events
     data_list_reboots = []
@@ -549,14 +553,18 @@ def get_mobileInstall(files_found, report_folder, seeker):
         data_list_reboots.append((row[0],row[1]))
         sysstatecount = sysstatecount + 1
     
-    location =f'{filename}'
-    description = 'Reboots detected in Local Time.'
-    report = ArtifactHtmlReport('State - Reboots')
-    report.start_artifact_report(report_folder, 'State - Reboots', description)
-    report.add_script()
-    data_headers = ('Timestamp (Local Time)', 'Description')
-    report.write_artifact_data_table(data_headers, data_list_reboots, location)
-    report.end_artifact_report()
+    if len(all_rows) > 0:
+        location =f'{filename}'
+        description = 'Reboots detected in Local Time.'
+        report = ArtifactHtmlReport('State - Reboots')
+        report.start_artifact_report(report_folder, 'State - Reboots', description)
+        report.add_script()
+        data_headers_reboots = ('Timestamp (Local Time)', 'Description')
+        report.write_artifact_data_table(data_headers_reboots, data_list_reboots, location)
+        report.end_artifact_report()
+        
+        tsvname = 'Mobile Installation Logs - Reboots'
+        tsv(report_folder, data_headers_reboots, data_list_reboots, tsvname)
 
     logfunc(f"Total apps: {totalapps}")
     logfunc(f"Total installed apps: {installedcount}")
@@ -565,11 +573,9 @@ def get_mobileInstall(files_found, report_folder, seeker):
     logfunc(f"Total system state events: {sysstatecount}")
     
     
-    tsvname = 'Mobile Installation Logs - Reboots'
-    tsv(report_folder, data_headers_reboots, data_list_reboots, tsvname)
     
-    tsvname = 'Mobile Installation Logs - History'
-    tsv(report_folder, tsv_data_headers, tsv_tml_data_list, tsvname)
+    
+    
     
     '''
     data_headers_reboots = ('Timestamp (Local Time)', 'Description')

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -148,6 +148,7 @@ from scripts.artifacts.filesAppsdb import get_filesAppsdb
 from scripts.artifacts.filesAppsclient import get_filesAppsclient
 from scripts.artifacts.icloudSharedalbums import get_icloudSharedalbums
 from scripts.artifacts.appGrouplisting import get_appGrouplisting
+from scripts.artifacts.deviceActivator import get_deviceActivator
 
 from scripts.ilapfuncs import *
 
@@ -234,6 +235,7 @@ tosearch = {'lastBuild':('IOS Build', '*LastBuildInfo.plist'),
             'filesAppsclient': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/client.db*'),
             'icloudSharedalbums': ('iCloud Shared Albums', '*/private/var/mobile/Media/PhotoData/PhotoCloudSharingData/*'),
             'appGrouplisting': ('Installed Apps', '*/private/var/mobile/Containers/Shared/AppGroup/*/*.metadata.plist'),
+            'deviceActivator': ('IOS Build', '*private/var/mobile/Library/Logs/mobileactivationd/ucrt_oob_request.txt')
             }
 
 '''


### PR DESCRIPTION
Parser for the ucrt_oob_request file. 

Quick fix for mobileinstallation logs to avoid a 'No data available in table' entry in the html report when no data is found.