### PR TITLE
Update ilapfuncs.py - get_birthday fix

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -1121,8 +1121,8 @@ def convert_plist_date_to_utc(plist_date):
         return plist_date
 
 def get_birthdate(date):
-    ns_date = date + 978307200
-    utc_date = datetime.utcfromtimestamp(ns_date)
+    cocoa_epoch = datetime(2001, 1, 1, tzinfo=timezone.utc) # Create our own epoch to avoid gmtime() errors in fromtimestamp().
+    utc_date = cocoa_epoch + timedelta(seconds=date)
     return utc_date.strftime('%d %B %Y') if utc_date.year != 1604 else utc_date.strftime('%d %B')
 
 def convert_bytes_to_unit(size):


### PR DESCRIPTION
If a birthday is added to a contact without a year, it is stored with the year 1604. These dates can cause an issue in Windows Python with the current function that is used to parse these dates. If one of these dates is found the addressBook.py artifact causes the error: "OSError: [Errno 22] Invalid argument" and completely fails to output any results. This change replaces datetime.utcfromtimestamp (which is also depreciated) with manually creating a Cocoa Epoch to avoid out of range date problems. The datetime.fromtimestamp function is also susceptible to this problem.