### PR TITLE
Implement and Adopt New Self Documenting Artifact Info Structure v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,27 +84,49 @@ $ python ileapp.py --help
 
 ## Contributing artifact plugins
 
-Each plugin is a Python source file which should be added to the `scripts/artifacts` folder which will be loaded 
-dynamically each time ILEAPP is run.
+Each plugin is a Python source file which should be added to the `scripts/artifacts` folder which will be loaded dynamically each time ILEAPP is run.
 
-The plugin source file must contain a dictionary named `__artifacts__` which defines the artifacts which the plugin 
-processes. The keys in the `__artifacts__` dictionary should be IDs for the artifact(s) which must be unique within
-ILEAPP; the values should be tuples containing 3 items: the category of the artifact as a string; a tuple of strings
-containing glob search patterns to match the path of the data that the plugin expects for the artifact; and the function 
-which is the entry point for the artifact's processing (more on this shortly).
+The plugin source file must contain a dictionary named `__artifacts_v2__` at the very beginning of the module, which defines the artifacts that the plugin processes. The keys in the `__artifacts_v2__` dictionary should be IDs for the artifact(s) which must be unique within ILEAPP. The values should be dictionaries containing the following keys:
+
+- `name`: The name of the artifact as a string.
+- `description`: A description of the artifact as a string.
+- `author`: The author of the plugin as a string.
+- `version`: The version of the artifact as a string.
+- `date`: The date of the last update to the artifact as a string.
+- `requirements`: Any requirements for processing the artifact as a string.
+- `category`: The category of the artifact as a string.
+- `notes`: Any additional notes as a string.
+- `paths`: A tuple of strings containing glob search patterns to match the path of the data that the plugin expects for the artifact.
+- `function`: The name of the function which is the entry point for the artifact's processing as a string.
 
 For example:
 
 ```python
-__artifacts__ = {
-    "cool_artifact_1": (
-        "Really cool artifacts",
-        ('*/com.android.cooldata/databases/database*.db'),
-        get_cool_data1),
-    "cool_artifact_2": (
-        "Really cool artifacts",
-        ('*/com.android.cooldata/files/cool.xml'),
-        get_cool_data2)
+__artifacts_v2__ = {
+    "cool_artifact_1": {
+        "name": "Cool Artifact 1",
+        "description": "Extracts cool data from database files",
+        "author": "@username",
+        "version": "0.1",
+        "date": "2022-10-25",
+        "requirements": "none",
+        "category": "Really cool artifacts",
+        "notes": "",
+        "paths": ('*/com.android.cooldata/databases/database*.db',),
+        "function": "get_cool_data1"
+    },
+    "cool_artifact_2": {
+        "name": "Cool Artifact 2",
+        "description": "Extracts cool data from XML files",
+        "author": "@username",
+        "version": "0.1",
+        "date": "2022-10-25",
+        "requirements": "none",
+        "category": "Really cool artifacts",
+        "notes": "",
+        "paths": ('*/com.android.cooldata/files/cool.xml',),
+        "function": "get_cool_data2"
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ the timeline. Functions for generating this output can be found in the `artifact
 At a high level, an example might resemble:
 
 ```python
+__artifacts_v2__ = {
+    "cool_artifact_1": {
+        "name": "Cool Artifact 1",
+        "description": "Extracts cool data from database files",
+        "author": "@username",  # Replace with the actual author's username or name
+        "version": "0.1",  # Version number
+        "date": "2022-10-25",  # Date of the latest version
+        "requirements": "none",
+        "category": "Really cool artifacts",
+        "notes": "",
+        "paths": ('*/com.android.cooldata/databases/database*.db',),
+        "function": "get_cool_data1"
+    }
+}
+
 import datetime
 from scripts.artifact_report import ArtifactHtmlReport
 import scripts.ilapfuncs
@@ -176,13 +191,6 @@ def get_cool_data1(files_found, report_folder, seeker, wrap_text):
     # Timeline:
     scripts.ilapfuncs.timeline(report_folder, report_name, rows, headers)
 
-
-__artifacts__ = {
-    "cool_artifact_1": (
-        "Really cool artifacts",
-        ('*/com.android.cooldata/databases/database*.db'),
-        get_cool_data1)
-}
 ```
 
 ## Acknowledgements

--- a/scripts/artifacts/ControlCenter.py
+++ b/scripts/artifacts/ControlCenter.py
@@ -1,8 +1,18 @@
-# Module Description: Parses controls/apps added to the Control Center
-# Author: @KevinPagano3
-# Date: 2022-04-28
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "controlcenter": {
+        "name": "Control Center Configuration",
+        "description": "Parses controls/apps added to the Control Center",
+        "author": "@KevinPagano3",
+        "version": "0.0.1",
+        "date": "2022-04-28",
+        "requirements": "none",
+        "category": "Control Center",
+        "notes": "",
+        "paths": ('*/mobile/Library/ControlCenter/ModuleConfiguration.plist',),
+        "function": "get_ControlCenter"
+    }
+}
+
 
 import plistlib
 import scripts.artifacts.artGlobals
@@ -104,9 +114,9 @@ def get_ControlCenter(files_found, report_folder, seeker, wrap_text):
     else:
         logfunc('No Control Center - User Toggled Controls data available')
 
-__artifacts__ = {
-    "controlcenter": (
-        "Control Center",
-        ('*/mobile/Library/ControlCenter/ModuleConfiguration.plist'),
-        get_ControlCenter)
-}
+# __artifacts__ = {
+#     "controlcenter": (
+#         "Control Center",
+#         ('*/mobile/Library/ControlCenter/ModuleConfiguration.plist'),
+#         get_ControlCenter)
+# }

--- a/scripts/artifacts/adId.py
+++ b/scripts/artifacts/adId.py
@@ -1,3 +1,11 @@
+__artifacts_v2__ = {
+    "adId": {
+        "category": "Identifiers",
+        "paths": ('*/containers/Shared/SystemGroup/*/Library/Caches/com.apple.lsdidentifiers.plist',),
+        "function": 'get_adId'
+    }
+}
+
 import datetime
 import os
 import plistlib
@@ -16,9 +24,9 @@ def get_adId(files_found, report_folder, seeker, wrap_text):
                 adId = val
                 logdevinfo(f"Advertiser Identifier: {adId}")
                 
-__artifacts__ = {
-    "adId": (
-        "Identifiers",
-        ('*/containers/Shared/SystemGroup/*/Library/Caches/com.apple.lsdidentifiers.plist'),
-        get_adId)
-}
+# __artifacts__ = {
+#     "adId": (
+#         "Identifiers",
+#         ('*/containers/Shared/SystemGroup/*/Library/Caches/com.apple.lsdidentifiers.plist'),
+#         get_adId)
+# }

--- a/scripts/artifacts/addressBook.py
+++ b/scripts/artifacts/addressBook.py
@@ -1,3 +1,19 @@
+__artifacts_v2__ = {
+    "addressbook": {
+        "name": "Address Book Contacts",
+        "description": "Extract information from the native contacts application",
+        "author": "@AlexisBrignoni",
+        "version": "0.3",
+        "date": "2022-10-25",
+        "requirements": "none",
+        "category": "Address Book",
+        "notes": "",
+        "paths": ('**/AddressBook.sqlitedb*',),
+        "function": "get_addressBook"
+    }
+}
+
+
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
@@ -64,9 +80,9 @@ def get_addressBook(files_found, report_folder, seeker, wrap_text):
     db.close()
     return
 
-__artifacts__ = {
-    "addressbook": (
-        "Address Book",
-        ('**/AddressBook.sqlitedb*'),
-        get_addressBook)
-}
+# __artifacts__ = {
+#     "addressbook": (
+#         "Address Book",
+#         ('**/AddressBook.sqlitedb*'),
+#         get_addressBook)
+# }

--- a/scripts/artifacts/cloudkitSharing.py
+++ b/scripts/artifacts/cloudkitSharing.py
@@ -1,3 +1,21 @@
+__artifacts_v2__ = {
+    "cloudkitsharing": {
+        "name": "Cloudkit Sharing",
+        "description": "This module processes data related to CloudKit sharing, encompassing information on notes "
+                       "shared via CloudKit and the accounts participating in CloudKit shares. It allows for the "
+                       "retrieval of Record ID from the ZICCLOUDSYNCINGOBJECT.ZIDENTIFIER column for shared notes, "
+                       "and provides details on CloudKit participants.",
+        "author": "@DFIRScience",
+        "version": "0.3",
+        "date": "2022-08-09",
+        "requirements": "",
+        "category": "Cloudkit",
+        "notes": "",
+        "paths": ('*NoteStore.sqlite*',),
+        "function": "get_cloudkitSharing"
+    }
+}
+
 import glob
 import os
 import nska_deserialize as nd
@@ -8,6 +26,7 @@ import io
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
+
 def get_cloudkitSharing(files_found, report_folder, seeker, wrap_text):
     for file_found in files_found:
         file_found = str(file_found)
@@ -15,6 +34,7 @@ def get_cloudkitSharing(files_found, report_folder, seeker, wrap_text):
         if file_found.endswith('NoteStore.sqlite'):
             get_cloudkitServerRecordData(file_found, report_folder, seeker, wrap_text)
             get_cloudkitServerSharedData(file_found, report_folder, seeker, wrap_text)
+
 
 def get_cloudkitServerSharedData(file_found, report_folder, seeker, wrap_text):
     user_dictionary = {}
@@ -31,12 +51,12 @@ def get_cloudkitServerSharedData(file_found, report_folder, seeker, wrap_text):
 
     all_rows = cursor.fetchall()
     for row in all_rows:
-        
-        filename = os.path.join(report_folder, 'zserversharedata_'+str(row[0])+'.bplist')
-        output_file = open(filename, "wb") 
+
+        filename = os.path.join(report_folder, 'zserversharedata_' + str(row[0]) + '.bplist')
+        output_file = open(filename, "wb")
         output_file.write(row[1])
         output_file.close()
-        
+
         deserialized_plist = nd.deserialize_plist(io.BytesIO(row[1]))
         for item in deserialized_plist:
             if 'Participants' in item:
@@ -44,14 +64,20 @@ def get_cloudkitServerSharedData(file_found, report_folder, seeker, wrap_text):
                     record_id = participant['UserIdentity']['UserRecordID']['RecordName']
                     email_address = participant['UserIdentity']['LookupInfo']['EmailAddress']
                     phone_number = participant['UserIdentity']['LookupInfo']['PhoneNumber']
-                    first_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.givenName']
-                    middle_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.middleName']
-                    last_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.familyName']
-                    name_prefix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.namePrefix']
-                    name_suffix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nameSuffix']
+                    first_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate'][
+                        'NS.givenName']
+                    middle_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate'][
+                        'NS.middleName']
+                    last_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate'][
+                        'NS.familyName']
+                    name_prefix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate'][
+                        'NS.namePrefix']
+                    name_suffix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate'][
+                        'NS.nameSuffix']
                     nickname = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nickname']
-        
-                    user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name, middle_name, last_name, name_suffix, nickname]
+
+                    user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name,
+                                                  middle_name, last_name, name_suffix, nickname]
     db.close()
 
     # Build the array after dealing with all the files 
@@ -62,15 +88,18 @@ def get_cloudkitServerSharedData(file_found, report_folder, seeker, wrap_text):
         report = ArtifactHtmlReport('Participants')
         report.start_artifact_report(report_folder, 'Participants', description)
         report.add_script()
-        user_headers = ('Record ID','Email Address','Phone Number','Name Prefix','First Name','Middle Name','Last Name','Name Suffix','Nickname')     
+        user_headers = (
+        'Record ID', 'Email Address', 'Phone Number', 'Name Prefix', 'First Name', 'Middle Name', 'Last Name',
+        'Name Suffix', 'Nickname')
         report.write_artifact_data_table(user_headers, user_list, '', write_location=False)
         report.end_artifact_report()
-        
+
         tsvname = 'Cloudkit Participants'
         tsv(report_folder, user_headers, user_list, tsvname)
     else:
         logfunc('No Cloudkit - Cloudkit Participants data available')
-    
+
+
 def get_cloudkitServerRecordData(file_found, report_folder, seeker, wrap_text):
     db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
@@ -88,12 +117,12 @@ def get_cloudkitServerRecordData(file_found, report_folder, seeker, wrap_text):
     if result_number > 0:
 
         for row in all_rows:
-            
-            filename = os.path.join(report_folder, 'zserverrecorddata_'+str(row[0])+'.bplist')
-            output_file = open(filename, "wb") 
+
+            filename = os.path.join(report_folder, 'zserverrecorddata_' + str(row[0]) + '.bplist')
+            output_file = open(filename, "wb")
             output_file.write(row[1])
             output_file.close()
-            
+
             deserialized_plist = nd.deserialize_plist(io.BytesIO(row[1]))
             creator_id = ''
             last_modified_id = ''
@@ -117,17 +146,19 @@ def get_cloudkitServerRecordData(file_found, report_folder, seeker, wrap_text):
                     record_type = item['RecordType']
                 elif 'RecordID' in item:
                     record_id = item['RecordID']['RecordName']
-            
-            note_data.append([record_id,record_type,creation_date,creator_id,last_modified_date,last_modified_id,last_modified_device])
+
+            note_data.append([record_id, record_type, creation_date, creator_id, last_modified_date, last_modified_id,
+                              last_modified_device])
 
         description = 'CloudKit Note Sharing - Notes information shared via CloudKit. Look up the Record ID in the ZICCLOUDSYYNCINGOBJECT.ZIDENTIFIER column. '
         report = ArtifactHtmlReport('Note Sharing')
         report.start_artifact_report(report_folder, 'Note Sharing', description)
         report.add_script()
-        note_headers = ('Record ID','Record Type','Creation Date','Creator ID','Modified Date','Modifier ID','Modifier Device')     
+        note_headers = (
+        'Record ID', 'Record Type', 'Creation Date', 'Creator ID', 'Modified Date', 'Modifier ID', 'Modifier Device')
         report.write_artifact_data_table(note_headers, note_data, file_found)
         report.end_artifact_report()
-        
+
         tsvname = 'Cloudkit Note Sharing'
         tsv(report_folder, note_headers, note_data, tsvname)
     else:
@@ -135,9 +166,9 @@ def get_cloudkitServerRecordData(file_found, report_folder, seeker, wrap_text):
 
     db.close()
 
-__artifacts__ = {
-    "cloudkitsharing": (
-        "Cloudkit",
-        ('*NoteStore.sqlite*'),
-        get_cloudkitSharing)
-}
+# __artifacts__ = {
+#     "cloudkitsharing": (
+#         "Cloudkit",
+#         ('*NoteStore.sqlite*'),
+#         get_cloudkitSharing)
+# }

--- a/scripts/artifacts/telegramMesssages.py
+++ b/scripts/artifacts/telegramMesssages.py
@@ -1,3 +1,23 @@
+__artifacts_v2__ = {
+    "TelegramMessages": {
+        "name": "Telegram Messages",
+        "description": "",
+        "author": "Stek29 / Victor Oreshkin",
+        "version": "",
+        "date": "",
+        "requirements": "",
+        "category": "Telegram",
+        "notes": "Github: https://gist.github.com/stek29; "
+                 "Code: https://gist.github.com/stek29/8a7ac0e673818917525ec4031d77a713",
+        "paths": (
+            '*/telegram-data/account-*/postbox/db/db_sqlite',
+            '*/telegram-data/account-*/postbox/media/**'
+        ),
+        "function": "get_telegramMessages"
+    }
+}
+
+
 import sqlite3
 import io
 import struct

--- a/scripts/artifacts/viber.py
+++ b/scripts/artifacts/viber.py
@@ -1,30 +1,33 @@
-# Get Viber settings, contacts, recent calls and messages information
-# Author : Evangelos Dragonas (@theAtropos4n6)
-# website : atropos4n6.com
-# Date : 2022-03-15
-# Version : 0.0.2
-# 
-# The script queries Settings.data and Contacts.data Viber dbs and creates a report of findings including KML geolcation data
-# Settings hold the user's personal data and configurations
-# Contacts hold contacts, calls, messages and more..
-# 
-# The code is divided in 4 queries-artifacts blocks. 
-# 
-# The 1st parses settings db, extracts and reports on user's available information regarding Viber configuartion
-#
-# The 2nd parses contacts db, extracts and reports on user's contacts. 
-# Be advised that a contact may not participate in a chat (therefore a contact is not a chat 'member') and vice versa. A chat 'member' may not be registered as a Viber contact. 
-# Hope it makes sense.
-#
-# The 3rd parses contacts db, extracts and reports on user's recent calls that have no corresponding message (ZVIBERMESSAGE) entry. This indicates that these messages have been deleted and therefore
-# calls are deleted as well. Unfortunately no remote partner information can be retrieved at this moment. 
-#
-# The 4rth parses contacts db, extracts and reports on user's chats. 2 extra columns with each chat's grouped participants and phone numbers is also available. 
-#
-# Also, be aware that there is more information stored within the above databases. This artifact assist in parsing the most out of it (but not all).
-#
-# Should you face a bug or want a specific field extracted, DM me.
-#
+__artifacts_v2__ = {
+    "viber": {
+        "name": "Viber Artifacts",
+        "description": "Get Viber settings, contacts, recent calls and messages information. This script queries "
+					   "Settings.data and Contacts.data Viber dbs and creates a report of findings including KML "
+					   "geolocation data. Settings hold the user's personal data and configurations. Contacts hold "
+					   "contacts, calls, messages and more.",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "version": "0.0.2",
+        "date": "2022-03-15",
+        "requirements": "",
+        "category": "Viber",
+        "notes": "The code is divided into 4 queries-artifacts blocks. The 1st parses settings db, extracts and "
+				 "reports on user's available information regarding Viber configuration. The 2nd parses contacts db, "
+				 "extracts and reports on user's contacts. Be advised that a contact may not participate in a chat ("
+				 "therefore a contact is not a chat 'member') and vice versa. A chat 'member' may not be registered as "
+				 "a Viber contact. The 3rd parses contacts db, extracts and reports on user's "
+				 "recent calls that have no corresponding message (ZVIBERMESSAGE) entry, indicating these messages "
+				 "have been deleted. The 4th parses contacts db, extracts and reports on user's chats, including extra "
+				 "columns with each chat's grouped participants and phone numbers. More information is stored within "
+				 "the above databases, and this artifact assists in parsing the most out of it. ",
+        "paths": (
+            '**/com.viber/settings/Settings.data',
+            '**/com.viber/database/Contacts.data',
+            '**/Containers/Data/Application/*/Documents/Attachments/*.*',
+            '**/com.viber/ViberIcons/*.*'
+        ),
+        "function": "get_viber"
+    }
+}
 
 
 import glob
@@ -690,10 +693,3 @@ def get_viber(files_found, report_folder, seeker, wrap_text):
 				db.close()
 			else:
 				logfunc('No Viber data found.')
-	
-__artifacts__ = {
-    "viber": (
-        "Viber",
-        ('**/com.viber/settings/Settings.data','**/com.viber/database/Contacts.data','**/Containers/Data/Application/*/Documents/Attachments/*.*','**/com.viber/ViberIcons/*.*'),
-        get_viber)
-}

--- a/scripts/artifacts/whatsappContacts.py
+++ b/scripts/artifacts/whatsappContacts.py
@@ -1,3 +1,19 @@
+__artifacts_v2__ = {
+    "whatsappContacts": {
+        "name": "Whatsapp Contacts",
+        "description": "",
+        "author": "",
+        "version": "",
+        "date": "",
+        "requirements": "",
+        "category": "Whatsapp",
+        "notes": "",
+        "paths": ('*/var/mobile/Containers/Shared/AppGroup/*/ContactsV2.sqlite*',),
+        "function": "get_whatsappContacts"
+    }
+}
+
+
 import sqlite3
 import io
 import json
@@ -58,9 +74,3 @@ def get_whatsappContacts(files_found, report_folder, seeker, wrap_text):
     else:
         logfunc('Whatsapp - Contacts data available')
         
-__artifacts__ = {
-    "whatsappContacts": (
-        "Whatsapp",
-        ('*/var/mobile/Containers/Shared/AppGroup/*/ContactsV2.sqlite*'),
-        get_whatsappContacts)
-}

--- a/scripts/artifacts/whatsappMessages.py
+++ b/scripts/artifacts/whatsappMessages.py
@@ -1,3 +1,22 @@
+__artifacts_v2__ = {
+    "whatsappMessages": {
+        "name": "Whatsapp Messages",
+        "description": "",
+        "author": "",
+        "version": "",
+        "date": "",
+        "requirements": "",
+        "category": "Whatsapp",
+        "notes": "",
+        "paths": (
+            '*/var/mobile/Containers/Shared/AppGroup/*/ChatStorage.sqlite*',
+            '*/var/mobile/Containers/Shared/AppGroup/*/Message/Media/*/*/*/*.*'
+        ),
+        "function": "get_whatsappMessages"
+    }
+}
+
+
 import sqlite3
 import io
 import json
@@ -114,10 +133,3 @@ def get_whatsappMessages(files_found, report_folder, seeker, wrap_text):
         
     else:
         logfunc('Whatsapp - Messages data available')
-        
-__artifacts__ = {
-    "whatsappMessages": (
-        "Whatsapp",
-        ('*/var/mobile/Containers/Shared/AppGroup/*/ChatStorage.sqlite*','*/var/mobile/Containers/Shared/AppGroup/*/Message/Media/*/*/*/*.*'),
-        get_whatsappMessages)
-}


### PR DESCRIPTION
Some of the modules have comments at the top of the code to share information about what the module does, who wrote it, release date, and more. I've created a new format of the artifact structure that was at the bottom of the code, and included the ability for the comments and the artifact info to be combined into one structure and placed at the top of the code in a self documenting type of fashion. I then updated the module loaded to use v2 but kept backwards compatibility with modules not updated to v2.

- Introduced a new artifact structure `__artifacts_v2__` to replace the previous `__artifacts__` structure, enhancing readability and organization of metadata.
- Updated the plugin loader to accommodate the new `__artifacts_v2__` structure while retaining backward compatibility with the old `__artifacts__` structure.
- Converted a few existing modules to the new `__artifacts_v2__` format to demonstrate the improved structure and serve as examples for future conversions.
- Updated the README.md to reflect the new `__artifacts_v2__` structure and provided guidelines for contributing plugins using the new format.