### PR TITLE
resolve kml error issue with 'all' in output_types

### DIFF
--- a/scripts/artifacts/ATXDatastore.py
+++ b/scripts/artifacts/ATXDatastore.py
@@ -3,13 +3,13 @@ __artifacts_v2__ = {
         "name": "iOS ATXDatastore",
         "description": "Parses ATXDataStore and matches actions with Frequent locations, when available.",
         "author": "@magpol",
-        "version": "0.0.3",
-        "date": "2023-11-21",
+        "version": "0.1.4",
+        "date": "2023-10-11",
         "requirements": "none",
         "category": "Location",
         "notes": "",
         "paths": ('*DuetExpertCenter/_ATXDataStore.db*', '*routined/Local.sqlite*'),
-        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml']
+        "output_types": "all"
     }
 }
 

--- a/scripts/artifacts/accountConfig.py
+++ b/scripts/artifacts/accountConfig.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Account Configuration",
         "description": "Extracts account configuration information",
         "author": "@AlexisBrignoni",
-        "version": "0.2",
-        "date": "2022-08-09",
+        "version": "0.1.3",
+        "date": "2020-04-30",
         "requirements": "none",
         "category": "Accounts",
         "notes": "",
@@ -27,5 +27,5 @@ def get_confaccts(files_found, report_folder, seeker, wrap_text, timezone_offset
         for key, val in pl.items():
             data_list.append((key, val))
     
-    data_headers = ('Key', 'Data')
+    data_headers = ('Account ID', 'Data Value')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/accountData.py
+++ b/scripts/artifacts/accountData.py
@@ -3,13 +3,13 @@ __artifacts_v2__ = {
         "name": "Account Data",
         "description": "Extract information about configured user accounts",
         "author": "@AlexisBrignoni",
-        "version": "0.2",
-        "date": "2023-11-21",
+        "version": "0.4.3",
+        "date": "2020-04-30",
         "requirements": "none",
         "category": "Accounts",
         "notes": "",
         "paths": ('*/mobile/Library/Accounts/Accounts3.sqlite*'),
-        "output_types": "all"
+        "output_types": "standard"
     }
 }
 

--- a/scripts/artifacts/advertisingID.py
+++ b/scripts/artifacts/advertisingID.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Advertising Identifier",
         "description": "Extract Apple advertising identifier",
         "author": "@AlexisBrignoni",
-        "version": "0.2",
-        "date": "2024-05-09",
+        "version": "0.2.1",
+        "date": "2023-10-03",
         "requirements": "none",
         "category": "Identifiers",
         "notes": "",
@@ -31,5 +31,5 @@ def get_adId(files_found, report_folder, seeker, wrap_text, timezone_offset):
                 id_values.append(f"<b>Apple Advertising Identifier: </b>{val}")
 
     device_info("Advertising Identifier", id_values)
-    data_headers = ('Key', 'Data')
+    data_headers = ('Identifier', 'Data Value')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/airdropId.py
+++ b/scripts/artifacts/airdropId.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Airdrop ID",
         "description": "Extract Airdrop ID",
         "author": "@AlexisBrignoni",
-        "version": "0.2",
-        "date": "2024-05-09",
+        "version": "0.2.1",
+        "date": "2023-10-03",
         "requirements": "none",
         "category": "Identifiers",
         "notes": "",
@@ -30,6 +30,6 @@ def get_airdropId(files_found, report_folder, seeker, wrap_text, timezone_offset
                 data_list.append('Airdrop ID', val)
                 id_values.append(f"<b>Airdrop ID: </b>{val}")
 
-    data_headers = ('Key', 'Data')
+    data_headers = ('Identifer', 'Data Value')
     device_info("Airdrop", id_values)
     return data_headers, data_list, source_path

--- a/scripts/artifacts/alarms.py
+++ b/scripts/artifacts/alarms.py
@@ -3,13 +3,13 @@ __artifacts_v2__ = {
         "name": "Alarms",
         "description": "Extraction of alarms set",
         "author": "Anna-Mariya Mateyna",
-        "version": "0.5",
-        "date": "2023-10-11",
+        "version": "0.3",
+        "date": "2021-01-17",
         "requirements": "none",
         "category": "Alarms",
         "notes": "",
         "paths": ('*/mobile/Library/Preferences/com.apple.mobiletimerd.plist',),
-        "output_types": "all"
+        "output_types": "standard"
     }
 }
 

--- a/scripts/artifacts/appGrouplisting.py
+++ b/scripts/artifacts/appGrouplisting.py
@@ -3,14 +3,14 @@ __artifacts_v2__ = {
         "name": "Bundle ID by AppGroup & PluginKit IDs",
         "description": "List can included once installed but not present apps. Each file is named .com.apple.mobile_container_manager.metadata.plist",
         "author": "@AlexisBrignoni",
-        "version": "0.1",
-        "date": "2022-09-20",
+        "version": "0.3",
+        "date": "2020-09-22",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/Containers/Shared/AppGroup/*/.com.apple.mobile_container_manager.metadata.plist', '**/PluginKitPlugin/*.metadata.plist',),
         "function": "get_appGrouplisting",
-        "output_types": "all"
+        "output_types": ["html", "tsv", "lava"]
     }
 }
 
@@ -59,6 +59,6 @@ def get_appGrouplisting(files_found, report_folder, seeker, wrap_text, timezone_
     else:
         logfunc('No data on Bundle ID - AppGroup ID - PluginKit ID')
         """
-        data_headers = ('Bundle ID','Type','Directory GUID','Path')
+        data_headers = ('Bundle ID', 'Type', 'Directory GUID', 'Path')
         return data_headers, data_list, filelocdesc
     

--- a/scripts/artifacts/appItunesmeta.py
+++ b/scripts/artifacts/appItunesmeta.py
@@ -3,14 +3,14 @@ __artifacts_v2__ = {
         "name": "Apps - Itunes Metadata",
         "description": "iTunes & Bundle ID Metadata contents for apps",
         "author": "@AlexisBrignoni",
-        "version": "0.1",
-        "date": "2020-08-03",
+        "version": "0.2",
+        "date": "2020-10-04",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/iTunesMetadata.plist', '**/BundleMetadata.plist',),
         "function": "get_appItunesmeta",
-        "output_types": "all"
+        "output_types": "standard"
     }
 }
 
@@ -25,8 +25,7 @@ import pytz
 
 #from scripts.artifact_report import ArtifactHtmlReport
 #from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-from scripts.ilapfuncs import artifact_processor
-from scripts.ilapfuncs import convert_ts_human_to_utc, convert_ts_human_to_timezone_offset, convert_utc_human_to_timezone, convert_time_obj_to_utc
+from scripts.ilapfuncs import artifact_processor, convert_ts_human_to_timezone_offset, convert_time_obj_to_utc
 
 def convert_plist_date_to_timezone_offset_b(plist_date, timezone_offset):
     if plist_date:
@@ -103,7 +102,21 @@ def get_appItunesmeta(files_found, report_folder, seeker, wrap_text, timezone_of
     else:
         logfunc('No data on Apps - Itunes Bundle Metadata')
         """
-        data_headers = (('Installed Date','datetime'), ('App Purchase Date','datetime'),'Bundle ID', 'Item Name', 'Artist Name', 'Version Number', 'Downloaded by', 'Genre', 'Factory Install', 'App Release Date', 'Source App', 'Sideloaded?', 'Variant ID', 'Source File Location')
+        data_headers = (
+            ('Installed Date','datetime'), 
+            ('App Purchase Date','datetime'),
+            'Bundle ID', 
+            'Item Name', 
+            'Artist Name', 
+            'Version Number', 
+            'Downloaded by', 
+            'Genre', 
+            'Factory Install', 
+            'App Release Date', 
+            'Source App', 
+            'Sideloaded?', 
+            'Variant ID', 
+            'Source File Location')
         return data_headers, data_list, fileloc
         
 

--- a/scripts/artifacts/appleMapsApplication.py
+++ b/scripts/artifacts/appleMapsApplication.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Data/Application/*/Library/Preferences/com.apple.Maps.plist'),
         "function": "get_appleMapsApplication",
-        "output_types": "all"
+        "output_types": ["html", "tsv", "lava"]
     }
 }
 
@@ -20,8 +20,7 @@ import blackboxprotobuf
 import scripts.artifacts.artGlobals
 
 #from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows
-from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data
+from scripts.ilapfuncs import logfunc, tsv, lava_process_artifact, lava_insert_sqlite_data
 
 def get_appleMapsApplication(files_found, report_folder, seeker, wrap_text, timezone_offset):
     versionnum = 0
@@ -61,7 +60,8 @@ def get_appleMapsApplication(files_found, report_folder, seeker, wrap_text, time
             data_headers = ['Latitude','Longitude']
             
         
-            table_name1, object_columns1, column_map1 = lava_process_artifact(category, module_name, 'Apple Maps Last Activity Camera', data_headers, len(data_list))
+            table_name1, object_columns1, column_map1 = lava_process_artifact(
+                category, module_name, 'Apple Maps Last Activity Camera', data_headers, len(data_list))
             lava_insert_sqlite_data(table_name1, data_list, object_columns1, data_headers, column_map1)
         
         else:

--- a/scripts/artifacts/applicationstate.py
+++ b/scripts/artifacts/applicationstate.py
@@ -3,14 +3,14 @@ __artifacts_v2__ = {
         "name": "Application State",
         "description": "Extract information about bundle container path and data path for Applications",
         "author": "@AlexisBrignoni",
-        "version": "0.2",
-        "date": "2023-11-21",
+        "version": "0.2.2",
+        "date": "2020-04-30",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/mobile/Library/FrontBoard/applicationState.db*'),
         "function": "get_applicationstate",
-        "output_types": "all"
+        "output_types": ["html", "tsv", "lava"]
     }
 }
 
@@ -93,7 +93,7 @@ def get_applicationstate(files_found, report_folder, seeker, wrap_text, timezone
         tsvname = 'Application State'
         tsv(report_folder, data_headers, data_list, tsvname)
     '''
-        data_headers = ('Bundle ID','Bundle Path','Sandbox Path')
+        data_headers = ('Bundle ID', 'Bundle Path', 'Sandbox Path')
         return data_headers, data_list, file_found
     
     else:

--- a/scripts/artifacts/callHistory.py
+++ b/scripts/artifacts/callHistory.py
@@ -2,14 +2,14 @@ __artifacts_v2__ = {
     "get_callHistory": {
         "name": "Call History",
         "description": "Extract Call History",
-        "author": "",
-        "version": "0.5",
-        "date": "2023-01-01",
+        "author": "@AlexisBrignoni",
+        "version": "0.7",
+        "date": "2020-04-30",
         "requirements": "none",
         "category": "Call History",
         "notes": "",
         "paths": ('*/CallHistory.storedata*','*/call_history.db',),
-        "output_types": "all"
+        "output_types": "standard"
     }
 }
 

--- a/scripts/artifacts/tcc.py
+++ b/scripts/artifacts/tcc.py
@@ -3,13 +3,13 @@ __artifacts_v2__ = {
         "name": "Application Permissions",
         "description": "Extract application permissions from TCC.db database",
         "author": "@AlexisBrignoni - @KevinPagano3 - @johannplw",
-        "version": "0.6.1",
-        "date": "2023-11-21",
+        "version": "0.7.2",
+        "date": "2020-12-15",
         "requirements": "none",
         "category": "App Permissions",
         "notes": "",
         "paths": ('*/mobile/Library/TCC/TCC.db*',),
-        "output_types": "all",
+        "output_types": "standard",
         "function": "get_tcc"
     }
 }
@@ -96,14 +96,15 @@ def get_tcc(files_found, report_folder, seeker, wrap_text, timezone_offset):
         timeline(report_folder, tlactivity, data_list, data_headers)
         """
         if last_modified_timestamp:
-            data_headers = (('Last Modified Timestamp', 'datetime'), 'Bundle ID', 'Service','Access')
+            data_headers = (
+                ('Last Modified Timestamp', 'datetime'), 
+                'Bundle ID', 
+                'Service', 
+                'Access')
         else:
-            data_headers = ('Bundle ID', 'Service','Access','Prompt Count')    
+            data_headers = ('Bundle ID', 'Service', 'Access', 'Prompt Count')    
         
         return data_headers, data_list, file_found
         
-    else:
-        logfunc('No data available in TCC database.')
-    
     db.close()
     

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -41,6 +41,8 @@ def strip_tuple_from_headers(data_headers):
 def check_output_types(type, output_types):
     if type in output_types or type == output_types or 'all' in output_types or 'all' == output_types:
         return True
+    elif type != 'kml' and ('standard' in output_types or 'standard' == output_types):
+        return True
     else:
         return False
 
@@ -445,6 +447,8 @@ def timeline(report_folder, tlactivity, data_list, data_headers):
     db.close()
 
 def kmlgen(report_folder, kmlactivity, data_list, data_headers):
+    if 'Longitude' not in data_list or 'Latitude' not in data_list:
+        return
     report_folder = report_folder.rstrip('/')
     report_folder = report_folder.rstrip('\\')
     report_folder_base = os.path.dirname(os.path.dirname(report_folder))


### PR DESCRIPTION
- `standard` output type was added and export data in HTML, TSV, Timeline and LAVA
- `all` output type is now used to export data in HTML, TSV, Timeline, kml and LAVA
- kml func retracts if there is no timestamp, longitude and latitude column in data_headers
- artifacts were updated to reflect `standard` output type