### PR TITLE
New `get_sqlite_db_records(path, query)` function

### DIFF
--- a/scripts/artifacts/subscriberInfo.py
+++ b/scripts/artifacts/subscriberInfo.py
@@ -15,35 +15,33 @@ __artifacts_v2__ = {
 }
 
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_timezone_offset, device_info
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, convert_cocoa_core_data_ts_to_utc, device_info
 
 @artifact_processor
 def subscriberInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
     data_list = []
     db_file = ''
+    db_records = []
+
+    query = '''
+    SELECT
+        last_update_time,
+        slot_id,
+        subscriber_id,
+        subscriber_mdn
+    FROM subscriber_info
+    '''
 
     for file_found in files_found:
         if file_found.endswith('CellularUsage.db'):
             db_file = file_found
+            db_records = get_sqlite_db_records(db_file, query)
             break
-    
-    with open_sqlite_db_readonly(db_file) as db:
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-            datetime(last_update_time+978307200,'unixepoch'),
-            slot_id,
-            subscriber_id,
-            subscriber_mdn
-        FROM subscriber_info
-        ''')
 
-        all_rows = cursor.fetchall()
-
-        for row in all_rows:
-            last_update_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            data_list.append((last_update_time, row[1], row[2], row[3]))
-            device_info("Cellular", "SIM Cards", f"Slot {row[1]} -> ICCID: {row[2]} | MSISDN: {row[3]} | Last Update: {last_update_time}", db_file)
+    for record in db_records:
+        last_update_time = convert_cocoa_core_data_ts_to_utc(record[0])
+        data_list.append((last_update_time, record[1], record[2], record[3]))
+        device_info("Cellular", "SIM Cards", f"Slot {record[1]} -> ICCID: {record[2]} | MSISDN: {record[3]} | Last Update: {last_update_time}", db_file)
 
     data_headers = (
         ('Last update time', 'datetime'),
@@ -51,4 +49,5 @@ def subscriberInfo(files_found, report_folder, seeker, wrap_text, timezone_offse
         'ICCID', 
         'MSISDN', 
         )
+    
     return data_headers, data_list, db_file


### PR DESCRIPTION
Add new `get_sqlite_db_records(path, query)` function to handle SQLite databases properly.
`subscriberInfo` module was updated with this new function.

Old code:
```python3
__artifacts_v2__ = {...}

from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_timezone_offset, device_info

@artifact_processor
def subscriberInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
    data_list = []
    db_file = ''

    for file_found in files_found:
        if file_found.endswith('CellularUsage.db'):
            db_file = file_found
            break
    
    with open_sqlite_db_readonly(db_file) as db:
        cursor = db.cursor()
        cursor.execute('''
        SELECT
            datetime(last_update_time+978307200,'unixepoch'),
            slot_id,
            subscriber_id,
            subscriber_mdn
        FROM subscriber_info
        ''')

        all_rows = cursor.fetchall()

        for row in all_rows:
            last_update_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
            data_list.append((last_update_time, row[1], row[2], row[3]))
            device_info("Cellular", "SIM Cards", f"Slot {row[1]} -> ICCID: {row[2]} | MSISDN: {row[3]} | Last Update: {last_update_time}", db_file)

    data_headers = (
        ('Last update time', 'datetime'),
        'Slot ID',
        'ICCID', 
        'MSISDN', 
        )
    return data_headers, data_list, db_file
```

New code:
```python3
__artifacts_v2__ = {...}

from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, convert_cocoa_core_data_ts_to_utc, device_info

@artifact_processor
def subscriberInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
    data_list = []
    db_file = ''
    db_records = []

    query = '''
    SELECT
        last_update_time,
        slot_id,
        subscriber_id,
        subscriber_mdn
    FROM subscriber_info
    '''

    for file_found in files_found:
        if file_found.endswith('CellularUsage.db'):
            db_file = file_found
            db_records = get_sqlite_db_records(db_file, query)
            break

    for record in db_records:
        last_update_time = convert_cocoa_core_data_ts_to_utc(record[0])
        data_list.append((last_update_time, record[1], record[2], record[3]))
        device_info("Cellular", "SIM Cards", f"Slot {record[1]} -> ICCID: {record[2]} | MSISDN: {record[3]} | Last Update: {last_update_time}", db_file)

    data_headers = (
        ('Last update time', 'datetime'),
        'Slot ID',
        'ICCID', 
        'MSISDN', 
        )
    
    return data_headers, data_list, db_file
```