### PR TITLE
Update iTunesBackupInfo.py - Fix bug with tabs in home page report

### DIFF
--- a/scripts/artifacts/iTunesBackupInfo.py
+++ b/scripts/artifacts/iTunesBackupInfo.py
@@ -116,7 +116,7 @@ def get_iTunesBackupInfo(files_found, report_folder, seeker, wrap_text, timezone
             index = keys.index(info)
             info_key = data_list[index][0]
             value_key = data_list[index][1]
-            logdevinfo(f"<b>{info_key}: <b/>{value_key}")
+            logdevinfo(f"<b>{info_key}: </b>{value_key}")
 
     report = ArtifactHtmlReport('iTunes Backup')
     report.start_artifact_report(report_folder, 'iTunes Backup Information')


### PR DESCRIPTION
Fixing a bug in the report home page. When the report was generated from a backup, the tabs do not work properly.