### PR TITLE
Remove extra calls to os.path.dirname calls, Fixes #1021.

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -589,7 +589,7 @@ def device_info(category, label, value, source_file=""):
 def tsv(report_folder, data_headers, data_list, tsvname):
     report_folder = report_folder.rstrip('/')
     report_folder = report_folder.rstrip('\\')
-    report_folder_base = os.path.dirname(os.path.dirname(report_folder))
+    report_folder_base = report_folder
     tsv_report_folder = os.path.join(report_folder_base, '_TSV Exports')
 
     if os.path.isdir(tsv_report_folder):


### PR DESCRIPTION
This PR just edits one line to remove extra calls to os.path.dirname which were causing the `_TSV Exports` folder to be created two levels higher than intended.

Fixes #1021