### PR TITLE
Update ileapp.py

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -327,7 +327,7 @@ def crunch_artifacts(
     seeker = None
     try:
         if extracttype == 'fs':
-            seeker = FileSeekerDir(input_path)
+            seeker = FileSeekerDir(input_path, out_params.temp_folder)
 
         elif extracttype in ('tar', 'gz'):
             seeker = FileSeekerTar(input_path, out_params.temp_folder)
@@ -425,7 +425,8 @@ def crunch_artifacts(
                 logfunc('Error was {}'.format(str(ex)))
                 logfunc('Exception Traceback: {}'.format(traceback.format_exc()))
                 continue  # nope
-
+        else:
+            logfunc(f"No file found")
         logfunc('{} [{}] artifact completed'.format(plugin.name, plugin.module_name))
     log.close()
 


### PR DESCRIPTION
Add output folder path for FileSeekerDir as files are now extracted into 'data' folder when input is a directory
Add "No file found" into the logs when no matching file was found after starting an artifact.