### PR TITLE
Code cleaning

### DIFF
--- a/scripts/artifacts/backupSettings.py
+++ b/scripts/artifacts/backupSettings.py
@@ -14,27 +14,26 @@ __artifacts_v2__ = {
 }
 
 import plistlib
-from datetime import datetime
-from scripts.ilapfuncs import artifact_processor, logfunc, logdevinfo, timestampsconv
+from scripts.ilapfuncs import artifact_processor, logfunc, logdevinfo, webkit_timestampsconv
 
 @artifact_processor
 def get_backupSettings(files_found, report_folder, seeker, wrap_text, timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     
-    with open(file_found, "rb") as fp:
+    with open(source_path, "rb") as fp:
         pl = plistlib.load(fp)
         if len(pl) > 0:
             for key, val in pl.items():
                 if key == 'LastiTunesBackupDate':
-                    lastime = timestampsconv(val)
+                    lastime = webkit_timestampsconv(val)
                     data_list.append(('Last iTunes Backup Date', lastime))
                     logdevinfo(f"<b>Last iTunes Backup Date: </b>{lastime}")
                 elif key == 'LastiTunesBackupTZ':
                     data_list.append((key, val))
                     logdevinfo(f"<b>Last iTunes Backup TZ: </b>{val}")
                 elif key == 'LastCloudBackupDate':
-                    lastcloudtime = timestampsconv(val)
+                    lastcloudtime = webkit_timestampsconv(val)
                     data_list.append(('Last Cloud iTunes Backup Date', lastcloudtime))
                     logdevinfo(f"<b>Last Cloud iTunes Backup Date: </b>{lastcloudtime}")
                 elif key == 'LastCloudBackupTZ':

--- a/scripts/artifacts/biomeAirpMode.py
+++ b/scripts/artifacts/biomeAirpMode.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from scripts.ccl import ccl_segb1
 from scripts.ccl import ccl_segb2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv, convert_ts_int_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv, convert_ts_int_to_utc
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -109,8 +109,8 @@ def get_biomeAirpMode(files_found, report_folder, seeker, wrap_text, timezone_of
                 if state == 'Written':
                     
                     protostuff, types = blackboxprotobuf.decode_message(data[8:],typess)
-                    timestart = (timestampsconv(protostuff['2']))
-                    #timeend = (timestampsconv(protostuff['3']))
+                    timestart = (webkit_timestampsconv(protostuff['2']))
+                    #timeend = (webkit_timestampsconv(protostuff['3']))
                     #timeend = convert_ts_int_to_utc(timeend)
                     event = protostuff['1']['1']
                     guid = protostuff['5'].decode()
@@ -136,8 +136,8 @@ def get_biomeAirpMode(files_found, report_folder, seeker, wrap_text, timezone_of
                 if state == 'Written':
                     
                     protostuff, types = blackboxprotobuf.decode_message(data,typess)
-                    timestart = (timestampsconv(protostuff['2']))
-                    #timeend = (timestampsconv(protostuff['3']))
+                    timestart = (webkit_timestampsconv(protostuff['2']))
+                    #timeend = (webkit_timestampsconv(protostuff['3']))
                     #timeend = convert_ts_int_to_utc(timeend)
                     event = protostuff['1']['1'].decode()
                     guid = protostuff['5'].decode()

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc 
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
@@ -123,11 +118,11 @@ def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_
                 protostuff, types = blackboxprotobuf.decode_message(protostuff, typess)
             
                 activity = (protostuff['1']['1'])
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 
                 
-                timeend = (timestampsconv(protostuff['3']))
+                timeend = (webkit_timestampsconv(protostuff['3']))
                 timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
                 bundleid = (protostuff['4']['3'])
@@ -146,7 +141,7 @@ def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_
                 else:
                     bundleinfo = ''
                 
-                timewrite = (timestampsconv(protostuff['8']))
+                timewrite = (webkit_timestampsconv(protostuff['8']))
                 timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 data_list.append((timestart, timeend, timewrite, activity, bundleid, bundleinfo, appinfo1, appinfo2, actionguid ))

--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeBacklight(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'int', 'name': ''}}
@@ -122,7 +117,7 @@ def get_biomeBacklight(files_found, report_folder, seeker, wrap_text, timezone_o
                 protostuff, types = blackboxprotobuf.decode_message(protostuff,typess)
                 #print(protostuff)
                 
-                timestart = (timestampsconv(protostuff['1']))
+                timestart = (webkit_timestampsconv(protostuff['1']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 state = (protostuff['2'])
                 

--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'double', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
@@ -116,12 +111,12 @@ def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_of
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             
@@ -143,13 +138,13 @@ def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_of
                 
                 
                 activity = (protostuff['1']['1'])
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 
-                timeend = (timestampsconv(protostuff['3']))
+                timeend = (webkit_timestampsconv(protostuff['3']))
                 timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
-                timewrite = (timestampsconv(protostuff['8']))
+                timewrite = (webkit_timestampsconv(protostuff['8']))
                 timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 percent = (protostuff['4']['5'])

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeBluetooth(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'fixed64', 'name': ''}, '10': {'type': 'int', 'name': ''}}
@@ -116,14 +111,14 @@ def get_biomeBluetooth(files_found, report_folder, seeker, wrap_text, timezone_o
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             convertedtime1 = convert_utc_human_to_timezone(convertedtime1, timezone_offset)
             #print(convertedtime1)
             segbtime = convertedtime1
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             

--- a/scripts/artifacts/biomeCarplayisconnected.py
+++ b/scripts/artifacts/biomeCarplayisconnected.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -109,12 +109,12 @@ def get_biomeCarplayisconnected(files_found, report_folder, seeker, wrap_text, t
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime1 = timestampsconv(date2)
+            convertedtime1 = webkit_timestampsconv(date2)
             #print(convertedtime1)
             
             
@@ -131,13 +131,13 @@ def get_biomeCarplayisconnected(files_found, report_folder, seeker, wrap_text, t
                 protostuff, types = blackboxprotobuf.decode_message(protostuff, typess)
                 activity = (protostuff['1']['1'])
                 
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 
-                timeend = (timestampsconv(protostuff['3']))
+                timeend = (webkit_timestampsconv(protostuff['3']))
                 timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
-                timewrite = (timestampsconv(protostuff['8']))
+                timewrite = (webkit_timestampsconv(protostuff['8']))
                 timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 actionguid = (protostuff['5'])

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ccl import ccl_segb1
 from scripts.ccl import ccl_segb2
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv, convert_ts_int_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, convert_ts_int_to_utc
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
@@ -116,12 +111,12 @@ def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_o
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             
@@ -142,13 +137,13 @@ def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_o
                 #print(types)
                 
                 activity = (protostuff['1']['1'])
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 
-                timeend = (timestampsconv(protostuff['3']))
+                timeend = (webkit_timestampsconv(protostuff['3']))
                 timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
-                timewrite = (timestampsconv(protostuff['8']))
+                timewrite = (webkit_timestampsconv(protostuff['8']))
                 timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 con = (protostuff['4']['4'])

--- a/scripts/artifacts/biomeHardware.py
+++ b/scripts/artifacts/biomeHardware.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeHardware(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'str', 'name': ''}}
@@ -116,14 +111,14 @@ def get_biomeHardware(files_found, report_folder, seeker, wrap_text, timezone_of
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             convertedtime1 = convert_utc_human_to_timezone(convertedtime1, timezone_offset)
             #print(convertedtime1)
             segbtime = convertedtime1
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -119,13 +119,13 @@ def get_biomeInfocus(files_found, report_folder, seeker, wrap_text, timezone_off
                 #print(protostuff)
                 
                 activity = (protostuff['1']['1'])
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 
-                timeend = (timestampsconv(protostuff['3']))
+                timeend = (webkit_timestampsconv(protostuff['3']))
                 timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
-                timewrite = (timestampsconv(protostuff['8']))
+                timewrite = (webkit_timestampsconv(protostuff['8']))
                 timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 actionguid = (protostuff['5'])

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeIntents(files_found, report_folder, seeker, wrap_text, timezone_offset):
     
     files_found = sorted(files_found)

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -7,7 +7,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -112,12 +112,12 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime1 = timestampsconv(date2)
+            convertedtime1 = webkit_timestampsconv(date2)
             #print(convertedtime1)
             
             
@@ -137,10 +137,10 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
                 #pp.pprint(protostuff)
                 
                 activity = (protostuff['1']['1'])
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 
-                timeend = (timestampsconv(protostuff['3']))
+                timeend = (webkit_timestampsconv(protostuff['3']))
                 timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
                 bundle = (protostuff['4']['3'])
@@ -176,7 +176,7 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
                     deserialized_plist = nd.deserialize_plist_from_string(data6)
                     data6 = (deserialized_plist['NS.relative'])
                     
-                timewrite = (timestampsconv(protostuff['8']))
+                timewrite = (webkit_timestampsconv(protostuff['8']))
                 timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 data_list.append((timestart, timeend, timewrite, activity, bundle, bundle2, data0, data1, data2, data3, data4, data5, data6, actionguid ))

--- a/scripts/artifacts/biomeNotes.py
+++ b/scripts/artifacts/biomeNotes.py
@@ -7,7 +7,7 @@ from io import StringIO
 from io import BytesIO
 from pathlib import Path
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -120,7 +120,7 @@ def get_biomeNotes(files_found, report_folder, seeker, wrap_text, timezone_offse
                 protostuff, types = blackboxprotobuf.decode_message(protostuff,typess)
                 #print(protostuff)
                 recordcounter = recordcounter + 1
-                time = (timestampsconv(protostuff['3']))
+                time = (webkit_timestampsconv(protostuff['3']))
                 time = convert_utc_human_to_timezone(time, timezone_offset)
                 identifier1 = protostuff['1']
                 identifier2 = protostuff['2']

--- a/scripts/artifacts/biomeNotificationsPub.py
+++ b/scripts/artifacts/biomeNotificationsPub.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeNotificationsPub(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'str', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'int', 'name': ''}, '4': {'type': 'str', 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'str', 'name': ''}, '9': {'type': 'str', 'name': ''}, '11': {'type': 'int', 'name': ''}, '12': {'type': 'str', 'name': ''}, '14': {'type': 'str', 'name': ''}, '16': {'type': 'int', 'name': ''}}
@@ -122,7 +117,7 @@ def get_biomeNotificationsPub(files_found, report_folder, seeker, wrap_text, tim
                 protostuff, types = blackboxprotobuf.decode_message(protostuff,typess)
                 #print(protostuff)
                 
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 bundleid = (protostuff['14'])
                 data1 = (protostuff.get('8',''))

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeNowplaying(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'2': {'type': 'double', 'name': ''}, '3': {'type': 'int', 'name': ''}, '5': {'type': 'str', 'name': ''}, '6': {'type': 'int', 'name': ''}, '8': {'type': 'str', 'name': ''}, '9': {'type': 'int', 'name': ''}, '10': {'type': 'str', 'name': ''}, '13': {'type': 'int', 'name': ''}, '14': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '15': {'type': 'str', 'name': ''}}
@@ -122,7 +117,7 @@ def get_biomeNowplaying(files_found, report_folder, seeker, wrap_text, timezone_
                 protostuff, types = blackboxprotobuf.decode_message(protostuff,typess)
                 #print(protostuff)
                 
-                timestart = (timestampsconv(protostuff['2']))
+                timestart = (webkit_timestampsconv(protostuff['2']))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 bundleid = (protostuff['15'])
                 info = (protostuff.get('10',''))

--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from scripts.ccl import ccl_segb1
 from scripts.ccl import ccl_segb2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv, convert_ts_int_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv, convert_ts_int_to_utc
 
 def checksegbv(in_path):
     MAGIC = b"SEGB"
@@ -112,7 +112,7 @@ def get_biomeSafari(files_found, report_folder, seeker, wrap_text, timezone_offs
                     #print(protostuff)
                     #print(offset, metadata_offset, ts, state)
                     activity = (protostuff['1']['1'])
-                    timestart = (timestampsconv(protostuff['2']))
+                    timestart = (webkit_timestampsconv(protostuff['2']))
                     url = (protostuff['4']['3'])
                     guid = (protostuff['5'])
                     detail1 = (protostuff['6']['1'])
@@ -146,7 +146,7 @@ def get_biomeSafari(files_found, report_folder, seeker, wrap_text, timezone_offs
                     #print(protostuff)
                     #print(offset, metadata_offset, ts, state)
                     activity = (protostuff['1']['1'])
-                    timestart = (timestampsconv(protostuff['2']))
+                    timestart = (webkit_timestampsconv(protostuff['2']))
                     print(timestart)
                     url = (protostuff['4']['3'])
                     guid = (protostuff['5'])

--- a/scripts/artifacts/biomeTextinputses.py
+++ b/scripts/artifacts/biomeTextinputses.py
@@ -6,7 +6,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -66,11 +66,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     typess = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'str', 'name': ''}, '4': {'type': 'int', 'name': ''}}
@@ -116,13 +111,13 @@ def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezon
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             segbtime = convertedtime1
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             
@@ -143,7 +138,7 @@ def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezon
 
                 duration = protostuff['1']
                 #Seems like the time is stored with an extra cocoa core offset added? we have to subtract it
-                timestart = (timestampsconv(protostuff['2']-978307200))
+                timestart = (webkit_timestampsconv(protostuff['2']-978307200))
                 timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 bundleid = (protostuff.get('3',''))
                 

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -8,7 +8,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc 
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, convert_time_obj_to_utc, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -68,11 +68,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    return(finaltime)
-
 def get_biomeUseractmeta(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     #typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'double', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
@@ -118,12 +113,12 @@ def get_biomeUseractmeta(files_found, report_folder, seeker, wrap_text, timezone
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             

--- a/scripts/artifacts/biomeWifi.py
+++ b/scripts/artifacts/biomeWifi.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from scripts.ccl import ccl_segb1
 from scripts.ccl import ccl_segb2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, timestampsconv, convert_ts_int_to_utc
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_utc_human_to_timezone, webkit_timestampsconv, convert_ts_int_to_utc
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -109,8 +109,8 @@ def get_biomeWifi(files_found, report_folder, seeker, wrap_text, timezone_offset
                 if state == 'Written':
                     
                     protostuff, types = blackboxprotobuf.decode_message(data[8:],typess)
-                    timestart = (timestampsconv(protostuff['2']))
-                    #timeend = (timestampsconv(protostuff['3']))
+                    timestart = (webkit_timestampsconv(protostuff['2']))
+                    #timeend = (webkit_timestampsconv(protostuff['3']))
                     #timeend = convert_ts_int_to_utc(timeend)
                     event = protostuff['1']['1']
                     guid = protostuff['5'].decode()
@@ -139,8 +139,8 @@ def get_biomeWifi(files_found, report_folder, seeker, wrap_text, timezone_offset
                 if state == 'Written':
                     
                     protostuff, types = blackboxprotobuf.decode_message(data,typess)
-                    timestart = (timestampsconv(protostuff['2']))
-                    #timeend = (timestampsconv(protostuff['3']))
+                    timestart = (webkit_timestampsconv(protostuff['2']))
+                    #timeend = (webkit_timestampsconv(protostuff['3']))
                     #timeend = convert_ts_int_to_utc(timeend)
                     event = protostuff['1']['1']
                     guid = protostuff['5'].decode()

--- a/scripts/artifacts/carCD.py
+++ b/scripts/artifacts/carCD.py
@@ -5,12 +5,7 @@ import scripts.artifacts.artGlobals
 
 from packaging import version
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, kmlgen, tsv, is_platform_windows, open_sqlite_db_readonly
-
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.utcfromtimestamp(unix_timestamp)
-    return(finaltime)
+from scripts.ilapfuncs import logfunc, logdevinfo, timeline, kmlgen, tsv, is_platform_windows, open_sqlite_db_readonly, webkit_timestampsconv
 
 def get_carCD(files_found, report_folder, seeker, wrap_text, timezone_offset):
     
@@ -29,8 +24,8 @@ def get_carCD(files_found, report_folder, seeker, wrap_text, timezone_offset):
                 if key == 'LastVehicleConnection':
                     lastconn = value
                     contype = lastconn[2]
-                    connected = timestampsconv(lastconn[0])
-                    disconnected = timestampsconv(lastconn[1])
+                    connected = webkit_timestampsconv(lastconn[0])
+                    disconnected = webkit_timestampsconv(lastconn[1])
                     logdevinfo(f'<b>Vehicle - Last Connected: </b>{connected} - <b>Last Disconnected: </b>{disconnected} - <b>Type: </b>{contype}')
                     data_list.append((key, f'Last Connected: {connected} <br> Last Disconnected: {disconnected} <br> Type: {contype}'))
                     

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -31,7 +31,7 @@ from packaging import version
 from scripts.ccl import ccl_segb1
 from scripts.ccl import ccl_segb2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, media_to_html,timestampsconv, convert_utc_human_to_timezone,convert_ts_int_to_utc,is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, media_to_html,webkit_timestampsconv, convert_utc_human_to_timezone,convert_ts_int_to_utc,is_platform_windows
 import scripts.artifacts.artGlobals
 
 
@@ -59,8 +59,8 @@ def get_chatgpt(files_found, report_folder, seeker, wrap_text, time_offset):
                 try:
                     conversation_id = data.get("id", "")
                     conversation_title = data.get("title", "")
-                    creation_time = convert_utc_human_to_timezone(timestampsconv(int(data.get("creation_date", 0))),time_offset)
-                    modification_time = convert_utc_human_to_timezone(timestampsconv(int(data.get("modification_date", 0))),time_offset)
+                    creation_time = convert_utc_human_to_timezone(webkit_timestampsconv(int(data.get("creation_date", 0))),time_offset)
+                    modification_time = convert_utc_human_to_timezone(webkit_timestampsconv(int(data.get("modification_date", 0))),time_offset)
                     model = data.get("configuration", {}).get("model", "")
                     custom_instructions_model = data.get("configuration", {}).get("custom_instructions", {}).get("about_model_message", "")
                     custom_instructions_user = data.get("configuration", {}).get("custom_instructions", {}).get("about_user_message", "")

--- a/scripts/artifacts/duetLocations.py
+++ b/scripts/artifacts/duetLocations.py
@@ -7,7 +7,7 @@ from time import mktime
 from io import StringIO
 from io import BytesIO
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen, webkit_timestampsconv
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
@@ -67,11 +67,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
     
     return mis_encoded_utf8_present, "".join(output)
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.utcfromtimestamp(unix_timestamp)
-    return(finaltime)
-
 def get_duetLocations(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
     for file_found in files_found:
@@ -114,13 +109,13 @@ def get_duetLocations(files_found, report_folder, seeker, wrap_text, timezone_of
             
             date1 = ab.read(8) 
             date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = timestampsconv(date1)
+            convertedtime1 = webkit_timestampsconv(date1)
             #print(convertedtime1)
             segbtime = convertedtime1
             
             date2 = ab.read(8)
             date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = timestampsconv(date2)
+            convertedtime2 = webkit_timestampsconv(date2)
             #print(convertedtime2)
             
             
@@ -145,7 +140,7 @@ def get_duetLocations(files_found, report_folder, seeker, wrap_text, timezone_of
                             horzacc = value
                         elif key == 'kCLLocationCodingKeyTimestamp':
                             timestamp = value
-                            timestamp = timestampsconv(timestamp)
+                            timestamp = webkit_timestampsconv(timestamp)
                         elif key == 'kCLLocationCodingKeyAltitude':
                             altitude = value
                         elif key == 'kCLLocationCodingKeySpeed':

--- a/scripts/artifacts/notificationsDuet.py
+++ b/scripts/artifacts/notificationsDuet.py
@@ -8,7 +8,7 @@ import blackboxprotobuf
 from datetime import datetime, timezone
 from time import mktime
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, webkit_timestampsconv
 
 def checksegbv(in_path):
     MAGIC = b"SEGB"
@@ -77,11 +77,6 @@ def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
         handle_bad_data(len(input_string), "")
     
     return mis_encoded_utf8_present, "".join(output)
-
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.utcfromtimestamp(unix_timestamp)
-    return(finaltime)
 
 def get_notificationsDuet(files_found, report_folder, seeker, wrap_text, timezone_offset):
     for file_found in files_found:
@@ -197,7 +192,7 @@ def get_notificationsDuet(files_found, report_folder, seeker, wrap_text, timezon
                 date1 = mensaje.read(8) #Date in hex
                 #print(f'Date1: {date1}')
                 date1 = (struct.unpack_from("<d",date1)[0])
-                convertedtime1 = timestampsconv(date1)
+                convertedtime1 = webkit_timestampsconv(date1)
                 #print(convertedtime1)
                 
                 mensaje.read(27)
@@ -207,7 +202,7 @@ def get_notificationsDuet(files_found, report_folder, seeker, wrap_text, timezon
                 for x in date2:
                     #print(hex(x))
                 date2 = (struct.unpack_from("<d",date2)[0])
-                convertedtime2 = timestampsconv(date2)
+                convertedtime2 = webkit_timestampsconv(date2)
                 #print(convertedtime2)
                 """
                 test = mensaje.read(1)
@@ -392,7 +387,7 @@ def get_notificationsDuet(files_found, report_folder, seeker, wrap_text, timezon
                 lastdate = mensaje.read(8)
                 #print(lastdate)
                 date2 = (struct.unpack_from("<d",lastdate)[0])
-                convertedtime2 = timestampsconv(date2)
+                convertedtime2 = webkit_timestampsconv(date2)
                 #print(f'Date2: {convertedtime2}')
                 data_list.append((convertedtime1,guid,title,subtitle,bundledata,bodyread,bundleidread,optionaltextread,bundleid2read,optionalgmarkeread,appleidread,convertedtime2, filename))
                 

--- a/scripts/artifacts/timezoneInfo.py
+++ b/scripts/artifacts/timezoneInfo.py
@@ -3,12 +3,7 @@ import os
 import plistlib
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows 
-
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.utcfromtimestamp(unix_timestamp)
-    return(finaltime)
+from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows, webkit_timestampsconv
 
 def get_timezoneInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
     data_list = []
@@ -22,7 +17,7 @@ def get_timezoneInfo(files_found, report_folder, seeker, wrap_text, timezone_off
                 logdevinfo(f"<b>Last Bootstrap Timezone: </b>{val}")
                 
             elif key == 'lastBootstrapDate':
-                times = timestampsconv(val)
+                times = webkit_timestampsconv(val)
                 data_list.append(('lastBootstrapDate', times))
                 logdevinfo(f"<b>Last Bootstrap Date: </b>{times}")
                 

--- a/scripts/artifacts/wifiIdent.py
+++ b/scripts/artifacts/wifiIdent.py
@@ -7,11 +7,6 @@ from packaging import version
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, logdevinfo, timeline, kmlgen, tsv, is_platform_windows, open_sqlite_db_readonly
 
-def timestampsconv(webkittime):
-    unix_timestamp = webkittime + 978307200
-    finaltime = datetime.utcfromtimestamp(unix_timestamp)
-    return(finaltime)
-
 def get_wifiIdent(files_found, report_folder, seeker, wrap_text, timezone_offset):
     
     data_list = []

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -136,7 +136,7 @@ def convert_ts_int_to_timezone(time, time_offset):
     #return the converted value
     return timezone_time
 
-def timestampsconv(webkittime):
+def webkit_timestampsconv(webkittime):
     unix_timestamp = webkittime + 978307200
     finaltime = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
     return(finaltime)


### PR DESCRIPTION
Many modules were using a timestampsconv function to convert webkit timestamps.
This function was defined in ilapfunc.py and also in several modules.
Function definition was deleted in involved modules and was renamed webkit_timestampsconv (more explicit) in ilapfunc.py.

All modules using this function have been updated to take account of these changes.