### PR TITLE
handle negative timestamps

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -1,6 +1,7 @@
 # common standard imports
 import codecs
 import csv
+import datetime
 from datetime import *
 import json
 import os
@@ -105,7 +106,10 @@ def convert_ts_int_to_utc(ts): #This int timestamp to human format & utc
 
 def get_birthdate(date):
     ns_date = date + 978307200
-    utc_date = datetime.utcfromtimestamp(ns_date)
+    if ns_date < 0:
+        utc_date = datetime.fromtimestamp(0, timezone.utc) - timedelta(seconds=abs(ns_date))
+    else:
+        utc_date = datetime.fromtimestamp(ns_date, timezone.utc)
     return utc_date.strftime('%d %B %Y') if utc_date.year != 1604 else utc_date.strftime('%d %B')
 
 def is_platform_linux():


### PR DESCRIPTION
negative numbers too low will cause error on some python interpreters. (years less than 1970)