### PR TITLE
Update ilapfuncs.py : media datatype for exports

### DIFF
--- a/scripts/artifacts/voicemail.py
+++ b/scripts/artifacts/voicemail.py
@@ -80,7 +80,6 @@ def voicemail(files_found, report_folder, seeker, wrap_text, timezone_offset):
         audio_filename = f'{record[-1]}.amr'
         audio_file_path = f'*/mobile/Library/Voicemail/{audio_filename}'
         media_item = check_in_media(seeker, audio_file_path, artifact_info)
-        # audio_tag = media_to_html(audio_filename, files_found, report_folder)
         if table_map_exists:
             data_list.append(
                 (timestamp, record[1], record[2], record[3], record[4], media_item.id))
@@ -146,8 +145,6 @@ def deletedVoicemail(files_found, report_folder, seeker, wrap_text, timezone_off
         audio_filename = f'{record[-1]}.amr'
         audio_file_path = f'*/mobile/Library/Voicemail/{audio_filename}'
         media_item = check_in_media(seeker, audio_file_path, artifact_info)
-        # audio_tag = media_to_html(audio_filename, files_found, report_folder)
-        # report.write_artifact_data_table(data_headers, data_list, dirname(file_found), html_no_escape=['Audio File'])
         if table_map_exists:
             data_list.append(
                 (timestamp, record[1], record[2], record[3], record[4], trashed_date, media_item.id))


### PR DESCRIPTION
Update ilapfuncs.py:
- Update `artifact processor` function to detects:
  - `media` datatype in `data_headers`
  - `media_style` in `__artifact_v2__` to be able to customize styles of media items in HTML reports
  - `html_columns` in `__artifact_v2__` to replace previous `html_no_escape` argument in `report.write_artifact_data_table` when manually generating HTML reports
- New `html_media_tag` function to generate HTML reports with columns containing media directly from `artifact processor` function
