### PR TITLE
Added support for mbdb manifests

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -139,7 +139,7 @@ def main():
                               "'fs' for a folder containing extracted files with normal paths and names, "
                               "'tar', 'zip', or 'gz' for compressed packages containing files with normal names, "
                               "or 'itunes' for a folder containing a raw iTunes backup with hashed paths and names."
-                             "If you have an older iTunes backup using the Manifest.mbdb format instead, us 'itunes-mbdb'.))
+                             "If you have an older iTunes backup using the Manifest.mbdb format instead, us 'itunes-mbdb'."))
     parser.add_argument('-o', '--output_path', required=False, action="store",
                         help='Path to base output folder (this must exist)')
     parser.add_argument('-i', '--input_path', required=False, action="store", help='Path to input file/folder')

--- a/ileapp.py
+++ b/ileapp.py
@@ -134,11 +134,12 @@ def create_casedata(path):
 
 def main():
     parser = argparse.ArgumentParser(description='iLEAPP: iOS Logs, Events, And Plists Parser.')
-    parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'itunes'], required=False, action="store",
+    parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'itunes', 'itunes-mbdb'], required=False, action="store",
                         help=("Specify the input type. "
                               "'fs' for a folder containing extracted files with normal paths and names, "
                               "'tar', 'zip', or 'gz' for compressed packages containing files with normal names, "
-                              "or 'itunes' for a folder containing a raw iTunes backup with hashed paths and names."))
+                              "or 'itunes' for a folder containing a raw iTunes backup with hashed paths and names."
+                             "If you have an older iTunes backup using the Manifest.mbdb format instead, us 'itunes-mbdb'.))
     parser.add_argument('-o', '--output_path', required=False, action="store",
                         help='Path to base output folder (this must exist)')
     parser.add_argument('-i', '--input_path', required=False, action="store", help='Path to input file/folder')
@@ -319,6 +320,8 @@ def crunch_artifacts(
 
         elif extracttype == 'itunes':
             seeker = FileSeekerItunes(input_path, out_params.temp_folder)
+        elif extracttype == 'itunes-mbdb':
+            seeker = FileSeekerItunesMbdb(input_path, out_params.temp_folder)
 
         else:
             logfunc('Error on argument -o (input type)')

--- a/scripts/artifacts/callHistory.py
+++ b/scripts/artifacts/callHistory.py
@@ -24,7 +24,7 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, c
 def get_callHistory(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     #call_history.db schema taken from here https://avi.alkalay.net/2011/12/iphone-call-history.html 
-    query1 = '''
+    query = '''
     select
     datetime(ZDATE+978307200,'unixepoch'),
     CASE

--- a/scripts/artifacts/callHistory.py
+++ b/scripts/artifacts/callHistory.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Call History",
         "notes": "",
-        "paths": ('**/CallHistory.storedata*',),
+        "paths": ('**/CallHistory.storedata*','**/call_history.db',),
         "function": "get_callHistory"
     }
 }
@@ -22,16 +22,9 @@ from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_bytes_to_unit
 
 def get_callHistory(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        if file_found.endswith('.storedata'):
-            break
-    
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
+
+    #call_history.db schema taken from here https://avi.alkalay.net/2011/12/iphone-call-history.html 
+    query1 = '''
     select
     datetime(ZDATE+978307200,'unixepoch'),
     CASE
@@ -65,7 +58,49 @@ def get_callHistory(files_found, report_folder, seeker, wrap_text, timezone_offs
     upper(ZISO_COUNTRY_CODE),
     ZLOCATION
     from ZCALLRECORD
-    ''')
+    '''
+
+    query_old = '''
+    select
+    datetime(date, 'unixepoch'),
+    CASE
+        WHEN datetime(date,'unixepoch') = datetime((date + duration),'unixepoch') then 'No Call Duration'
+        ELSE datetime((date + duration), 'unixepoch')
+    END,
+    'N/A' as ZSERVICE_PROVIDER,
+    CASE
+        WHEN flags&4=4 then 'Phone Call'
+        When flags&16=16 then 'FaceTime Call'
+    END,
+    CASE 
+        WHEN flags=0 then 'Incoming'
+        WHEN flags&1=1 then 'Outgoing'
+    END,
+    address,
+    CASE read
+        WHEN 0 then 'No'
+        WHEN 1 then 'Yes'
+    END,
+    strftime('%H:%M:%S', duration, 'unixepoch'),
+    face_time_data,
+    'N/A' as ZDISCONNECTED_CAUSE,
+    country_code,
+    'N/A' as ZLOCATION
+    from call
+    '''
+
+    for file_found in files_found:
+        file_found = str(file_found)
+    
+        if file_found.endswith('.storedata'):
+            break
+        elif file_found.endswith('.db'):
+            query = query_old
+            break
+    
+    db = open_sqlite_db_readonly(file_found)
+    cursor = db.cursor()
+    cursor.execute(query)
 
     all_rows = cursor.fetchall()
     usageentries = len(all_rows)

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -171,7 +171,7 @@ class FileSeekerItunesMbdb(FileSeekerBase):
                 numprops, offset = getint(data, offset, 1)
                 for ii in range(numprops):
                     _, offset = getstring(data, offset)
-                    _, offset = getstring(data, offset)
+                    _, offset = getstring(data, offset, True)
                 hash_filename = hashlib.sha1(f"{domain}-{filename}".encode()).hexdigest()
                 files.append((hash_filename,domain,filename))
             return files

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -155,9 +155,9 @@ class FileSeekerItunesMbdb(FileSeekerBase):
             while offset < len(data):
                 domain, offset = getstring(data, offset)
                 filename, offset = getstring(data, offset)
-                _, offset = getstring(data, offset)
                 _, offset = getstring(data, offset, True)
-                _, offset = getstring(data, offset)
+                _, offset = getstring(data, offset, True)
+                _, offset = getstring(data, offset, True)
                 _, offset = getint(data, offset, 2)
                 _, offset = getint(data, offset, 4)
                 _, offset = getint(data, offset, 4)
@@ -170,7 +170,7 @@ class FileSeekerItunesMbdb(FileSeekerBase):
                 _, offset = getint(data, offset, 1)
                 numprops, offset = getint(data, offset, 1)
                 for ii in range(numprops):
-                    _, offset = getstring(data, offset)
+                    _, offset = getstring(data, offset, True)
                     _, offset = getstring(data, offset, True)
                 hash_filename = hashlib.sha1(f"{domain}-{filename}".encode()).hexdigest()
                 files.append((hash_filename,domain,filename))


### PR DESCRIPTION
Old iTunes backups dont seem to work at the moment as they use the Manifest.mbdb instead of the Manifest.db. Support has been added through a new seeker type to allow parsing old backups.

Mostly from this discussion here: https://stackoverflow.com/questions/3085153/how-to-parse-the-manifest-mbdb-file-in-an-ios-4-0-itunes-backup
Changed to fit iLEAPP