### PR TITLE
More graceful fail for encrypted backups

### DIFF
--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -51,25 +51,28 @@ class FileSeekerItunes(FileSeekerBase):
 
     def build_files_list(self, directory):
         '''Populates paths from Manifest.db files into _all_files'''
-        db = sqlite3.connect(os.path.join(directory, "Manifest.db"))
-        cursor = db.cursor()
-        cursor.execute(
-            """
-            SELECT
-            fileID,
-            relativePath
-            FROM
-            Files
-            WHERE
-            flags=1
-            """
-        )
-        all_rows = cursor.fetchall()
-        for row in all_rows:
-            hash_filename = row[0]
-            relative_path = row[1]
-            self._all_files[relative_path] = hash_filename
-        db.close()
+        try: 
+            db = sqlite3.connect(os.path.join(directory, "Manifest.db"))
+            cursor = db.cursor()
+            cursor.execute(
+                """
+                SELECT
+                fileID,
+                relativePath
+                FROM
+                Files
+                WHERE
+                flags=1
+                """
+            )
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                hash_filename = row[0]
+                relative_path = row[1]
+                self._all_files[relative_path] = hash_filename
+            db.close()
+        except Exception as ex:
+            logfunc(f'Error opening Manifest.db from {directory}, ' + str(ex))
 
     def search(self, filepattern):
         pathlist = []


### PR DESCRIPTION
This doesn't (yet) decrypt the manifest.db, but at least it gracefully fails if it can't read the Manifest.db for whatever reason. Happy to take a stab at decrypting later, this is just a quick solution for the last issue in #84 to make sure things can still work.