### PR TITLE
Add iOS object to get iOS_version in artifacts in read only mode

### DIFF
--- a/scripts/artifacts/iTunesBackupInfo.py
+++ b/scripts/artifacts/iTunesBackupInfo.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Extract information from the Info.plist file of an iTunes backup",
         "author": "@AlexisBrignoni - @johannplw",
         "creation_date": "2023-10-11",
-        "last_update_date": "2025-01-20",
+        "last_update_date": "2025-03-28",
         "requirements": "none",
         "category": "iTunes Backup",
         "notes": "",
@@ -33,10 +33,8 @@ import datetime
 import plistlib
 import scripts.artifacts.artGlobals
 
-from base64 import b64encode
-
 from scripts.ilapfuncs import artifact_processor, \
-    get_file_path, get_plist_file_content, check_in_embedded_media, device_info, logfunc
+    get_file_path, get_plist_file_content, check_in_embedded_media, device_info, logfunc, iOS
 
 @artifact_processor
 def iTunesBackupInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
@@ -50,7 +48,7 @@ def iTunesBackupInfo(files_found, report_folder, seeker, wrap_text, timezone_off
         if isinstance(val, str) or isinstance(val, int) or isinstance(val, datetime.datetime):
             data_list.append((key, val))
             if key == ('Product Version'):
-                scripts.artifacts.artGlobals.versionf = val
+                iOS.set_version(val)
                 logfunc(f"iOS version: {val}")
         elif key == "Applications":
             apps = val

--- a/scripts/artifacts/lastBuild.py
+++ b/scripts/artifacts/lastBuild.py
@@ -3,66 +3,44 @@ __artifacts_v2__ = {
         "name": "iOS Information",
         "description": "Extract iOS information from the LastBuildInfo.plist file",
         "author": "@AlexisBrignoni - @ydkhatri - @stark4n6",
-        "version": "0.5.5",
         "creation_date": "2020-04-30",
-        "last_update_date": "2025-03-27",
+        "last_update_date": "2025-03-28",
         "requirements": "none",
         "category": "IOS Build",
         "notes": "",
-        "paths": ('*/installd/Library/MobileInstallation/LastBuildInfo.plist','*/logs/SystemVersion/SystemVersion.plist'),
+        "paths": (
+            '*/installd/Library/MobileInstallation/LastBuildInfo.plist', 
+            '*/logs/SystemVersion/SystemVersion.plist'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "git-commit"
     }
 }
 
-import scripts.artifacts.artGlobals 
-
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_plist_file_content, logfunc, device_info
+from scripts.ilapfuncs import artifact_processor, \
+    get_file_path, get_plist_file_content, logfunc, device_info, iOS
 
 @artifact_processor
 def lastBuild(files_found, report_folder, seeker, wrap_text, time_offset):
-    for file_found in files_found:
-        file_found = str(file_found)
-        if file_found.endswith('LastBuildInfo.plist'):
-            source_path = get_file_path(files_found, "LastBuildInfo.plist")
-            data_list = []
-            
-            pl = get_plist_file_content(source_path)
-            for key, val in pl.items():
-                data_list.append((key, val))
-                if key == ("ProductVersion"):
-                    scripts.artifacts.artGlobals.versionf = val
-                    logfunc(f"iOS version: {val}")
-                    device_info("Device Information", "iOS version", val, source_path)
-                
-                if key == "ProductBuildVersion":
-                    device_info("Device Information", "ProductBuildVersion", val, source_path)
-                
-                if key == ("ProductName"):
-                    logfunc(f"Product: {val}")
-                    device_info("Device Information", "Product Name", val, source_path)
+    last_build_path = get_file_path(files_found, "LastBuildInfo.plist")
+    system_version_path = get_file_path(files_found, "SystemVersion.plist")
+    source_path = last_build_path if last_build_path else system_version_path
 
-            data_headers = ('Property','Property Value' )     
-            return data_headers, data_list, source_path
-            
-        elif file_found.endswith('SystemVersion.plist'):
-            source_path = get_file_path(files_found, "SystemVersion.plist")
-            data_list = []
-            
-            pl = get_plist_file_content(source_path)
-            for key, val in pl.items():
-                data_list.append((key, val))
-                if key == ("ProductVersion"):
-                    scripts.artifacts.artGlobals.versionf = val
-                    logfunc(f"iOS version: {val}")
-                    device_info("Device Information", "iOS version", val, source_path)
-                
-                if key == "ProductBuildVersion":
-                    device_info("Device Information", "ProductBuildVersion", val, source_path)
-                
-                if key == ("ProductName"):
-                    logfunc(f"Product: {val}")
-                    device_info("Device Information", "Product Name", val, source_path)
+    data_list = []
 
-            data_headers = ('Property','Property Value' )     
-            return data_headers, data_list, source_path
+    pl = get_plist_file_content(source_path)
+    for key, val in pl.items():
+        data_list.append((key, val))
+        if key == ("ProductVersion"):
+            iOS.set_version(val)
+            logfunc(f"iOS version: {val}")
+            device_info("Device Information", "iOS version", val, source_path)
+        
+        if key == "ProductBuildVersion":
+            device_info("Device Information", "ProductBuildVersion", val, source_path)
+        
+        if key == ("ProductName"):
+            logfunc(f"Product: {val}")
+            device_info("Device Information", "Product Name", val, source_path)
+
+    data_headers = ('Property', 'Property Value')
+    return data_headers, data_list, source_path

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -43,6 +43,21 @@ thumb_size = 256, 256
 identifiers = {}
 icons = {}
 
+class iOS:
+    _version = None
+
+    @staticmethod
+    def get_version():
+        """Return the value of the class property."""
+        return iOS._version
+
+    @staticmethod
+    def set_version(os_version):
+        """Assign a value to the class property once."""
+        if iOS._version is None:
+            iOS._version = os_version
+
+
 class OutputParameters:
     '''Defines the parameters that are common for '''
     # static parameters


### PR DESCRIPTION
**ilapfuncs.py**
- Add an iOS object with a _version class property
  - set_version() can set a value to _version once
  - get_version() returns the _version value

**lastBuild.py**
- Code refactorization
- Set _version to iOS object

**iTunesBackupInfo**
- Set _version to iOS object