### PR TITLE
feature: update media checkin to fix path bug and allow modules to set more media info

### DIFF
--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -14,6 +14,7 @@ from scripts.search_files import *
 from scripts.tz_offset import tzvalues
 from scripts.modules_to_exclude import modules_to_exclude
 from scripts.lavafuncs import *
+from scripts.context import Context
 
 
 def pickModules():
@@ -238,6 +239,7 @@ def process(casedata):
         progress_bar.config(maximum=len(selected_modules))
         casedata = {key: value.get() for key, value in casedata.items()}
         out_params = OutputParameters(output_folder)
+        Context.set_output_params(out_params)
         wrap_text = True
         time_offset = timezone_set.get()
         if time_offset == '':
@@ -252,7 +254,7 @@ def process(casedata):
         crunch_successful = ileapp.crunch_artifacts(
             selected_modules, extracttype, input_path, out_params, wrap_text,
             loader, casedata, time_offset, profile_filename, None, decryption_keys)
-        
+
         lava_finalize_output(out_params.report_folder_base)
 
         if crunch_successful:

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -249,16 +249,16 @@ def process(casedata):
         bottom_frame.grid_remove()
         progress_bar.grid(padx=16, sticky='we')
 
-        initialize_lava(input_path, out_params.report_folder_base, extracttype)
+        initialize_lava(input_path, out_params.output_folder_base, extracttype)
 
         crunch_successful = ileapp.crunch_artifacts(
             selected_modules, extracttype, input_path, out_params, wrap_text,
             loader, casedata, time_offset, profile_filename, None, decryption_keys)
 
-        lava_finalize_output(out_params.report_folder_base)
+        lava_finalize_output(out_params.output_folder_base)
 
         if crunch_successful:
-            report_path = os.path.join(out_params.report_folder_base, 'index.html')
+            report_path = os.path.join(out_params.output_folder_base, 'index.html')
             if report_path.startswith('\\\\?\\'):  # windows
                 report_path = report_path[4:]
             if report_path.startswith('\\\\'):  # UNC path

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -15,6 +15,7 @@ class Context:
     methods for retrieving and manipulating this data.
     """
 
+    _output_params = None
     _report_folder = None
     _seeker = None
     _artifact_info = None
@@ -27,6 +28,17 @@ class Context:
     _device_boards = {}
     _os_builds = {}
     _installed_os_version = ""
+
+    @staticmethod
+    def set_output_params(output_params):
+        """
+        Sets the OutputParameters instance in the Context. This should only be
+        called once at the start of a run.
+
+        Args:
+            output_params: The initialized OutputParameters object.
+        """
+        Context._output_params = output_params
 
     @staticmethod
     def set_report_folder(report_folder):
@@ -168,6 +180,21 @@ class Context:
                 filename_lookup[filename] = []
             filename_lookup[filename].append(full_path)
         return filename_lookup
+
+    @staticmethod
+    def get_output_params():
+        """
+        Retrieves the current OutputParameters instance from the Context.
+
+        Raises:
+            ValueError: If the output parameters are not set.
+
+        Returns:
+            OutputParameters: The OutputParameters instance.
+        """
+        if not Context._output_params:
+            raise ValueError("Context not set. OutputParameters not available.")
+        return Context._output_params
 
     @staticmethod
     def get_report_folder():
@@ -433,8 +460,8 @@ class Context:
     def clear():
         """
         Resets all context-related class variables to None, effectively
-        clearing any stored state or references, except for the device IDs and
-        OS builds which are retained for efficiency.
+        clearing any stored state or references, except for the device IDs,
+        OS builds, and output parameters which are retained for efficiency.
         """
         Context._report_folder = None
         Context._seeker = None

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -246,12 +246,17 @@ def _check_in_media(media_id, source_path, is_embedded, name, media_data=None, c
         if suffix and not suffix.startswith('.'):
             suffix = f".{suffix}"
 
+        extraction_path = Context.get_source_file_path(source_path)
+        file_info = seeker.file_infos.get(extraction_path)
+        if file_info:
+            media_item.source_path = file_info.source_path
+        else:
+            media_item.source_path = source_path
+
         if is_embedded:
             media_item.created_at = force_creation_date if force_creation_date else 0
             media_item.updated_at = force_modification_date if force_modification_date else 0
-            media_item.source_path = source_path
         else:
-            extraction_path = Context.get_source_file_path(source_path)
             if not extraction_path:
                 return None
 
@@ -259,24 +264,19 @@ def _check_in_media(media_id, source_path, is_embedded, name, media_data=None, c
             if not file_to_copy.is_file():
                 return None
 
-            file_info = seeker.file_infos.get(extraction_path)
             if force_creation_date:
                 media_item.created_at = force_creation_date
             elif file_info:
                 media_item.created_at = file_info.creation_date
             else:
                 media_item.created_at = 0
+
             if force_modification_date:
                 media_item.updated_at = force_modification_date
             elif file_info:
                 media_item.updated_at = file_info.modification_date
             else:
                 media_item.updated_at = 0
-
-            if file_info:
-                media_item.source_path = file_info.source_path
-            else:
-                media_item.source_path = source_path
 
         # 1. Create the canonical media file
         canonical_media_path = Path(output_params.media_folder).joinpath(media_id).with_suffix(suffix)

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -64,14 +64,14 @@ def initialize_lava(input_path, output_path, input_type):
                         type TEXT, 
                         metadata TEXT, 
                         created_at INTEGER, 
-                        updated_at INTEGER)''')
+                        updated_at INTEGER,
+                        is_embedded INTEGER)''')
     cursor.execute('''CREATE TABLE _lava_media_references (
                         id TEXT PRIMARY KEY, 
                         media_item_id TEXT, 
                         module_name TEXT, 
                         artifact_name TEXT, 
                         name TEXT,
-                        media_path TEXT,
                         FOREIGN KEY (media_item_id) REFERENCES _lava_media_items(id))''')
     cursor.execute('''CREATE VIEW _lava_media_info AS
                         SELECT 
@@ -80,13 +80,13 @@ def initialize_lava(input_path, output_path, input_type):
                             lmr.module_name, 
                             lmr.artifact_name, 
                             lmr.name, 
-                            lmr.media_path,
                             lmi.source_path, 
                             lmi.extraction_path, 
                             lmi.type, 
                             lmi.metadata, 
                             lmi.created_at, 
-                            lmi.updated_at 
+                            lmi.updated_at,
+                            lmi.is_embedded
                         FROM _lava_media_references as lmr 
                         LEFT JOIN _lava_media_items as lmi ON lmr.media_item_id = lmi.id''')
 
@@ -300,14 +300,24 @@ def lava_get_media_item(media_id):
 
 def lava_insert_sqlite_media_item(media_item):
     global lava_db
-    created_at = media_item.created_at if media_item.created_at else 'NULL'
-    updated_at = media_item.updated_at if media_item.updated_at else 'NULL'
     cursor = lava_db.cursor()
+    sql = '''INSERT INTO _lava_media_items 
+                ("id", "source_path", "extraction_path", "type", "metadata", "created_at", "updated_at", "is_embedded") 
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)'''
+
+    params = (
+        media_item.id,
+        str(media_item.source_path),
+        str(media_item.extraction_path),
+        media_item.mimetype,
+        media_item.metadata,
+        media_item.created_at if media_item.created_at else None,
+        media_item.updated_at if media_item.updated_at else None,
+        media_item.is_embedded
+    )
+
     try:
-        cursor.execute(f'''INSERT INTO _lava_media_items 
-                    ("id", "source_path", "extraction_path", "type", "metadata", "created_at", "updated_at") 
-                    VALUES ("{media_item.id}", "{media_item.source_path}", "{media_item.extraction_path}", 
-                    "{media_item.mimetype}", "{media_item.metadata}", {created_at}, {updated_at})''')
+        cursor.execute(sql, params)
         lava_db.commit()
     except sqlite3.IntegrityError as e:
         print(str(e))
@@ -321,11 +331,18 @@ def lava_get_media_references(media_ref):
 def lava_insert_sqlite_media_references(media_references):
     global lava_db
     cursor = lava_db.cursor()
-    cursor.execute(f'''INSERT INTO _lava_media_references 
-                ("id", "media_item_id", "module_name", "artifact_name", "name", "media_path")
-                VALUES ("{media_references.id}", "{media_references.media_item_id}", 
-                "{media_references.module_name}", "{media_references.artifact_name}", 
-                "{media_references.name}", "{media_references.media_path}")''')
+    sql = '''INSERT INTO _lava_media_references 
+                ("id", "media_item_id", "module_name", "artifact_name", "name")
+                VALUES (?, ?, ?, ?, ?)'''
+    
+    params = (
+        media_references.id,
+        media_references.media_item_id,
+        media_references.module_name,
+        media_references.artifact_name,
+        media_references.name
+    )
+    cursor.execute(sql, params)
     lava_db.commit()
 
 def lava_get_full_media_info(media_ref_id):


### PR DESCRIPTION
- add `is_embedded` to media item table
- remove `media_path` from media references table
- create central media folder and link/copy all media
- create html media folder and link/copy all html media
- change sql inserts to use parameters
- move media check in logic to single internal function
- public media check functions point to internal
- add output parameters to context
- add force params to let modules set mime type, extension, created, modified