### PR TITLE
Adding Load/Save Case Data file both in GUI an CLI

### DIFF
--- a/scripts/report.py
+++ b/scripts/report.py
@@ -1022,22 +1022,23 @@ def get_file_content(path):
 
 def create_index_html(reportfolderbase, time_in_secs, time_HMS, extraction_type, image_input_path, nav_list_data, casedata):
     '''Write out the index.html page to the report folder'''
+    case_list = []
     content = '<br />'
     content += """
                    <div class="card bg-white" style="padding: 20px;">
                    <h2 class="card-title">Case Information</h2>
                """  # CARD start
 
-    case_list = [
+    if len(casedata) > 0:
+        for key, value in casedata.items():
+            case_list.append([key, value])
+    
+    case_list += [
         ['Extraction location', image_input_path],
         ['Extraction type', extraction_type],
         ['Report directory', reportfolderbase],
         ['Processing time', f'{time_HMS} (Total {time_in_secs} seconds)']
     ]
-    
-    if len(casedata) > 0:
-        for key, value in casedata.items():
-            case_list.append([key, value])
     
     tab1_content = generate_key_val_table_without_headings('', case_list) + \
         """

--- a/zCaseDataExample.alprofile
+++ b/zCaseDataExample.alprofile
@@ -1,1 +1,0 @@
-{"Case Number": "0123-45-6789", "Agency": "The Justice League", "Examiner": "Victor Stone"}

--- a/zCaseDataExample.lcasedata
+++ b/zCaseDataExample.lcasedata
@@ -1,0 +1,1 @@
+{"leapp": "case_data", "case_data_values": {"Case Number": "0123-45-6789", "Agency": "The Justice League", "Examiner": "Victor Stone"}}

--- a/zProfileExample.ilprofile
+++ b/zProfileExample.ilprofile
@@ -1,0 +1,1 @@
+{"leapp": "ileapp", "format_version": 1, "plugins": ["calendar", "voicemail", "addressbook", "blockedContacts"]}


### PR DESCRIPTION
'Load Case Data' button was replaced with a 'Add Case Data' button in the GUI.

![image](https://github.com/abrignoni/iLEAPP/assets/27498476/dc53aa35-ba7c-41b6-a396-b3ce7601b12a)

![image](https://github.com/abrignoni/iLEAPP/assets/27498476/2ce5a67a-e09a-486e-830f-b8c977f362ea)

In the CLI:
- '-m' is used to load an iLEAPP profile file (.ilprofile)
- '-d' is used to load a LEAPP case data file
- -'c' is used to create an iLEAPP profile file and/or a LEAPP case data file

<img width="518" alt="image" src="https://github.com/abrignoni/iLEAPP/assets/27498476/2627459a-f84c-4c78-aea2-83e3e6a2754a">

--- 
Two example files (zCaseDataExample.lcasedata & zProfileExample.ilprofile) are available at the root or the repo.
