### PR TITLE
Add cloudkit stuff

### DIFF
--- a/scripts/artifacts/cloudkitNoteSharing.py
+++ b/scripts/artifacts/cloudkitNoteSharing.py
@@ -1,0 +1,79 @@
+import glob
+import os
+import nska_deserialize as nd
+import sqlite3
+import datetime
+import io
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows 
+
+
+def get_cloudkitNoteSharing(files_found, report_folder, seeker):
+    for file_found in files_found:
+        file_found = str(file_found)
+
+        if file_found.endswith('NoteStore.sqlite'):
+            db = sqlite3.connect(file_found)
+            cursor = db.cursor()
+            cursor.execute('''
+            SELECT Z_PK, ZSERVERRECORDDATA 
+            FROM
+            ZICCLOUDSYNCINGOBJECT
+            WHERE
+            ZSERVERRECORDDATA NOT NULL
+            ''')
+
+            note_data = []
+            all_rows = cursor.fetchall()
+            result_number = len(all_rows)
+            if result_number > 0:
+
+                for row in all_rows:
+                    
+                    filename = os.path.join(report_folder, 'zserverrecorddata_'+str(row[0])+'.bplist')
+                    output_file = open(filename, "wb") 
+                    output_file.write(row[1])
+                    output_file.close()
+                    
+                    deserialized_plist = nd.deserialize_plist(io.BytesIO(row[1]))
+                    creator_id = ''
+                    last_modified_id = ''
+                    creation_date = ''
+                    last_modified_date = ''
+                    last_modified_device = ''
+                    record_type = ''
+                    record_id = ''
+                    for item in deserialized_plist:
+                        if 'RecordCtime' in item:
+                            creation_date = item['RecordCtime']
+                        elif 'RecordMtime' in item:
+                            last_modified_date = item['RecordMtime']
+                        elif 'LastModifiedUserRecordID' in item:
+                            last_modified_id = item['LastModifiedUserRecordID']['RecordName']
+                        elif 'CreatorUserRecordID' in item:
+                            creator_id = item['CreatorUserRecordID']['RecordName']
+                        elif 'ModifiedByDevice' in item:
+                            last_modified_device = item['ModifiedByDevice']
+                        elif 'RecordType' in item:
+                            record_type = item['RecordType']
+                        elif 'RecordID' in item:
+                            record_id = item['RecordID']['RecordName']
+                    
+                    note_data.append([record_id,record_type,creation_date,creator_id,last_modified_date,last_modified_id,last_modified_device])
+
+                description = 'CloudKit Note Sharing - Notes information shared via CloudKit. Look up the Record ID in the ZICCLOUDSYYNCINGOBJECT.ZIDENTIFIER column. '
+                report = ArtifactHtmlReport('Note Sharing')
+                report.start_artifact_report(report_folder, 'Note Sharing', description)
+                report.add_script()
+                note_headers = ('Record ID','Record Type','Creation Date','Creator ID','Modified Date','Modifier ID','Modifier Device')     
+                report.write_artifact_data_table(note_headers, note_data, file_found)
+                report.end_artifact_report()
+                
+                tsvname = 'Cloudkit Note Sharing'
+                tsv(report_folder, note_headers, note_data, tsvname)
+            else:
+                logfunc('No Cloudkit - Cloudkit Note Sharing data available')
+
+            db.close()
+

--- a/scripts/artifacts/cloudkitParticipants.py
+++ b/scripts/artifacts/cloudkitParticipants.py
@@ -10,54 +10,55 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
 
 def get_cloudkitParticipants(files_found, report_folder, seeker):
-    for file_found in files_found:
-        file_found = str(file_found)
 
     user_dictionary = {}    
 
-    # Can add a separate section for each file this information is found in.
-    # This is for Apple Notes.
-    if file_found.endswith('NoteStore.sqlite'):
-        db = sqlite3.connect(file_found)
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT Z_PK, ZSERVERSHAREDATA 
-        FROM
-        ZICCLOUDSYNCINGOBJECT
-        WHERE
-        ZSERVERSHAREDATA NOT NULL
-        ''')
+    for file_found in files_found:
+        file_found = str(file_found)
 
-        all_rows = cursor.fetchall()
-        for row in all_rows:
-            
-            filename = os.path.join(report_folder, 'zserversharedata_'+str(row[0])+'.bplist')
-            output_file = open(filename, "wb") 
-            output_file.write(row[1])
-            output_file.close()
-            
-            deserialized_plist = nd.deserialize_plist(io.BytesIO(row[1]))
-            for item in deserialized_plist:
-                if 'Participants' in item:
-                    for participant in item['Participants']:
-                        record_id = participant['UserIdentity']['UserRecordID']['RecordName']
-                        email_address = participant['UserIdentity']['LookupInfo']['EmailAddress']
-                        phone_number = participant['UserIdentity']['LookupInfo']['PhoneNumber']
-                        first_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.givenName']
-                        middle_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.middleName']
-                        last_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.familyName']
-                        name_prefix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.namePrefix']
-                        name_suffix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nameSuffix']
-                        nickname = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nickname']
-            
-                        user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name, middle_name, last_name, name_suffix, nickname]
-        db.close()
+        # Can add a separate section for each file this information is found in.
+        # This is for Apple Notes.
+        if file_found.endswith('NoteStore.sqlite'):
+            db = sqlite3.connect(file_found)
+            cursor = db.cursor()
+            cursor.execute('''
+            SELECT Z_PK, ZSERVERSHAREDATA 
+            FROM
+            ZICCLOUDSYNCINGOBJECT
+            WHERE
+            ZSERVERSHAREDATA NOT NULL
+            ''')
+
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                
+                filename = os.path.join(report_folder, 'zserversharedata_'+str(row[0])+'.bplist')
+                output_file = open(filename, "wb") 
+                output_file.write(row[1])
+                output_file.close()
+                
+                deserialized_plist = nd.deserialize_plist(io.BytesIO(row[1]))
+                for item in deserialized_plist:
+                    if 'Participants' in item:
+                        for participant in item['Participants']:
+                            record_id = participant['UserIdentity']['UserRecordID']['RecordName']
+                            email_address = participant['UserIdentity']['LookupInfo']['EmailAddress']
+                            phone_number = participant['UserIdentity']['LookupInfo']['PhoneNumber']
+                            first_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.givenName']
+                            middle_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.middleName']
+                            last_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.familyName']
+                            name_prefix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.namePrefix']
+                            name_suffix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nameSuffix']
+                            nickname = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nickname']
+                
+                            user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name, middle_name, last_name, name_suffix, nickname]
+            db.close()
     
-    # Build the array        
+    # Build the array after dealing with all the files 
     user_list = list(user_dictionary.values())
 
     if len(user_list) > 0:
-        description = 'Cloudkit Participants - Cloudkit accounts participating in CloudKit shares.'
+        description = 'CloudKit Participants - Cloudkit accounts participating in CloudKit shares.'
         report = ArtifactHtmlReport('Participants')
         report.start_artifact_report(report_folder, 'Participants', description)
         report.add_script()

--- a/scripts/artifacts/cloudkitParticipants.py
+++ b/scripts/artifacts/cloudkitParticipants.py
@@ -63,7 +63,7 @@ def get_cloudkitParticipants(files_found, report_folder, seeker):
         report.start_artifact_report(report_folder, 'Participants', description)
         report.add_script()
         user_headers = ('Record ID','Email Address','Phone Number','Name Prefix','First Name','Middle Name','Last Name','Name Suffix','Nickname')     
-        report.write_artifact_data_table(user_headers, user_list, file_found)
+        report.write_artifact_data_table(user_headers, user_list, '', write_location=False)
         report.end_artifact_report()
         
         tsvname = 'Cloudkit Participants'

--- a/scripts/artifacts/cloudkitParticipants.py
+++ b/scripts/artifacts/cloudkitParticipants.py
@@ -1,0 +1,73 @@
+import glob
+import os
+import nska_deserialize as nd
+import sqlite3
+import datetime
+import io
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows 
+
+
+def get_cloudkitParticipants(files_found, report_folder, seeker):
+    for file_found in files_found:
+        file_found = str(file_found)
+
+    user_dictionary = {}    
+
+    # Can add a separate section for each file this information is found in.
+    # This is for Apple Notes.
+    if file_found.endswith('NoteStore.sqlite'):
+        db = sqlite3.connect(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+        SELECT Z_PK, ZSERVERSHAREDATA 
+        FROM
+        ZICCLOUDSYNCINGOBJECT
+        WHERE
+        ZSERVERSHAREDATA NOT NULL
+        ''')
+
+        all_rows = cursor.fetchall()
+        for row in all_rows:
+            
+            filename = os.path.join(report_folder, 'zserversharedata_'+str(row[0])+'.bplist')
+            output_file = open(filename, "wb") 
+            output_file.write(row[1])
+            output_file.close()
+            
+            deserialized_plist = nd.deserialize_plist(io.BytesIO(row[1]))
+            for item in deserialized_plist:
+                if 'Participants' in item:
+                    for participant in item['Participants']:
+                        record_id = participant['UserIdentity']['UserRecordID']['RecordName']
+                        email_address = participant['UserIdentity']['LookupInfo']['EmailAddress']
+                        phone_number = participant['UserIdentity']['LookupInfo']['PhoneNumber']
+                        first_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.givenName']
+                        middle_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.middleName']
+                        last_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.familyName']
+                        name_prefix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.namePrefix']
+                        name_suffix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nameSuffix']
+                        nickname = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nickname']
+            
+                        user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name, middle_name, last_name, name_suffix, nickname]
+        db.close()
+    
+    # Build the array        
+    user_list = list(user_dictionary.values())
+
+    if len(user_list) > 0:
+        description = 'Cloudkit Participants - Cloudkit accounts participating in CloudKit shares.'
+        report = ArtifactHtmlReport('Participants')
+        report.start_artifact_report(report_folder, 'Participants', description)
+        report.add_script()
+        user_headers = ('Record ID','Email Address','Phone Number','Name Prefix','First Name','Middle Name','Last Name','Name Suffix','Nickname')     
+        report.write_artifact_data_table(user_headers, user_list, file_found)
+        report.end_artifact_report()
+        
+        tsvname = 'Cloudkit Participants'
+        tsv(report_folder, user_headers, user_list, tsvname)
+    else:
+        logfunc('No Cloudkit - Cloudkit Participants data available')
+
+    

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -153,6 +153,7 @@ from scripts.artifacts.appGrouplisting import get_appGrouplisting
 from scripts.artifacts.deviceActivator import get_deviceActivator
 from scripts.artifacts.kikMessages import get_kikMessages
 from scripts.artifacts.appItunesmeta import get_appItunesmeta
+from scripts.artifacts.cloudkitParticipants import get_cloudkitParticipants
 
 from scripts.ilapfuncs import *
 
@@ -242,7 +243,8 @@ tosearch = {'lastBuild':('IOS Build', '*LastBuildInfo.plist'),
             'appGrouplisting': ('Installed Apps', ('*/private/var/mobile/Containers/Shared/AppGroup/*/*.metadata.plist','**/PluginKitPlugin/*.metadata.plist')),
             'deviceActivator': ('IOS Build', '*private/var/mobile/Library/Logs/mobileactivationd/ucrt_oob_request.txt'),
             'kikMessages': ('Kik', '**/kik.sqlite*'),
-            'appItunesmeta':('Installed Apps', ('**/iTunesMetadata.plist', '**/BundleMetadata.plist'))
+            'appItunesmeta':('Installed Apps', ('**/iTunesMetadata.plist', '**/BundleMetadata.plist')),
+            'cloudkitParticipants': ('Cloudkit', '*NoteStore.sqlite*')
             }
 
 '''

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -154,6 +154,7 @@ from scripts.artifacts.deviceActivator import get_deviceActivator
 from scripts.artifacts.kikMessages import get_kikMessages
 from scripts.artifacts.appItunesmeta import get_appItunesmeta
 from scripts.artifacts.cloudkitParticipants import get_cloudkitParticipants
+from scripts.artifacts.cloudkitNoteSharing import get_cloudkitNoteSharing
 
 from scripts.ilapfuncs import *
 
@@ -244,7 +245,8 @@ tosearch = {'lastBuild':('IOS Build', '*LastBuildInfo.plist'),
             'deviceActivator': ('IOS Build', '*private/var/mobile/Library/Logs/mobileactivationd/ucrt_oob_request.txt'),
             'kikMessages': ('Kik', '**/kik.sqlite*'),
             'appItunesmeta':('Installed Apps', ('**/iTunesMetadata.plist', '**/BundleMetadata.plist')),
-            'cloudkitParticipants': ('Cloudkit', '*NoteStore.sqlite*')
+            'cloudkitParticipants': ('Cloudkit', '*NoteStore.sqlite*'),
+            'cloudkitNoteSharing': ('Cloudkit', '*NoteStore.sqlite*')
             }
 
 '''

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -113,6 +113,9 @@ def get_icon_name(category, artifact):
         if artifact == 'APPLICATIONS': icon = 'grid'
         elif artifact == 'MAP TILE CACHE': icon = 'map'
         elif artifact == 'PD PLACE CACHE': icon = 'map-pin'
+    elif category == 'CLOUDKIT':
+        if artifact == 'PARTICIPANTS': icon = 'user'
+        elif artifact == 'NOTE SHARING': icon = 'share-2'
 
     return icon
     


### PR DESCRIPTION
This adds basic parsing for the CloudKit information identified in [this article](https://ciofecaforensics.com/2020/10/20/apple-notes-cloudkit-data/). It creates a CloudKit section, assuming more uses will be found, and adds two artifacts: Participants and Note Sharing. 

Participants rips through the other iCloud accounts identified in CKShareParticipant records. It currently only supports the Notes database, but others can be added as well. 

Note Sharing identifies the information about shared accounts, folders, notes, and attachments and uses the CloudKit identifier which can be looked up in the participants output. 