### PR TITLE
Update alarms.py for lava-output

### DIFF
--- a/scripts/artifacts/alarms.py
+++ b/scripts/artifacts/alarms.py
@@ -1,65 +1,31 @@
+__artifacts_v2__ = {
+    "get_alarms": {
+        "name": "Alarms",
+        "description": "Extraction of alarms set in the device",
+        "author": "Anna-Mariya Mateyna",
+        "version": "0.5",
+        "date": "2023-10-11",
+        "requirements": "none",
+        "category": "Alarms",
+        "notes": "",
+        "paths": ('*/mobile/Library/Preferences/com.apple.mobiletimerd.plist',),
+        "output_types": "all"
+    }
+}
+
 import plistlib
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline
-
-
-def get_alarms(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-
-    for file_found in files_found:
-        with open(file_found, "rb") as plist_file:
-            pl = plistlib.load(plist_file)
-
-            if 'MTAlarms' in pl:
-                if 'MTAlarms' in pl['MTAlarms']:
-                    for alarms in pl['MTAlarms']['MTAlarms']:
-                        alarms_dict = alarms['$MTAlarm']
-
-                        alarm_title = alarms_dict.get('MTAlarmTitle', 'Alarm')
-                        fire_date = alarms_dict.get('MTAlarmFireDate', '')
-                        dismiss_date = alarms_dict.get('MTAlarmDismissDate', '')
-                        repeat_schedule = decode_repeat_schedule(alarms_dict['MTAlarmRepeatSchedule'])
-
-                        data_list.append((alarm_title, alarms_dict['MTAlarmEnabled'], fire_date, dismiss_date,
-                                          alarms_dict['MTAlarmLastModifiedDate'], ', '.join(repeat_schedule),
-                                          alarms_dict['MTAlarmSound']['$MTSound']['MTSoundToneID'],
-                                          alarms_dict['MTAlarmIsSleep'], alarms_dict['MTAlarmBedtimeDoNotDisturb'], ''))
-
-                if 'MTSleepAlarm' in pl['MTAlarms']:
-                    for sleep_alarms in pl['MTAlarms']['MTSleepAlarm']:
-                        sleep_alarm_dict = pl['MTAlarms']['MTSleepAlarm'][sleep_alarms]
-
-                        alarm_title = sleep_alarm_dict.get('MTAlarmTitle', 'Bedtime')
-
-                        repeat_schedule = decode_repeat_schedule(sleep_alarm_dict['MTAlarmRepeatSchedule'])
-
-                        data_list.append((alarm_title, sleep_alarm_dict['MTAlarmEnabled'], sleep_alarm_dict['MTAlarmFireDate'],
-                                          sleep_alarm_dict['MTAlarmDismissDate'], sleep_alarm_dict['MTAlarmLastModifiedDate'],
-                                         ', '.join(repeat_schedule), sleep_alarm_dict['MTAlarmSound']['$MTSound']['MTSoundToneID'],
-                                          sleep_alarm_dict['MTAlarmIsSleep'], sleep_alarm_dict['MTAlarmBedtimeDoNotDisturb'],
-                                          sleep_alarm_dict['MTAlarmBedtimeFireDate']))
-
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Alarms')
-        report.start_artifact_report(report_folder, 'Alarms')
-        report.add_script()
-        data_headers = ('Alarm Title', 'Alarm Enabled', 'Fire Date', 'Dismiss Date', 'Last Modified', 'Repeat Schedule', 'Alarm Sound', 'Is Sleep Alarm', 'Bedtime Not Disturbed', 'Bedtime Fire Date')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-
-        tsvname = 'Alarms'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = 'Alarms'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Alarms found')
-
+from scripts.ilapfuncs import artifact_processor, logfunc, convert_plist_date_to_timezone_offset
 
 def decode_repeat_schedule(repeat_schedule_value):
-    days_list = {64: 'Sunday', 32: 'Saturday', 16: 'Friday', 8: 'Thursday', 4: 'Wednesday', 2: 'Tuesday', 1: 'Monday'}
+    days_list = {
+        64: 'Sunday', 
+        32: 'Saturday', 
+        16: 'Friday', 
+        8: 'Thursday', 
+        4: 'Wednesday', 
+        2: 'Tuesday', 
+        1: 'Monday'
+        }
     schedule = []
 
     if repeat_schedule_value == 127:
@@ -75,9 +41,85 @@ def decode_repeat_schedule(repeat_schedule_value):
             schedule.append(days_list[day])
     return reversed(schedule)
 
-__artifacts__ = {
-    "alarms": (
-        "Alarms",
-        ('*/mobile/Library/Preferences/com.apple.mobiletimerd.plist'),
-        get_alarms)
-}
+
+@artifact_processor
+def get_alarms(files_found, report_folder, seeker, wrap_text, timezone_offset):
+    data_list = []
+    data_headers = ()
+    source_path = str(files_found[0])
+
+    if not source_path:
+        logfunc('com.apple.mobiletimerd.plist not found')
+        return data_headers, data_list, source_path
+
+    with open(source_path, "rb") as plist_file:
+        pl = plistlib.load(plist_file)
+        if len(pl) > 0:
+            if 'MTAlarms' in pl:
+                if 'MTAlarms' in pl['MTAlarms']:
+                    for alarms in pl['MTAlarms']['MTAlarms']:
+                        alarms_dict = alarms['$MTAlarm']
+
+                        alarm_title = alarms_dict.get('MTAlarmTitle', 'Alarm')
+                        fire_date = alarms_dict.get('MTAlarmFireDate', '')
+                        fire_date = convert_plist_date_to_timezone_offset(fire_date, timezone_offset)
+                        dismiss_date = alarms_dict.get('MTAlarmDismissDate', '')
+                        dismiss_date = convert_plist_date_to_timezone_offset(dismiss_date, timezone_offset)
+                        last_modified_date = alarms_dict.get('MTAlarmLastModifiedDate', '')
+                        last_modified_date = convert_plist_date_to_timezone_offset(last_modified_date, timezone_offset)
+                        repeat_schedule = decode_repeat_schedule(alarms_dict['MTAlarmRepeatSchedule'])
+
+                        data_list.append(
+                            (fire_date, 
+                             alarm_title, 
+                             alarms_dict['MTAlarmEnabled'], 
+                             dismiss_date,
+                             last_modified_date, 
+                             ', '.join(repeat_schedule),
+                             alarms_dict['MTAlarmSound']['$MTSound']['MTSoundToneID'],
+                             alarms_dict['MTAlarmIsSleep'], 
+                             alarms_dict['MTAlarmBedtimeDoNotDisturb'],
+                             '')
+                            )
+
+                if 'MTSleepAlarm' in pl['MTAlarms']:
+                    for sleep_alarms in pl['MTAlarms']['MTSleepAlarm']:
+                        sleep_alarm_dict = pl['MTAlarms']['MTSleepAlarm'][sleep_alarms]
+
+                        alarm_title = sleep_alarm_dict.get('MTAlarmTitle', 'Bedtime')
+                        fire_date = sleep_alarm_dict.get('MTAlarmFireDate', '')
+                        fire_date = convert_plist_date_to_timezone_offset(fire_date, timezone_offset)
+                        dismiss_date = sleep_alarm_dict.get('MTAlarmDismissDate', '')
+                        dismiss_date = convert_plist_date_to_timezone_offset(dismiss_date, timezone_offset)
+                        last_modified_date = sleep_alarm_dict.get('MTAlarmLastModifiedDate', '')
+                        last_modified_date = convert_plist_date_to_timezone_offset(last_modified_date, timezone_offset)
+                        repeat_schedule = decode_repeat_schedule(sleep_alarm_dict['MTAlarmRepeatSchedule'])
+
+                        data_list.append(
+                            (fire_date, 
+                             alarm_title, 
+                             sleep_alarm_dict['MTAlarmEnabled'], 
+                             dismiss_date, 
+                             last_modified_date, 
+                             ', '.join(repeat_schedule), 
+                             sleep_alarm_dict['MTAlarmSound']['$MTSound']['MTSoundToneID'], 
+                             sleep_alarm_dict['MTAlarmIsSleep'], 
+                             sleep_alarm_dict['MTAlarmBedtimeDoNotDisturb'], 
+                             sleep_alarm_dict['MTAlarmBedtimeFireDate'])
+                             )
+        else:
+            logfunc('No alarms found')
+
+    data_headers = (
+        ('Fire Date', 'datetime'), 
+        'Alarm Title', 
+        'Alarm Enabled', 
+        ('Dismiss Date', 'datetime'), 
+        ('Last Modified', 'datetime'), 
+        'Repeat Schedule', 
+        'Alarm Sound', 
+        'Is Sleep Alarm', 
+        'Bedtime Not Disturbed', 
+        'Bedtime Fire Date'
+        )
+    return data_headers, data_list, source_path

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -153,6 +153,25 @@ def convert_ts_int_to_utc(ts): #This int timestamp to human format & utc
     timestamp = datetime.fromtimestamp(ts, tz=timezone.utc)
     return timestamp
 
+def convert_ts_human_to_timezone_offset(ts, timezone_offset):
+    return convert_utc_human_to_timezone(convert_ts_human_to_utc(ts), timezone_offset) if ts else ts
+    # if ts:
+    #     timestamp = convert_ts_human_to_utc(ts)
+    #     return convert_utc_human_to_timezone(timestamp, timezone_offset)
+    # else:
+    #     return ts
+
+def convert_plist_date_to_timezone_offset(plist_date, timezone_offset):
+    if plist_date:
+        str_date = '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
+            plist_date.year, plist_date.month, plist_date.day, 
+            plist_date.hour, plist_date.minute, plist_date.second
+            )
+        iso_date = datetime.fromisoformat(str_date).strftime("%Y-%m-%d %H:%M:%S")
+        return convert_ts_human_to_timezone_offset(iso_date, timezone_offset)
+    else:
+        return plist_date
+
 def get_birthdate(date):
     ns_date = date + 978307200
     utc_date = datetime.utcfromtimestamp(ns_date)
@@ -731,9 +750,11 @@ def get_resolution_for_model_id(model_id: str):
 
 
 def convert_bytes_to_unit(size):
-    for unit in ['bytes', 'KB', 'MB', 'GB']:
-        if size < 1024.0:
-            return f"{size:3.1f} {unit}"
-        size /= 1024.0
-    return size
-
+    if size:
+        for unit in ['bytes', 'KB', 'MB', 'GB']:
+            if size < 1024.0:
+                return f"{size:3.1f} {unit}"
+            size /= 1024.0
+        return size
+    else:
+        return size


### PR DESCRIPTION
Column order was changed to get a timestamp first in timeline.

**Issues**
- Timestamps in HTML were not able to support timezone offset parameter.
- Inconsistencies were observed between HTML and SQLite. I noticed that timestamps were not added appropriately in the lava SQLite. Timestamps are stored in the plist file as datetime objets and not str. When they were converted to be added in the SQLite database, datetime objets were considered in local time instead of UTC and then were converted in UTC. 

**Corrective action**
A new convert_plist_date_to_timezone_offset function was created in ilapfuncs.py to:
- manage date objets 'YYYY-MM-DDTHH:MM:SSZ' in plist files
- convert them to support timezone offset chosen by the user
- add them in the correct timestamp in the lava SQLite database

