### PR TITLE
Support com.apple.wifi.known-networks.plist

### DIFF
--- a/scripts/artifacts/appleWifiPlist.py
+++ b/scripts/artifacts/appleWifiPlist.py
@@ -52,6 +52,10 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
                     enabled = ''
                     last_joined = ''
                     add_reason = ''
+                    carplay = ''
+                    bundle = ''
+                    system_joined = ''
+                    user_joined = ''
 
                     if 'SSID_STR' in known_network:
                         ssid = str(known_network['SSID_STR'])
@@ -91,8 +95,29 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
                             serial_number = known_network['WPS_PROB_RESP_IE']['IE_KEY_WPS_SERIAL_NUM']
                         if 'IE_KEY_WPS_MODEL_NAME' in known_network['WPS_PROB_RESP_IE']: 
                             model_name = known_network['WPS_PROB_RESP_IE']['IE_KEY_WPS_MODEL_NAME']
+
+                    if 'CARPLAY_NETWORK' in known_network:
+                        carplay = str(known_network['CARPLAY_NETWORK'])
                     
-                    known_data_list.append([ssid, bssid, net_usage, country_code, device_name, manufacturer, serial_number, model_name, last_joined, last_auto_joined, last_updated, enabled, wnpmd, add_reason, file_found]) 
+                    known_data_list.append([ssid,
+                                            bssid, 
+                                            net_usage, 
+                                            country_code, 
+                                            device_name, 
+                                            manufacturer, 
+                                            serial_number, 
+                                            model_name, 
+                                            last_joined, 
+                                            last_auto_joined, 
+                                            system_joined,
+                                            user_joined,
+                                            last_updated, 
+                                            enabled, 
+                                            wnpmd, 
+                                            carplay, 
+                                            add_reason, 
+                                            bundle, 
+                                            file_found]) 
 
             if 'com.apple.wifi.known-networks.plist' in file_found:
                 known_files.append(file_found)
@@ -112,32 +137,61 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
                     enabled = ''
                     last_joined = ''
                     add_reason = ''
+                    bundle = ''
+                    system_joined = ''
+                    user_joined = ''
 
                     if 'SSID' in known_network:
                         ssid = str(known_network['SSID'])
 
-                    if 'BSSID' in known_network['__OSSpecific__']:
-                        bssid = str(known_network['__OSSpecific__']['BSSID'])
-
                     if 'AddReason' in known_network:
                         add_reason = str(known_network['AddReason'])
-
-                    if 'networkUsage' in known_network['__OSSpecific__']:
-                        net_usage = str(known_network['__OSSpecific__']['networkUsage'])
 
                     if 'UpdatedAt' in known_network:
                         last_updated = str(known_network['UpdatedAt'])
 
                     if 'JoinedBySystemAt' in known_network:
-                        last_auto_joined = str(known_network['JoinedBySystemAt'])
+                        system_joined = str(known_network['JoinedBySystemAt'])
 
                     if 'JoinedByUserAt' in known_network:
-                        last_joined = str(known_network['JoinedByUserAt'])
+                        user_joined = str(known_network['JoinedByUserAt'])
 
-                    if 'WiFiNetworkPasswordModificationDate' in known_network:
-                        wnpmd = str(known_network['__OSSpecific__']['WiFiNetworkPasswordModificationDate'])
+                    if 'BundleID' in known_network:
+                        bundle = str(known_network['BundleID'])
 
-                    known_data_list.append([ssid, bssid, net_usage, country_code, device_name, manufacturer, serial_number, model_name, last_joined, last_auto_joined, last_updated, enabled, wnpmd, add_reason, file_found]) 
+                    if '__OSSpecific__' in known_network:
+
+                        if 'BSSID' in known_network['__OSSpecific__']:
+                            bssid = str(known_network['__OSSpecific__']['BSSID'])
+
+                        if 'networkUsage' in known_network['__OSSpecific__']:
+                            net_usage = str(known_network['__OSSpecific__']['networkUsage'])
+
+                        if 'WiFiNetworkPasswordModificationDate' in known_network['__OSSpecific__']:
+                            wnpmd = str(known_network['__OSSpecific__']['WiFiNetworkPasswordModificationDate'])
+
+                        if 'CARPLAY_NETWORK' in known_network['__OSSpecific__']:
+                            carplay = str(known_network['__OSSpecific__']['CARPLAY_NETWORK'])
+
+                    known_data_list.append([ssid,
+                                            bssid, 
+                                            net_usage, 
+                                            country_code, 
+                                            device_name, 
+                                            manufacturer, 
+                                            serial_number, 
+                                            model_name, 
+                                            last_joined, 
+                                            last_auto_joined, 
+                                            system_joined,
+                                            user_joined,
+                                            last_updated, 
+                                            enabled, 
+                                            wnpmd, 
+                                            carplay, 
+                                            add_reason, 
+                                            bundle, 
+                                            file_found]) 
 
             if 'List of scanned networks with private mac' in deserialized:
                 scanned_files.append(file_found)
@@ -185,7 +239,7 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
         report = ArtifactHtmlReport('Locations')
         report.start_artifact_report(report_folder, 'WiFi Known Networks', description)
         report.add_script()
-        data_headers = ['SSID','BSSID','Network Usage','Country Code','Device Name','Manufacturer','Serial Number','Model Name','Last Joined','Last Auto Joined','Last Updated','Enabled','WiFi Network Password Modification Date','Add Reason','File']
+        data_headers = ['SSID','BSSID','Network Usage','Country Code','Device Name','Manufacturer','Serial Number','Model Name','Last Joined','Last Auto Joined','System Joined','User Joined','Last Updated','Enabled','WiFi Network Password Modification Date','Carplay Network','Add Reason','Bundle ID','File']
         report.write_artifact_data_table(data_headers, known_data_list, ', '.join(known_files))
         report.end_artifact_report()
         

--- a/scripts/artifacts/appleWifiPlist.py
+++ b/scripts/artifacts/appleWifiPlist.py
@@ -51,6 +51,7 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
                     model_name = ''
                     enabled = ''
                     last_joined = ''
+                    add_reason = ''
 
                     if 'SSID_STR' in known_network:
                         ssid = str(known_network['SSID_STR'])
@@ -91,7 +92,52 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
                         if 'IE_KEY_WPS_MODEL_NAME' in known_network['WPS_PROB_RESP_IE']: 
                             model_name = known_network['WPS_PROB_RESP_IE']['IE_KEY_WPS_MODEL_NAME']
                     
-                    known_data_list.append([ssid, bssid, net_usage, country_code, device_name, manufacturer, serial_number, model_name, last_joined, last_auto_joined, last_updated, enabled, wnpmd, file_found]) 
+                    known_data_list.append([ssid, bssid, net_usage, country_code, device_name, manufacturer, serial_number, model_name, last_joined, last_auto_joined, last_updated, enabled, wnpmd, add_reason, file_found]) 
+
+            if 'com.apple.wifi.known-networks.plist' in file_found:
+                known_files.append(file_found)
+                for network_key in deserialized:
+                    known_network = deserialized[network_key]
+                    ssid = ''
+                    bssid = ''
+                    last_updated = ''
+                    last_auto_joined = ''
+                    wnpmd = ''
+                    net_usage = ''
+                    country_code = ''
+                    device_name = ''
+                    manufacturer = ''
+                    serial_number = ''
+                    model_name = ''
+                    enabled = ''
+                    last_joined = ''
+                    add_reason = ''
+
+                    if 'SSID' in known_network:
+                        ssid = str(known_network['SSID'])
+
+                    if 'BSSID' in known_network['__OSSpecific__']:
+                        bssid = str(known_network['__OSSpecific__']['BSSID'])
+
+                    if 'AddReason' in known_network:
+                        add_reason = str(known_network['AddReason'])
+
+                    if 'networkUsage' in known_network['__OSSpecific__']:
+                        net_usage = str(known_network['__OSSpecific__']['networkUsage'])
+
+                    if 'UpdatedAt' in known_network:
+                        last_updated = str(known_network['UpdatedAt'])
+
+                    if 'JoinedBySystemAt' in known_network:
+                        last_auto_joined = str(known_network['JoinedBySystemAt'])
+
+                    if 'JoinedByUserAt' in known_network:
+                        last_joined = str(known_network['JoinedByUserAt'])
+
+                    if 'WiFiNetworkPasswordModificationDate' in known_network:
+                        wnpmd = str(known_network['__OSSpecific__']['WiFiNetworkPasswordModificationDate'])
+
+                    known_data_list.append([ssid, bssid, net_usage, country_code, device_name, manufacturer, serial_number, model_name, last_joined, last_auto_joined, last_updated, enabled, wnpmd, add_reason, file_found]) 
 
             if 'List of scanned networks with private mac' in deserialized:
                 scanned_files.append(file_found)
@@ -139,7 +185,7 @@ def get_appleWifiPlist(files_found, report_folder, seeker):
         report = ArtifactHtmlReport('Locations')
         report.start_artifact_report(report_folder, 'WiFi Known Networks', description)
         report.add_script()
-        data_headers = ['SSID','BSSID','Network Usage','Country Code','Device Name','Manufacturer','Serial Number','Model Name','Last Joined','Last Auto Joined','Last Updated','Enabled','WiFi Network Password Modification Date','File']
+        data_headers = ['SSID','BSSID','Network Usage','Country Code','Device Name','Manufacturer','Serial Number','Model Name','Last Joined','Last Auto Joined','Last Updated','Enabled','WiFi Network Password Modification Date','Add Reason','File']
         report.write_artifact_data_table(data_headers, known_data_list, ', '.join(known_files))
         report.end_artifact_report()
         


### PR DESCRIPTION
Although iLEAPP was selecting files matching `**/com.apple.wifi.known-networks.plist` for the "Wifi Known Networks" report, this file wasn't actually being parsed. Based on git blame, I believe this is my fault. The reason this wasn't being parsed is the structure is different from `com.apple.wifi.plist` which has a "List of known networks" section. `com.apple.wifi.known-networks.plist` purely contains a table of Wifi networks, indexed by what appears to be the SSID (wifi.network.ssid.[SSID]). 

For example:
```
{"wifi.network.ssid.12345"=>
  {"SSID"=>"12345",
   "__OSSpecific__"=>
    {"BSSID"=>"aa:bb:cc:dd:ee:ff",
     "AP_MODE"=>2,
     "WiFiNetworkPasswordModificationDate"=>2018-04-13 07:13:45 -0700},
   "AddedAt"=>2018-04-13 07:13:45 -0700,
   "Hidden"=>false,
   "SupportedSecurityTypes"=>"WPA2 Personal",
   "UpdatedAt"=>2018-04-13 07:13:45 1234567/1234567 -0700},
````

I have tried to achieve parity with what is pulled from `com.apple.wifi.plist` and where fields weren't exactly clear, erred on the side of making a new column and exposing the information, instead of assuming and putting it in the wrong place. This is why you now see Last Joined, User Joined, and System Joined as three separate fields. 
