### PR TITLE
Improve media file lookup speed

### DIFF
--- a/scripts/context.py
+++ b/scripts/context.py
@@ -1,3 +1,7 @@
+from os.path import basename
+from pathlib import Path
+
+
 class Context:
     _report_folder = None
     _seeker = None
@@ -6,6 +10,7 @@ class Context:
     _module_file_path = None
     _artifact_name = None
     _files_found = None
+    _filename_lookup_map = None
 
     @staticmethod
     def set_report_folder(report_folder):
@@ -34,6 +39,20 @@ class Context:
     @staticmethod
     def set_files_found(files_found):
         Context._files_found = files_found
+
+    @staticmethod
+    def _build_lookup_map():
+        """Builds and returns a dictionary mapping filenames to a list of full paths."""
+        if Context._files_found is None:
+            raise ValueError("Cannot build lookup map: _files_found is not set.")
+
+        filename_lookup = {}
+        for full_path in Context._files_found:
+            filename = basename(full_path)
+            if filename not in filename_lookup:
+                filename_lookup[filename] = []
+            filename_lookup[filename].append(full_path)
+        return filename_lookup
 
     @staticmethod
     def get_report_folder():
@@ -73,9 +92,46 @@ class Context:
 
     @staticmethod
     def get_files_found():
-        if not Context._files_found:
+        if Context._files_found is None:
             raise ValueError("Context not set. This function should be called from within an artifact.")
         return Context._files_found
+
+    @staticmethod
+    def get_filename_lookup_map():
+        if Context._filename_lookup_map is None:
+            Context._filename_lookup_map = Context._build_lookup_map()
+        return Context._filename_lookup_map
+
+    @staticmethod
+    def get_source_file_path(partial_path):
+        """
+        Finds the full source path for a given partial or relative path.
+
+        This function uses a pre-computed lookup map for high-speed searching.
+        It first finds candidate paths based on the filename and then verifies
+        the match using the full partial path provided.
+
+        Args:
+            partial_path (str): The partial or relative path of the file to find.
+
+        Returns:
+            str: The full path of the matching source file, or None if not found.
+        """
+        lookup_map = Context.get_filename_lookup_map()
+
+        # Defensive check to satisfy the linter. This state should not be possible in practice.
+        if lookup_map is None:
+            return None
+
+        filename = basename(partial_path)
+
+        if filename in lookup_map:
+            candidate_paths = lookup_map[filename]
+            for candidate in candidate_paths:
+                if Path(candidate).match(partial_path):
+                    return candidate
+        
+        return None
 
     @staticmethod
     def clear():
@@ -86,3 +142,4 @@ class Context:
         Context._module_file_path = None
         Context._artifact_name = None
         Context._files_found = None
+        Context._filename_lookup_map = None

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -181,12 +181,15 @@ def set_media_references(media_ref_id, media_id, module_name, artifact_name, nam
 def check_in_media(file_path, name="", converted_file_path=False):
     report_folder = Context.get_report_folder()
     seeker = Context.get_seeker()
-    files_found = Context.get_files_found()
     module_name = Context.get_module_name()
     artifact_name = Context.get_artifact_name()
 
-    extraction_path = next(
-        (path for path in files_found if Path(path).match(file_path)), None)
+    extraction_path = Context.get_source_file_path(file_path)
+
+    if not extraction_path:
+        logfunc(f'No matching file found for "{file_path}"')
+        return None
+
     file_info = seeker.file_infos.get(extraction_path)
     if file_info:
         extraction_path = converted_file_path if converted_file_path else Path(extraction_path)


### PR DESCRIPTION
Replaces the slow, linear search in `check_in_media` with a high-performance, two-stage lookup.

The previous O(N) search caused severe slowdowns on artifacts with many files. This is now an O(k) operation using a lazy-loaded dictionary on the `Context` object.

A new `Context.get_source_file_path()` API is introduced to centralize this new, efficient logic.