### PR TITLE
Fix issue reading an iterative variable after the iterating loop.

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -153,13 +153,13 @@ def crunch_artifacts(search_list, extracttype, input_path, out_params, ratio):
                 log.write(f'No files found for {key} -> {artifact_search_regex}<br><br>')
             else:
                 files_found.extend(found)
+                for pathh in found:
+                    if pathh.startswith('\\\\?\\'):
+                        pathh = pathh[4:]
+                    log.write(f'Files for {artifact_search_regex} located at {pathh}<br><br>')
         if files_found:
             logfunc()
             process_artifact(files_found, key, artifact_pretty_name, seeker, out_params.report_folder_base)
-            for pathh in files_found:
-                if pathh.startswith('\\\\?\\'):
-                    pathh = pathh[4:]
-                log.write(f'Files for {artifact_search_regex} located at {pathh}<br><br>')
         categories_searched += 1
         GuiWindow.SetProgressBar(categories_searched * ratio)
     log.close()


### PR DESCRIPTION
Move logging of which files match a given regular expression into the loop iterating over regular expressions. Tested on Linux and Windows. Fixes #272 