### PR TITLE
Add installed_os_version used by several modules into context

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -183,7 +183,7 @@ def main():
     loader = plugin_loader.PluginLoader()
     for plugin in sorted(loader.plugins, key=lambda p: p.category):
         if (plugin.module_name == 'iTunesBackupInfo'
-                or plugin.name == 'lastBuild'
+                or plugin.name == 'last_build'
                 or plugin.module_name == 'logarchive' and plugin.name != 'logarchive'):
             continue
         else:
@@ -392,11 +392,11 @@ def crunch_artifacts(
         return False
 
     # Now ready to run
-    # add lastBuild at the start except for iTunes backups
+    # add last_build at the start except for iTunes backups
     if extracttype != 'itunes':
-        plugins.insert(0, loader["lastBuild"])
+        plugins.insert(0, loader["last_build"])
 
-    logfunc(f'Info: {len(loader) - 2} modules loaded.') # excluding lastbuild and iTunesBackupInfo
+    logfunc(f'Info: {len(loader) - 2} modules loaded.') # excluding last_build and iTunesBackupInfo
     if profile_filename:
         logfunc(f'Loaded profile: {profile_filename}')
     logfunc(f'Artifact to parse: {len(plugins)}')
@@ -422,7 +422,7 @@ def crunch_artifacts(
                 except (FileExistsError, FileNotFoundError) as ex:
                     logfunc('Error creating report directory at path {}'.format(report_folder))
                     logfunc('Error was {}'.format(str(ex)))
-            loader["iTunesBackupInfo"].method([info_plist_path], report_folder, seeker, wrap_text, time_offset)
+            loader["itunes_backup_info"].method([info_plist_path], report_folder, seeker, wrap_text, time_offset)
             report_folder = os.path.join(out_params.report_folder_base, '_HTML', 'Installed Apps')
             if not os.path.exists(report_folder):
                 try:
@@ -430,8 +430,8 @@ def crunch_artifacts(
                 except (FileExistsError, FileNotFoundError) as ex:
                     logfunc('Error creating report directory at path {}'.format(report_folder))
                     logfunc('Error was {}'.format(str(ex)))
-            loader["iTunesBackupInstalledApplications"].method([info_plist_path], report_folder, seeker, wrap_text, time_offset)
-            #del search_list['lastBuild'] # removing lastBuild as this takes its place
+            loader["itunes_backup_installed_applications"].method([info_plist_path], report_folder, seeker, wrap_text, time_offset)
+            #del search_list['last_build'] # removing last_build as this takes its place
             print([info_plist_path])  # TODO Remove special consideration for itunes? Merge into main search
         else:
             logfunc('Info.plist not found for iTunes Backup!')

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -18,7 +18,7 @@ from scripts.lavafuncs import *
 
 def pickModules():
     '''Create a list of available modules:
-        - iTunesBackupInfo, iTunesBackupInstalledApplications, lastBuild and Ph100-UFED-device-values-Plist that need 
+        - itunes_backup_info, itunes_backup_installed_applications, last_build and Ph100-UFED-device-values-Plist that need 
         to be executed first are excluded
         - logarchive_artifacts is also excluded as it uses the LAVA SQLite database to extract 
         relevant event messages from the logarchive table and must be executed only if logarchive 
@@ -27,7 +27,7 @@ def pickModules():
     global mlist
     for plugin in sorted(loader.plugins, key=lambda p: p.category.upper()):
         if (plugin.module_name == 'iTunesBackupInfo'
-                or plugin.name == 'lastBuild'
+                or plugin.name == 'last_build'
                 or plugin.module_name == 'logarchive' and plugin.name != 'logarchive'):
             continue
         # Items that take a long time to execute are deselected by default

--- a/scripts/artifacts/Ph100UFEDdevcievaluesplist.py
+++ b/scripts/artifacts/Ph100UFEDdevcievaluesplist.py
@@ -1,76 +1,83 @@
+""" See artifact description below """
+
 __artifacts_v2__ = {
-    'Ph100UFEDdevicevaluesPlist': {
-        'name': 'Ph100-UFED-device-values-Plist',
-        'description': 'Parses basic data from */device_values.plist which is a part of a UFED Advance Logical'
-                       ' acquisitions with non-encrypted backups. The parsing of this file will allow for iLEAPP'
-                       ' to parse some basic information such as */PhotoData/Photos.sqlite.'
-                       ' Based on research and published blogs written by Scott Koenig https://theforensicscooter.com/',
-        'author': 'Scott Koenig',
-        'version': '5.0',
-        'date': '2025-01-05',
-        'requirements': 'Acquisition that contains device_values.plist',
-        'category': 'Photos-Z-Settings',
-        'notes': '',
-        'paths': ('*/device_values.plist',),
+    "ph_100_ufed_device_values_plist": {
+        "name": "Ph100-UFED-device-values-Plist",
+        "description": "Parses basic data from */device_values.plist which is a "
+                       "part of a UFED Advance Logical acquisitions with "
+                       "non-encrypted backups. The parsing of this file will "
+                       "allow for iLEAPP to parse some basic information such "
+                       "as */PhotoData/Photos.sqlite. "
+                       "Based on research and published blogs written by "
+                       "Scott Koenig https://theforensicscooter.com/",
+        "author": "Scott Koenig",
+        "creation_date": "2025-01-05",
+        "last_update_date": "2025-10-14",
+        "requirements": "Acquisition that contains device_values.plist",
+        "category": "Photos-Z-Settings",
+        "notes": "",
+        "paths": ("*/device_values.plist",),
         "output_types": ["standard", "tsv", "none"],
         "artifact_icon": "settings"
     }
 }
-import os
-import plistlib
-import biplist
-import nska_deserialize as nd
-from scripts.ilapfuncs import artifact_processor, logfunc, device_info, get_file_path, iOS
+
+from scripts.ilapfuncs import artifact_processor, get_plist_file_content, logfunc, \
+    device_info, iOS
+
 
 @artifact_processor
-def Ph100UFEDdevicevaluesPlist(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def ph_100_ufed_device_values_plist(context):
+    """ See artifact description """
+    data_source = context.get_source_file_path('device_values.plist')
     data_list = []
-    source_path = str(files_found[0])
 
-    with open(source_path, "rb") as fp:
-        pl = plistlib.load(fp)
+    with open(data_source, "rb") as pl:
+        pl = get_plist_file_content(data_source)
         for key, val in pl.items():
             data_list.append((key, str(val)))
 
             if key == "ProductVersion":
-                iOS.set_version(str(val))
+                iOS.set_version(val)
+                context.set_installed_os_version(val)
                 logfunc(f"iOS version: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Product Version", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Product Version", str(val), data_source)
 
             if key == "BuildVersion":
                 logfunc(f"Build Version: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Build Version", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Build Version", str(val), data_source)
 
             if key == "ProductType":
                 logfunc(f"Product Type: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Product Type", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Product Type", str(val), data_source)
 
             if key == "HardwareModel":
                 logfunc(f"Hardware Model: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Hardware Model", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Hardware Model", str(val), data_source)
 
             if key == "InternationalMobileEquipmentIdentity":
                 logfunc(f"IMEI: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "IMEI", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "IMEI", str(val), data_source)
 
             if key == "SerialNumber":
                 logfunc(f"Serial Number: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Serial Number", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Serial Number", str(val), data_source)
 
             if key == "DeviceName":
                 logfunc(f"Device Name: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Device Name", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Device Name", str(val), data_source)
 
             if key == "PasswordProtected":
                 logfunc(f"Password Protected: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "Password Protected", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "Password Protected", str(val), data_source)
 
             if key == "TimeZone":
                 logfunc(f"TimeZone: {val}")
-                device_info("devicevaluesplist-ufedadvlog", "TimeZone", str(val), source_path)
+                device_info("devicevaluesplist-ufedadvlog", "TimeZone", str(val), data_source)
 
             else:
                 data_list.append((key, str(val)))
 
-    data_headers = ('Property','Property Value')
-    return data_headers, data_list, source_path
+    data_headers = ("Property", "Property Value")
+
+    return data_headers, data_list, data_source

--- a/scripts/artifacts/iTunesBackupInfo.py
+++ b/scripts/artifacts/iTunesBackupInfo.py
@@ -1,54 +1,57 @@
+""" See artifact description below """
+
 __artifacts_v2__ = {
-    "iTunesBackupInfo": {
+    "itunes_backup_info": {
         "name": "iTunes Backup Information",
         "description": "Extract information from the Info.plist file of an iTunes backup",
         "author": "@AlexisBrignoni - @johannplw",
         "creation_date": "2023-10-11",
-        "last_update_date": "2025-03-28",
+        "last_update_date": "2025-10-14",
         "requirements": "none",
         "category": "iTunes Backup",
         "notes": "",
-        "paths": ('info.plist',),
+        "paths": ("info.plist",),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "refresh-cw"
     },
-    "iTunesBackupInstalledApplications": {
+    "itunes_backup_installed_applications": {
         "name": "iTunes Backup - Installed Applications",
-        "description": "Extract information about installed applications from the Info.plist file of an iTunes backup",
+        "description": "Extract information about installed applications from the "
+                       "Info.plist file of an iTunes backup",
         "author": "@johannplw",
         "creation_date": "2023-10-11",
-        "last_update_date": "2025-05-13",
+        "last_update_date": "2025-10-14",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",
-        "paths": ('info.plist',),
+        "paths": ("info.plist",),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "package"
     }
 }
 
 
-import inspect
 import datetime
 import plistlib
-from scripts.ilapfuncs import artifact_processor, \
-    get_file_path, get_plist_file_content, check_in_embedded_media, \
-    device_info, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_plist_file_content, \
+    check_in_embedded_media, device_info, logfunc, iOS
 
 
 @artifact_processor
-def iTunesBackupInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, "Info.plist")
+def itunes_backup_info(context):
+    """ See artifact description """
+    data_source = context.get_source_file_path('Info.plist')
     data_list = []
     installed_apps = None
     apps = None
 
-    pl = get_plist_file_content(source_path)
+    pl = get_plist_file_content(data_source)
     for key, val in pl.items():
         if isinstance(val, str) or isinstance(val, int) or isinstance(val, datetime.datetime):
             data_list.append((key, val))
             if key == ('Product Version'):
                 iOS.set_version(val)
+                context.set_installed_os_version(val)
                 logfunc(f"iOS version: {val}")
         elif key == "Applications":
             apps = val
@@ -60,28 +63,29 @@ def iTunesBackupInfo(files_found, report_folder, seeker, wrap_text, timezone_off
 
     # Device details
     keys = [data[0] for data in data_list]
-    dev_info = ('Product Name', 'Product Type', 'Device Name', 'Product Version', 'Build Version', 
-                   'Serial Number', 'MEID', 'IMEI', 'IMEI 2', 'ICCID', 'Phone Number', 
-                   'Unique Identifier', 'Last Backup Date')
+    dev_info = ('Product Name', 'Product Type', 'Device Name', 'Product Version',
+                'Build Version', 'Serial Number', 'MEID', 'IMEI', 'IMEI 2', 'ICCID',
+                'Phone Number', 'Unique Identifier', 'Last Backup Date')
     for info in dev_info:
         if info in keys:
             index = keys.index(info)
             info_key = data_list[index][0]
             value_key = data_list[index][1]
-            device_info("iTunes Backup Information", info_key, value_key, source_path)
+            device_info("iTunes Backup Information", info_key, value_key, data_source)
 
     data_headers = ('Property', 'Property Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, data_source
+
 
 @artifact_processor
-def iTunesBackupInstalledApplications(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, "Info.plist")
+def itunes_backup_installed_applications(context):
+    """ See artifact description """
+    data_source = context.get_source_file_path('Info.plist')
     data_list = []
-    artifact_info = inspect.stack()[0]
     installed_apps = None
     apps = None
 
-    pl = get_plist_file_content(source_path)
+    pl = get_plist_file_content(data_source)
     for key, val in pl.items():
         if key == "Applications":
             apps = val
@@ -128,24 +132,26 @@ def iTunesBackupInstalledApplications(files_found, report_folder, seeker, wrap_t
                 messages_extension = itunes_metadata.get('hasMessagesExtension', '')
                 icon = app_data.get('PlaceholderIcon', '')
                 if icon:
-                    icon_item = check_in_embedded_media(source_path, icon, item_name)
+                    icon_item = check_in_embedded_media(data_source, icon, item_name)
                 else:
                     icon_item = ''
 
-                data_list.append((bundle_id, icon_item, item_name, artist_name, version, genre, 
-                                install_date, apple_id, purchase_date, release_date, 
-                                source_app, auto_download, purchased_redownload, 
-                                factory_install, side_loaded, game_center_enabled, 
-                                game_center_ever_enabled, messages_extension))
+                data_list.append((bundle_id, icon_item, item_name, artist_name,
+                                  version, genre, install_date, apple_id, purchase_date,
+                                  release_date, source_app, auto_download, purchased_redownload,
+                                  factory_install, side_loaded, game_center_enabled,
+                                  game_center_ever_enabled, messages_extension))
             elif 'info_plist_bundle_id' in app_data.keys():
                 app_info = (bundle_id, )
                 app_info += ('',) * 17
                 data_list.append(app_info)
-        
-    data_headers = ('Bundle ID', ('App Icon', 'media', 'width: 60px;'), 'Item Name', 'Artist Name', 'Version', 
-                    'Genre', ('Install Date', 'date'), 'Downloaded by', ('Purchase Date', 'datetime'), 
-                    ('Release Date', 'datetime'), 'Source App', 'Auto Download', 
-                    'Purchased Redownload', 'Factory Install', 'Side Loaded', 
-                    'Game Center Enabled', 'Game Center Ever Enabled', 
+
+    data_headers = ('Bundle ID', ('App Icon', 'media', 'width: 60px;'), 'Item Name',
+                    'Artist Name', 'Version', 'Genre', ('Install Date', 'date'),
+                    'Downloaded by', ('Purchase Date', 'datetime'),
+                    ('Release Date', 'datetime'), 'Source App', 'Auto Download',
+                    'Purchased Redownload', 'Factory Install', 'Side Loaded',
+                    'Game Center Enabled', 'Game Center Ever Enabled',
                     'Messages Extension')
-    return data_headers, data_list, source_path
+
+    return data_headers, data_list, data_source

--- a/scripts/artifacts/lastBuild.py
+++ b/scripts/artifacts/lastBuild.py
@@ -1,5 +1,7 @@
+""" See description below """
+
 __artifacts_v2__ = {
-    "lastBuild": {
+    "last_build": {
         "name": "iOS Information",
         "description": "Extract iOS information from the LastBuildInfo.plist file",
         "author": "@AlexisBrignoni - @ydkhatri - @stark4n6",
@@ -9,38 +11,41 @@ __artifacts_v2__ = {
         "category": "IOS Build",
         "notes": "",
         "paths": (
-            '*/installd/Library/MobileInstallation/LastBuildInfo.plist', 
+            '*/installd/Library/MobileInstallation/LastBuildInfo.plist',
             '*/logs/SystemVersion/SystemVersion.plist'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "git-commit"
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, \
-    get_file_path, get_plist_file_content, logfunc, device_info, iOS
+from scripts.ilapfuncs import artifact_processor, get_plist_file_content, logfunc, \
+    device_info, iOS
+
 
 @artifact_processor
-def lastBuild(files_found, report_folder, seeker, wrap_text, time_offset):
-    last_build_path = get_file_path(files_found, "LastBuildInfo.plist")
-    system_version_path = get_file_path(files_found, "SystemVersion.plist")
-    source_path = last_build_path if last_build_path else system_version_path
+def last_build(context):
+    """ See artifact description """
+    last_build_path = context.get_source_file_path("LastBuildInfo.plist")
+    system_version_path = context.get_source_file_path("SystemVersion.plist")
+    data_source = last_build_path if last_build_path else system_version_path
 
     data_list = []
 
-    pl = get_plist_file_content(source_path)
+    pl = get_plist_file_content(data_source)
     for key, val in pl.items():
         data_list.append((key, val))
         if key == ("ProductVersion"):
             iOS.set_version(val)
+            context.set_installed_os_version(val)
             logfunc(f"iOS version: {val}")
-            device_info("Device Information", "iOS version", val, source_path)
-        
+            device_info("Device Information", "iOS version", val, data_source)
+
         if key == "ProductBuildVersion":
-            device_info("Device Information", "ProductBuildVersion", val, source_path)
-        
+            device_info("Device Information", "ProductBuildVersion", val, data_source)
+
         if key == ("ProductName"):
             logfunc(f"Product: {val}")
-            device_info("Device Information", "Product Name", val, source_path)
+            device_info("Device Information", "Product Name", val, data_source)
 
     data_headers = ('Property', 'Property Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, data_source

--- a/scripts/artifacts/systemVersionPlist.py
+++ b/scripts/artifacts/systemVersionPlist.py
@@ -1,62 +1,73 @@
+""" See artifact description below """
+
 __artifacts_v2__ = {
-    'systemVersionPlist': {
-        'name': 'System Version plist',
-        'description': 'Parses basic data from */System/Library/CoreServices/SystemVersion.plist'
-                       ' which is a plist in GK Logical Plus extractions and sysdiagnose archives' 
-                       ' that will contain the iOS version. Previously named Ph99SystemVersionPlist.py',
-        'author': 'Scott Koenig',
-        'version': '5.1',
-        'date': '2025-06-02',
-        'requirements': 'Acquisition that contains SystemVersion.plist',
-        'category': 'IOS Build',
-        'notes': 'Added parsing of SystemVersion.plist in a sysdiagnose archive by C_Peter',
-        'paths': ('*/System/Library/CoreServices/SystemVersion.plist','**/sysdiagnose_*.tar.gz'),
-        "output_types": ["standard", "tsv", "none"]
+    "system_version_plist": {
+        "name": "System Version plist",
+        "description": "Parses basic data from */System/Library/CoreServices/SystemVersion.plist "
+                       "which is a plist in GK Logical Plus extractions and sysdiagnose archives "
+                       "that will contain the iOS version. Previously named Ph99SystemVersionPlist.py",
+        "author": "Scott Koenig",
+        "creation_date": "2025-06-02",
+        "last_update_date": "2025-10-14",
+        "requirements": "Acquisition that contains SystemVersion.plist",
+        "category": "IOS Build",
+        "notes": "Added parsing of SystemVersion.plist in a sysdiagnose archive by C_Peter",
+        "paths": (
+            "*/System/Library/CoreServices/SystemVersion.plist",
+            "*/sysdiagnose_*.tar.gz"),
+        "output_types": ["standard", "tsv", "none"],
+        "artifact_icon": "git-commit"
     }
 }
 
-import plistlib
 import tarfile
-from scripts.ilapfuncs import artifact_processor, logfunc, device_info, iOS
+from scripts.ilapfuncs import artifact_processor, get_plist_file_content, logfunc, \
+    device_info, iOS
+
 
 @artifact_processor
-def systemVersionPlist(files_found, report_folder, seeker, wrap_text, time_offset):
+def system_version_plist(context):
+    """ See artifact description """
     data_list = []
-    for filename in files_found:
-        if "SystemVersion.plist" in filename:
-            source_path = str(filename)
-            with open(source_path, "rb") as fp:
-                pl = plistlib.load(fp)
-            break
-        elif 'sysdiagnose_' in filename and not "IN_PROGRESS_" in filename:
-            source_path = str(filename)
-            tar = tarfile.open(filename)
-            root = tar.getmembers()[0].name.split('/')[0]
-            try:
-                tarf = tar.extractfile(f"{root}/logs/SystemVersion/SystemVersion.plist")
-                pl = plistlib.load(tarf)
-            except:
-                pl = None
-    
-    if pl != None:
+    data_source = ""
+    pl = None
+
+    plist_file = context.get_source_file_path("SystemVersion.plist")
+    sysdiagnose_archive = context.get_source_file_path("sysdiagnose_*.tar.gz")
+
+    if plist_file:
+        data_source = system_version_plist
+        pl = get_plist_file_content(data_source)
+    elif 'sysdiagnose_' in sysdiagnose_archive and "IN_PROGRESS_" not in sysdiagnose_archive:
+        tar = tarfile.open(sysdiagnose_archive)
+        root = tar.getmembers()[0].name.split('/')[0]
+        try:
+            data_source = tar.extractfile(f"{root}/logs/SystemVersion/SystemVersion.plist")
+            pl = get_plist_file_content(data_source)
+        except KeyError:
+            pl = None
+
+    if pl is not None:
         for key, val in pl.items():
             data_list.append((key, val))
             if key == "Product Build Version":
-                device_info("Device Information", "Product Build Version", val, source_path)
+                device_info("Device Information", "Product Build Version", val, data_source)
 
             if key == "ProductVersion":
                 iOS.set_version(val)
+                context.set_installed_os_version(val)
                 logfunc(f"iOS Version: {val}")
-                device_info("Device Information", "iOS Version", val, source_path)
+                device_info("Device Information", "iOS Version", val, data_source)
 
             if key == "ProductName":
-                device_info("Device Information", "Product Name", val, source_path)
-                
-            if key == "BuildID":
-                device_info("Device Information", "Build ID", val, source_path)
-                
-            if key == "SystemImageID":
-                device_info("Device Information", "System Image ID", val, source_path)
+                device_info("Device Information", "Product Name", val, data_source)
 
-    data_headers = ('Property','Property Value')
-    return data_headers, data_list, source_path
+            if key == "BuildID":
+                device_info("Device Information", "Build ID", val, data_source)
+
+            if key == "SystemImageID":
+                device_info("Device Information", "System Image ID", val, data_source)
+
+    data_headers = ('Property', 'Property Value')
+
+    return data_headers, data_list, data_source

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -26,6 +26,7 @@ class Context:
     _device_ids = {}
     _device_boards = {}
     _os_builds = {}
+    _installed_os_version = ""
 
     @staticmethod
     def set_report_folder(report_folder):
@@ -142,6 +143,14 @@ class Context:
             __file__).parent.absolute().joinpath('data', 'os_builds.json')
         with open(os_builds_path, 'rt', encoding='utf-8') as json_file:
             Context._os_builds = json.load(json_file)
+
+    @staticmethod
+    def set_installed_os_version(os_version):
+        """
+        Sets the OS version of the analyzed device only once.
+        """
+        if not Context._installed_os_version:
+            Context._installed_os_version = os_version
 
     @staticmethod
     def _build_lookup_map():
@@ -411,6 +420,14 @@ class Context:
             if build in builds:
                 os_version.append(Context._os_builds[os_family][build])
         return (" or ").join(os_version)
+
+    @staticmethod
+    def get_installed_os_version():
+        """
+        Retrieves the OS version of the installed device.
+        """
+
+        return Context._installed_os_version
 
     @staticmethod
     def clear():


### PR DESCRIPTION
- Add a new method to the `context.py` file to get the version of the operating system installed on the analyzed device. Its purpose is to replace the iOS class in the `ilapfunc.py`file.
- The iOS class will be removed when all module will be updated with context.