### PR TITLE
Faster walStrings

### DIFF
--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -1,56 +1,47 @@
 import os
-import textwrap
-import datetime
-import sys
 import re
 import string
+
 from pathlib import Path
 from html import escape
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, is_platform_windows
 
-def strings(filename, min=4):
-    with open(filename, errors="ignore") as f:  # Python 3.x
-    # with open(filename, "rb") as f:           # Python 2.x
-        result = ""
-        for c in f.read():
-            if c in string.printable:
-                result += c
-                continue
-            if len(result) >= min:
-                yield result
-            result = ""
-        if len(result) >= min:  # catch result at EOF
-            yield result
+control_chars = ''.join(map(chr, range(0,32))) + ''.join(map(chr, range(127,160)))
+not_control_char_re = re.compile(f'[^{control_chars}]' + '{4,}')
+# If  we only want ascii, use 'ascii_chars_re' below
+printable_chars_for_re = string.printable.replace('\\', '\\\\').replace('[', '\\[').replace(']', '\\]')
+ascii_chars_re = re.compile(f'[{printable_chars_for_re}]' + '{4,}')
 
 def get_walStrings(files_found, report_folder, seeker):
     x = 0
     data_list =[]
     for file_found in files_found:
         x = x + 1
-        sx = str(x)
         journalName = os.path.basename(file_found)
-        outputpath = os.path.join(report_folder, sx+'_'+journalName+'.txt') # name of file in txt
-        #linkpath = os.path.basename(
+        outputpath = os.path.join(report_folder, str(x) + '_' + journalName + '.txt') # name of file in txt
+
         level2, level1 = (os.path.split(outputpath))
         level2 = (os.path.split(level2)[1])
-        final = level2+'/'+level1
+        final = level2 + '/' + level1
         
         filesize = Path(file_found).stat().st_size
-        #logfunc(str(filesize))
-        
+
         if filesize == 0:
             pass
         else:
+            unique_items = set() # For deduplication of strings found
             with open(outputpath, 'w') as g:
-                for s in strings(file_found):
-                    g.write(s)
-                    g.write('\n')
+                with open(file_found, errors="ignore") as f:  # Python 3.x
+                    data =  f.read()
+                    #for match in not_control_char_re.finditer(data): # This gets all unicode chars, can include lot of garbage if you only care about English, will miss out other languages
+                    for match in ascii_chars_re.finditer(data): # Matches ONLY Ascii (old behavior) , good if you only care about English
+                        if match.group() not in unique_items:
+                            g.write(match.group())
+                            g.write('\n')
+                            unique_items.add(match.group())
         
-        if filesize == 0:
-            pass
-        else:
             out = (f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>') 
             data_list.append((out, file_found))
         


### PR DESCRIPTION
Replaced the code to use regex. This is much faster now. Also added deduplication, so strings don't show up multiple times.
The speed improvement is big. On the one I am testing on, it went from 40 seconds down to 7 seconds (ascii char matching) or 8 seconds (unicode char matching).

I'm not merging this yet because there are some issues to be considered. The old code was only getting ASCII chars, as it was filtering characters with `string.printable`, which only works for printable ascii characters. That is good if you know you are only going to have English language text. 

Enabling unicode matching is better in theory as you get English + any other language characters, but that also means that you get a lot of garbage too (especially if you are primarily looking for English text). 

The description in the plugin says ASCII & Unicode both, but it was only getting ASCII earlier. 

The current code keeps old behavior (ASCII only), but you can toggle to full Unicode (which automatically gets you ASCII too) on line 38/39.