### PR TITLE
Shorten location artifact data

### DIFF
--- a/scripts/artifacts/voiceRecordings.py
+++ b/scripts/artifacts/voiceRecordings.py
@@ -50,7 +50,7 @@ def get_voiceRecordings(files_found, report_folder, seeker):
         report.start_artifact_report(report_folder, 'Voice Recordings')
         report.add_script()
         data_headers = ('Creation Date', 'Title', 'Path to File', 'Audio File')
-        report.write_artifact_data_table(data_headers, data_list, ', '.join(files_found), html_no_escape=['Audio File'])
+        report.write_artifact_data_table(data_headers, data_list, dirname(files_found), html_no_escape=['Audio File'])
         report.end_artifact_report()
 
         tsvname = 'Voice Recordings'

--- a/scripts/artifacts/voiceTriggers.py
+++ b/scripts/artifacts/voiceTriggers.py
@@ -2,7 +2,7 @@ import json
 import datetime
 import shutil
 from os import listdir
-from os.path import isfile, join, basename
+from os.path import isfile, join, basename, dirname
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline
@@ -50,7 +50,7 @@ def get_voiceTriggers(files_found, report_folder, seeker):
         report.start_artifact_report(report_folder, 'Voice Triggers')
         report.add_script()
         data_headers = ('Creation Date', 'Device', 'Path to File', 'Audio File')
-        report.write_artifact_data_table(data_headers, data_list, ', '.join(files_found), html_no_escape=['Audio File'])
+        report.write_artifact_data_table(data_headers, data_list, dirname(file_found), html_no_escape=['Audio File'])
         report.end_artifact_report()
 
         tsvname = 'Voice Triggers'


### PR DESCRIPTION
Since the report has the location per artifact no need to list it in detail at the start of the report since it clutters the report.