### PR TITLE
Improve regex searches and file copies

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -137,12 +137,11 @@ def create_casedata(path):
 
 def main():
     parser = argparse.ArgumentParser(description='iLEAPP: iOS Logs, Events, And Plists Parser.')
-    parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'itunes', 'itunes-mbdb'], required=False, action="store",
+    parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'itunes'], required=False, action="store",
                         help=("Specify the input type. "
                               "'fs' for a folder containing extracted files with normal paths and names, "
                               "'tar', 'zip', or 'gz' for compressed packages containing files with normal names, "
-                              "'itunes' for a folder containing a raw iTunes backup with hashed paths and names, "
-                              "or 'itunes-mbdb' if you have an older iTunes backup using the Manifest.mbdb format instead."))
+                              "'itunes' for a folder containing a raw iTunes backup with hashed paths and names."))
     parser.add_argument('-o', '--output_path', required=False, action="store",
                         help='Path to base output folder (this must exist)')
     parser.add_argument('-i', '--input_path', required=False, action="store", help='Path to input file/folder')
@@ -334,8 +333,6 @@ def crunch_artifacts(
 
         elif extracttype == 'itunes':
             seeker = FileSeekerItunes(input_path, out_params.temp_folder)
-        elif extracttype == 'itunes-mbdb':
-            seeker = FileSeekerItunesMbdb(input_path, out_params.temp_folder)
 
         else:
             logfunc('Error on argument -o (input type)')
@@ -385,7 +382,10 @@ def crunch_artifacts(
         files_found = []
         log.write(f'<b>For {plugin.name} module</b>')
         for artifact_search_regex in search_regexes:
-            found = seeker.search(artifact_search_regex)
+            if artifact_search_regex in seeker.searched:
+                found = seeker.searched[artifact_search_regex]
+            else:
+                found = seeker.search(artifact_search_regex)
             if not found:
                 log.write(f'<ul><li>No file found for regex <i>{artifact_search_regex}</i></li></ul>')
             else:

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -128,10 +128,8 @@ def ValidateInput():
     elif not os.path.exists(i_path):
         tk_msgbox.showerror(title='Error', message='INPUT file/folder does not exist!', parent=main_window)
         return False, ext_type
-    elif os.path.isdir(i_path) and os.path.exists(os.path.join(i_path, 'Manifest.db')):
+    elif os.path.isdir(i_path) and (os.path.exists(os.path.join(i_path, 'Manifest.db')) or os.path.exists(os.path.join(i_path, 'Manifest.mbdb'))):
         ext_type = 'itunes'
-    elif os.path.isdir(i_path) and os.path.exists(os.path.join(i_path, 'Manifest.mbdb')):
-        ext_type = 'itunes-mbdb'
     elif os.path.isdir(i_path):
         ext_type = 'fs'
     else:

--- a/scripts/artifacts/ATXDatastore.py
+++ b/scripts/artifacts/ATXDatastore.py
@@ -35,7 +35,7 @@ def get_atxDatastore(files_found, report_folder, seeker, wrap_text, timezone_off
     db = open_sqlite_db_readonly(atxdb)
     cursor = db.cursor()
 
-    cursor.execute(f'''ATTACH DATABASE "{localdb}" AS Local ''')
+    cursor.execute(f'''ATTACH DATABASE "file:{localdb}?mode=ro" AS Local ''')
     cursor.execute('''
     SELECT 
         alog.id AS Id,

--- a/scripts/artifacts/Health.py
+++ b/scripts/artifacts/Health.py
@@ -54,7 +54,7 @@ def get_Health(files_found, report_folder, seeker, wrap_text, timezone_offset):
     db = open_sqlite_db_readonly(healthdb_secure)
     cursor = db.cursor()
 
-    cursor.execute('''attach database "''' + healthdb + '''" as healthdb ''')
+    cursor.execute('''ATTACH DATABASE "file:''' + healthdb + '''?mode=ro" AS healthdb ''')
 
     iOS_version = scripts.artifacts.artGlobals.versionf
 

--- a/scripts/artifacts/addressBook.py
+++ b/scripts/artifacts/addressBook.py
@@ -55,8 +55,8 @@ def get_addressBook(files_found, report_folder, seeker, wrap_text, timezone_offs
     
     db = open_sqlite_db_readonly(address_book_db)
     cursor = db.cursor()
-
-    cursor.execute('''ATTACH DATABASE "''' + address_book_images_db + '''" AS ABI ''')
+    
+    cursor.execute('''ATTACH DATABASE "file:''' + address_book_images_db + '''?mode=ro" AS ABI ''')
 
     cursor.execute('''SELECT    
     ABPerson.ROWID,

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -27,7 +27,7 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text, timezone_offset):
             data_list = []
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
-            cursor.execute(f"ATTACH DATABASE '{attachdb}' as AwemeIM;")
+            cursor.execute(f'ATTACH DATABASE "file:{attachdb}?mode=ro" as AwemeIM;')
             cursor.execute("SELECT name FROM AwemeIM.sqlite_master WHERE type='table' and name like 'AwemeContactsV%';")
             table_results = cursor.fetchall()
 

--- a/scripts/artifacts/tikTokReplied.py
+++ b/scripts/artifacts/tikTokReplied.py
@@ -27,7 +27,7 @@ def get_tiktok_replied(files_found, report_folder, seeker, wrap_text, timezone_o
             data_list = []
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
-            cursor.execute(f"ATTACH DATABASE '{attachdb}' as AwemeIM;")
+            cursor.execute(f'ATTACH DATABASE "file:{attachdb}?mode=ro" as AwemeIM;')
             cursor.execute("SELECT name FROM AwemeIM.sqlite_master WHERE type='table' and name like 'AwemeContactsV%';")
             table_results = cursor.fetchall()
 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -96,7 +96,7 @@ class OutputParameters:
         currenttime = str(now.strftime('%Y-%m-%d_%A_%H%M%S'))
         self.report_folder_base = os.path.join(output_folder,
                                                'iLEAPP_Reports_' + currenttime)  # aleapp , aleappGUI, ileap_artifacts, report.py
-        self.temp_folder = os.path.join(self.report_folder_base, 'temp')
+        self.temp_folder = os.path.join(self.report_folder_base, 'data')
         OutputParameters.screen_output_file_path = os.path.join(self.report_folder_base, 'Script Logs',
                                                                 'Screen Output.html')
         OutputParameters.screen_output_file_path_devinfo = os.path.join(self.report_folder_base, 'Script Logs',
@@ -164,11 +164,8 @@ def convert_ts_human_to_timezone_offset(ts, timezone_offset):
 
 def convert_plist_date_to_timezone_offset(plist_date, timezone_offset):
     if plist_date:
-        str_date = '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
-            plist_date.year, plist_date.month, plist_date.day, 
-            plist_date.hour, plist_date.minute, plist_date.second
-            )
-        iso_date = datetime.fromisoformat(str_date).strftime("%Y-%m-%d %H:%M:%S")
+        plist_date = datetime.strptime(plist_date, '%Y-%m-%dT%H:%M:%SZ')
+        iso_date = plist_date.strftime("%Y-%m-%d %H:%M:%S")
         return convert_ts_human_to_timezone_offset(iso_date, timezone_offset)
     else:
         return plist_date

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -33,6 +33,7 @@ class FileSeekerDir(FileSeekerBase):
         logfunc('Building files listing...')
         self.build_files_list(directory)
         logfunc(f'File listing complete - {len(self._all_files)} files')
+        self.searched = {}
 
     def build_files_list(self, directory):
         '''Populates all paths in directory into _all_files'''
@@ -51,12 +52,15 @@ class FileSeekerDir(FileSeekerBase):
         if return_on_first_hit:
             for item in self._all_files:
                 if pat( root + normcase(item) ) is not None:
+                    self.searched[filepattern] = [item]
                     return [item]
+            self.searched[filepattern] = []
             return []
         pathlist = []
         for item in self._all_files:
             if pat( root + normcase(item) ) is not None:
                 pathlist.append(item)
+        self.searched[filepattern] = pathlist
         return pathlist
 
 class FileSeekerItunes(FileSeekerBase):
@@ -66,10 +70,17 @@ class FileSeekerItunes(FileSeekerBase):
         self._all_files = {}
         self.temp_folder = temp_folder
         logfunc('Building files listing...')
-        self.build_files_list(directory)
+        if os.path.exists(os.path.join(directory, "Manifest.db")):
+            self.build_files_list_from_manifest_db(directory)
+            self.backup_type = "Manifest.db"
+        elif os.path.exists(os.path.join(directory, "Manifest.mbdb")):
+            self.build_files_list_from_manifest_mbdb(directory)
+            self.backup_type = "Manifest.mbdb"
         logfunc(f'File listing complete - {len(self._all_files)} files')
+        self.searched = {}
+        self.copied = set()
     
-    def build_files_list(self, directory):
+    def build_files_list_from_manifest_db(self, directory):
         '''Populates paths from Manifest.db files into _all_files'''
         try: 
             db = open_sqlite_db_readonly(os.path.join(directory, "Manifest.db"))
@@ -99,34 +110,7 @@ class FileSeekerItunes(FileSeekerBase):
             logfunc(f'Error opening Manifest.db from {directory}, ' + str(ex))
             raise ex
 
-    def search(self, filepattern, return_on_first_hit=False):
-        pathlist = []
-        matching_keys = fnmatch.filter(self._all_files, filepattern)
-        for relative_path in matching_keys:
-            hash_filename = self._all_files[relative_path]
-            original_location = os.path.join(self.directory, hash_filename[:2], hash_filename)
-            temp_location = os.path.join(self.temp_folder, sanitize_file_path(relative_path))
-            if is_platform_windows():
-                temp_location = temp_location.replace('/', '\\')
-            try:
-                os.makedirs(os.path.dirname(temp_location), exist_ok=True)
-                copyfile(original_location, temp_location)
-                pathlist.append(temp_location)
-            except Exception as ex:
-                logfunc(f'Could not copy {original_location} to {temp_location} ' + str(ex))
-        return pathlist
-
-class FileSeekerItunesMbdb(FileSeekerBase):
-    def __init__(self, directory, temp_folder):
-        FileSeekerBase.__init__(self)
-        self.directory = directory
-        self._all_files = {}
-        self.temp_folder = temp_folder
-        logfunc('Building files listing...')
-        self.build_files_list(directory)
-        logfunc(f'File listing complete - {len(self._all_files)} files')
-    
-    def build_files_list(self, directory):
+    def build_files_list_from_manifest_mbdb(self, directory):
         '''Populates paths from Manifest.mbdb files into _all_files'''
         def getint(data, offset, intsize):
             """Retrieve an integer (big-endian) and new offset from the current offset"""
@@ -194,18 +178,23 @@ class FileSeekerItunesMbdb(FileSeekerBase):
         matching_keys = fnmatch.filter(self._all_files, filepattern)
         for relative_path in matching_keys:
             hash_filename = self._all_files[relative_path]
-            original_location = os.path.join(self.directory, hash_filename)
+            if self.backup_type == "Manifest.db":
+                original_location = os.path.join(self.directory, hash_filename[:2], hash_filename)
+            else:
+                original_location = os.path.join(self.directory, hash_filename)
             temp_location = os.path.join(self.temp_folder, sanitize_file_path(relative_path))
             if is_platform_windows():
                 temp_location = temp_location.replace('/', '\\')
-            try:
-                os.makedirs(os.path.dirname(temp_location), exist_ok=True)
-                copyfile(original_location, temp_location)
-                pathlist.append(temp_location)
-            except Exception as ex:
-                logfunc(f'Could not copy {original_location} to {temp_location} ' + str(ex))
+            if original_location not in self.copied:
+                try:
+                    os.makedirs(os.path.dirname(temp_location), exist_ok=True)
+                    copyfile(original_location, temp_location)
+                    self.copied.add(original_location)
+                except Exception as ex:
+                    logfunc(f'Could not copy {original_location} to {temp_location} ' + str(ex))
+            pathlist.append(temp_location)
+        self.searched[filepattern] = pathlist
         return pathlist
-
 
 
 class FileSeekerTar(FileSeekerBase):
@@ -216,6 +205,8 @@ class FileSeekerTar(FileSeekerBase):
         self.tar_file = tarfile.open(tar_file_path, mode)
         self.temp_folder = temp_folder
         self.directory = temp_folder
+        self.searched = {}
+        self.copied = set()
 
     def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
@@ -223,22 +214,26 @@ class FileSeekerTar(FileSeekerBase):
         root = normcase("root/")
         for member in self.tar_file.getmembers():
             if pat( root + normcase(member.name) ) is not None:
-                try:
-                    clean_name = sanitize_file_path(member.name)
-                    full_path = os.path.join(self.temp_folder, Path(clean_name))
-                    if member.isdir():
-                        os.makedirs(full_path, exist_ok=True)
-                    else:
-                        parent_dir = os.path.dirname(full_path)
-                        if not os.path.exists(parent_dir):
-                            os.makedirs(parent_dir)
-                        with open(full_path, "wb") as fout:
-                            fout.write(tarfile.ExFileObject(self.tar_file, member).read())
-                            fout.close()
-                        os.utime(full_path, (member.mtime, member.mtime))
-                    pathlist.append(full_path)
-                except Exception as ex:
-                    logfunc(f'Could not write file to filesystem, path was {member.name} ' + str(ex))
+                clean_name = sanitize_file_path(member.name)
+                full_path = os.path.join(self.temp_folder, Path(clean_name))
+                if member.name not in self.copied:
+                    try:
+                        if full_path not in self.copied:
+                            if member.isdir():
+                                os.makedirs(full_path, exist_ok=True)
+                            else:
+                                parent_dir = os.path.dirname(full_path)
+                                if not os.path.exists(parent_dir):
+                                    os.makedirs(parent_dir)
+                                with open(full_path, "wb") as fout:
+                                    fout.write(tarfile.ExFileObject(self.tar_file, member).read())
+                                    fout.close()
+                                    self.copied.add(member.name)
+                                os.utime(full_path, (member.mtime, member.mtime))
+                    except Exception as ex:
+                        logfunc(f'Could not write file to filesystem, path was {member.name} ' + str(ex))
+                pathlist.append(full_path)
+        self.searched[filepattern] = pathlist
         return pathlist
 
     def cleanup(self):
@@ -251,23 +246,30 @@ class FileSeekerZip(FileSeekerBase):
         self.name_list = self.zip_file.namelist()
         self.temp_folder = temp_folder
         self.directory = temp_folder
+        self.searched = {}
+        self.copied = set()
 
     def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
         pat = _compile_pattern( normcase(filepattern) )
         root = normcase("root/")
         for member in self.name_list:
+            if member.startswith("__MACOSX"):
+                continue
             if pat( root + normcase(member) ) is not None:
-                try:
-                    extracted_path = self.zip_file.extract(member, path=self.temp_folder) # already replaces illegal chars with _ when exporting
-                    f = self.zip_file.getinfo(member)
-                    date_time = f.date_time
-                    date_time = timex.mktime(date_time + (0, 0, -1))
-                    os.utime(extracted_path, (date_time, date_time))
-                    pathlist.append(extracted_path)
-                except Exception as ex:
-                    member = member.lstrip("/")
-                    logfunc(f'Could not write file to filesystem, path was {member} ' + str(ex))
+                if member not in self.copied:
+                    try:
+                        extracted_path = self.zip_file.extract(member, path=self.temp_folder) # already replaces illegal chars with _ when exporting
+                        self.copied.add(member)
+                        f = self.zip_file.getinfo(member)
+                        date_time = f.date_time
+                        date_time = timex.mktime(date_time + (0, 0, -1))
+                        os.utime(extracted_path, (date_time, date_time))
+                    except Exception as ex:
+                        member = member.lstrip("/")
+                        logfunc(f'Could not write file to filesystem, path was {member} ' + str(ex))
+                pathlist.append(os.path.join(self.temp_folder, member))
+        self.searched[filepattern] = pathlist
         return pathlist
 
     def cleanup(self):


### PR DESCRIPTION
- In the report folder, `temp` directory was renamed `data`
- Convert_plist_date_to_timezone_offset function updated
- Fix SQLite database attached in SQL queries in read-write mode
- Improve regex searches:
  - When a module uses a regex already processed by another one, the result of the previous searching operation is returned. Files are not searched again in the input source
  - Check if a file was already copied in the report folder to avoid duplicate copy operations
  - For Mac archives, __MACOSX folder is now ignored
- iTunes Backups (Manifest.db and Manifest.mbdb) use the same -itunes parameter instead of -itunes and itunes-mbdb. Duplicate code was removed. 