### PR TITLE
modified file copy to handle NFS share mount permissions

### DIFF
--- a/scripts/artifacts/bluetoothOther.py
+++ b/scripts/artifacts/bluetoothOther.py
@@ -13,7 +13,6 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
 def get_bluetoothOther(files_found, report_folder, seeker):
 	file_found = str(files_found[0])
-	os.chmod(file_found, 0o0777)
 	db = sqlite3.connect(file_found)
 	cursor = db.cursor()
 

--- a/scripts/artifacts/bluetoothPaired.py
+++ b/scripts/artifacts/bluetoothPaired.py
@@ -13,7 +13,6 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
 def get_bluetoothPaired(files_found, report_folder, seeker):
 	file_found = str(files_found[0])
-	os.chmod(file_found, 0o0777)
 	db = sqlite3.connect(file_found)
 	cursor = db.cursor()
 

--- a/scripts/artifacts/bluetoothPairedReg.py
+++ b/scripts/artifacts/bluetoothPairedReg.py
@@ -13,7 +13,6 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
 def get_bluetoothPairedReg(files_found, report_folder, seeker):
 	file_found = str(files_found[0])
-	os.chmod(file_found, 0o0777)
 	data_list = [] 
 	with open(file_found, 'rb') as f:
 		deserialized = plistlib.load(f)

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -192,13 +192,23 @@ def generate_report(reportfolderbase, time_in_secs, time_HMS, extraction_type, i
     elements_folder = os.path.join(reportfolderbase, '_elements')
     os.mkdir(elements_folder)
     __location__ = os.path.dirname(os.path.abspath(__file__))
-    
-    shutil.copy2(os.path.join(__location__,"logo.jpg"), elements_folder)
-    shutil.copy2(os.path.join(__location__,"dashboard.css"), elements_folder)
-    shutil.copy2(os.path.join(__location__,"feather.min.js"), elements_folder)
-    shutil.copy2(os.path.join(__location__,"dark-mode.css"), elements_folder)
-    shutil.copy2(os.path.join(__location__,"dark-mode-switch.js"), elements_folder)
-    shutil.copytree(os.path.join(__location__,"MDB-Free_4.13.0"), os.path.join(elements_folder, 'MDB-Free_4.13.0'))
+   
+    def copy_no_perm(src, dst, *, follow_symlinks=True):
+        if not os.path.isdir(dst):
+            shutil.copyfile(src, dst)
+        return dst
+
+    try:
+        shutil.copyfile(os.path.join(__location__,"logo.jpg"), os.path.join(elements_folder,"logo.jpg"))
+        shutil.copyfile(os.path.join(__location__,"dashboard.css"), os.path.join(elements_folder,"dashboard.css"))
+        shutil.copyfile(os.path.join(__location__,"feather.min.js"), os.path.join(elements_folder,"feather.min.js"))
+        shutil.copyfile(os.path.join(__location__,"dark-mode.css"), os.path.join(elements_folder,"dark-mode.css"))
+        shutil.copyfile(os.path.join(__location__,"dark-mode-switch.js"), os.path.join(elements_folder,"dark-mode-switch.js"))
+        shutil.copytree(os.path.join(__location__,"MDB-Free_4.13.0"), os.path.join(elements_folder, 'MDB-Free_4.13.0'), copy_function=copy_no_perm)
+    except shutil.Error:
+        print("shutil reported an error. Maybe due to recursive directory copying.")
+        if os.path.exists(os.path.join(elements_folder,'MDB-Free_4.13.0')):
+            print("_elements folder seems fine. Probably nothing to worry about")
 
 def get_file_content(path):
     f = open(path, 'r', encoding='utf8')


### PR DESCRIPTION
When using iLEAPP on nfs mounts, it can not modify permissions (set by nfs server). shutil.copy2 (or shutil.copy) is also copying permissions from files in git repo. 
It makes sense to inherit of local output directory and it make it work on nfs mounts :)

Also deleted for same reason some chmod in bluetooth scripts. No sure what is their use...

Do not solve issue #70 as it concern samba, but same kind of problem.

NB : My weird error handling would be solved by python 3.8 and option dirs_exist_ok in shutil.copytree.