### PR TITLE
detect proper file based on ios version comments

### DIFF
--- a/scripts/artifacts/idstatuscache.py
+++ b/scripts/artifacts/idstatuscache.py
@@ -17,6 +17,8 @@ __artifacts_v2__ = {
 import plistlib
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, convert_ts_int_to_utc, convert_utc_human_to_timezone
+import scripts.artifacts.artGlobals
+from packaging import version
 
 # service type and partner
 def get_service_type_and_partner(value : str):
@@ -333,7 +335,13 @@ def get_idstatuscache(files_found, report_folder, seeker, wrap_text, timezone_of
         
     for file_found in files_found:
         # com.apple.identityservices.idstatuscache.plist (until iOS 14.6.0)
-        # idstatuscache.plist (from iOS 14.7.0)           
-        if file_found.endswith('com.apple.identityservices.idstatuscache.plist') or file_found.endswith('idstatuscache.plist'):
-            get_identity_services(file_found, identifiers, report_folder, timezone_offset)
-            break
+        # idstatuscache.plist (from iOS 14.7.0)
+        iosversion = scripts.artifacts.artGlobals.versionf
+        if version.parse(iosversion) < version.parse("14.7.0"):
+            if file_found.endswith('com.apple.identityservices.idstatuscache.plist'):
+                get_identity_services(file_found, identifiers, report_folder, timezone_offset)
+                break
+        elif version.parse(iosversion) >= version.parse("14.7.0"):
+            if not file_found.endswith('com.apple.identityservices.idstatuscache.plist') and file_found.endswith('idstatuscache.plist'):
+                get_identity_services(file_found, identifiers, report_folder, timezone_offset)
+                break


### PR DESCRIPTION
detect proper file to process based on ios version. Without this code, the opposite file may be present but empty and the loop broke early and never processed the correct file for the ios version in use. 