### PR TITLE
Use python-magic package instead of python-magic-bin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ biplist
 simplekml
 pandas
 pycryptodome
-python-magic-bin
+python-magic


### PR DESCRIPTION
The `python-magic-bin` package has not been updated since 2017 and is not available for Linux.

This patch replaces it with the general `python-magic` package instead, which is available for all OS.

It also fixes https://github.com/abrignoni/iLEAPP/issues/256