### PR TITLE
Update media manager

### DIFF
--- a/scripts/artifacts/BeReal.py
+++ b/scripts/artifacts/BeReal.py
@@ -34,15 +34,14 @@ __artifacts_v2__ = {
         "author": "@djangofaiola",
         "version": "0.1",
         "creation_date": "2024-12-20",
-        "last_update_date": "2024-03-08",
+        "last_update_date": "2025-04-02",
         "requirements": "none",
         "category": "BeReal",
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Caches/disk-bereal-RelationshipsContactsManager-contact/*'),
         "output_types": [ "lava", "html", "tsv" ],
         "html_columns": [ "Profile picture"],
-        "artifact_icon": "users",
-        "media_style": ("height: 80px; border-radius: 50%;", "height: 80px;")
+        "artifact_icon": "users"
     },
     "bereal_persons": {
         "name": "BeReal Persons",
@@ -640,8 +639,15 @@ def bereal_accounts(files_found, report_folder, seeker, wrap_text, timezone_offs
 @artifact_processor
 def bereal_contacts(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
-    data_headers = [ 'Full name', 'Family name', 'Middle name', 'Given name', 'Nick name', 'Profile picture', 'Organization name',
-                     'Phone numbers', 'Source file name', 'Location' ]
+    data_headers = ('Full name', 
+                    'Family name', 
+                    'Middle name', 
+                    'Given name', 'Nick name', 
+                    ('Profile picture', 'media', 'height: 80px'), 
+                    'Organization name', 
+                    'Phone numbers', 
+                    'Source file name', 
+                    'Location')
     data_list = []
     data_list_html = []
     source_paths = set()
@@ -687,8 +693,7 @@ def bereal_contacts(files_found, report_folder, seeker, wrap_text, timezone_offs
                 photo_b64 = contact.get('photo')
                 if bool(photo_b64):
                     photo_raw = standard_b64decode(photo_b64)   # bytes
-                    photo_item = check_in_embedded_media(seeker, file_found, photo_raw, artifact_info)
-                    photo = photo_item.id
+                    photo = check_in_embedded_media(seeker, file_found, photo_raw, artifact_info)
                 else:
                     photo = ''
                 # organization name
@@ -711,9 +716,6 @@ def bereal_contacts(files_found, report_folder, seeker, wrap_text, timezone_offs
         except Exception as e:
             logfunc(f"Error: {str(e)}")
             pass
-
-    # lava types
-    data_headers[5] = (data_headers[5], 'media')
 
     # paths
     source_path = ', '.join(source_paths)

--- a/scripts/artifacts/addressBook.py
+++ b/scripts/artifacts/addressBook.py
@@ -1,23 +1,23 @@
 __artifacts_v2__ = {
-    "addressBook": {
-        "name": "Address Book",
-        "description": "Extract information from the native contacts application",
-        "author": "@AlexisBrignoni - @JohannPLW",
-        "creation_date": "2020-04-30",
-        "last_update_date": "2024-12-20",
-        "requirements": "none",
-        "category": "Contacts",
-        "notes": "",
-        "paths": ('*/mobile/Library/AddressBook/AddressBook*.sqlitedb*',),
-        "output_types": "standard",
-        "artifact_icon": "user",
-        "media_style": ("height: 80px; border-radius: 50%;", "height: 80px;")
+    'addressBook': {
+        'name': 'Address Book',
+        'description': 'Extract information from the native contacts application',
+        'author': '@AlexisBrignoni - @JohannPLW',
+        'creation_date': '2020-04-30',
+        'last_update_date': '2025-04-03',
+        'requirements': 'none',
+        'category': 'Contacts',
+        'notes': '',
+        'paths': ('*/mobile/Library/AddressBook/AddressBook*.sqlitedb*',),
+        'output_types': 'standard',
+        'artifact_icon': 'user'
     }
 }
 
+
 import inspect
-from scripts.ilapfuncs import artifact_processor, get_file_path, \
-    get_sqlite_db_records, attach_sqlite_db_readonly, check_in_embedded_media, \
+from scripts.ilapfuncs import artifact_processor, \
+    get_file_path, get_sqlite_db_records, attach_sqlite_db_readonly, check_in_embedded_media, \
     convert_cocoa_core_data_ts_to_utc, get_birthdate
 
 
@@ -34,10 +34,11 @@ def remove_unused_rows(data, count_rows):
     data = [i for r, i in enumerate(data) if r not in rows_to_remove]
     return tuple(data)
 
+
 @artifact_processor
 def addressBook(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, "AddressBook.sqlitedb")
-    address_book_images_db = get_file_path(files_found, "AddressBookImages.sqlitedb")
+    source_path = get_file_path(files_found, 'AddressBook.sqlitedb')
+    address_book_images_db = get_file_path(files_found, 'AddressBookImages.sqlitedb')
 
     data_list = []
     artifact_info = inspect.stack()[0]
@@ -45,117 +46,140 @@ def addressBook(files_found, report_folder, seeker, wrap_text, timezone_offset):
     attach_query = attach_sqlite_db_readonly(address_book_images_db, 'ABI')
     query = '''
     SELECT    
-    ABPerson.ROWID,
-    ABPerson.CreationDate,
-    (SELECT ABI.ABThumbnailImage.data
-    FROM ABI.ABThumbnailImage
-    WHERE ABI.ABThumbnailImage.record_id = ABPerson.ROWID AND ABI.ABThumbnailImage.format = 0) AS 'Thumbnail',
-    (SELECT ABI.ABFullSizeImage.data
-    FROM ABI.ABFullSizeImage
-    WHERE ABI.ABFullSizeImage.record_id = ABPerson.ROWID) AS 'Full Image',
-    ABPerson.Prefix,
-    ABPerson.First,
-    ABPerson.Middle,
-    ABPerson.Last,
-    ABPerson.Suffix,
-    ABPerson.DisplayName,
-    ABPerson.FirstPhonetic,
-    ABPerson.MiddlePhonetic,
-    ABPerson.LastPhonetic,
-    ABPerson.Organization,
-    ABPerson.Department,
-    ABPerson.JobTitle,
-    (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
-    FROM ABMultiValue
-    LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-    WHERE ABMultiValue.property = 3 AND ABMultiValue.record_id = ABPerson.ROWID
-    GROUP BY ABMultiValue.record_id) AS 'Phone Numbers',
-    (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
-    FROM ABMultiValue
-    LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-    WHERE ABMultiValue.property = 4 AND ABMultiValue.record_id = ABPerson.ROWID
-    GROUP BY ABMultiValue.record_id) AS 'Email addresses',
-    (WITH 
-        addresses(id, address) AS
-        (WITH MVE(p, k, v) AS
-            (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntry.key, ABMultiValueEntry.value 
-            FROM ABMultiValueEntry 
-            ORDER BY ABMultiValueEntry.parent_id, ABMultiValueEntry.key)
-        SELECT p, group_concat(v, ' - ') FROM MVE GROUP BY p),
-        MV(label, rid, uid) AS 
+        ABPerson.ROWID,
+        ABPerson.CreationDate,
+        (SELECT ABI.ABThumbnailImage.data
+        FROM ABI.ABThumbnailImage
+        WHERE ABI.ABThumbnailImage.record_id = ABPerson.ROWID AND ABI.ABThumbnailImage.format = 0) AS 'Thumbnail',
+        (SELECT ABI.ABFullSizeImage.data
+        FROM ABI.ABFullSizeImage
+        WHERE ABI.ABFullSizeImage.record_id = ABPerson.ROWID) AS 'Full Image',
+        ABPerson.Prefix,
+        ABPerson.First,
+        ABPerson.Middle,
+        ABPerson.Last,
+        ABPerson.Suffix,
+        ABPerson.DisplayName,
+        ABPerson.FirstPhonetic,
+        ABPerson.MiddlePhonetic,
+        ABPerson.LastPhonetic,
+        ABPerson.Organization,
+        ABPerson.Department,
+        ABPerson.JobTitle,
+        (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
+        FROM ABMultiValue
+        LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
+        WHERE ABMultiValue.property = 3 AND ABMultiValue.record_id = ABPerson.ROWID
+        GROUP BY ABMultiValue.record_id) AS 'Phone Numbers',
+        (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
+        FROM ABMultiValue
+        LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
+        WHERE ABMultiValue.property = 4 AND ABMultiValue.record_id = ABPerson.ROWID
+        GROUP BY ABMultiValue.record_id) AS 'Email addresses',
+        (WITH 
+            addresses(id, address) AS
+            (WITH MVE(p, k, v) AS
+                (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntry.key, ABMultiValueEntry.value 
+                FROM ABMultiValueEntry 
+                ORDER BY ABMultiValueEntry.parent_id, ABMultiValueEntry.key)
+            SELECT p, group_concat(v, ' - ') FROM MVE GROUP BY p),
+            MV(label, rid, uid) AS 
+                (SELECT ABMultiValueLabel.value, ABMultiValue.record_id, ABMultiValue.UID
+                FROM ABMultiValue
+                LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
+                WHERE ABMultiValue.property = 5 AND ABMultiValue.record_id = ABPerson.ROWID)
+            SELECT group_concat(ifnull(label, ' ') || ': ' || address, CHAR(13))
+            FROM MV
+            LEFT JOIN addresses ON uid = id
+            GROUP BY rid) as 'Addresses',
+        (WITH
+            MVE_U(up, uv) AS
+            (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntry.value
+            FROM ABMultiValueEntry
+            LEFT JOIN ABMultiValueEntryKey ON ABMultiValueEntry.key = ABMultiValueEntryKey.ROWID
+            WHERE ABMultiValueEntryKey.value = 'username'),
+            MVE_S(sp, sv) AS
+            (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntry.value
+            FROM ABMultiValueEntry
+            LEFT JOIN ABMultiValueEntryKey ON ABMultiValueEntry.key = ABMultiValueEntryKey.ROWID
+            WHERE ABMultiValueEntryKey.value = 'service'),
+            MV(label, rid, uid) AS 
             (SELECT ABMultiValueLabel.value, ABMultiValue.record_id, ABMultiValue.UID
             FROM ABMultiValue
             LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-            WHERE ABMultiValue.property = 5 AND ABMultiValue.record_id = ABPerson.ROWID)
-        SELECT group_concat(ifnull(label, ' ') || ': ' || address, CHAR(13))
+            WHERE ABMultiValue.property = 13 AND ABMultiValue.record_id = ABPerson.ROWID)
+        SELECT group_concat(ifnull(label, ' ') || ': ' || uv || ' (' || sv || ')', CHAR(13))
         FROM MV
-        LEFT JOIN addresses ON uid = id
-        GROUP BY rid) as 'Addresses',
-    (WITH
-        MVE_U(up, uv) AS
-        (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntry.value
-        FROM ABMultiValueEntry
-        LEFT JOIN ABMultiValueEntryKey ON ABMultiValueEntry.key = ABMultiValueEntryKey.ROWID
-        WHERE ABMultiValueEntryKey.value = 'username'),
-        MVE_S(sp, sv) AS
-        (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntry.value
-        FROM ABMultiValueEntry
-        LEFT JOIN ABMultiValueEntryKey ON ABMultiValueEntry.key = ABMultiValueEntryKey.ROWID
-        WHERE ABMultiValueEntryKey.value = 'service'),
-        MV(label, rid, uid) AS 
-        (SELECT ABMultiValueLabel.value, ABMultiValue.record_id, ABMultiValue.UID
+        LEFT JOIN MVE_U ON uid = up
+        LEFT JOIN MVE_S ON up = sp
+        GROUP BY rid) AS 'Instant Message',
+        (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
         FROM ABMultiValue
         LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-        WHERE ABMultiValue.property = 13 AND ABMultiValue.record_id = ABPerson.ROWID)
-    SELECT group_concat(ifnull(label, ' ') || ': ' || uv || ' (' || sv || ')', CHAR(13))
-    FROM MV
-    LEFT JOIN MVE_U ON uid = up
-    LEFT JOIN MVE_S ON up = sp
-    GROUP BY rid) AS 'Instant Message',
-    (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
-    FROM ABMultiValue
-    LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-    WHERE ABMultiValue.property = 22 AND ABMultiValue.record_id = ABPerson.ROWID
-    GROUP BY ABMultiValue.record_id) AS 'URL',
-    (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
-    FROM ABMultiValue
-    LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-    WHERE ABMultiValue.property = 23 AND ABMultiValue.record_id = ABPerson.ROWID
-    GROUP BY ABMultiValue.record_id) AS 'Related Name',
-    (WITH
-        MVE(p, k, v) AS
-        (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntryKey.value, ABMultiValueEntry.value
-        FROM ABMultiValueEntry
-        LEFT JOIN ABMultiValueEntryKey ON ABMultiValueEntry.key = ABMultiValueEntryKey.ROWID),
-        MV(label, rid, uid) AS 
-        (SELECT ABMultiValueLabel.value, ABMultiValue.record_id, ABMultiValue.UID
+        WHERE ABMultiValue.property = 22 AND ABMultiValue.record_id = ABPerson.ROWID
+        GROUP BY ABMultiValue.record_id) AS 'URL',
+        (SELECT group_concat(ifnull(ABMultiValueLabel.value, ' ') || ': ' || ABMultiValue.value, CHAR(13))
         FROM ABMultiValue
         LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
-        WHERE ABMultiValue.property = 46 AND ABMultiValue.record_id = ABPerson.ROWID)
-    SELECT group_concat(k || ': ' || v, CHAR(13))
-    FROM MV
-    LEFT JOIN MVE ON uid = p
-    GROUP BY rid) AS 'Profile',
-    ABPerson.Nickname,
-    ABPerson.Note,
-    CAST(ABPerson.Birthday AS INT) AS 'Birthday',
-    (SELECT group_concat(ABGroup.Name, ', ')
-    FROM ABGroupMembers
-    LEFT JOIN ABGroup ON ABGroupMembers.group_id = ABGroup.ROWID
-    WHERE ABGroupMembers.member_id = ABPerson.ROWID
-    GROUP BY ABGroupMembers.member_id) AS 'Group',
-    ABStore.Name,
-    ABPerson.ModificationDate
+        WHERE ABMultiValue.property = 23 AND ABMultiValue.record_id = ABPerson.ROWID
+        GROUP BY ABMultiValue.record_id) AS 'Related Name',
+        (WITH
+            MVE(p, k, v) AS
+            (SELECT ABMultiValueEntry.parent_id, ABMultiValueEntryKey.value, ABMultiValueEntry.value
+            FROM ABMultiValueEntry
+            LEFT JOIN ABMultiValueEntryKey ON ABMultiValueEntry.key = ABMultiValueEntryKey.ROWID),
+            MV(label, rid, uid) AS 
+            (SELECT ABMultiValueLabel.value, ABMultiValue.record_id, ABMultiValue.UID
+            FROM ABMultiValue
+            LEFT JOIN ABMultiValueLabel ON ABMultiValue.label = ABMultiValueLabel.ROWID
+            WHERE ABMultiValue.property = 46 AND ABMultiValue.record_id = ABPerson.ROWID)
+        SELECT group_concat(k || ': ' || v, CHAR(13))
+        FROM MV
+        LEFT JOIN MVE ON uid = p
+        GROUP BY rid) AS 'Profile',
+        ABPerson.Nickname,
+        ABPerson.Note,
+        CAST(ABPerson.Birthday AS INT) AS 'Birthday',
+        (SELECT group_concat(ABGroup.Name, ', ')
+        FROM ABGroupMembers
+        LEFT JOIN ABGroup ON ABGroupMembers.group_id = ABGroup.ROWID
+        WHERE ABGroupMembers.member_id = ABPerson.ROWID
+        GROUP BY ABGroupMembers.member_id) AS 'Group',
+        ABStore.Name,
+        ABPerson.ModificationDate
     FROM ABPerson
     LEFT JOIN ABStore ON ABPerson.StoreID = ABStore.ROWID
     '''
 
-    data_headers = [('Creation Date', 'datetime'), ('Thumbnail', 'media'), ('Full Size Image', 'media'), 'Prefix', 'First Name', 'Middle Name', 
-                    'Last Name', 'Suffix', 'Display Name', 'First Name Phonetic', 'Middle Name Phonetic', 
-                    'Last Name Phonetic', 'Company', 'Department', 'Job Title', 'Phone Numbers', 
-                    'Email addresses', 'Addresses', 'Instant Messages', 'URL', 'Related Names',
-                    'Profiles', 'Nickname', 'Notes', 'Birthday', 'Group Name', 'Storage Place', 
-                    ('Modification Date', 'datetime')]
+    data_headers = [
+        ('Creation Date', 'datetime'), 
+        ('Thumbnail', 'media', 'height: 80px; border-radius: 50%;'), 
+        ('Full Size Image', 'media', 'height: 80px;'), 
+        'Prefix', 
+        'First Name', 
+        'Middle Name', 
+        'Last Name', 
+        'Suffix', 
+        'Display Name', 
+        'First Name Phonetic', 
+        'Middle Name Phonetic', 
+        'Last Name Phonetic', 
+        'Company', 
+        'Department', 
+        'Job Title', 
+        ('Phone Numbers', 'phonenumber'), 
+        'Email addresses', 
+        'Addresses', 
+        'Instant Messages', 
+        'URL', 
+        'Related Names', 
+        'Profiles', 
+        'Nickname', 
+        'Notes', 
+        'Birthday', 
+        'Group Name', 
+        'Storage Place', 
+        ('Modification Date', 'datetime')]
 
     db_records = get_sqlite_db_records(source_path, query, attach_query)
 
@@ -165,11 +189,13 @@ def addressBook(files_found, report_folder, seeker, wrap_text, timezone_offset):
         
         thumbnail = record[2]
         if thumbnail:
-            thumbnail = check_in_embedded_media(seeker, address_book_images_db, thumbnail, artifact_info, media_name)
+            thumbnail = check_in_embedded_media(
+                seeker, address_book_images_db, thumbnail, artifact_info, media_name)
 
         full_size_image = record[3]
         if full_size_image:
-                full_size_image = check_in_embedded_media(seeker, address_book_images_db, full_size_image, artifact_info, media_name)
+                full_size_image = check_in_embedded_media(
+                    seeker, address_book_images_db, full_size_image, artifact_info, media_name)
 
         phone_numbers = record[16]
         if phone_numbers:
@@ -204,24 +230,64 @@ def addressBook(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
         modified_date = convert_cocoa_core_data_ts_to_utc(record[-1])
         
-        data_list.append([creation_date, thumbnail, full_size_image, record[4], record[5], record[6], record[7], record[8], 
-                          record[9], record[10], record[11], record[12], record[13], record[14], record[15], 
-                          phone_numbers, email_addresses, addresses, instant_message, url, related_name, profile, 
-                          record[23], record[24], birthday, record[26], record[27], modified_date])
+        data_list.append([creation_date, thumbnail, full_size_image, record[4], record[5], record[6], 
+                          record[7], record[8], record[9], record[10], record[11], record[12], record[13], 
+                          record[14], record[15], phone_numbers, email_addresses, addresses, instant_message, 
+                          url, related_name, profile, record[23], record[24], birthday, record[26], 
+                          record[27], modified_date])
 
     # Removing unused columns
     remove_empty_cols_query = '''
-    SELECT 'Create', count(ABI.ABThumbnailImage.data), count(ABI.ABFullSizeImage.data), count(ABPerson.Prefix), 'First', count(ABPerson.Middle), 'Last', 
-    count(ABPerson.Suffix), count(ABPerson.DisplayName), count(ABPerson.FirstPhonetic), count(ABPerson.MiddlePhonetic), count(ABPerson.LastPhonetic), 
-    count(ABPerson.Organization), count(ABPerson.Department), count(ABPerson.JobTitle), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 3 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 4 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 5 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 13 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 22 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 23 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count((SELECT ABMultiValue.property FROM ABMultiValue WHERE ABMultiValue.property = 46 AND ABMultiValue.record_id = ABPerson.ROWID)), 
-    count(ABPerson.Nickname), count(ABPerson.Note), count(ABPerson.Birthday), count(ABGroupMembers.member_id), 'Store', 'Modif'
+    SELECT 
+        'Create', 
+        count(ABI.ABThumbnailImage.data), 
+        count(ABI.ABFullSizeImage.data), 
+        count(ABPerson.Prefix), 
+        'First', 
+        count(ABPerson.Middle), 
+        'Last', 
+        count(ABPerson.Suffix), 
+        count(ABPerson.DisplayName), 
+        count(ABPerson.FirstPhonetic), 
+        count(ABPerson.MiddlePhonetic), 
+        count(ABPerson.LastPhonetic), 
+        count(ABPerson.Organization), 
+        count(ABPerson.Department), 
+        count(ABPerson.JobTitle),
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 3 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 4 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 5 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 13 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 22 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 23 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count((
+            SELECT ABMultiValue.property 
+            FROM ABMultiValue 
+            WHERE ABMultiValue.property = 46 AND ABMultiValue.record_id = ABPerson.ROWID)), 
+        count(ABPerson.Nickname), 
+        count(ABPerson.Note), 
+        count(ABPerson.Birthday), 
+        count(ABGroupMembers.member_id), 
+        'Store', 
+        'Modif'
     FROM ABPerson
     LEFT JOIN ABGroupMembers ON ABPerson.ROWID = ABGroupMembers.member_id
     LEFT JOIN ABI.ABThumbnailImage ON ABPerson.ROWID = ABI.ABThumbnailImage.record_id

--- a/scripts/artifacts/iTunesBackupInfo.py
+++ b/scripts/artifacts/iTunesBackupInfo.py
@@ -17,24 +17,24 @@ __artifacts_v2__ = {
         "description": "Extract information about installed applications from the Info.plist file of an iTunes backup",
         "author": "@johannplw",
         "creation_date": "2023-10-11",
-        "last_update_date": "2025-01-20",
+        "last_update_date": "2025-04-02",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*Info.plist',),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "package",
-        "media_style": "width: 60px;"
+        "artifact_icon": "package"
     }
 }
+
 
 import inspect
 import datetime
 import plistlib
-import scripts.artifacts.artGlobals
-
 from scripts.ilapfuncs import artifact_processor, \
-    get_file_path, get_plist_file_content, check_in_embedded_media, device_info, logfunc, iOS
+    get_file_path, get_plist_file_content, check_in_embedded_media, \
+    device_info, logfunc, iOS
+
 
 @artifact_processor
 def iTunesBackupInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
@@ -142,7 +142,7 @@ def iTunesBackupInstalledApplications(files_found, report_folder, seeker, wrap_t
                 app_info += ('',) * 17
                 data_list.append(app_info)
         
-    data_headers = ('Bundle ID', ('App Icon', 'media'), 'Item Name', 'Artist Name', 'Version', 
+    data_headers = ('Bundle ID', ('App Icon', 'media', 'width: 60px;'), 'Item Name', 'Artist Name', 'Version', 
                     'Genre', 'Install Date', 'Downloaded by', 'Purchase Date', 
                     'Release Date', 'Source App', 'Auto Download', 
                     'Purchased Redownload', 'Factory Install', 'Side Loaded', 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -144,8 +144,13 @@ def logfunc(message=""):
 def strip_tuple_from_headers(data_headers):
     return [header[0] if isinstance(header, tuple) else header for header in data_headers]
 
-def get_media_header_position(data_headers):
-    return [i for i, header in enumerate(data_headers) if isinstance(header, tuple) and header[1] == 'media']
+def get_media_header_info(data_headers):
+    media_header_info = {}
+    for index, header in enumerate(data_headers):
+        if isinstance(header, tuple) and header[1] == 'media':
+            style = header[2] if len(header) == 3 else ''
+            media_header_info[index] = style
+    return media_header_info
 
 def check_output_types(type, output_types):
     if type in output_types or type == output_types or 'all' in output_types or 'all' == output_types:
@@ -272,38 +277,38 @@ def html_media_tag(media_path, mimetype, style, title=''):
         thumb = f'<a href="{media_path}" target="_blank"> Link to {filename} file</>'
     return thumb
 
-def get_data_list_with_media(media_header_idx, data_list, media_style):
+def get_data_list_with_media(media_header_info, data_list):
     ''' 
-    For columns with media item:
-      - Generate a new data list with HTML code
-      - Remove them in a new data list for TSV, KML and Timeline exports  
+    For columns with media item, generate:
+      - A data list with HTML code for HTML output
+      - A data list with extraaction path of media items for TSV, KML and Timeline exports  
     '''
     html_data_list = []
     txt_data_list = []
     for data in data_list:
         html_data = list(data)
-        media_style_idx = 0
-        for idx in media_header_idx:
+        txt_data = list(data)
+        for idx, style in media_header_info.items():
             if html_data[idx]:
-                try:
-                    style = media_style[media_style_idx] if isinstance(media_style, tuple) else media_style
-                except:
-                    style = media_style
                 media_ref_id = html_data[idx]
-                html_code = ''
                 if isinstance(media_ref_id, list):
+                    html_code = ''
+                    path_list = []
                     for item in media_ref_id:
                         media_item = lava_get_full_media_info(item)
                         html_code += html_media_tag(media_item[6], media_item[7], style, media_item[4])
+                        path_list.append(media_item[6])
+                    txt_code = ' | '.join(path_list)
                 else:
                     media_item = lava_get_full_media_info(media_ref_id)
                     html_code = html_media_tag(media_item[6], media_item[7], style, media_item[4])
+                    txt_code = media_item[6]
                 html_data[idx] = html_code
+                txt_data[idx] = txt_code
             else:
                 html_data[idx] = ''
-            media_style_idx += 1
+                txt_data[idx] = ''
         html_data_list.append(tuple(html_data))
-        txt_data = [i for media_idx, i in enumerate(data) if media_idx not in media_header_idx]
         txt_data_list.append(tuple(txt_data))
     return html_data_list, txt_data_list
 
@@ -314,14 +319,13 @@ def artifact_processor(func):
         func_name = func.__name__
 
         func_object = func.__globals__.get(func_name, {})
-        artifact_info = func_object.artifact_info #get('artifact_info', {})
+        artifact_info = func_object.artifact_info  #get('artifact_info', {})
 
         artifact_name = artifact_info.get('name', func_name)
         category = artifact_info.get('category', '')
         description = artifact_info.get('description', '')
         icon = artifact_info.get('artifact_icon', '')
         html_columns = artifact_info.get('html_columns', [])
-        media_style = artifact_info.get('media_style', '')
 
         output_types = artifact_info.get('output_types', ['html', 'tsv', 'timeline', 'lava', 'kml'])
 
@@ -342,12 +346,10 @@ def artifact_processor(func):
             stripped_headers = strip_tuple_from_headers(data_headers)
 
             # Check if headers contains a 'media' type
-            media_header_idx = get_media_header_position(data_headers)
-            if media_header_idx:
-                html_columns.extend([data_headers[idx][0] for idx in media_header_idx])
-                html_data_list, txt_data_list = get_data_list_with_media(media_header_idx, data_list, media_style)
-
-            txt_headers = [i for media_idx, i in enumerate(stripped_headers) if media_idx not in media_header_idx] if media_header_idx else stripped_headers
+            media_header_info = get_media_header_info(data_headers)
+            if media_header_info:
+                html_columns.extend([data_headers[idx][0] for idx in media_header_info])
+                html_data_list, txt_data_list = get_data_list_with_media(media_header_info, data_list)
 
             if check_output_types('html', output_types):
                 report = artifact_report.ArtifactHtmlReport(artifact_name)
@@ -357,17 +359,17 @@ def artifact_processor(func):
                 report.end_artifact_report()
 
             if check_output_types('tsv', output_types):
-                tsv(report_folder, txt_headers, txt_data_list if media_header_idx else data_list, artifact_name)
+                tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, artifact_name)
             
             if check_output_types('timeline', output_types):
-                timeline(report_folder, artifact_name, txt_data_list if media_header_idx else data_list, txt_headers)
+                timeline(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
 
             if check_output_types('lava', output_types):
                 table_name, object_columns, column_map = lava_process_artifact(category, module_name, artifact_name, data_headers, len(data_list), data_views=artifact_info.get("data_views"))
                 lava_insert_sqlite_data(table_name, data_list, object_columns, data_headers, column_map)
 
             if check_output_types('kml', output_types):
-                kmlgen(report_folder, artifact_name, txt_data_list if media_header_idx else data_list, txt_headers)
+                kmlgen(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
 
         else:
             if output_types != 'none':
@@ -533,6 +535,7 @@ def attach_sqlite_db_readonly(path, db_name):
 
 def get_sqlite_db_records(path, query, attach_query=None):
     db = open_sqlite_db_readonly(path)
+    db.row_factory = sqlite3.Row  # For fetching columns by name
     if db:
         try:
             cursor = db.cursor()

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -150,7 +150,7 @@ def lava_create_sqlite_table(table_name, data):
 
     for item in data:
         if isinstance(item, tuple):
-            original_name, data_type = item
+            original_name, data_type = item[:2]  # Only take the first two elements as media item can have more
             sanitized_name = sanitize_sql_name(original_name)
             sql_type = get_sql_type(data_type)
             columns.append(f"{sanitized_name} {sql_type}")


### PR DESCRIPTION
Remove `media_style` from `__artifact_v2__`.

Now, style for media items is directly inserted in data_headers as it can contain different styles for each column. 