### PR TITLE
Another few optimizations

### DIFF
--- a/scripts/artifacts/appSnapshots.py
+++ b/scripts/artifacts/appSnapshots.py
@@ -23,7 +23,10 @@ def save_ktx_to_png_if_valid(ktx_path, save_to_path):
                 #     logfunc('Skipping image as it is blank')
                 #     return False
                     
-                dec_img.save(save_to_path, "PNG")
+                dec_img.save(save_to_path, "PNG", compress_type=3)
+                #                                    ^
+                # as per https://github.com/python-pillow/Pillow/issues/5986
+
                 return True
         except (OSError, ValueError, liblzfse.error) as ex:
             logfunc(f'Had an exception - {str(ex)}')

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -58,6 +58,7 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
     for filename in files_found:
         file = open(filename, "r", encoding="utf8")
         filescounter = filescounter + 1
+        file_datainserts = []
         for line in file:
             counter = counter + 1
             matchObj = re.search(
@@ -112,11 +113,12 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     bundleid,
                     "",
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
                 path = ''
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
 
@@ -167,11 +169,12 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     bundleid,
                     path,
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
 
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
                 # logfunc()
@@ -221,11 +224,12 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     bundleid,
                     path,
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
 
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
                 # logfunc()
@@ -274,11 +278,12 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     bundleid,
                     path,
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
 
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
 
@@ -320,11 +325,12 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     bundleid,
                     "",
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
 
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
 
@@ -356,11 +362,12 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     "",
                     "",
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
 
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
 
@@ -408,14 +415,24 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text):
                     bundleid,
                     path,
                 )
-                cursor.execute(
-                    "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                    datainsert,
-                )
-                db.commit()
+                # cursor.execute(
+                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                #     datainsert,
+                # )
+                # db.commit()
+                file_datainserts.append(datainsert)
 
                 tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
                 # logfunc()
+        # end for line in file:
+        if file_datainserts:
+            cursor.executemany(
+                "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
+                file_datainserts,
+            )
+            db.commit()
+        else:
+            print("Had no commits to do...")
 
     logfunc(f"Logs processed: {filescounter}")
     logfunc(f"Lines processed: {counter}")

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -30,18 +30,18 @@ def get_walStrings(files_found, report_folder, seeker, wrap_text):
         final = level2 + '/' + level1
         
         unique_items = set() # For deduplication of strings found
-        with open(outputpath, 'w') as g:
-            with open(file_found, errors="ignore") as f:  # Python 3.x
-                data =  f.read()
-                #for match in not_control_char_re.finditer(data): # This gets all unicode chars, can include lot of garbage if you only care about English, will miss out other languages
-                for match in ascii_chars_re.finditer(data): # Matches ONLY Ascii (old behavior) , good if you only care about English
-                    if match.group() not in unique_items:
-                        g.write(match.group())
-                        g.write('\n')
-                        unique_items.add(match.group())
-            g.close()
+        out_lines = []
+        with open(file_found, errors="ignore") as f:  # Python 3.x
+            data =  f.read()
+            #for match in not_control_char_re.finditer(data): # This gets all unicode chars, can include lot of garbage if you only care about English, will miss out other languages
+            for match in ascii_chars_re.findall(data): # Matches ONLY Ascii (old behavior) , good if you only care about English
+                if match not in unique_items:
+                    out_lines.append(match)
+                    unique_items.add(match)
 
         if unique_items:
+            with open(outputpath, 'w') as g:
+                g.write('\n'.join(out_lines) + '\n')
             out = (f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>')
             data_list.append((out, file_found))
         else:


### PR DESCRIPTION
Sat down and worked a bit on iLEAPP this time, there wasn't too much to do as it's already quite fast everywhere, but there were 3 spots that needed some attention:

- The mobileInstall artifact used up to 60% of the whole execution time. After this PR it goes down to ~2%.
- appSnapshots spent a lot of time saving PNGs, but you can trade a bit of storage space (worse compression) for much faster saving.
- walstrings got a small % faster after a few changes, details in the commits.

I kept on my sleeve a cache for appSnapshots because I don't like that change. I think there's a better way checking out the [astc decompressor](https://github.com/K0lb3/astc_decomp/). I'd have to clone that and get it working, and then test a few changes that _may_ improve things (but can't promise anything until I get that set up).

As for walstrings, I tried Cythonizing things and you can get to go faster (about 30%, then I/O begins to dominate). But that's a whole discussion on its own and just for one plugin it may add too much complexity. Maybe some of those things could be spoff up to a pypi project that becomes a dependency? astc is Cythonized after all. 