### PR TITLE
Update tcc.py

### DIFF
--- a/scripts/artifacts/tcc.py
+++ b/scripts/artifacts/tcc.py
@@ -21,8 +21,8 @@ def get_tcc(files_found, report_folder, seeker, wrap_text):
     if version.parse(iOSversion) >= version.parse("9"):
         cursor = db.cursor()
         cursor.execute('''
-        datetime(last_modified,'unixepoch'),
-        select client,
+        select datetime(last_modified,'unixepoch'),
+        client,
         service
         from access
         order by client


### PR DESCRIPTION
Fixing SQLite query typo:
Error was near "datetime": syntax error
Exception Traceback: Traceback (most recent call last): File "/Users/jpolewcz/Developer/Python/iLEAPP/ileapp.py", line 191, in crunch_artifacts plugin.method(files_found, category_folder, seeker, wrap_text) File "/Users/jpolewcz/Developer/Python/iLEAPP/scripts/artifacts/tcc.py", line 23, in get_tcc cursor.execute(''' sqlite3.OperationalError: near "datetime": syntax error