### PR TITLE
Removed ALEAPP references with iLEAPP

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -111,6 +111,7 @@ def create_profile(available_plugins, path):
             return
         else:
             print('Please enter a valid choice!!!\n')
+            user_choice = ''
   
 
 

--- a/ileapp.py
+++ b/ileapp.py
@@ -10,7 +10,7 @@ import traceback
 
 from scripts.search_files import *
 from scripts.ilapfuncs import *
-from scripts.version_info import aleapp_version
+from scripts.version_info import ileapp_version
 from time import process_time, gmtime, strftime, perf_counter
 
 def validate_args(args):
@@ -138,7 +138,6 @@ def main():
     loader = plugin_loader.PluginLoader()
     available_plugins = list(loader.plugins)
     profile_filename = None
-    selected_plugins = available_plugins.copy()
     # Move lastbuild plugin to first position
     lastbuild_index = next((i for i, selected_plugin in enumerate(available_plugins) 
                   if selected_plugin.name == 'lastbuild'), -1)
@@ -146,6 +145,7 @@ def main():
         available_plugins.insert(0, available_plugins.pop(lastbuild_index))
 
     print(f"Info: {len(available_plugins)} plugins loaded.")
+    selected_plugins = available_plugins.copy()
 
     args = parser.parse_args()
 
@@ -236,7 +236,7 @@ def crunch_artifacts(
     logfunc('Processing started. Please wait. This may take a few minutes...')
 
     logfunc('\n--------------------------------------------------------------------------------------')
-    logfunc(f'iLEAPP v{aleapp_version}: iOS Logs, Events, And Plists Parser')
+    logfunc(f'iLEAPP v{ileapp_version}: iOS Logs, Events, And Plists Parser')
     logfunc('Objective: Triage iOS Full File System and iTunes Backup Extractions.')
     logfunc('By: Alexis Brignoni | @AlexisBrignoni | abrignoni.com')
     logfunc('By: Yogesh Khatri   | @SwiftForensics | swiftforensics.com\n')
@@ -275,7 +275,6 @@ def crunch_artifacts(
     logfunc('\n--------------------------------------------------------------------------------------')
 
     log = open(os.path.join(out_params.report_folder_base, 'Script Logs', 'ProcessedFilesLog.html'), 'w+', encoding='utf8')
-    nl = '\n' #literal in order to have new lines in fstrings that create text files
     log.write(f'Extraction/Path selected: {input_path}<br><br>')
     log.write(f'Timezone selected: {time_offset}<br><br>')
     

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -1,14 +1,11 @@
 import json
-#import time
-import pathlib
 import typing
 import ileapp
 import PySimpleGUI as sg
 import webbrowser
 import plugin_loader
 from scripts.ilapfuncs import *
-from scripts.version_info import aleapp_version
-from time import process_time, gmtime, strftime
+from scripts.version_info import ileapp_version
 from scripts.search_files import *
 
 MODULE_START_INDEX = 1000
@@ -73,7 +70,7 @@ def pickModules():
     for plugin in sorted(loader.plugins, key=lambda p: p.category.upper()):
         if plugin.module_name == 'iTunesBackupInfo':
             continue
-        disabled = plugin.module_name == 'usagestatsVersion'
+        disabled = plugin.module_name == 'lastbuild'
         mlist.append(CheckList(f'{plugin.category} [{plugin.name} - {plugin.module_name}.py]', module_end_index, plugin.name, disabled))
         module_end_index = module_end_index + 1
         
@@ -108,10 +105,10 @@ layout = [  [sg.Text('iOS Logs, Events, And Plists Parser', font=("Helvetica", 2
              sg.Button('Load Profile', key='LOAD PROFILE'), sg.Button('Save Profile', key='SAVE PROFILE'),
              # sg.FileBrowse(
              #     button_text='Load Profile', key='LOADPROFILE', enable_events=True, target='LOADPROFILE',
-             #     file_types=(('ALEAPP Profile (*.alprofile)', '*.alprofile'), ('All Files', '*'))),
+             #     file_types=(('iLEAPP Profile (*.ilprofile)', '*.ilprofile'), ('All Files', '*'))),
              # sg.FileSaveAs(
              #     button_text='Save Profile', key='SAVEPROFILE', enable_events=True, target='SAVEPROFILE',
-             #     file_types=(('ALEAPP Profile (*.alprofile)', '*.alprofile'), ('All Files', '*')),
+             #     file_types=(('iLEAPP Profile (*.ilprofile)', '*.ilprofile'), ('All Files', '*')),
              #     default_extension='.alprofile')
             sg.Text('  |', font=("Helvetica", 14)),
             sg.Button('Load Case Data', key='LOAD CASE DATA'),
@@ -124,7 +121,7 @@ layout = [  [sg.Text('iOS Logs, Events, And Plists Parser', font=("Helvetica", 2
             [sg.Submit('Process', font=normal_font), sg.Button('Close', font=normal_font)] ]
             
 # Create the Window
-window = sg.Window(f'iLEAPP version {aleapp_version}', layout)
+window = sg.Window(f'iLEAPP version {ileapp_version}', layout)
 GuiWindow.progress_bar_handle = window['PROGRESSBAR']
 profile_filename = None
 
@@ -196,8 +193,8 @@ while True:
     if event == 'LOAD CASE DATA':
         destination_path = sg.popup_get_file(
             "Load a case data", save_as=False,
-            file_types=(('ALEAPP Profile (*.alprofile)', '*.alprofile'), ('All Files', '*')),
-            default_extension='.alprofile', no_window=True)
+            file_types=(('iLEAPP Profile (*.ilprofile)', '*.ilprofile'), ('All Files', '*')),
+            default_extension='.ilprofile', no_window=True)
         
         if destination_path and os.path.exists(destination_path):
             profile_load_error = None

--- a/scripts/artifact_report.py
+++ b/scripts/artifact_report.py
@@ -2,7 +2,7 @@ import html
 import os
 from scripts.html_parts import *
 from scripts.ilapfuncs import is_platform_windows
-from scripts.version_info import aleapp_version
+from scripts.version_info import ileapp_version
 
 class ArtifactHtmlReport:
 
@@ -21,7 +21,7 @@ class ArtifactHtmlReport:
         '''Creates the report HTML file and writes the artifact name as a heading'''
         self.report_file = open(os.path.join(report_folder, f'{artifact_file_name}.temphtml'), 'w', encoding='utf8')
         self.report_file.write(page_header.format(f'iLEAPP - {self.artifact_name} report'))
-        self.report_file.write(body_start.format(f'iLEAPP {aleapp_version}'))
+        self.report_file.write(body_start.format(f'iLEAPP {ileapp_version}'))
         self.report_file.write(body_sidebar_setup)
         self.report_file.write(body_sidebar_dynamic_data_placeholder) # placeholder for sidebar data
         self.report_file.write(body_sidebar_trailer)

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -40,7 +40,7 @@ class OutputParameters:
         now = datetime.now()
         currenttime = str(now.strftime('%Y-%m-%d_%A_%H%M%S'))
         self.report_folder_base = os.path.join(output_folder,
-                                               'iLEAPP_Reports_' + currenttime)  # aleapp , aleappGUI, ileap_artifacts, report.py
+                                               'iLEAPP_Reports_' + currenttime)  # ileapp , ileappGUI, ileap_artifacts, report.py
         self.temp_folder = os.path.join(self.report_folder_base, 'temp')
         OutputParameters.screen_output_file_path = os.path.join(self.report_folder_base, 'Script Logs',
                                                                 'Screen Output.html')

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -8,7 +8,7 @@ import sys
 from collections import OrderedDict
 from scripts.html_parts import *
 from scripts.ilapfuncs import logfunc
-from scripts.version_info import aleapp_version, aleapp_contributors
+from scripts.version_info import ileapp_version, ileapp_contributors
 
 # Icon Mappings Dictionary
 # The icon_mappings dictionary is organized by category and is used to map categories and artifacts to icons.
@@ -1059,7 +1059,7 @@ def create_index_html(reportfolderbase, time_in_secs, time_HMS, extraction_type,
 
     content += '</div>'  # CARD end
 
-    authors_data = generate_authors_table_code(aleapp_contributors)
+    authors_data = generate_authors_table_code(ileapp_contributors)
     credits_code = credits_block.format(authors_data)
 
     # WRITE INDEX.HTML LAST
@@ -1071,7 +1071,7 @@ def create_index_html(reportfolderbase, time_in_secs, time_HMS, extraction_type,
 
     f = open(os.path.join(reportfolderbase, filename), 'w', encoding='utf8')
     f.write(page_header.format(page_title))
-    f.write(body_start.format(f"iLEAPP {aleapp_version}"))
+    f.write(body_start.format(f"iLEAPP {ileapp_version}"))
     f.write(body_sidebar_setup + active_nav_list_data + body_sidebar_trailer)
     f.write(body_main_header + body_main_data_title.format(body_heading, body_description))
     f.write(content)
@@ -1080,9 +1080,9 @@ def create_index_html(reportfolderbase, time_in_secs, time_HMS, extraction_type,
     f.write(body_main_trailer + body_end + nav_bar_script_footer + page_footer)
     f.close()
 
-def generate_authors_table_code(aleapp_contributors):
+def generate_authors_table_code(ileapp_contributors):
     authors_data = ''
-    for author_name, blog, tweet_handle, git in aleapp_contributors:
+    for author_name, blog, tweet_handle, git in ileapp_contributors:
         author_data = ''
         if blog:
             author_data += f'<a href="{blog}" target="_blank">{blog_icon}</a> &nbsp;\n'

--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -1,9 +1,9 @@
-aleapp_version = '1.18.7'
+ileapp_version = '1.18.7'
 
 # Contributors List
 # Format = [ Name, Blog-url, Twitter-handle, Github-url]
 # Leave blank if not available
-aleapp_contributors = [
+ileapp_contributors = [
     ['Alexis Brignoni', 'https://abrignoni.com', '@AlexisBrignoni', 'https://github.com/abrignoni'],
     ['Yogesh Khatri', 'https://swiftforensics.com', '@SwiftForensics', 'https://github.com/ydkhatri'],
     ['Agam Dua', 'https://loopback.dev', '@loopbackdev', 'https://github.com/agamdua'],


### PR DESCRIPTION
- Removed unused imports
- References to ALEAPP were replaced with iLEAPP
- Removed usagestatsVersion parser with lastbuild
- Fixed
  - Profile creation exited in the CLI is user entered a number before choosing the option to add or remove a parser
  - lastBuild parser was not executed first in the CLI if no profile file was loaded
