### PR TITLE
SMS chat rendering issues

### DIFF
--- a/scripts/artifacts/sms.py
+++ b/scripts/artifacts/sms.py
@@ -70,6 +70,9 @@ def get_sms(files_found, report_folder, seeker):
                     shutil.copy(attachment[0], os.path.join(report_folder, cleanFilename))
                     pathToAttachment = os.path.join(report_folder, cleanFilename)
                 else:
+                    if not attachment:
+                        logfunc(' [!] Unable to extract attachment file: "{}"'.format(rec['FILENAME']))
+                        return
                     shutil.copy(attachment[0], os.path.join(report_folder, os.path.basename(rec["FILENAME"])))
             return pathToAttachment
         

--- a/scripts/artifacts/sms.py
+++ b/scripts/artifacts/sms.py
@@ -60,7 +60,7 @@ def get_sms(files_found, report_folder, seeker):
         def copyAttachments(rec):
             pathToAttachment = None
             if rec["FILENAME"]:
-                attachment = seeker.search('**'+rec["FILENAME"].replace('~', ''), return_on_first_hit=True)
+                attachment = seeker.search('**'+rec["FILENAME"].replace('~', '', 1), return_on_first_hit=True)
                 pathToAttachment = os.path.join((os.path.basename(os.path.abspath(report_folder))), os.path.basename(rec["FILENAME"]))
                 if is_platform_windows():
                     invalid = '<>:"/\|?*'

--- a/scripts/chat_rendering.py
+++ b/scripts/chat_rendering.py
@@ -158,6 +158,7 @@ mimeTypeIcon = {
     "video":"🎥",
     "animated":"🎡",
     "application":"📎",
+    "text":"Ŧ"
 }
 
 """
@@ -188,14 +189,14 @@ def integrateAtt(rec):
               <source src="{0}" type="{1}">
               <p><a href="{0}"></a> </p>
             </audio>
-            """.format(rec["content-type"])
+            """.format(rec['file-path'], rec["content-type"])
         elif att_type == 'video':
             source = """
             <video controls width="256">
               <source src="{0}" type="{1}">
               <p><a href="{0}"></a> </p>
             </video>
-            """.format(rec["content-type"])
+            """.format(rec['file-path'], rec["content-type"])
         else:
             source = '<a href="{}">{}</a>'.format(rec["file-path"],filename)
         


### PR DESCRIPTION
I ran into a few minor SMS chat rendering issues when working with multiple iTunes backups that were decrypted using @jfarley248's iTunes Backup Reader.  Found that I had to decrypt to 'filesystem' rather than a decrypted iTunes backup as iLEAPP does not extract SMS attachments; I intend to open a new issue (and hopefully a PR if I can wrap my head around that functionality) to address this.