### PR TITLE
Updated requirements.txt to bump numpy versionand fix python-magic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.19.3
+numpy==1.21.4
 astc_decomp
 biplist
 bs4
@@ -15,4 +15,6 @@ biplist
 simplekml
 pandas
 pycryptodome
-python-magic-bin==0.4.14
+python-magic==0.4.24; platform_system == "Linux"
+python-magic-bin==0.4.14; platform_system == "Windows"
+python-magic-bin==0.4.14; platform_system == "Darwin"


### PR DESCRIPTION
Fixes #266 and #257 by bumping the numpy version to be compatible with python 3.10 and ensuring that Linux users still fall back on python-magic, not the python-magic-bin package. I haven't been able to extensively test this, it would be worthwhile to make sure it works appropriately on Mac since I think you use them more than me. I've just tried it on Linux and it fixed the issues immediately.