### PR TITLE
Change Longitude to Logitude to match scripts/artifacts/knowClocation.py

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -191,7 +191,7 @@ def kmlgen(report_folder, kmlactivity, data_list, data_headers):
     while a < length:
         modifiedDict = dict(zip(data_headers, data_list[a]))
         times = modifiedDict['Timestamp']
-        lon = modifiedDict['Longitude']
+        lon = modifiedDict['Logitude']
         lat = modifiedDict['Latitude']
         if lat:
             pnt = kml.newpoint()


### PR DESCRIPTION
This PR normalizes the spelling of Longitude between `scripts/artifacts/knowClocation.py` and `scripts/ilapfuncs.py` to be "Logitude". This matches the data headers when generated.

Fixes #111.