### PR TITLE
Chrome Fix and TextInputSession Fix

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1463,6 +1463,7 @@ def chromeOfflinePages(files_found, report_folder, seeker, wrap_text, timezone_o
     return all_data_headers, all_data, report_file
 
 
+@artifact_processor
 def chromeMediaHistorySessions(files_found, report_folder, seeker, wrap_text, timezone_offset):
     # all_data will be a consolidated list of all browsers with an extra column to discriminate the browser
     all_data = []


### PR DESCRIPTION
Text Input Session Fixes #804 - Apparently the timestamp is cocoacore time on older ios versions when in "public" folder, and now its unix time in "restricted" folder