### PR TITLE
refactor report categories

### DIFF
--- a/scripts/report.py
+++ b/scripts/report.py
@@ -10,456 +10,438 @@ from scripts.html_parts import *
 from scripts.ilapfuncs import logfunc
 from scripts.version_info import aleapp_version, aleapp_contributors
 
+# Icon Mappings Dictionary
+# The icon_mappings dictionary is organized by category and is used to map categories and artifacts to icons.
+# Please maintain the list in alphabetical order by category for ease of navigation and updating.
+#
+# To specify an icon for a particular artifact within a category, use the structure:
+# 'CATEGORY': {'ARTIFACT': 'icon-name', ...}
+# Example:
+# 'CHROMIUM': {'BOOKMARKS': 'bookmark', 'DOWNLOADS': 'download', ...}
+#
+# To specify a default icon for all artifacts within a category or a single icon for the entire category, use:
+# 'CATEGORY': 'icon-name' or 'CATEGORY': {'default': 'icon-name', ...}
+# Example:
+# 'ADDRESS BOOK': 'book-open'
+#
+# If a category or artifact does not have a specified icon, the 'alert-triangle' icon will be used as a fallback.
+#
+# Icons are sourced from Feather Icons (feathericons.com). When adding a new icon, ensure that the icon name
+# matches the name listed on the Feather Icons website.
+#
+# The optional '_mode' key can be used to specify a search mode for finding matching artifacts within a category:
+# 'CATEGORY': {'_mode': 'search', ...}
+# In search mode, the function will attempt to find a partial match for the artifact name within the specified category.
+
+icon_mappings = \
+{
+    'ACCOUNT': {
+        'AUTH': 'key',
+        'default': 'user',
+        '_mode': 'search',
+    },
+    'ADDRESS BOOK': 'book-open',
+    'AGGREGATE DICTIONARY': 'book',
+    'AIRTAGS': 'map-pin',
+    'ALARMS': 'clock',
+    'ALLTRAILS': {
+        'ALLTRAILS - TRAIL DETAILS': 'map',
+        'ALLTRAILS - USER INFO': 'user',
+    },
+    'APP CONDUIT': 'activity',
+    'APP PERMISSIONS': 'key',
+    'APP UPDATES': 'codepen',
+    'APPLE MAIL': 'mail',
+    'APPLE PODCASTS': 'play-circle',
+    'APPLE WALLET': {
+        'CARDS': 'credit-card',
+        'PASSES': 'send',
+        'TRANSACTIONS': 'dollar-sign',
+        'default': 'credit-card',
+    },
+    'APPLICATIONS': 'grid',
+    'BIOME': 'eye',
+    'BIOME APP INSTALL': 'eye',
+    'BIOME BACKLIGHT': 'eye',
+    'BIOME BATTERY PERC': 'eye',
+    'BIOME BLUETOOTH': 'eye',
+    'BIOME CARPLAY CONN': 'eye',
+    'BIOME DEVICE PLUG': 'eye',
+    'BIOME HARDWARE': 'eye',
+    'BIOME IN FOCUS': 'eye',
+    'BIOME INTENTS': 'eye',
+    'BIOME LOCATION ACT': 'eye',
+    'BIOME NOTES': 'eye',
+    'BIOME NOTIFICATIONS PUB': 'eye',
+    'BIOME NOW PLAYING': 'eye',
+    'BIOME SAFARI': 'eye',
+    'BIOME SYNC': 'smartphone',
+    'BIOME TEXT INPUT': 'eye',
+    'BIOME USER ACT META': 'eye',
+    'BIOME WIFI': 'eye',
+    'BITTORRENT': 'share',
+    'BLUETOOTH': 'bluetooth',
+    'BUMBLE': {
+        'BUMBLE - ACCOUNT DETAILS': 'user',
+        'BUMBLE - MESSAGES': 'message-circle',
+    },
+    'CACHE DATA': 'box',
+    'CALENDAR': 'calendar',
+    'CALL HISTORY': {
+        'CALL HISTORY': 'phone-call',
+        'DELETED VOICEMAIL': 'mic-off',
+        'VOICEMAIL': 'mic',
+    },
+    'CARPLAY': 'package',
+    'CASH APP': 'credit-card',
+    'CELLULAR WIRELESS': 'bar-chart',
+    'CHROMIUM': {
+        'AUTOFILL': 'edit-3',
+        'BOOKMARKS': 'bookmark',
+        'DOWNLOADS': 'download',
+        'LOGIN': 'log-in',
+        'MEDIA HISTORY': 'video',
+        'NETWORK ACTION PREDICTOR': 'type',
+        'OFFLINE PAGES': 'cloud-off',
+        'SEARCH TERMS': 'search',
+        'TOP SITES': 'list',
+        'WEB VISITS': 'globe',
+        'default': 'chrome',
+        '_mode': 'search',
+    },
+    'CLOUDKIT': {
+        'NOTE SHARING': 'share-2',
+        'PARTICIPANTS': 'user',
+    },
+    'CONNECTED TO': 'zap',
+    'CONTROL CENTER': {
+        'CONTROL CENTER - ACTIVE CONTROLS': 'sliders',
+        'CONTROL CENTER - DISABLED CONTROLS': 'x-square',
+        'CONTROL CENTER - USER TOGGLED CONTROLS': 'check-square',
+    },
+    'CORE ACCESSORIES': {
+        'ACCESSORYD': 'zap',
+        'USER EVENT AGENT': 'activity',
+    },
+    'COREDUET': {
+        'AIRPLANE MODE': 'pause',
+        'LOCK STATE': 'lock',
+        'PLUGGED IN': 'battery-charging',
+    },
+    'DAHUA TECHNOLOGY (DMSS)': {
+        'CHANNELS': 'film',
+        'DEVICES': 'tablet',
+        'INFO': 'settings',
+        'NOTIFICATIONS': 'bell',
+        'PIN': 'unlock',
+        'SENSORS': 'smartphone',
+        'USER CREATED MEDIA': 'video',
+        '_mode': 'search',
+    },
+    'DATA USAGE': 'wifi',
+    'DEVICE DATA': 'file',
+    'DEVICE INFO': {
+        'BUILD INFO': 'terminal',
+        'DEFAULT': 'info',
+        'IOS SYSTEM VERSION': 'git-commit',
+        'PARTNER SETTINGS': 'settings',
+        'SETTINGS_SECURE_': 'settings',
+        '_mode': 'search',
+    },
+    'DHCP': 'settings',
+    'DISCORD': {
+        'DISCORD ACCOUNT': 'user',
+        'DISCORD MANIFEST': 'file-text',
+        'DISCORD MESSAGES': 'message-square',
+    },
+    'DRAFT NATIVE MESSAGES': 'message-circle',
+    'FACEBOOK MESSENGER': 'facebook',
+    'FILES APP': 'file-text',
+    'GEOLOCATION': {
+        'APPLICATIONS': 'grid',
+        'DEFAULT': 'map-pin',
+        'MAP TILE CACHE': 'map',
+        'MAPSSYNC': 'map',
+        'PD PLACE CACHE': 'map-pin',
+    },
+    'GMAIL': {
+        'GMAIL - LABEL DETAILS': 'mail',
+        'GMAIL - OFFLINE SEARCH': 'search',
+    },
+    'GOOGLE CHAT': 'message-square',
+    'GOOGLE DUO': {
+        'GOOGLE DUO - CALL HISTORY': 'phone-call',
+        'GOOGLE DUO - CLIPS': 'video',
+        'GOOGLE DUO - CONTACTS': 'user',
+    },
+    'HEALTH': {
+        'DEFAULT': 'heart',
+        'HEALTH - ACHIEVEMENTS': 'star',
+        'HEALTH - HEADPHONE AUDIO LEVELS': 'headphones',
+        'HEALTH - HEART RATE': 'activity',
+        'HEALTH - RESTING HEART RATE': 'activity',
+        'HEALTH - STEPS': 'activity',
+        'HEALTH - WORKOUTS': 'activity',
+    },
+    'HIKVISION': {
+        'CCTV ACTIVITY': 'activity',
+        'CCTV CHANNELS': 'film',
+        'CCTV INFO': 'settings',
+        'USER CREATED MEDIA': 'video',
+        '_mode': 'search',
+    },
+    'ICLOUD QUICK LOOK': 'file',
+    'ICLOUD RETURNS': 'cloud',
+    'ICLOUD SHARED ALBUMS': 'cloud',
+    'IDENTIFIERS': 'file',
+    'IMO HD CHAT': {
+        'IMO HD CHAT - CONTACTS': 'user',
+        'IMO HD CHAT - MESSAGES': 'message-circle',
+    },
+    'INSTAGRAM': {
+        'INSTAGRAM THREADS': 'message-square',
+        'INSTAGRAM THREADS CALLS': 'phone',
+    },
+    'INSTALLED APPS': 'package',
+    'INTENTS': 'command',
+    'INTERACTIONC': {
+        'ATTACHMENTS': 'paperclip',
+        'CONTACTS': 'user',
+    },
+    'IOS ATXDATASTORE': 'database',
+    'IOS BUILD': 'git-commit',
+    'IOS BUILD (ITUNES BACKUP)': 'git-commit',
+    'IOS SCREENS': 'maximize',
+    'KEYBOARD': {
+        'KEYBOARD APPLICATION USAGE': 'type',
+        'KEYBOARD DYNAMIC LEXICON': 'type',
+    },
+    'KIK': {
+        'KIK GROUP ADMINISTRATORS': 'user-plus',
+        'KIK LOCAL ACCOUNT': 'user-check',
+        'KIK MEDIA METADATA': 'file-plus',
+        'KIK MESSAGES': 'message-square',
+        'KIK PENDING UPLOADS': 'upload',
+        'KIK USERS': 'user',
+        'KIK USERS IN GROUPS': 'user',
+    },
+    'KNOWLEDGEC': {
+        'DEFAULT': 'activity',
+        'KNOWLEDGEC BATTERY LEVEL': 'battery',
+        'KNOWLEDGEC DEVICE LOCKED': 'lock',
+        'KNOWLEDGEC PLUGGED IN': 'battery-charging',
+    },
+    'LEAPP_REPORT': {
+        'DEFAULT': 'git-commit',
+        '_mode': 'search',
+    },
+    'LOCATION SERVICES CONFIGURATIONS': 'settings',
+    'LOCATIONS': {
+        'APPLE MAPS SEARCH HISTORY': 'search',
+        'DEFAULT': 'map-pin',
+    },
+    'MEDIA LIBRARY': 'play-circle',
+    'MEDIA METADATA': 'file-plus',
+    'MEDICAL ID': 'thermometer',
+    'METAMASK': {
+        'BROWSER': 'globe',
+        'CONTACTS': 'users',
+        '_mode': 'search',
+    },
+    'MICROSOFT TEAMS': {
+        'TEAMS CALL LOGS': 'phone',
+        'TEAMS CONTACT': 'users',
+        'TEAMS MESSAGES': 'message-square',
+        'TEAMS SHARED LOCATIONS': 'map-pin',
+        'TEAMS USER': 'user',
+    },
+    'MICROSOFT TEAMS - LOGS': {
+        'TEAMS LOCATIONS': 'map-pin',
+        'TEAMS MOTION': 'move',
+        'TEAMS POWER LOG': 'battery-charging',
+        'TEAMS STATE CHANGE': 'truck',
+        'TEAMS TIMEZONE': 'clock',
+    },
+    'MOBILE ACTIVATION LOGS': 'clipboard',
+    'MOBILE BACKUP': 'save',
+    'MOBILE CONTAINER MANAGER': 'save',
+    'MOBILE INSTALLATION LOGS': 'clipboard',
+    'MOBILE SOFTWARE UPDATE': 'refresh-cw',
+    'NETWORK USAGE': {
+        'APP_DATA': 'activity',
+        'CONNECTIONS': 'bar-chart',
+        'default': 'send',
+        '_mode': 'search',
+    },
+    'NOTES': 'file-text',
+    'NOTIFICATIONS': 'bell',
+    'OFFLINE PAGES': 'cloud-off',
+    'PHOTOS': {
+        'DEFAULT': 'image',
+        'MIGRATIONS': 'chevrons-up',
+    },
+    'POWERLOG': 'power',
+    'POWERLOG BACKUPS': 'power',
+    'PREFERENCES PLIST': 'file',
+    'PROTON MAIL': 'mail',
+    'RECENT ACTIVITY': 'activity',
+    'REMINDERS': 'list',
+    'ROUTINED': 'map',
+    'SAFARI BROWSER': 'compass',
+    'SCREENTIME': 'monitor',
+    'SCRIPT LOGS': 'archive',
+    'SECRET CALCULATOR PHOTO ALBUM': 'image',
+    'SIM INFO': 'info',
+    'SLACK': {
+        'SLACK ATTACHMENTS': 'paperclip',
+        'SLACK CHANNEL DATA': 'slack',
+        'SLACK MESSAGES': 'message-square',
+        'SLACK TEAM DATA': 'slack',
+        'SLACK USER DATA': 'user',
+        'SLACK WORKSPACE DATA': 'slack',
+    },
+    'SMS & IMESSAGE': 'message-square',
+    'SQLITE JOURNALING': 'book-open',
+    'TELEGRAM': 'message-square',
+    'TEXT INPUT MESSAGES': 'message-square',
+    'TIKTOK': {
+        'TIKTOK CONTACTS': 'user',
+        'TIKTOK MESSAGES': 'message-square',
+        'TIKTOK SEARCH': 'search',
+    },
+    'USER DICTIONARY': 'book',
+    'VENMO': 'dollar-sign',
+    'VIBER': {
+        'VIBER - CALL REMNANTS': 'phone-call',
+        'VIBER - CHATS': 'message-square',
+        'VIBER - CONTACTS': 'users',
+        'VIBER - SETTINGS': 'settings',
+    },
+    'VIPPS': {
+        'DEFAULT': 'dollar-sign',
+        'VIPPS CONTACTS': 'users',
+    },
+    'VOICE-RECORDINGS': 'mic',
+    'VOICE-TRIGGERS': 'mic',
+    'WHATSAPP': {
+        'WHATSAPP - CONTACTS': 'users',
+        'WHATSAPP - MESSAGES': 'message-square',
+    },
+    'WIFI CONNECTIONS': 'wifi',
+    'WIFI KNOWN NETWORKS': 'wifi',
+}
+
+# function that can be run against the list to sort and output to console
+def sort_and_print_mappings():
+    sorted_keys = sorted(icon_mappings.keys(), key=lambda x: x.lower())
+    sorted_dict = {key: icon_mappings[key] for key in sorted_keys}
+
+    print("{")
+    for category, mappings in sorted_dict.items():
+        if isinstance(mappings, dict):
+            print(f"    '{category}': {{")
+            # Sort the artifacts, with 'default' and '_mode' at the end
+            sorted_artifacts = sorted(
+                [(k, v) for k, v in mappings.items() if k not in ['default', '_mode']],
+                key=lambda x: x[0]
+            )
+            # Append 'default' and '_mode' at the end if they exist
+            if 'default' in mappings:
+                sorted_artifacts.append(('default', mappings['default']))
+            if '_mode' in mappings:
+                sorted_artifacts.append(('_mode', mappings['_mode']))
+            for artifact, icon in sorted_artifacts:
+                print(f"        '{artifact}': '{icon}',")
+            print("    },")
+        else:
+            print(f"    '{category}': '{mappings}',")
+    print("}")
+
+
+if __name__ == '__main__':
+    # Call the function to print the sorted mappings to the console
+    sort_and_print_mappings()
 
 def get_icon_name(category, artifact):
-    ''' Returns the icon name from the feathericons collection. To add an icon type for 
-        an artifact, select one of the types from ones listed @ feathericons.com
-        If no icon is available, the alert triangle is returned as default icon.
-    '''
+    """
+    Returns the icon name from the feathericons collection. To add an icon type for
+    an artifact, select one of the types from ones listed @ feathericons.com
+    If no icon is available, the alert triangle is returned as default icon.
+    """
     category = category.upper()
     artifact = artifact.upper()
     icon = 'alert-triangle'  # default (if not defined!)
 
-    ## Please keep list below SORTED by category
+    category_match = icon_mappings.get(category)
 
-    if category.find('ACCOUNT') >= 0:
-        if artifact.find('AUTH') >= 0:
-            icon = 'key'
-        else:
-            icon = 'user'
-    elif category == 'ADDRESS BOOK':
-        icon = 'book-open'
-    elif category == 'CACHE DATA':
-        icon = 'box'
-    elif category == 'AIRTAGS':
-        icon = 'map-pin'
-    elif category == 'SIM INFO':
-        icon = 'info'
-    elif category == 'INTENTS':
-        icon = 'command'
-    elif category == 'ALARMS':
-        icon = 'clock'
-    elif category == 'ALLTRAILS':
-        if artifact == 'ALLTRAILS - TRAIL DETAILS':
-            icon = 'map'
-        if artifact == 'ALLTRAILS - USER INFO':
-            icon = 'user'
-    elif category == 'APPLE MAIL':
-        icon = 'mail'
-    elif category == 'APPLE PODCASTS':
-        icon = 'play-circle'
-    elif category == 'APPLE WALLET':
-        if artifact == 'TRANSACTIONS':
-            icon = 'dollar-sign'
-        elif artifact == 'CARDS':
-            icon = 'credit-card'
-        elif artifact == 'PASSES':
-            icon = 'send'
-        else:
-            icon = 'credit-card'
-    elif category == 'APP CONDUIT':
-        icon = 'activity'
-    elif category == 'APP PERMISSIONS':
-        icon = 'key'
-    elif category == 'APP UPDATES':
-        icon = 'codepen'
-    elif category == 'APPLICATIONS':
-        icon = 'grid'
-    elif category == 'AGGREGATE DICTIONARY':
-        icon = 'book'
-    elif category == 'BIOME':
-        icon = 'eye'
-    elif category == 'BIOME APP INSTALL':
-        icon = 'eye'
-    elif category == 'BIOME BACKLIGHT':
-        icon = 'eye'
-    elif category == 'BIOME BATTERY PERC':
-        icon = 'eye'
-    elif category == 'BIOME BLUETOOTH':
-        icon = 'eye'
-    elif category == 'BIOME CARPLAY CONN':
-        icon = 'eye'
-    elif category == 'BIOME DEVICE PLUG':
-        icon = 'eye'
-    elif category == 'BIOME HARDWARE':
-        icon = 'eye'
-    elif category == 'BIOME IN FOCUS':
-        icon = 'eye'
-    elif category == 'BIOME INTENTS':
-        icon = 'eye'
-    elif category == 'BIOME LOCATION ACT':
-        icon = 'eye'
-    elif category == 'BIOME INTENTS':
-        icon = 'eye'
-    elif category == 'BIOME NOTES':
-        icon = 'eye'
-    elif category == 'BIOME NOTIFICATIONS PUB':
-        icon = 'eye'
-    elif category == 'BIOME NOW PLAYING':
-        icon = 'eye'
-    elif category == 'BIOME SAFARI':
-        icon = 'eye'
-    elif category == 'BIOME SYNC':
-        icon = 'smartphone'
-    elif category == 'BIOME TEXT INPUT':
-        icon = 'eye'
-    elif category == 'BIOME USER ACT META':
-        icon = 'eye'
-    elif category == 'BIOME WIFI':
-        icon = 'eye'
-    elif category == 'BITTORRENT':
-        icon = 'share'
-    elif category == 'BLUETOOTH':
-        icon = 'bluetooth'
-    elif category == 'BUMBLE':
-        if artifact == 'BUMBLE - MESSAGES':
-            icon = 'message-circle'
-        if artifact == 'BUMBLE - ACCOUNT DETAILS':
-            icon = 'user'
-    elif category == 'CALENDAR':
-        icon = 'calendar'
-    elif category == 'CALL HISTORY':
-        if artifact == 'CALL HISTORY':
-            icon = 'phone-call'
-        if artifact == 'VOICEMAIL':
-            icon = 'mic'
-        if artifact == 'DELETED VOICEMAIL':
-            icon = 'mic-off'
-    elif category == 'CARPLAY':
-        icon = 'package'
-    elif category == 'CASH APP':
-        icon = 'credit-card'
-    elif category == 'CELLULAR WIRELESS':
-        icon = 'bar-chart'
-    elif category == 'CHROMIUM':          
-        if artifact.find('AUTOFILL') >= 0:        icon = 'edit-3'
-        elif artifact.find('BOOKMARKS') >= 0:       icon = 'bookmark'
-        elif artifact.find('DOWNLOADS') >= 0:       icon = 'download'
-        elif artifact.find('LOGIN') >= 0:           icon = 'log-in'
-        elif artifact.find('MEDIA HISTORY') >= 0:   icon = 'video'
-        elif artifact.find('NETWORK ACTION PREDICTOR') >=0:    icon = 'type'
-        elif artifact.find('OFFLINE PAGES') >= 0:   icon = 'cloud-off'
-        elif artifact.find('SEARCH TERMS') >= 0:      icon = 'search'
-        elif artifact.find('TOP SITES') >= 0:       icon = 'list'
-        elif artifact.find('WEB VISITS') >= 0:      icon = 'globe'
-        else:                                       icon = 'chrome'
-    elif category == 'CLOUDKIT':
-        if artifact == 'PARTICIPANTS':
-            icon = 'user'
-        elif artifact == 'NOTE SHARING':
-            icon = 'share-2'
-    elif category == 'CONNECTED TO':
-        icon = 'zap'
-    elif category == 'CONTROL CENTER':
-        if artifact == 'CONTROL CENTER - DISABLED CONTROLS':
-            icon = 'x-square'
-        if artifact == 'CONTROL CENTER - ACTIVE CONTROLS':
-            icon = 'sliders'
-        if artifact == 'CONTROL CENTER - USER TOGGLED CONTROLS':
-            icon = 'check-square'
-    elif category == 'COREDUET':
-        if artifact == 'AIRPLANE MODE':
-            icon = 'pause'
-        if artifact == 'LOCK STATE':
-            icon = 'lock'
-        if artifact == 'PLUGGED IN':
-            icon = 'battery-charging'
-    elif category == 'DATA USAGE':
-        icon = 'wifi'
-    elif category == 'DEVICE INFO':
-        if artifact == 'BUILD INFO':
-            icon = 'terminal'
-        elif artifact == 'IOS SYSTEM VERSION':
-            icon = 'git-commit'
-        elif artifact == 'PARTNER SETTINGS':
-            icon = 'settings'
-        elif artifact.find('SETTINGS_SECURE_') >= 0:
-            icon = 'settings'
-        else:
-            icon = 'info'
-    elif category == 'DHCP':
-        icon = 'settings'
-    elif category == 'IOS ATXDATASTORE':
-        icon = 'database'
-    elif category == 'DISCORD':
-        if artifact == 'DISCORD MESSAGES':
-            icon = 'message-square'
-        if artifact == 'DISCORD ACCOUNT':
-            icon = 'user'
-        if artifact == 'DISCORD MANIFEST':
-            icon = 'file-text'
-    elif category == 'FACEBOOK MESSENGER':
-        icon = 'facebook'
-    elif category == 'FILES APP':
-        icon = 'file-text'
-    elif category == 'GEOLOCATION':
-        if artifact == 'APPLICATIONS':
-            icon = 'grid'
-        elif artifact == 'MAP TILE CACHE':
-            icon = 'map'
-        elif artifact == 'MAPSSYNC':
-            icon = 'map'
-        elif artifact == 'PD PLACE CACHE':
-            icon = 'map-pin'
-        else:
-          icon = 'map-pin'
-    elif category == 'DRAFT NATIVE MESSAGES':
-          icon = 'message-circle'
-    elif category == 'GMAIL':
-        if artifact == 'GMAIL - LABEL DETAILS':
-            icon = 'mail'
-        if artifact == 'GMAIL - OFFLINE SEARCH':
-            icon = 'search'
-    elif category == 'GOOGLE CHAT':
-        icon = 'message-square'
-    elif category == 'GOOGLE DUO':
-        if artifact == 'GOOGLE DUO - CALL HISTORY':
-            icon = 'phone-call'
-        if artifact == 'GOOGLE DUO - CONTACTS':
-            icon = 'user'
-        if artifact == 'GOOGLE DUO - CLIPS':
-            icon = 'video'
-    elif category == 'HEALTH':
-        if artifact == 'HEALTH - ACHIEVEMENTS':
-            icon = 'star'
-        elif artifact == 'HEALTH - HEADPHONE AUDIO LEVELS':
-            icon = 'headphones'
-        elif artifact == 'HEALTH - HEART RATE':
-            icon = 'activity'
-        elif artifact == 'HEALTH - RESTING HEART RATE':
-            icon = 'activity'
-        elif artifact == 'HEALTH - STEPS':
-            icon = 'activity'
-        elif artifact == 'HEALTH - WORKOUTS':
-            icon = 'activity'
-        else:
-            icon = 'heart'
-    elif category == 'ICLOUD QUICK LOOK':
-        icon = 'file'
-    elif category == 'PREFERENCES PLIST':
-        icon = 'file'
-    elif category == 'DEVICE DATA':
-        icon = 'file'
-    elif category == 'IDENTIFIERS':
-        icon = 'file'
-    elif category == 'ICLOUD RETURNS':
-        icon = 'cloud'
-    elif category == 'ICLOUD SHARED ALBUMS':
-        icon = 'cloud'
-    elif category == 'IMO HD CHAT':
-        if artifact == 'IMO HD CHAT - MESSAGES':
-            icon = 'message-circle'
-        if artifact == 'IMO HD CHAT - CONTACTS':
-            icon = 'user'
-    elif category == 'INSTAGRAM':
-        if artifact == 'INSTAGRAM THREADS':
-            icon = 'message-square'
-        if artifact == 'INSTAGRAM THREADS CALLS':
-            icon = 'phone'
-    elif category == 'INSTALLED APPS':
-        icon = 'package'
-    elif category == 'INTERACTIONC':
-        if artifact == 'CONTACTS':
-            icon = 'user'
-        elif artifact == 'ATTACHMENTS':
-            icon = 'paperclip'
-    elif category == 'IOS BUILD' or category == 'IOS BUILD (ITUNES BACKUP)':
-        icon = 'git-commit'
-    elif category == 'IOS SCREENS':
-        icon = 'maximize'
-    elif category == 'KEYBOARD':
-        if artifact == 'KEYBOARD DYNAMIC LEXICON':
-            icon = 'type'
-        elif artifact == 'KEYBOARD APPLICATION USAGE':
-            icon = 'type'
-    elif category == 'KIK':
-        if artifact == 'KIK MESSAGES':
-            icon = 'message-square'
-        elif artifact == 'KIK GROUP ADMINISTRATORS':
-            icon = 'user-plus'
-        elif artifact == 'KIK LOCAL ACCOUNT':
-            icon = 'user-check'
-        elif artifact == 'KIK USERS':
-            icon = 'user'
-        elif artifact == 'KIK USERS IN GROUPS':
-            icon = 'user'
-        elif artifact == 'KIK MEDIA METADATA':
-            icon = 'file-plus'
-        elif artifact == 'KIK PENDING UPLOADS':
-            icon = 'upload'
-    elif category == 'KNOWLEDGEC':
-        if artifact == 'KNOWLEDGEC DEVICE LOCKED':
-            icon = 'lock'
-        elif artifact == 'KNOWLEDGEC PLUGGED IN':
-            icon = 'battery-charging'
-        elif artifact == 'KNOWLEDGEC BATTERY LEVEL':
-            icon = 'battery'
-        else:
-            icon = 'activity'
-    elif category == 'LOCATIONS':
-        if artifact == 'APPLE MAPS SEARCH HISTORY':
-            icon = 'search'
-        else:
-            icon = 'map-pin'
-    elif category == 'LOCATION SERVICES CONFIGURATIONS':
-        icon = 'settings'
-    elif category == 'MEDIA LIBRARY':
-        icon = 'play-circle'
-    elif category == 'MEDIA METADATA':
-        icon = 'file-plus'
-    elif category == 'MEDICAL ID':
-        icon = 'thermometer'
-    elif category == 'METAMASK':
-        if artifact.find('BROWSER') >= 0:   icon = 'globe'
-        elif artifact.find('CONTACTS') >= 0:   icon = 'users'
-        else:   icon = 'dollar-sign'
-    elif category == 'MICROSOFT TEAMS - LOGS':
-        if artifact == 'TEAMS LOCATIONS':
-            icon = 'map-pin'
-        if artifact == 'TEAMS MOTION':
-            icon = 'move'
-        if artifact == 'TEAMS STATE CHANGE':
-            icon = 'truck'
-        if artifact == 'TEAMS POWER LOG':
-            icon = 'battery-charging'
-        if artifact == 'TEAMS TIMEZONE':
-            icon = 'clock'
-    elif category == 'MICROSOFT TEAMS':
-        if artifact == 'TEAMS MESSAGES':
-            icon = 'message-square'
-        if artifact == 'TEAMS CONTACT':
-            icon = 'users'
-        if artifact == 'TEAMS USER':
-            icon = 'user'
-        if artifact == 'TEAMS CALL LOGS':
-            icon = 'phone'
-        if artifact == 'TEAMS SHARED LOCATIONS':
-            icon = 'map-pin'
-    elif category == 'MOBILE ACTIVATION LOGS':
-        icon = 'clipboard'
-    elif category == 'MOBILE BACKUP':
-        icon = 'save'
-    elif category == 'MOBILE CONTAINER MANAGER':
-        icon = 'save'
-    elif category == 'MOBILE INSTALLATION LOGS':
-        icon = 'clipboard'
-    elif category == 'MOBILE SOFTWARE UPDATE':
-        icon = 'refresh-cw'
-    elif category == 'NETWORK USAGE':
-        if artifact.find('APP DATA') >= 0:   icon = 'activity'
-        if artifact.find('CONNECTIONS') >= 0:   icon = 'bar-chart'
-    elif category == 'NOTES':
-        icon = 'file-text'
-    elif category == 'NOTIFICATIONS':
-        icon = 'bell'
-    elif category == 'OFFLINE PAGES':
-        icon = 'cloud-off'
-    elif category == 'PHOTOS':
-        if artifact == 'MIGRATIONS':
-            icon = 'chevrons-up'
-        else:
-            icon = 'image'
-    elif category == 'POWERLOG':
-        icon = 'power'
-    elif category == 'POWERLOG BACKUPS':
-        icon = 'power'
-    elif category == 'PROTON MAIL':
-        icon = 'mail'
-    elif category == 'RECENT ACTIVITY':
-        icon = 'activity'
-    elif category == 'REMINDERS':
-        icon = 'list'
-    elif category == 'ROUTINED':
-        icon = 'map'
-    elif category == 'SAFARI BROWSER':
-        icon = 'compass'
-    elif category == 'SCREENTIME':
-        icon = 'monitor'
-    elif category == 'SCRIPT LOGS':
-        icon = 'archive'
-    elif category == 'SLACK':
-        if artifact == 'SLACK MESSAGES':
-            icon = 'message-square'
-        if artifact == 'SLACK USER DATA':
-            icon = 'user'
-        if artifact == 'SLACK ATTACHMENTS':
-            icon = 'paperclip'
-        if artifact == 'SLACK WORKSPACE DATA':
-            icon = 'slack'
-        if artifact == 'SLACK TEAM DATA':
-            icon = 'slack'
-        if artifact == 'SLACK CHANNEL DATA':
-            icon = 'slack'
-    elif category == 'SMS & IMESSAGE':
-        icon = 'message-square'
-    elif category == 'SQLITE JOURNALING':
-        icon = 'book-open'
-    elif category == 'TEXT INPUT MESSAGES':
-        icon = 'message-square'
-    elif category == 'TIKTOK':
-        if artifact == 'TIKTOK MESSAGES':
-            icon = 'message-square'
-        if artifact == 'TIKTOK CONTACTS':
-            icon = 'user'
-        if artifact == 'TIKTOK SEARCH':
-            icon = 'search'
-    elif category == 'USER DICTIONARY':
-        icon = 'book'
-    elif category == 'VIPPS':
-        if artifact == 'VIPPS CONTACTS':
-            icon = 'users'
-        else:
-            icon = 'dollar-sign'
-    elif category == 'VENMO':
-        icon = 'dollar-sign'  
-    elif category == 'VIBER':
-        if artifact == 'VIBER - SETTINGS':
-            icon = 'settings'
-        if artifact == 'VIBER - CONTACTS':
-            icon = 'users'
-        if artifact == 'VIBER - CHATS':
-            icon = 'message-square'
-        if artifact == 'VIBER - CALL REMNANTS':
-            icon = 'phone-call'
-    elif category == 'VOICE-RECORDINGS':
-        icon = 'mic'
-    elif category == 'TELEGRAM':
-        icon = 'message-square'
-    elif category == 'VOICE-TRIGGERS':
-        icon = 'mic'
-    elif category == 'WHATSAPP':
-        if artifact == 'WHATSAPP - MESSAGES':
-            icon = 'message-square'
-        if artifact == 'WHATSAPP - CONTACTS':
-            icon = 'users'
-    elif category == 'WIFI CONNECTIONS':
-        icon = 'wifi'
-    elif category == 'WIFI KNOWN NETWORKS':
-        icon = 'wifi'
-    elif category == 'OFFLINE PAGES':
-        icon = 'cloud-off'
-    elif category == 'HIKVISION':
-        if artifact.find('CCTV CHANNELS') >=0: icon = 'film'
-        elif artifact.find('CCTV ACTIVITY') >=0: icon = 'activity'
-        elif artifact.find('CCTV INFO') >=0: icon = 'settings'
-        elif artifact.find('USER CREATED MEDIA') >= 0:    icon = 'video'  
-    elif category == 'DAHUA TECHNOLOGY (DMSS)':
-        if artifact.find('PIN') >=0: icon = 'unlock'
-        elif artifact.find('CHANNELS') >=0: icon = 'film'
-        elif artifact.find('INFO') >=0: icon = 'settings'
-        elif artifact.find('USER CREATED MEDIA') >= 0:   icon = 'video'
-        elif artifact.find('SENSORS') >=0: icon = 'smartphone'
-        elif artifact.find('DEVICES') >=0: icon = 'tablet'
-        elif artifact.find('NOTIFICATIONS') >=0: icon = 'bell'
-    elif category == 'SECRET CALCULATOR PHOTO ALBUM':
-        icon = 'image'
-    elif category == 'CORE ACCESSORIES':
-        if artifact == 'USER EVENT AGENT':
-            icon = 'activity'
-        elif artifact == 'ACCESSORYD':
-            icon = 'zap'
+    if category_match:
+        if isinstance(category_match, str):
+            return category_match
+        elif isinstance(category_match, dict):
+            artifact_match = category_match.get(artifact)
+            if artifact_match:
+                return artifact_match
+            else:
+                if category_match.get('_mode') == 'search':
+                    for key, value in category_match.items():
+                        if artifact.find(key) >= 0:
+                            return value
+                    art_default = category_match.get('default')
+                    if art_default:
+                        return art_default
+                art_default = category_match.get('default')
+                if art_default:
+                    return art_default
+    else:
+        # search_set = get_search_mode_categories()
+        for r in search_set:
+            for record in search_set:
+                category_key, category_mapping = list(record.items())[0]
+                if category.find(category_key) >= 0:
+                    for key, value in category_mapping.items():
+                        if artifact.find(key) >= 0:
+                            return value
+                    art_default = category_mapping.get('default')
+                    if art_default:
+                        return art_default
 
-    return icon
+            # category_match = category.find(r[0])
+            # if category_match:
+            #     if len(category_match) == 1:
+            #         return category_match[1]
+            #     else:
+            #         for key, value in category_match.items():
+            #             if artifact.find(category_match):
+            #                 return value
+
+    return 'alert-triangle'
+
+
+def get_search_mode_categories():
+    search_mode_categories = []
+    for category, mappings in icon_mappings.items():
+        if isinstance(mappings, dict) and mappings.get('_mode') == 'search':
+            search_mode_categories.append({category: mappings})
+    return search_mode_categories
+# get them populated
+search_set = get_search_mode_categories()
+
+
+def get_metamask_icon(artifact):
+    if 'BROWSER' in artifact:
+        return 'globe'
+    elif 'CONTACTS' in artifact:
+        return 'users'
+    else:
+        return 'dollar-sign'
+
+
+def get_network_usage_icon(artifact):
+    if 'APP DATA' in artifact:
+        return 'activity'
+    elif 'CONNECTIONS' in artifact:
+        return 'bar-chart'
+
 
 
 def generate_report(reportfolderbase, time_in_secs, time_HMS, extraction_type, image_input_path, casedata):


### PR DESCRIPTION
refactored the icons into a dictionary object and kept the search ability by including a "_mode" key. first pass is a direct lookup for an exact match of the key. if that isn't found, it moves to search mode with a reduced set of records based on those with a `_mode` : `search` in their record. if search mode is declared, both category and artifact keys are searched. goal here would be to make this file the same across all xLEAPP versions. if someone contributes a new icon mapping in one xLEAPP, then it would be simple to do a diff merge into all the other xLEAPP versions.

function `def sort_and_print_mappings():` reads in the `icon_mappings` object and prints it back out sorted to console

its called by the `if __name__ == '__main__':` if you run the `report.py` file as a standalone script.

Then you can copy paste back into the script from the console and the object will be sorted.