### PR TITLE
LAVA only notifications

### DIFF
--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Logs",
         "notes": "",
         "paths": ('*/logarchive.json',),
-        "output_types": ["lava"],
+        "output_types": "lava_only",
         "artifact_icon": "user"
     }
 }

--- a/scripts/html_parts.py
+++ b/scripts/html_parts.py
@@ -172,7 +172,7 @@ r"""
 """
 # tabs code for Case information in index.html
 # Variables are {case_table_code}, {script_run_log}, {processed_file_list}
-tabs_code = \
+tabs_nav = \
 """
     <ul class="nav nav-tabs" id="myTab" role="tablist">
         <li class="nav-item">
@@ -187,14 +187,32 @@ tabs_code = \
         <li class="nav-item">
             <a class="nav-link" id="files-list-tab" data-toggle="tab" href="#files" role="tab" aria-controls="files" aria-selected="false">Processed files list</a>
         </li>
+"""
+tabs_nav_with_lava = tabs_nav + \
+"""
+        <li class="nav-item">
+            <a class="nav-link" id="lava-tab" data-toggle="tab" href="#lava-only" role="tab" aria-controls="lava" aria-selected="false">LAVA only artifacts</a>
+        </li>
+"""
+tabs_contents = \
+"""
     </ul>
     <div class="tab-content" id="myTabContent">
         <div class="tab-pane fade show active" id="case" role="tabpanel" aria-labelledby="case-tab"><br />{}</div>
         <div class="tab-pane fade" id="device" role="tabpanel" aria-labelledby="device-tab"><br />{}</div>
         <div class="tab-pane fade text-monospace" id="run" role="tabpanel" aria-labelledby="script-run-tab"><br />{}</div>
         <div class="tab-pane fade" id="files" role="tabpanel" aria-labelledby="profile-tab"><br />{}</div>
+"""
+tabs_code_with_lava = tabs_nav_with_lava + tabs_contents + \
+"""
+        <div class="tab-pane fade" id="lava-only" role="tabpanel" aria-labelledby="lava-tab"><br />{}</div>
     </div>
 """
+tabs_code = tabs_nav + tabs_contents + \
+"""
+    </div>
+"""
+
 # thank you note , at bottom of index.html
 thank_you_note = \
 """


### PR DESCRIPTION
When an artifact with `lava_only` output_type is selected, a notification appears as a pop-up in the GUI when processing is finished as well as in the generated main HTML report advising that artifacts that are larger than what it is possible to show with an HTML report. It will advise to look into the `LAVA only artifacts` tab to see what artifacts fall in that category and it will direct the user to look into the _lava_artifacts.db to query the artifact.
