### PR TITLE
more exception handling

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -1,7 +1,9 @@
 import argparse
+import io
 import os
 import scripts.report as report
 import shutil
+import traceback
 
 from scripts.search_files import *
 from scripts.ilapfuncs import *
@@ -56,20 +58,28 @@ def crunch_artifacts(search_list, extracttype, input_path, out_params, ratio):
     logdevinfo()
     
     seeker = None
-    if extracttype == 'fs':
-        seeker = FileSeekerDir(input_path)
+    try:
+        if extracttype == 'fs':
+            seeker = FileSeekerDir(input_path)
 
-    elif extracttype in ('tar', 'gz'):
-        seeker = FileSeekerTar(input_path, out_params.temp_folder)
+        elif extracttype in ('tar', 'gz'):
+            seeker = FileSeekerTar(input_path, out_params.temp_folder)
 
-    elif extracttype == 'zip':
-        seeker = FileSeekerZip(input_path, out_params.temp_folder)
+        elif extracttype == 'zip':
+            seeker = FileSeekerZip(input_path, out_params.temp_folder)
 
-    elif extracttype == 'itunes':
-        seeker = FileSeekerItunes(input_path, out_params.temp_folder)
+        elif extracttype == 'itunes':
+            seeker = FileSeekerItunes(input_path, out_params.temp_folder)
 
-    else:
-        logfunc('Error on argument -o (input type)')
+        else:
+            logfunc('Error on argument -o (input type)')
+            return
+    except Exception as ex:
+        logfunc('Had an exception in Seeker - see details below. Terminating Program!')
+        temp_file = io.StringIO()
+        traceback.print_exc(file=temp_file)
+        logfunc(temp_file.getvalue())
+        temp_file.close()
         return
 
     # Now ready to run

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -150,27 +150,21 @@ while True:
 
             GuiWindow.window_handle = window
             out_params = OutputParameters(output_folder)
-            ileapp.crunch_artifacts(search_list, extracttype, input_path, out_params, len(ileapp.tosearch)/s_items)
-
-            '''
-            if values[5] == True:
-                start = process_time()
-                logfunc('')
-                logfunc(f'CSV export starting. This might take a while...')
-                html2csv(out_params.report_folder_base) 
-                end = process_time()
-                csv_time_secs =  end - start
-                csv_time_HMS = strftime('%H:%M:%S', gmtime(csv_time_secs))
-                logfunc("CSV processing time = {}".format(csv_time_HMS))
-            '''
-            report_path = os.path.join(out_params.report_folder_base, 'index.html')
-            
-            if report_path.startswith('\\\\?\\'): # windows
-                report_path = report_path[4:]
-            if report_path.startswith('\\\\'): # UNC path
-                report_path = report_path[2:]
-            locationmessage = 'Report name: ' + report_path
-            sg.Popup('Processing completed', locationmessage)
-            webbrowser.open_new_tab('file://' + report_path)
+            crunch_successful = ileapp.crunch_artifacts(search_list, extracttype, input_path, out_params, len(ileapp.tosearch)/s_items)
+            if crunch_successful:
+                report_path = os.path.join(out_params.report_folder_base, 'index.html')
+                
+                if report_path.startswith('\\\\?\\'): # windows
+                    report_path = report_path[4:]
+                if report_path.startswith('\\\\'): # UNC path
+                    report_path = report_path[2:]
+                locationmessage = 'Report name: ' + report_path
+                sg.Popup('Processing completed', locationmessage)
+                webbrowser.open_new_tab('file://' + report_path)
+            else:
+                log_path = out_params.screen_output_file_path
+                if log_path.startswith('\\\\?\\'): # windows
+                    log_path = log_path[4:]
+                sg.Popup('Processing failed    :( ', f'See log for error details..\nLog file located at {log_path}')
             break
 window.close()

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -73,6 +73,7 @@ class FileSeekerItunes(FileSeekerBase):
             db.close()
         except Exception as ex:
             logfunc(f'Error opening Manifest.db from {directory}, ' + str(ex))
+            raise ex
 
     def search(self, filepattern):
         pathlist = []


### PR DESCRIPTION
This now catches all seeker initializing errors if there is a bad zip/tar file or bad Manifest.db.
Also prints stack trace for debugging.

![image](https://user-images.githubusercontent.com/13247440/94040848-700cd680-fd97-11ea-9308-dba2dc632869.png)
