### PR TITLE
Update builds_ids.py

### DIFF
--- a/scripts/builds_ids.py
+++ b/scripts/builds_ids.py
@@ -743,6 +743,7 @@ OS_build = {
     "21B80": "iOS 17.1",
     "21B91": "iOS 17.1.1",
     "21C5029g": "iOS 17.2 beta 1",
+    "21C5040g": "iOS 17.2 beta 2",
     "4K78": "Mac OS X 10.0",
     "4L8": "Mac OS X 10.0.1",
     "4L13": "Mac OS X 10.0.1",
@@ -1889,9 +1890,10 @@ OS_build = {
     "22G213": "macOS 13.6.1 RC",
     "22G311": "macOS 13.6.1 RC 2",
     "22G313": "macOS 13.6.1",
-    "22G417": "macOS 13.6.2 RC",
     "22G320": "macOS 13.6.2",
     "22G2321": "macOS 13.6.2",
+    "22G417": "macOS 13.6.3 RC",
+    "22G423": "macOS 13.6.3 RC 2",
     "23A5257q": "macOS 14.0 beta 1",
     "23A5276g": "macOS 14.0 beta 2",
     "23A5286g": "macOS 14.0 beta 3",
@@ -1913,6 +1915,7 @@ OS_build = {
     "23B81": "macOS 14.1.1",
     "23B2082": "macOS 14.1.1",
     "23C5030f": "macOS 14.2 beta 1",
+    "23C5041e": "macOS 14.2 beta 2",
     "12S507": "watchOS 1.0",
     "12S632": "watchOS 1.0.1",
     "13S5254w": "watchOS 2.0 beta 1",
@@ -2280,6 +2283,7 @@ OS_build = {
     "21S67": "watchOS 10.1",
     "21S71": "watchOS 10.1.1",
     "21S5331f": "watchOS 10.2 beta 1",
+    "21S5342e": "watchOS 10.2 beta 2",
 }
 
 device_id = {


### PR DESCRIPTION
Add:
- iOS 17.2 beta 2
- macOS 13.6.3 RC 2, macOS 14.2 beta 2
- watchOS 10.2 beta 2

Fix build 22G417 from macOS 13.6.2 RC to macOS 13.6.3 RC