### PR TITLE
Fix issues with iTunes backups

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -164,23 +164,28 @@ def main():
     profile_filename = None
     casedata = {}
 
-    plugins = []
-    plugins_parsed_first = []
-
-    for plugin in available_plugins:
-        if plugin.module_name == 'lastBuild':
-            plugins_parsed_first.append(plugin)
-        elif plugin.module_name != 'iTunesBackupInfo':
-            plugins.append(plugin)
-
-    selected_plugins = plugins.copy()
-
     # Check if no arguments were provided
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit()
 
     args = parser.parse_args()
+
+    extracttype = args.t
+
+    plugins = []
+    plugins_parsed_first = []
+
+    for plugin in available_plugins:
+        if plugin.module_name == 'lastBuild':
+            if extracttype == 'itunes':
+                continue
+            else:
+                plugins_parsed_first.append(plugin)
+        elif plugin.module_name != 'iTunesBackupInfo':
+            plugins.append(plugin)
+
+    selected_plugins = plugins.copy()
 
     try:
         validate_args(args)
@@ -283,7 +288,6 @@ def main():
                 return
     
     input_path = args.input_path
-    extracttype = args.t
     wrap_text = args.wrap_text
     output_path = os.path.abspath(args.output_path)
     time_offset = args.timezone

--- a/ileapp.py
+++ b/ileapp.py
@@ -364,6 +364,13 @@ def crunch_artifacts(
         if os.path.exists(info_plist_path):
             # process_artifact([info_plist_path], 'iTunesBackupInfo', 'Device Info', seeker, out_params.report_folder_base)
             #plugin.method([info_plist_path], out_params.report_folder_base, seeker, wrap_text)
+            report_folder = os.path.join(out_params.report_folder_base, '_HTML')
+            if not os.path.exists(report_folder):
+                try:
+                    os.makedirs(report_folder)
+                except (FileExistsError, FileNotFoundError) as ex:
+                    logfunc('Error creating report directory at path {}'.format(report_folder))
+                    logfunc('Error was {}'.format(str(ex)))
             loader["iTunesBackupInfo"].method([info_plist_path], out_params.report_folder_base, seeker, wrap_text, time_offset)
             #del search_list['lastBuild'] # removing lastBuild as this takes its place
             print([info_plist_path])  # TODO Remove special consideration for itunes? Merge into main search

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -172,7 +172,8 @@ def process(casedata):
 
         # re-create modules list based on user selection
         selected_modules = get_selected_modules()
-        selected_modules.insert(0, 'lastBuild')  # Force lastBuild as first item to be parsed
+        if extracttype != 'itunes':
+            selected_modules.insert(0, 'lastBuild')  # Force lastBuild as first item to be parsed
         selected_modules = [loader[module] for module in selected_modules]
         progress_bar.config(maximum=len(selected_modules))
         casedata = {key: value.get() for key, value in casedata.items()}


### PR DESCRIPTION
- Fix path issue with special processing iTunesBackup module
  - When no files or records were found for all selected modules, the button `Close & Open report` did not appear. As this module is executed first and not in the normal flow, temp HTML files were not created in the _HTML folder causing an error for final report generation.
  
- lastBuild is not executed anymore with iTunes backups.