### PR TITLE
Fix file is not a database on Windows

### DIFF
--- a/scripts/artifacts/Gmail.py
+++ b/scripts/artifacts/Gmail.py
@@ -15,7 +15,7 @@ def get_Gmail(files_found, report_folder, seeker, wrap_text, timezone_offset):
     for file_found in files_found:
         file_found = str(file_found)
         
-        if file_found.endswith('/searchsqlitedb'):
+        if file_found.endswith('searchsqlitedb'):
             
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
@@ -73,7 +73,7 @@ def get_Gmail(files_found, report_folder, seeker, wrap_text, timezone_offset):
             
             db.close()
                     
-        if file_found.endswith('/sqlitedb'):
+        if file_found.endswith('sqlitedb'):
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''

--- a/scripts/artifacts/accs.py
+++ b/scripts/artifacts/accs.py
@@ -22,7 +22,7 @@ def get_accs(files_found, report_folder, seeker, wrap_text, timezone_offset):
     for file_found in files_found:
         file_found = str(file_found)
     
-        if file_found.endswith('/Accounts3.sqlite'):
+        if file_found.endswith('Accounts3.sqlite'):
             break
 
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/applicationstate.py
+++ b/scripts/artifacts/applicationstate.py
@@ -26,7 +26,7 @@ def get_applicationstate(files_found, report_folder, seeker, wrap_text, timezone
     for file_found in files_found:
         file_found = str(file_found)
     
-        if file_found.endswith('/applicationState.db'):
+        if file_found.endswith('applicationState.db'):
             break
 
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/knowledgeC.py
+++ b/scripts/artifacts/knowledgeC.py
@@ -22,7 +22,7 @@ def get_knowledgeC_data(files_found, report_folder, seeker, wrap_text, timezone_
     for file_found in files_found:
         file_found = str(file_found)
 
-        if file_found.endswith('/knowledgeC.db'):
+        if file_found.endswith('knowledgeC.db'):
             break
 
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -22,7 +22,7 @@ def get_mediaLibrary(files_found, report_folder, seeker, wrap_text, timezone_off
     for file_found in files_found:
         file_found = str(file_found)
     
-        if file_found.endswith('/Medialibrary.sqlitedb'):
+        if file_found.endswith('Medialibrary.sqlitedb'):
             break
 
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/serialNumber.py
+++ b/scripts/artifacts/serialNumber.py
@@ -23,7 +23,7 @@ def get_serialNumber(files_found, report_folder, seeker, wrap_text, timezone_off
     for file_found in files_found:
         file_found = str(file_found)
         
-        if file_found.endswith('/consolidated.db'):
+        if file_found.endswith('consolidated.db'):
             break
     
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/tcc.py
+++ b/scripts/artifacts/tcc.py
@@ -21,7 +21,7 @@ def get_tcc(files_found, report_folder, seeker, wrap_text, timezone_offset):
     for file_found in files_found:
         file_found = str(file_found)
         
-        if file_found.endswith('/TCC.db'):
+        if file_found.endswith('TCC.db'):
             break
         
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/telegramMesssages.py
+++ b/scripts/artifacts/telegramMesssages.py
@@ -37,7 +37,7 @@ def get_telegramMessages(files_found, report_folder, seeker, wrap_text, timezone
     for file_found in files_found:
         file_found = str(file_found)
         
-        if (file_found.endswith('/db_sqlite')) and ('media' not in file_found):
+        if (file_found.endswith('db_sqlite')) and ('media' not in file_found):
             data_list= []
             
             class byteutil:

--- a/scripts/artifacts/twint.py
+++ b/scripts/artifacts/twint.py
@@ -23,7 +23,7 @@ def get_twint(files_found, report_folder, seeker, wrap_text, time_offset):
     for file_found in files_found:
         file_found = str(file_found)
     
-        if file_found.endswith('/Twint.sqlite'):
+        if file_found.endswith('Twint.sqlite'):
             break
 
     db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/viber.py
+++ b/scripts/artifacts/viber.py
@@ -48,7 +48,7 @@ def get_viber(files_found, report_folder, seeker, wrap_text, timezone_offset):
 			logfunc("Viber parsing has not be tested on this iOS " + iOSversion + " version. Please contact @theAtropos4n6 for resolving this issue.")
 
 		if version.parse(iOSversion) >= version.parse("14"):
-			if file_found.endswith('/Settings.data'):
+			if file_found.endswith('Settings.data'):
 				db = open_sqlite_db_readonly(file_found)
 				cursor = db.cursor()
 				cursor.execute('''
@@ -181,7 +181,7 @@ def get_viber(files_found, report_folder, seeker, wrap_text, timezone_offset):
 		
 				db.close()
 
-			elif file_found.endswith('/Contacts.data'):
+			elif file_found.endswith('Contacts.data'):
 
 				db = open_sqlite_db_readonly(file_found)
 				cursor = db.cursor()

--- a/scripts/artifacts/voicemail.py
+++ b/scripts/artifacts/voicemail.py
@@ -24,7 +24,7 @@ def get_voicemail(files_found, report_folder, seeker, wrap_text, timezone_offset
                    if basename(dirname(file)) == "Voicemail"]
 
     for file_found in files_found:
-        if file_found.endswith('/voicemail.db'):
+        if file_found.endswith('voicemail.db'):
             voicemail_db = str(file_found)
 
             db = open_sqlite_db_readonly(voicemail_db)


### PR DESCRIPTION
On Windows, some parsers did not execute due to a File is not a database error caused by the / in the string of `file_found.endswith('/filename')` to select the db file and not the wal or shm one.