### PR TITLE
Added an optimization for search results

### DIFF
--- a/scripts/artifacts/sms.py
+++ b/scripts/artifacts/sms.py
@@ -59,7 +59,7 @@ def get_sms(files_found, report_folder, seeker):
         def copyAttachments(rec):
             pathToAttachment = None
             if rec["FILENAME"]:
-                attachment = seeker.search('**'+rec["FILENAME"].replace('~',''))
+                attachment = seeker.search('**'+rec["FILENAME"].replace('~',''), return_on_first_hit=True)
                 pathToAttachment = os.path.join((os.path.basename(os.path.abspath(report_folder))), os.path.basename(rec["FILENAME"]))
                 if is_platform_windows():
                     invalid = '<>:"/\|?*'

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -5,92 +5,93 @@
 
 import traceback
 
-from scripts.artifacts.applicationstate import get_applicationstate
-from scripts.artifacts.appSnapshots import get_applicationSnapshots
-from scripts.artifacts.journalStrings import get_journalStrings 
-from scripts.artifacts.walStrings import get_walStrings
-from scripts.artifacts.confaccts import get_confaccts
+from time import process_time, gmtime, strftime
 from scripts.artifacts.accs import get_accs
-from scripts.artifacts.callHistory import get_callHistory
-from scripts.artifacts.conDev import get_conDev
-from scripts.artifacts.dataUsageA import get_dataUsageA
-from scripts.artifacts.dataUsageProcessA import get_dataUsageProcessA
-from scripts.artifacts.dataUsageB import get_dataUsageB
-from scripts.artifacts.dataUsageProcessB import get_dataUsageProcessB
-from scripts.artifacts.mobileInstall import get_mobileInstall
-from scripts.artifacts.sms import get_sms
-from scripts.artifacts.lastBuild import get_lastBuild, get_iTunesBackupInfo
-from scripts.artifacts.dataArk import get_dataArk
-from scripts.artifacts.iconsScreen import get_iconsScreen
-from scripts.artifacts.webClips import get_webClips
-from scripts.artifacts.notificationsXII import get_notificationsXII
-from scripts.artifacts.notificationsXI import get_notificationsXI
-from scripts.artifacts.celWireless import get_celWireless
 from scripts.artifacts.aggDict import get_aggDict
 from scripts.artifacts.aggDictScalars import get_aggDictScalars
+from scripts.artifacts.aggDictpasscode import get_aggDictpasscode
+from scripts.artifacts.aggDictpasscodetype import get_aggDictpasscodetype
+from scripts.artifacts.appConduit import get_appConduit
+from scripts.artifacts.appGrouplisting import get_appGrouplisting
+from scripts.artifacts.appItunesmeta import get_appItunesmeta
+from scripts.artifacts.appSnapshots import get_applicationSnapshots
+from scripts.artifacts.appleMapsApplication import get_appleMapsApplication
+from scripts.artifacts.appleMapsGroup import get_appleMapsGroup
+from scripts.artifacts.appleWifiPlist import get_appleWifiPlist  
+from scripts.artifacts.applewalletTransactions import get_applewalletTransactions
+from scripts.artifacts.applicationstate import get_applicationstate
+from scripts.artifacts.bluetoothOther import get_bluetoothOther
+from scripts.artifacts.bluetoothPaired import get_bluetoothPaired
+from scripts.artifacts.bluetoothPairedReg import get_bluetoothPairedReg
+from scripts.artifacts.cacheRoutesGmap import get_cacheRoutesGmap
+from scripts.artifacts.calendarAll import get_calendarAll
+from scripts.artifacts.callHistory import get_callHistory
+from scripts.artifacts.celWireless import get_celWireless
+from scripts.artifacts.cloudkitNoteSharing import get_cloudkitNoteSharing
+from scripts.artifacts.cloudkitParticipants import get_cloudkitParticipants
+from scripts.artifacts.conDev import get_conDev
+from scripts.artifacts.confaccts import get_confaccts
 from scripts.artifacts.coreDuetAirplane import get_coreDuetAirplane
 from scripts.artifacts.coreDuetLock import get_coreDuetLock
 from scripts.artifacts.coreDuetPlugin import get_coreDuetPlugin
-from scripts.artifacts.healthAll import get_healthAll
-from scripts.artifacts.interactionCcontacts import get_interactionCcontacts
-from scripts.artifacts.safariHistory import get_safariHistory
-from scripts.artifacts.safariWebsearch import get_safariWebsearch
-from scripts.artifacts.safariBookmarks import get_safariBookmarks
-from scripts.artifacts.safariTabs import get_safariTabs
-from scripts.artifacts.queryPredictions import get_queryPredictions
-from scripts.artifacts.dhcpl import get_dhcpl
+from scripts.artifacts.dataArk import get_dataArk
+from scripts.artifacts.dataUsageA import get_dataUsageA
+from scripts.artifacts.dataUsageB import get_dataUsageB
+from scripts.artifacts.dataUsageProcessA import get_dataUsageProcessA
+from scripts.artifacts.dataUsageProcessB import get_dataUsageProcessB
+from scripts.artifacts.deviceActivator import get_deviceActivator
 from scripts.artifacts.dhcphp import get_dhcphp
-from scripts.artifacts.powerlogAll import get_powerlogAll
-from scripts.artifacts.powerlogGZ import get_powerlogGZ
-from scripts.artifacts.locationDparkedhistorical import get_locationDparkedhistorical
-from scripts.artifacts.locationDparked import get_locationDparked
-from scripts.artifacts.knowCall import get_knowCall
-from scripts.artifacts.mailprotect import get_mailprotect
-from scripts.artifacts.screentimeAll import get_screentimeAll
-from scripts.artifacts.bluetoothPaired import get_bluetoothPaired
-from scripts.artifacts.bluetoothOther import get_bluetoothOther
-from scripts.artifacts.bluetoothPairedReg import get_bluetoothPairedReg
-from scripts.artifacts.locationDsteps import get_locationDsteps
-from scripts.artifacts.locationDallB import get_locationDallB
-from scripts.artifacts.calendarAll import get_calendarAll
-from scripts.artifacts.photosMetadata import get_photosMetadata
-from scripts.artifacts.aggDictpasscode import get_aggDictpasscode
-from scripts.artifacts.aggDictpasscodetype import get_aggDictpasscodetype
-from scripts.artifacts.ooklaSpeedtestData import get_ooklaSpeedtestData
-from scripts.artifacts.appleMapsGroup import get_appleMapsGroup
-from scripts.artifacts.appleMapsApplication import get_appleMapsApplication
-from scripts.artifacts.routineDlocations import get_routineDlocations
-from scripts.artifacts.routineDCloud import get_routineDCloud
-from scripts.artifacts.routineDLocationsLocal import get_routineDLocationsLocal
-from scripts.artifacts.cacheRoutesGmap import get_cacheRoutesGmap
-from scripts.artifacts.appleWifiPlist import get_appleWifiPlist  
-from scripts.artifacts.appConduit import get_appConduit
-from scripts.artifacts.mobileActivationLogs import get_mobileActivationLogs
-from scripts.artifacts.iCloudWifi import get_iCloudWifi
-from scripts.artifacts.mobileBackup import get_mobileBackup
-from scripts.artifacts.mobileContainerManager import get_mobileContainerManager
-from scripts.artifacts.mediaLibrary import get_mediaLibrary
+from scripts.artifacts.dhcpl import get_dhcpl
+from scripts.artifacts.discordAcct import get_discordAcct
+from scripts.artifacts.discordJson import get_discordJson
+from scripts.artifacts.discordManifest import get_discordManifest
+from scripts.artifacts.filesAppsclient import get_filesAppsclient
+from scripts.artifacts.filesAppsdb import get_filesAppsdb
+from scripts.artifacts.filesAppsm import get_filesAppsm
+from scripts.artifacts.geodApplications import get_geodApplications
 from scripts.artifacts.geodMapTiles import get_geodMapTiles
 from scripts.artifacts.geodPDPlaceCache import get_geodPDPlaceCache
-from scripts.artifacts.geodApplications import get_geodApplications
+from scripts.artifacts.healthAll import get_healthAll
+from scripts.artifacts.iCloudWifi import get_iCloudWifi
+from scripts.artifacts.icloudSharedalbums import get_icloudSharedalbums
+from scripts.artifacts.iconsScreen import get_iconsScreen
+from scripts.artifacts.interactionCcontacts import get_interactionCcontacts
+from scripts.artifacts.journalStrings import get_journalStrings 
+from scripts.artifacts.kikMessages import get_kikMessages
+from scripts.artifacts.knowCall import get_knowCall
+from scripts.artifacts.lastBuild import get_lastBuild, get_iTunesBackupInfo
+from scripts.artifacts.locationDallB import get_locationDallB
+from scripts.artifacts.locationDparked import get_locationDparked
+from scripts.artifacts.locationDparkedhistorical import get_locationDparkedhistorical
+from scripts.artifacts.locationDsteps import get_locationDsteps
+from scripts.artifacts.mailprotect import get_mailprotect
+from scripts.artifacts.mediaLibrary import get_mediaLibrary
+from scripts.artifacts.mobileActivationLogs import get_mobileActivationLogs
+from scripts.artifacts.mobileBackup import get_mobileBackup
+from scripts.artifacts.mobileContainerManager import get_mobileContainerManager
+from scripts.artifacts.mobileInstall import get_mobileInstall
+from scripts.artifacts.notificationsXI import get_notificationsXI
+from scripts.artifacts.notificationsXII import get_notificationsXII
+from scripts.artifacts.ooklaSpeedtestData import get_ooklaSpeedtestData
+from scripts.artifacts.photosMetadata import get_photosMetadata
+from scripts.artifacts.powerlogAll import get_powerlogAll
+from scripts.artifacts.powerlogGZ import get_powerlogGZ
+from scripts.artifacts.queryPredictions import get_queryPredictions
+from scripts.artifacts.routineDCloud import get_routineDCloud
+from scripts.artifacts.routineDLocationsLocal import get_routineDLocationsLocal
+from scripts.artifacts.routineDlocations import get_routineDlocations
+from scripts.artifacts.safariBookmarks import get_safariBookmarks
+from scripts.artifacts.safariHistory import get_safariHistory
+from scripts.artifacts.safariTabs import get_safariTabs
+from scripts.artifacts.safariWebsearch import get_safariWebsearch
+from scripts.artifacts.screentimeAll import get_screentimeAll
+from scripts.artifacts.sms import get_sms
 from scripts.artifacts.tileApp import get_tileApp
 from scripts.artifacts.tileAppDb import get_tileAppDb
-from scripts.artifacts.tileAppNetDb import get_tileAppNetDb
 from scripts.artifacts.tileAppDisc import get_tileAppDisc
-from scripts.artifacts.discordJson import get_discordJson
-from scripts.artifacts.discordAcct import get_discordAcct
-from scripts.artifacts.discordManifest import get_discordManifest
-from scripts.artifacts.filesAppsm import get_filesAppsm
-from scripts.artifacts.filesAppsdb import get_filesAppsdb
-from scripts.artifacts.filesAppsclient import get_filesAppsclient
-from scripts.artifacts.icloudSharedalbums import get_icloudSharedalbums
-from scripts.artifacts.appGrouplisting import get_appGrouplisting
-from scripts.artifacts.deviceActivator import get_deviceActivator
-from scripts.artifacts.kikMessages import get_kikMessages
-from scripts.artifacts.appItunesmeta import get_appItunesmeta
-from scripts.artifacts.cloudkitParticipants import get_cloudkitParticipants
-from scripts.artifacts.cloudkitNoteSharing import get_cloudkitNoteSharing
-from scripts.artifacts.applewalletTransactions import get_applewalletTransactions
+from scripts.artifacts.tileAppNetDb import get_tileAppNetDb
+from scripts.artifacts.walStrings import get_walStrings
+from scripts.artifacts.webClips import get_webClips
 
 from scripts.ilapfuncs import *
 
@@ -103,90 +104,90 @@ from scripts.ilapfuncs import *
 
 
 tosearch = {'lastBuild':('IOS Build', '*LastBuildInfo.plist'),
+            'accs':('Accounts', '**/Accounts3.sqlite'),
             'aggDictpasscode':('Aggregate Dictionary', '*/AggregateDictionary/ADDataStore.sqlitedb'),
             'aggDictpasscodetype':('Aggregate Dictionary', '*/AggregateDictionary/ADDataStore.sqlitedb'),
-            'dataArk':('IOS Build', '**/Library/Lockdown/data_ark.plist'),
-            'applicationstate':('Installed Apps', '**/applicationState.db'),
+            'appConduit':('App Conduit', '**/AppConduit.log.*'),
+            'appGrouplisting': ('Installed Apps', ('*/private/var/mobile/Containers/Shared/AppGroup/*/*.metadata.plist','**/PluginKitPlugin/*.metadata.plist')),
+            'appItunesmeta':('Installed Apps', ('**/iTunesMetadata.plist', '**/BundleMetadata.plist')),
+            'appleMapsApplication':('Locations', '**/Data/Application/*/Library/Preferences/com.apple.Maps.plist'),
+            'appleMapsGroup':('Locations', '**/Shared/AppGroup/*/Library/Preferences/group.com.apple.Maps.plist'),
+            'appleWifiPlist':('Wireless Networks', ('**/com.apple.wifi.plist','**/com.apple.wifi-networks.plist.backup','**/com.apple.wifi.known-networks.plist','**/com.apple.wifi-private-mac-networks.plist')),
+            'applewalletTransactions': ('Apple Wallet', '**/passes23.sqlite'),
             'applicationSnapshots':('Installed Apps', ('**/Library/Caches/Snapshots/*', '**/SplashBoard/Snapshots/*')),
-            'accs':('Accounts', '**/Accounts3.sqlite'),
-            'confaccts':('Accounts', '**/com.apple.accounts.exists.plist'),
+            'applicationstate':('Installed Apps', '**/applicationState.db'),
+            #'appUpdates':('App Updates', '**/AppUpdates.sqlitedb'),
+            'bluetoothOther':('Bluetooth', '**/Library/Database/com.apple.MobileBluetooth.ledevices.other.db'),
+            'bluetoothPaired':('Bluetooth', '**/com.apple.MobileBluetooth.ledevices.paired.db'),
+            'bluetoothPairedReg':('Bluetooth', '**/com.apple.MobileBluetooth.devices.plist'),
+            'cacheRoutesGmap':('Locations', '**/Library/Application Support/CachedRoutes/*.plist'),
+            'calendarAll':('Calendar', '**/Calendar.sqlitedb'),
             'callHistory':('Call logs', '**/CallHistory.storedata'),
+            'celWireless':('Cellular Wireless', '*wireless/Library/Preferences/com.apple.*'),
+            'cloudkitNoteSharing': ('Cloudkit', '*NoteStore.sqlite*'),
+            'cloudkitParticipants': ('Cloudkit', '*NoteStore.sqlite*'),
             'conDev':('Connected to', '**/iTunes_Control/iTunes/iTunesPrefs'),
+            'confaccts':('Accounts', '**/com.apple.accounts.exists.plist'),
             'coreDuetAirplane':('CoreDuet', '**/coreduetd.db'),
             'coreDuetLock':('CoreDuet', '**/coreduetd.db'),
             'coreDuetPlugin':('CoreDuet', '**/coreduetd.db'),
-            'safariHistory':('Safari Browser', '**/Safari/History.db'),
-            'safariWebsearch':('Safari Browser', '**/Safari/History.db'),
-            'safariBookmarks':('Safari Browser', '**/Safari/Bookmarks.db'),
-            'safariTabs':('Safari Browser', '**/Safari/BrowserState.db'),
-            'queryPredictions':('SMS & iMessage', '**/query_predictions.db'),
-            'dhcpl':('DHCP', '**/private/var/db/dhcpclient/leases/en*'),
-            'dhcphp':('DHCP', '**/private/var/db/dhcpd_leases*'),
+            'dataArk':('IOS Build', '**/Library/Lockdown/data_ark.plist'),
             'dataUsageA':('Data Usage', '**/DataUsage.sqlite'), 
             'dataUsageB':('Data Usage', '**/DataUsage-watch.sqlite'),
             'dataUsageProcessA':('Data Usage', '**/DataUsage-watch.sqlite'),
             'dataUsageProcessB':('Data Usage', '**/DataUsage.sqlite'),
-            'mobileInstall':('Mobile Installation Logs', '**/mobile_installation.log.*'), 
-            'sms':('SMS & iMessage', '**/sms.db'),
-            'iconsScreen':('iOS Screens', '**/SpringBoard/IconState.plist'),
-            'webClips':('iOS Screens', '*WebClips/*.webclip/*'),
-            'notificationsXI':('Notifications', '*PushStore*'),
-            'notificationsXII':('Notifications', '*private/var/mobile/Library/UserNotifications*'),
-            'celWireless':('Cellular Wireless', '*wireless/Library/Preferences/com.apple.*'),
-            'knowCall':('KnowledgeC', '**/CoreDuet/Knowledge/knowledgeC.db'),
-            'powerlogAll':('Powerlog', '**/CurrentPowerlog.PLSQL'),
-            'powerlogGZ':('Powerlog Backups', '**/Library/BatteryLife/Archives/powerlog_*.PLSQL.gz'),
-            'healthAll':('Health Data', '**/healthdb_secure.sqlite'),
-            'interactionCcontacts':('InteractionC', '**/interactionC.db'),
-            'locationDallB':('Locations', '**/cache_encryptedB.db'),
-            'screentimeAll':('Screentime', '**/RMAdminStore-Local.sqlite'),
-            'mailprotect':('iOS Mail', '**/private/var/mobile/Library/Mail/* Index*'),
-            'locationDparkedhistorical':('Locations', '**/Local.sqlite'),
-            'locationDparked':('Locations', '**/Local.sqlite'),
-            'bluetoothPaired':('Bluetooth', '**/com.apple.MobileBluetooth.ledevices.paired.db'),
-            'bluetoothPairedReg':('Bluetooth', '**/com.apple.MobileBluetooth.devices.plist'),
-            'bluetoothOther':('Bluetooth', '**/Library/Database/com.apple.MobileBluetooth.ledevices.other.db'),
-            'calendarAll':('Calendar', '**/Calendar.sqlitedb'),
-            'photosMetadata':('Photos', '**/Photos.sqlite'),
-            'ooklaSpeedtestData':('Applications', '**/speedtest.sqlite*'),
-            'appleMapsGroup':('Locations', '**/Shared/AppGroup/*/Library/Preferences/group.com.apple.Maps.plist'),
-            'appleMapsApplication':('Locations', '**/Data/Application/*/Library/Preferences/com.apple.Maps.plist'),
-            'routineDlocations':('Locations', '**/com.apple.routined/Cache.sqlite*'),
-            'routineDLocationsLocal':('Locations', '**/private/var/mobile/Library/Caches/com.apple.routined/Local.sqlite*'),
-            'routineDCloud':('Locations', '**/Library/Caches/com.apple.routined/Cloud-V2.sqlite*'),
-            'cacheRoutesGmap':('Locations', '**/Library/Application Support/CachedRoutes/*.plist'),
-            'appleWifiPlist':('Wireless Networks', ('**/com.apple.wifi.plist','**/com.apple.wifi-networks.plist.backup','**/com.apple.wifi.known-networks.plist','**/com.apple.wifi-private-mac-networks.plist')),
-            #'systemVersion':('Device Info', '**/SystemVersion.plist'),
-            'mobileActivationLogs':('Mobile Activation Logs', '**/mobileactivationd.log*'),
-            'iCloudWifi':('Wifi Connections', '**/com.apple.wifid.plist'),
-            'mobileBackup':('Mobile Backup', '*/Preferences/com.apple.MobileBackup.plist'),
-            'mobileContainerManager':('Mobile Container Manager', '**/containermanagerd.log.*'),
-            #'appUpdates':('App Updates', '**/AppUpdates.sqlitedb'),
-            'appConduit':('App Conduit', '**/AppConduit.log.*'),
-            'mediaLibrary':('Media Library', '**/Medialibrary.sqlitedb'),
+            'deviceActivator': ('IOS Build', '*private/var/mobile/Library/Logs/mobileactivationd/ucrt_oob_request.txt'),
+            'dhcphp':('DHCP', '**/private/var/db/dhcpd_leases*'),
+            'dhcpl':('DHCP', '**/private/var/db/dhcpclient/leases/en*'),
+            'discordAcct': ('Discord', '*/var/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default'),
+            'discordJson': ('Discord', '*/com.hammerandchisel.discord/fsCachedData/*'),
+            'discordManifest': ('Discord', '*/private/var/mobile/Containers/Data/Application/*/Documents/RCTAsyncLocalStorage_V1/manifest.json'),
+            'filesAppsclient': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/client.db*'),
+            'filesAppsdb': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/server.db*'),
+            'filesAppsm': ('Files App', '*private/var/mobile/Containers/Shared/AppGroup/*/smartfolders.db*'),
+            'geodApplications': ('Geolocation', '**/AP.db'),
             'geodMapTiles': ('Geolocation', '**/MapTiles.sqlitedb'),
             'geodPDPlaceCache': ('Geolocation', '**/PDPlaceCache.db'),
-            'geodApplications': ('Geolocation', '**/AP.db'),
+            'healthAll':('Health Data', '**/healthdb_secure.sqlite'),
+            'iCloudWifi':('Wifi Connections', '**/com.apple.wifid.plist'),
+            'icloudSharedalbums': ('iCloud Shared Albums', '*/private/var/mobile/Media/PhotoData/PhotoCloudSharingData/*'),
+            'iconsScreen':('iOS Screens', '**/SpringBoard/IconState.plist'),
+            'interactionCcontacts':('InteractionC', '**/interactionC.db'),
+            'journalStrings':('SQLite Journaling - journal', '**/*-journal'),
+            'kikMessages': ('Kik', '**/kik.sqlite*'),
+            'knowCall':('KnowledgeC', '**/CoreDuet/Knowledge/knowledgeC.db'),
+            'locationDallB':('Locations', '**/cache_encryptedB.db'),
+            'locationDparked':('Locations', '**/Local.sqlite'),
+            'locationDparkedhistorical':('Locations', '**/Local.sqlite'),
+            'mailprotect':('iOS Mail', '**/private/var/mobile/Library/Mail/* Index*'),
+            'mediaLibrary':('Media Library', '**/Medialibrary.sqlitedb'),
+            'mobileActivationLogs':('Mobile Activation Logs', '**/mobileactivationd.log*'),
+            'mobileBackup':('Mobile Backup', '*/Preferences/com.apple.MobileBackup.plist'),
+            'mobileContainerManager':('Mobile Container Manager', '**/containermanagerd.log.*'),
+            'mobileInstall':('Mobile Installation Logs', '**/mobile_installation.log.*'), 
+            'notificationsXI':('Notifications', '*PushStore*'),
+            'notificationsXII':('Notifications', '*private/var/mobile/Library/UserNotifications*'),
+            'ooklaSpeedtestData':('Applications', '**/speedtest.sqlite*'),
+            'photosMetadata':('Photos', '**/Photos.sqlite'),
+            'powerlogAll':('Powerlog', '**/CurrentPowerlog.PLSQL'),
+            'powerlogGZ':('Powerlog Backups', '**/Library/BatteryLife/Archives/powerlog_*.PLSQL.gz'),
+            'queryPredictions':('SMS & iMessage', '**/query_predictions.db'),
+            'routineDCloud':('Locations', '**/Library/Caches/com.apple.routined/Cloud-V2.sqlite*'),
+            'routineDLocationsLocal':('Locations', '**/private/var/mobile/Library/Caches/com.apple.routined/Local.sqlite*'),
+            'routineDlocations':('Locations', '**/com.apple.routined/Cache.sqlite*'),
+            'safariBookmarks':('Safari Browser', '**/Safari/Bookmarks.db'),
+            'safariHistory':('Safari Browser', '**/Safari/History.db'),
+            'safariTabs':('Safari Browser', '**/Safari/BrowserState.db'),
+            'safariWebsearch':('Safari Browser', '**/Safari/History.db'),
+            'screentimeAll':('Screentime', '**/RMAdminStore-Local.sqlite'),
+            'sms':('SMS & iMessage', '**/sms.db'),
+            #'systemVersion':('Device Info', '**/SystemVersion.plist'),
             'tileApp': ('Locations', '*private/var/mobile/Containers/Data/Application/*/Library/log/com.thetileapp.tile*'),
             'tileAppDb': ('Locations', '*private/var/mobile/Containers/Shared/AppGroup/*/com.thetileapp.tile-TileNetworkDB.sqlite*'),
-            'tileAppNetDb': ('Accounts', '*/private/var/mobile/Containers/Shared/AppGroup/*/com.thetileapp.tile-TileNetworkDB.sqlite*'),
             'tileAppDisc': ('Accounts', '*/private/var/mobile/Containers/Shared/AppGroup/*/com.thetileapp.tile-DiscoveredTileDB.sqlite*'),
-            'discordJson': ('Discord', '*/com.hammerandchisel.discord/fsCachedData/*'),
-            'discordAcct': ('Discord', '*/var/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default'),
-            'discordManifest': ('Discord', '*/private/var/mobile/Containers/Data/Application/*/Documents/RCTAsyncLocalStorage_V1/manifest.json'),
-            'filesAppsm': ('Files App', '*private/var/mobile/Containers/Shared/AppGroup/*/smartfolders.db*'),
-            'filesAppsdb': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/server.db*'),
-            'filesAppsclient': ('Files App', '*private/var/mobile/Library/Application Support/CloudDocs/session/db/client.db*'),
-            'icloudSharedalbums': ('iCloud Shared Albums', '*/private/var/mobile/Media/PhotoData/PhotoCloudSharingData/*'),
-            'appGrouplisting': ('Installed Apps', ('*/private/var/mobile/Containers/Shared/AppGroup/*/*.metadata.plist','**/PluginKitPlugin/*.metadata.plist')),
-            'deviceActivator': ('IOS Build', '*private/var/mobile/Library/Logs/mobileactivationd/ucrt_oob_request.txt'),
-            'kikMessages': ('Kik', '**/kik.sqlite*'),
-            'appItunesmeta':('Installed Apps', ('**/iTunesMetadata.plist', '**/BundleMetadata.plist')),
-            'cloudkitParticipants': ('Cloudkit', '*NoteStore.sqlite*'),
-            'cloudkitNoteSharing': ('Cloudkit', '*NoteStore.sqlite*'),
-            'applewalletTransactions': ('Apple Wallet', '**/passes23.sqlite'),
-            'journalStrings':('SQLite Journaling - journal', '**/*-journal'),
-            'walStrings':('SQLite Journaling - wal', '**/*-wal')
+            'tileAppNetDb': ('Accounts', '*/private/var/mobile/Containers/Shared/AppGroup/*/com.thetileapp.tile-TileNetworkDB.sqlite*'),
+            'walStrings':('SQLite Journaling - wal', '**/*-wal'),
+            'webClips':('iOS Screens', '*WebClips/*.webclip/*'),
             }
 
 '''
@@ -212,7 +213,7 @@ def process_artifact(files_found, artifact_func, artifact_name, seeker, report_f
 
             seeker: FileSeeker object to pass to method
     '''
-    
+    start_time = process_time()
     logfunc('{} [{}] artifact executing'.format(artifact_name, artifact_func))
     report_folder = os.path.join(report_folder_base, artifact_name) + slash
     try:
@@ -234,4 +235,7 @@ def process_artifact(files_found, artifact_func, artifact_name, seeker, report_f
         logfunc('Exception Traceback: {}'.format(traceback.format_exc()))
         return
 
-    logfunc('{} [{}] artifact completed'.format(artifact_name, artifact_func))
+    end_time = process_time()
+    run_time_secs =  end_time - start_time
+    #run_time_HMS = strftime('%H:%M:%S', gmtime(run_time_secs))
+    logfunc('{} [{}] artifact completed in time {} seconds'.format(artifact_name, artifact_func, run_time_secs))

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -288,7 +288,7 @@ searching for thumbnails, copy it to report folder and return tag  to insert in 
 '''
 def generate_thumbnail(imDirectory, imFilename, seeker, report_folder):
     thumb = thumbnail_root+imDirectory+'/'+imFilename+'/'
-    thumblist = seeker.search(thumb+'**.JPG')
+    thumblist = seeker.search(thumb+'**.JPG', return_on_first_hit=True)
     thumbname = imDirectory.replace('/','_')+'_'+imFilename+'.JPG'
     pathToThumb = os.path.join(os.path.basename(os.path.abspath(report_folder)), thumbname)
     htmlThumbTag = '<img src="{0}"></img>'.format(pathToThumb)
@@ -297,7 +297,7 @@ def generate_thumbnail(imDirectory, imFilename, seeker, report_folder):
     else:
         #recreate thumbnail from image
         #TODO: handle videos and HEIC
-        files = seeker.search(media_root+imDirectory+'/'+imFilename)
+        files = seeker.search(media_root+imDirectory+'/'+imFilename, return_on_first_hit=True)
         if files:
             try:
                 im = Image.open(files[0])

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 
 class FileSeekerBase:
     # This is an abstract base class
-    def search(self, filepattern_to_search):
+    def search(self, filepattern_to_search, return_on_first_hit=False):
         '''Returns a list of paths for files/folders that matched'''
         pass
 
@@ -23,8 +23,9 @@ class FileSeekerDir(FileSeekerBase):
         FileSeekerBase.__init__(self)
         self.directory = directory
         self._all_files = []
-        logfunc('Building files listing')
+        logfunc('Building files listing...')
         self.build_files_list(directory)
+        logfunc(f'File listing complete - {len(self._all_files)} files')
 
     def build_files_list(self, directory):
         '''Populates all paths in directory into _all_files'''
@@ -37,7 +38,12 @@ class FileSeekerDir(FileSeekerBase):
         except Exception as ex:
             logfunc(f'Error reading {directory} ' + str(ex))
 
-    def search(self, filepattern):
+    def search(self, filepattern, return_on_first_hit=False):
+        if return_on_first_hit:
+            for item in self._all_files:
+                if fnmatch.fnmatch(item, filepattern):
+                    return [item]
+            return []
         return fnmatch.filter(self._all_files, filepattern)
 
 class FileSeekerItunes(FileSeekerBase):
@@ -46,8 +52,9 @@ class FileSeekerItunes(FileSeekerBase):
         self.directory = directory
         self._all_files = {}
         self.temp_folder = temp_folder
-        logfunc('Building files listing')
+        logfunc('Building files listing...')
         self.build_files_list(directory)
+        logfunc(f'File listing complete - {len(self._all_files)} files')
 
     def build_files_list(self, directory):
         '''Populates paths from Manifest.db files into _all_files'''
@@ -75,7 +82,7 @@ class FileSeekerItunes(FileSeekerBase):
             logfunc(f'Error opening Manifest.db from {directory}, ' + str(ex))
             raise ex
 
-    def search(self, filepattern):
+    def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
         matching_keys = fnmatch.filter(self._all_files, filepattern)
         for relative_path in matching_keys:
@@ -100,7 +107,7 @@ class FileSeekerTar(FileSeekerBase):
         self.tar_file = tarfile.open(tar_file_path, mode)
         self.temp_folder = temp_folder
 
-    def search(self, filepattern):
+    def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
         for member in self.tar_file.getmembers():
             if fnmatch.fnmatch(member.name, filepattern):
@@ -132,15 +139,15 @@ class FileSeekerZip(FileSeekerBase):
         self.name_list = self.zip_file.namelist()
         self.temp_folder = temp_folder
 
-    def search(self, filepattern):
+    def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
         for member in self.name_list:
             if fnmatch.fnmatch(member, filepattern):
                 try:
                     extracted_path = self.zip_file.extract(member, path=self.temp_folder) # already replaces illegal chars with _ when exporting
-                    member = member.lstrip("/")
                     pathlist.append(extracted_path)
                 except Exception as ex:
+                    member = member.lstrip("/")
                     logfunc(f'Could not write file to filesystem, path was {member} ' + str(ex))
         return pathlist
 


### PR DESCRIPTION
Now there is an option to terminate the file search early, if you only need the first search result. The seeker.search has this option added, function is now: `def search(self, filepattern, return_on_first_hit=False)` 

For at least a couple of plugins, this results in much faster processing.

Using filesystem extraction type on the 'Ruth' ctf ios image.

**PhotosMetadata plugin**
563.5 sec - Before 
312.4 sec - Now

**SMS plugin**
25.51 sec - Before
13.59 sec - Now

I've also sorted the modules under `ilap_artifacts.py` for easy reading/editing.