### PR TITLE
Revert "Fix SQLite db path"

### DIFF
--- a/scripts/artifacts/accs.py
+++ b/scripts/artifacts/accs.py
@@ -55,7 +55,7 @@ def get_accs(files_found, report_folder, seeker, wrap_text, timezone_offset):
 __artifacts__ = {
     "accs": (
         "Accounts",
-        ('*/mobile/Library/Accounts/Accounts3.sqlite*'),
+        ('**/Accounts3.sqlite'),
         get_accs)
 }
         

--- a/scripts/artifacts/applicationstate.py
+++ b/scripts/artifacts/applicationstate.py
@@ -75,6 +75,6 @@ def get_applicationstate(files_found, report_folder, seeker, wrap_text, timezone
 __artifacts__ = {
     "applicationstate": (
         "Installed Apps",
-        ('*/mobile/Library/FrontBoard/applicationState.db*'),
+        ('**/applicationState.db'),
         get_applicationstate)
 }

--- a/scripts/artifacts/calendarAll.py
+++ b/scripts/artifacts/calendarAll.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Calendar",
         "notes": "",
-        "paths": ('*/mobile/Library/Calendar/Calendar.sqlitedb*',),
+        "paths": ('**/Calendar.sqlitedb',),
         "function": "get_calendar"
     }
 }

--- a/scripts/artifacts/dmss.py
+++ b/scripts/artifacts/dmss.py
@@ -344,6 +344,6 @@ def get_dmss(files_found, report_folder, seeker, wrap_text, timezone_offset):
 __artifacts__ = {
         "Dahua Technology (DMSS)": (
                 "Dahua Technology (DMSS)",
-                ('*/Library/Support/Devices.sqlite3*','*/Library/Support/configFile1','*/Library/Support/*/DMSSCloud.sqlite*','*/Documents/Captures/*','*/Documents/Videos/*'),
+                ('*/Library/Support/Devices.sqlite3','*/Library/Support/configFile1','*/Library/Support/*/DMSSCloud.sqlite','*/Documents/Captures/*','*/Documents/Videos/*'),
                 get_dmss)
 }

--- a/scripts/artifacts/knowledgeC_BatteryPercentage.py
+++ b/scripts/artifacts/knowledgeC_BatteryPercentage.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "KnowledgeC",
         "notes": "",
-        "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
+        "paths": ('**/CoreDuet/Knowledge/knowledgeC.db',),
         "function": "get_knowledgeC_BatteryPercentage"
     }
 }

--- a/scripts/artifacts/knowledgeC_MediaPlaying.py
+++ b/scripts/artifacts/knowledgeC_MediaPlaying.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "Query is a derivative of research provided by \
             - Sarah Edwards as part of her APOLLO project https://github.com/mac4n6/APOLLO \
             - Ian Wiffin blog post https://www.doubleblak.com/blogPosts.php?id=29",
-        "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
+        "paths": ('**/CoreDuet/Knowledge/knowledgeC.db',),
         "function": "get_knowledgeC_MediaPlaying"
     }
 }

--- a/scripts/artifacts/knowledgeC_isDevicePluggedin.py
+++ b/scripts/artifacts/knowledgeC_isDevicePluggedin.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "KnowledgeC",
         "notes": "",
-        "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
+        "paths": ('**/CoreDuet/Knowledge/knowledgeC.db',),
         "function": "get_knowledgeC_isDevicePluggedIn"
     }
 }

--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -113,6 +113,6 @@ def get_mediaLibrary(files_found, report_folder, seeker, wrap_text, timezone_off
 __artifacts__ = {
     "mediaLibrary": (
         "Media Library",
-        ('**/Medialibrary.sqlitedb*'),
+        ('**/Medialibrary.sqlitedb'),
         get_mediaLibrary)
 }

--- a/scripts/artifacts/serialNumber.py
+++ b/scripts/artifacts/serialNumber.py
@@ -2,8 +2,7 @@ import sqlite3
 import io
 import json
 import os
-import shutil
-
+import shutil
 import scripts.artifacts.artGlobals
 
 from packaging import version
@@ -52,6 +51,6 @@ def get_serialNumber(files_found, report_folder, seeker, wrap_text, timezone_off
 __artifacts__ = {
     "serialNumber": (
         "Identifiers",
-        ('*/Library/Caches/locationd/consolidated.db*'),
+        ('*/Library/Caches/locationd/consolidated.db'),
         get_serialNumber)
 }

--- a/scripts/artifacts/tcc.py
+++ b/scripts/artifacts/tcc.py
@@ -96,7 +96,7 @@ def get_tcc(files_found, report_folder, seeker, wrap_text, timezone_offset):
 __artifacts__ = {
     "tcc": (
         "App Permissions",
-        ('*/mobile/Library/TCC/TCC.db*'),
+        ('*TCC.db*'),
         get_tcc)
 }
     

--- a/scripts/artifacts/telegramMesssages.py
+++ b/scripts/artifacts/telegramMesssages.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "Github: https://gist.github.com/stek29; "
                  "Code: https://gist.github.com/stek29/8a7ac0e673818917525ec4031d77a713",
         "paths": (
-            '*/telegram-data/account-*/postbox/db/db_sqlite*',
+            '*/telegram-data/account-*/postbox/db/db_sqlite',
             '*/telegram-data/account-*/postbox/media/**'
         ),
         "function": "get_telegramMessages"

--- a/scripts/artifacts/twint.py
+++ b/scripts/artifacts/twint.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Twint Prepaid",
         "notes": "",
-        "paths": ('*/var/mobile/Containers/Data/Application/*/Library/Application Support/Twint.sqlite*'),
+        "paths": ('*/var/mobile/Containers/Data/Application/*/Library/Application Support/Twint.sqlite'),
         "function": "get_twint"
     }
 }

--- a/scripts/artifacts/viber.py
+++ b/scripts/artifacts/viber.py
@@ -20,8 +20,8 @@ __artifacts_v2__ = {
 				 "columns with each chat's grouped participants and phone numbers. More information is stored within "
 				 "the above databases, and this artifact assists in parsing the most out of it. ",
         "paths": (
-            '**/com.viber/settings/Settings.data*',
-            '**/com.viber/database/Contacts.data*',
+            '**/com.viber/settings/Settings.data',
+            '**/com.viber/database/Contacts.data',
             '**/Containers/Data/Application/*/Documents/Attachments/*.*',
             '**/com.viber/ViberIcons/*.*'
         ),

--- a/scripts/artifacts/voicemail.py
+++ b/scripts/artifacts/voicemail.py
@@ -164,6 +164,6 @@ def get_voicemail(files_found, report_folder, seeker, wrap_text, timezone_offset
 __artifacts__ = {
     "voicemail": (
         "Call History",
-        ('**/Voicemail/voicemail.db*','**/Voicemail/*.amr'),
+        ('**/Voicemail/voicemail.db','**/Voicemail/*.amr'),
         get_voicemail)
 }


### PR DESCRIPTION
Reverts abrignoni/iLEAPP#614

The change of the paths to add wal file processing needs to be paired with code that selects the database at query time and not the wal or shm file.

The code below will crash an artifact if files_found[0] is not the path for the database. 
<img width="516" alt="Screenshot 2023-11-21 at 7 10 56 AM" src="https://github.com/abrignoni/iLEAPP/assets/28718987/3451c1e2-8f9c-4d7b-a069-b6412f344ea5">

 Newer artifacts than these have examples on how to select the database for querying. For an example see here:
 <img width="507" alt="Screenshot 2023-11-21 at 7 15 51 AM" src="https://github.com/abrignoni/iLEAPP/assets/28718987/5d5f0739-1f2c-4856-ade4-7152702061cd">


