### PR TITLE
Add location vizualisation map

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ blackboxprotobuf
 nska-deserialize
 biplist
 simplekml
+folium
+pandas
+geopandas

--- a/scripts/location_map_constants.py
+++ b/scripts/location_map_constants.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+iLEAPP_KMLs = "_KML Exports"
+
+defaultShadowUrl = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png'
+
+defaultIconUrl = 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-{}.png'
+
+colors = ['red','green','blue','orange','violet','yellow', 'sienna', 'indigo','purple','cyan','darkgray']
+
+legend_tag = "<li><span style='background:{0};opacity:0.7;'></span>{1}</li>"
+
+legend_title_tag = "<div class='legend-title'>{0}</div>"
+
+legend_div = """
+<div class='legend-scale'>
+  <ul class='legend-labels'>
+    {0}
+  </ul>
+</div>
+"""
+
+template_part1 = """
+{% macro html(this, kwargs) %}
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>jQuery UI Draggable - Default functionality</title>
+  <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+
+  <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+
+  <script>
+  $( function() {
+    $( "#maplegend" ).draggable({
+                    start: function (event, ui) {
+                        $(this).css({
+                            right: "auto",
+                            top: "auto",
+                            bottom: "auto"
+                        });
+                    }
+                });
+});
+
+  </script>
+</head>
+<body>
+
+
+<div id='maplegend' class='maplegend'
+    style='position: absolute; z-index:9999; border:2px solid grey; background-color:rgba(255, 255, 255, 0.8);
+     border-radius:6px; padding: 10px; font-size:14px; right: 20px; bottom: 20px;'>
+"""
+template_part2 = """
+</div>
+
+</body>
+</html>
+
+<style type='text/css'>
+  .maplegend .legend-title {
+    text-align: left;
+    margin-bottom: 5px;
+    font-weight: bold;
+    font-size: 90%;
+    }
+  .maplegend .legend-scale ul {
+    margin: 0;
+    margin-bottom: 5px;
+    padding: 0;
+    float: left;
+    list-style: none;
+    }
+  .maplegend .legend-scale ul li {
+    font-size: 80%;
+    list-style: none;
+    margin-left: 0;
+    line-height: 18px;
+    margin-bottom: 2px;
+    }
+  .maplegend ul.legend-labels li span {
+    display: block;
+    float: left;
+    height: 16px;
+    width: 30px;
+    margin-right: 5px;
+    margin-left: 0;
+    border: 1px solid #999;
+    }
+  .maplegend .legend-source {
+    font-size: 80%;
+    color: #777;
+    clear: both;
+    }
+  .maplegend a {
+    color: #777;
+    }
+</style>
+{% endmacro %}
+"""
+

--- a/scripts/location_map_report.py
+++ b/scripts/location_map_report.py
@@ -1,0 +1,128 @@
+# coding: utf-8
+#Import the necessary Python modules
+import pandas as pd
+import geopandas as gpd
+import folium
+from folium import IFrame
+from folium.plugins import TimestampedGeoJson
+import shapely
+from shapely.geometry import Point
+import os
+import fiona
+from datetime import datetime
+from branca.element import Template, MacroElement
+import html
+from scripts.location_map_constants import iLEAPP_KMLs, defaultShadowUrl, defaultIconUrl, colors, legend_tag, legend_title_tag, legend_div, template_part1, template_part2
+
+from scripts.artifact_report import ArtifactHtmlReport
+
+#Helpers
+def htmlencode(string):
+    return string.encode(encoding='ascii',errors='xmlcharrefreplace').decode('utf-8')
+
+def geodfToFeatures(df, f, props):
+    coords = []
+    times = []
+    for i,row in df[df.Description.str.contains(f)].iterrows():
+        coords.append(
+            [row.geometry.x,row.geometry.y]
+        )
+        times.append(datetime.strptime(row.Name,'%Y-%m-%d %H:%M:%S').isoformat())
+    return {  
+        'type': 'Feature',
+        'geometry': {
+            'type': props[f]['fType'],
+            'coordinates': coords,
+        },
+        'properties': {
+            'times': times,
+            'style': {'color': props[f]['color']},
+            'icon': props[f]['icon'],
+            'iconstyle': {
+                'iconUrl': props[f]['iconUrl'],
+                'shadowUrl': props[f]['shadowUrl'],
+                'iconSize': [25, 41],
+                'iconAnchor': [12, 41],
+                'popupAnchor': [1, -34],
+                'shadowSize': [41, 41],
+                'radius': 5,
+            },
+        },
+    }
+
+
+def generate_location_map(reportfolderbase,legend_title):
+    KML_path = os.path.join(reportfolderbase,iLEAPP_KMLs)
+    location_path = os.path.join(reportfolderbase, 'LOCATIONS')
+    gpd.io.file.fiona.drvsupport.supported_drivers['KML'] = 'rw'
+
+    #import KML files to GeoPandas
+    #start with empty df
+    df = gpd.GeoDataFrame()
+
+    for filename in os.listdir(KML_path):
+        if filename.endswith("kml")  and not 'Photo' in filename:
+            s = gpd.read_file(os.path.join(KML_path,filename), driver='KML')
+            df = df.append(s, ignore_index=True)
+
+    #sorting is needed for correct display
+    df.sort_values(by=['Name'],inplace=True)
+
+    #Parse KML data and add to Folium Map
+    data_names = df.Description.str.extract(r'.{30} - (.*)')[0].unique()
+
+    featuresProp = {}
+
+    for c,d in zip(colors, data_names):
+        descFilter = d
+        if 'ZRT' in d:
+            fType =  'LineString'
+            icon = 'marker'
+            iconUrl = defaultIconUrl.format(c)
+            shadowUrl = defaultShadowUrl
+        else:
+            fType =  'MultiPoint'
+            icon = 'circle'
+            iconUrl = ''
+            shadowUrl = ''
+
+        color = c
+
+        featuresProp[d] = {
+                'fType': fType,
+                'color': c,
+                'icon': icon,
+                'iconUrl': iconUrl,
+                'shadowUrl': defaultShadowUrl,
+            }
+
+    location_map = folium.Map([df.iloc[0].geometry.y,df.iloc[0].geometry.x], prefer_canvas=True, zoom_start = 6)
+    location_map.fit_bounds([
+            (df.geometry.total_bounds[1],df.geometry.total_bounds[0]),
+            (df.geometry.total_bounds[3],df.geometry.total_bounds[2]),
+        ]
+    )
+
+    tsGeo = TimestampedGeoJson({
+        'type': 'FeatureCollection',
+        'features': [
+            geodfToFeatures(df, f, featuresProp) for f in data_names
+        ]
+    }, period="PT1M", duration="PT1H", loop=False, transition_time = 50, time_slider_drag_update=True, add_last_point=True, max_speed=200).add_to(location_map)
+
+
+    #legend
+    legend = '\n'.join([ legend_tag.format(featuresProp[f]['color'], htmlencode(f)) for f in data_names])
+    template = '\n'.join([template_part1, legend_title_tag.format(htmlencode(legend_title)), legend_div.format(legend), template_part2])
+
+    macro = MacroElement()
+    macro._template = Template(template)
+
+    location_map.get_root().add_child(macro)
+    
+    location_map.save(os.path.join(location_path,"Locations_Map.html"))
+
+    report = ArtifactHtmlReport('Locations Map')
+    report.start_artifact_report(location_path, 'Locations Map', 'Map plotting all locations')
+    report.write_raw_html(open(os.path.join(location_path,"Locations_Map.html")).read())
+    report.end_artifact_report()

--- a/scripts/location_map_report.py
+++ b/scripts/location_map_report.py
@@ -53,6 +53,9 @@ def geodfToFeatures(df, f, props):
 
 def generate_location_map(reportfolderbase,legend_title):
     KML_path = os.path.join(reportfolderbase,iLEAPP_KMLs)
+    if not os.path.isdir(KML_path) or not os.path.listdir(KML_path):
+        return
+
     location_path = os.path.join(reportfolderbase, 'LOCATIONS')
     gpd.io.file.fiona.drvsupport.supported_drivers['KML'] = 'rw'
 

--- a/scripts/location_map_report.py
+++ b/scripts/location_map_report.py
@@ -53,7 +53,7 @@ def geodfToFeatures(df, f, props):
 
 def generate_location_map(reportfolderbase,legend_title):
     KML_path = os.path.join(reportfolderbase,iLEAPP_KMLs)
-    if not os.path.isdir(KML_path) or not os.path.listdir(KML_path):
+    if not os.path.isdir(KML_path) or not os.listdir(KML_path):
         return
 
     location_path = os.path.join(reportfolderbase, 'LOCATIONS')

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from scripts.html_parts import *
 from scripts.ilapfuncs import logfunc
 from scripts.version_info import aleapp_version, aleapp_contributors
+from scripts.location_map_report import generate_location_map
 
 def get_icon_name(category, artifact):
     ''' Returns the icon name from the feathericons collection. To add an icon type for 
@@ -120,6 +121,9 @@ def get_icon_name(category, artifact):
     return icon
     
 def generate_report(reportfolderbase, time_in_secs, time_HMS, extraction_type, image_input_path):
+    
+    #generate loaation map with all KML files
+    generate_location_map(reportfolderbase, "Legend")
 
     control = None
     side_heading = \


### PR DESCRIPTION
I have been working on a way to visualise all locations at once (except photos). 
Takes files in KML export and plot on an interactive map (with a time slider). Only tested for iOS 12.1.4. 

Routine D ZRTXX are plotted as line because it seems to make more sense. All others are plotted as circles (wi-fi/cell). 

Using circles (instead of markers) because they are lighter and browser can remain fluid with a lot of them.

sample result on my dataset:
![image](https://user-images.githubusercontent.com/73934450/98371244-240eac00-203c-11eb-9409-044ccb9135fd.png)
