### PR TITLE
update iOS versions supported in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 iOS Logs, Events, And Plists Parser  
 Details in blog post here: https://abrignoni.blogspot.com/2019/12/ileapp-ios-logs-events-and-properties.html
 
-Supports iOS/iPadOS 11, 12, 13 and 14.
+Supports iOS/iPadOS 11, 12, 13 and 14, 15, 16.
 Select parsing directly from a compressed .tar/.zip file, or a decompressed directory, or an iTunes/Finder backup folder.
 
 ## Features
 
 Parses:  
 ⚙️ Mobile Installation Logs  
-⚙️ iOS 12 & 13 Notifications  
+⚙️ iOS 12+ Notifications  
 ⚙️ Build Info (iOS version, etc.)  
 ⚙️ Wireless cellular service info (IMEI, number, etc.)  
 ⚙️ Screen icons list by screen and in grid order.  


### PR DESCRIPTION
Verified iLEAPP works with backups from an iPhone running both of these versions:

- iOS 15
- iOS 16

I have not yet tested iOS 17, but I will soon.

P.S. Thank you so much for creating & maintaining such an awesome forensics tool!