### PR TITLE
Updated requirements.txt - Force PySimpleGUI 4.60.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pillow
 pillow_heif
 pycryptodome
 pyinstaller
-PySimpleGUI
+PySimpleGUI==4.60.5
 pyliblzfse
 pytz
 simplekml


### PR DESCRIPTION
Force using PySimpleGUI 4.60.5