### PR TITLE
Maite modules batch 8

### DIFF
--- a/scripts/artifacts/biomeAirpMode.py
+++ b/scripts/artifacts/biomeAirpMode.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
 
 import os
 import blackboxprotobuf
-from datetime import *
+from datetime import timezone
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv

--- a/scripts/artifacts/biomeAirpMode.py
+++ b/scripts/artifacts/biomeAirpMode.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Airplane Mode DKEvent",
         "description": "Parses airplane mode entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2020-04-30",
+        "creation_date": "2020-04-30",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -18,16 +18,57 @@ import blackboxprotobuf
 from datetime import *
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_ts_human_to_timezone_offset
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 @artifact_processor
-def get_biomeAirpMode(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeAirpMode(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'message_typedef': {'8': {'type': 'fixed64', 'name': ''}}, 'name': ''}}, 'name': ''}, '5': {'type': 'bytes', 'name': ''}, '8': {'type': 'fixed64', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {
+                    'type': 'bytes',
+                    'message_typedef': {
+                        '8': {'type': 'fixed64', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '5': {'type': 'bytes', 'name': ''},
+        '8': {'type': 'fixed64', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -35,8 +76,6 @@ def get_biomeAirpMode(files_found, report_folder, seeker, wrap_text, timezone_of
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -46,10 +85,9 @@ def get_biomeAirpMode(files_found, report_folder, seeker, wrap_text, timezone_of
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 timestart = (webkit_timestampsconv(protostuff['2']))
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                #timeend = convert_ts_int_to_utc(timeend)
                 event = protostuff['1']['1']
                 guid = protostuff['5'].decode()
 
@@ -61,6 +99,6 @@ def get_biomeAirpMode(files_found, report_folder, seeker, wrap_text, timezone_of
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), ('Timestamp2', 'datetime'), 'SEGB State'
                     , 'Event', 'GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'
 
 

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - App Install",
         "description": "Parses airplane mode entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -18,16 +18,79 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 @artifact_processor
-def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeAppinstall(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'str', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'str', 'name': ''},
+        '7': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {},
+                    'name': ''
+                },
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {
+                            'type': 'message',
+                            'message_typedef': {
+                                '1': {'type': 'int', 'name': ''},
+                                '2': {'type': 'int', 'name': ''}
+                            },
+                            'name': ''
+                        },
+                        '4': {'type': 'int', 'name': ''},
+                        '3': {'type': 'str', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '8': {'type': 'double', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -35,8 +98,6 @@ def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
     
@@ -46,15 +107,11 @@ def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_
 
             if record.state == EntryState.Written:
 
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
             
                 activity = (protostuff['1']['1'])
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
-                
-                
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
                 bundleid = (protostuff['4']['3'])
                 actionguid = (protostuff['5'])
@@ -73,7 +130,6 @@ def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_
                     bundleinfo = ''
                 
                 timewrite = (webkit_timestampsconv(protostuff['8']))
-                timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 data_list.append((ts, timestart, timeend, timewrite, record.state.name, activity, bundleid, bundleinfo,
                                   appinfo1, appinfo2, actionguid, filename, record.data_start_offset))
@@ -85,6 +141,6 @@ def get_biomeAppinstall(files_found, report_folder, seeker, wrap_text, timezone_
 
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), ('Time End', 'datetime'), ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Bundle ID', 'Bundle Info', 'App Info', 'App Info2', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'
 
 

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -115,7 +115,7 @@ def get_biomeAppinstall(context):
                 
                 bundleid = (protostuff['4']['3'])
                 actionguid = (protostuff['5'])
-                appinfo1 = appinfo2 = ''
+                appinfo1 = appinfo2 = bundleinfo = ''
                 if protostuff.get('7', '') != '':
                     if isinstance(protostuff['7'], list):
                         if len(protostuff['7']) < 3:
@@ -124,10 +124,6 @@ def get_biomeAppinstall(context):
                             appinfo1 = (protostuff['7'][0]['2'].get('3', ''))
                             bundleinfo = (protostuff['7'][1]['2'].get('3', ''))
                             appinfo2 = (protostuff['7'][2]['2'].get('3', ''))
-                    else:
-                        bundleinfo = ''
-                else:
-                    bundleinfo = ''
                 
                 timewrite = (webkit_timestampsconv(protostuff['8']))
                 

--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Backlight",
         "description": "Parses backlight entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,16 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeBacklight(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeBacklight(context):
 
     typess = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'int', 'name': ''}}
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +36,6 @@ def get_biomeBacklight(files_found, report_folder, seeker, wrap_text, timezone_o
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,10 +44,9 @@ def get_biomeBacklight(files_found, report_folder, seeker, wrap_text, timezone_o
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 timestart = (webkit_timestampsconv(protostuff['1']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 state = (protostuff['2'])
 
                 data_list.append((ts, timestart, record.state.name, state, filename, record.data_start_offset))
@@ -60,4 +56,4 @@ def get_biomeBacklight(files_found, report_folder, seeker, wrap_text, timezone_o
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'State', 'Filename',
                     'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Battery Percentage",
         "description": "Parses battery percentage entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,52 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeBattperc(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'double', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '5': {'type': 'double', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'str', 'name': ''},
+        '8': {'type': 'double', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +72,6 @@ def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_of
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,17 +80,12 @@ def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_of
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 
                 activity = (protostuff['1']['1'])
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
-                
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
-                
                 timewrite = (webkit_timestampsconv(protostuff['8']))
-                timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 percent = (protostuff['4']['5'])
                 actionguid = (protostuff['5'])
@@ -74,5 +102,5 @@ def get_biomeBattperc(files_found, report_folder, seeker, wrap_text, timezone_of
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Battery Percentage', 'Action GUID',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'
 

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
 
 import os
 import blackboxprotobuf
-from datetime import *
+from datetime import timezone
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Bluetooth",
         "description": "Parses bluetooth connection entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -23,11 +23,10 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_biomeBluetooth(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeBluetooth(context):
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -35,8 +34,6 @@ def get_biomeBluetooth(files_found, report_folder, seeker, wrap_text, timezone_o
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -59,4 +56,4 @@ def get_biomeBluetooth(files_found, report_folder, seeker, wrap_text, timezone_o
 
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'MAC', 'Name', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/Device.Wireless.Bluetooth/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "bluetooth"
     }
 }
 

--- a/scripts/artifacts/biomeCarplayisconnected.py
+++ b/scripts/artifacts/biomeCarplayisconnected.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Carplay",
         "description": "Parses carplay is connected entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -13,23 +13,57 @@ __artifacts_v2__ = {
     }
 }
 
-
 import os
 from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeCarplayisconnected(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeCarplayisconnected(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '4': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'str', 'name': ''},
+        '8': {'type': 'double', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +71,6 @@ def get_biomeCarplayisconnected(files_found, report_folder, seeker, wrap_text, t
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,18 +79,13 @@ def get_biomeCarplayisconnected(files_found, report_folder, seeker, wrap_text, t
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 activity = (protostuff['1']['1'])
                 
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
-                
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
-                
                 timewrite = (webkit_timestampsconv(protostuff['8']))
-                timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 actionguid = (protostuff['5'])
                 status = (protostuff['4']['4'])
@@ -73,4 +100,4 @@ def get_biomeCarplayisconnected(files_found, report_folder, seeker, wrap_text, t
     data_headers = (('SEGB Timestamp', 'datetime'), ('Time Start', 'datetime'), ('Time End', 'datetime'),
                     ('Time Write', 'datetime'), 'Activity', 'Status', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - In Focus DKEvent",
         "description": "Parses DKEvent InFocus Events from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,11 +19,11 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeDKInfocus(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeDKInfocus(context):
     
     typess = {
         '1': {'type': 'message', 'message_typedef': {
@@ -51,8 +51,7 @@ def get_biomeDKInfocus(files_found, report_folder, seeker, wrap_text, timezone_o
         '10': {'type': 'int', 'name': ''}}
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -60,8 +59,6 @@ def get_biomeDKInfocus(files_found, report_folder, seeker, wrap_text, timezone_o
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -70,17 +67,12 @@ def get_biomeDKInfocus(files_found, report_folder, seeker, wrap_text, timezone_o
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 
                 activity = (protostuff['1']['1'])
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
-                
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
-                
                 timewrite = (webkit_timestampsconv(protostuff['8']))
-                timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 actionguid = (protostuff['5'])
                 bundleid = (protostuff['4']['3'])
@@ -103,4 +95,4 @@ def get_biomeDKInfocus(files_found, report_folder, seeker, wrap_text, timezone_o
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Bundle ID', 'Transition', 'Action GUID',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDKKeybag.py
+++ b/scripts/artifacts/biomeDKKeybag.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome Keybag",
         "description": "Parses DKEvent Keybag IsLocked entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.1",
-        "date": "2025-04-29",
+        "creation_date": "2025-04-29",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome Keybag",
         "notes": "",
@@ -19,17 +19,52 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeDKKeybag(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeDKKeybag(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'bytes', 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '4': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'bytes', 'name': ''},
+        '8': {'type': 'double', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +72,6 @@ def get_biomeDKKeybag(files_found, report_folder, seeker, wrap_text, timezone_of
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,18 +80,13 @@ def get_biomeDKKeybag(files_found, report_folder, seeker, wrap_text, timezone_of
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 time2 = (webkit_timestampsconv(protostuff['2']))
-                time2 = convert_utc_human_to_timezone(time2, timezone_offset)
-
                 time3 = (webkit_timestampsconv(protostuff['3']))
-                time3 = convert_utc_human_to_timezone(time3, timezone_offset)
 
+                data_list.append((ts, time2, time3, '1 - Locked ' if protostuff['4']['4'] == 1 else '0 - Unlocked', filename))
 
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Start Time', 'datetime'), ('End Time', 'datetime'), 'isLocked', 'Filename')
 
-                data_list.append((ts, time2, time3, '1 - Locked ' if protostuff['4']['4'] == 1 else '0 - Unlocked'))
-
-    data_headers = (('SEGB Timestamp', 'datetime'), ('Start Time', 'datetime'), ('End Time', 'datetime'), 'isLocked')
-
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - WiFi Devices",
         "description": "Parses (device) WiFi connection entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,16 +19,15 @@ import blackboxprotobuf
 from datetime import *
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_biomeDevWifi(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeDevWifi(context):
     typess = {'1': {'type': 'str', 'name': 'SSID'}, '2': {'type': 'int', 'name': 'Connect'}}
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -36,8 +35,6 @@ def get_biomeDevWifi(files_found, report_folder, seeker, wrap_text, timezone_off
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -46,7 +43,7 @@ def get_biomeDevWifi(files_found, report_folder, seeker, wrap_text, timezone_off
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 ssid = protostuff['SSID']
                 status = 'Connected' if protostuff['Connect'] == 1 else 'Disconnected'
                 data_list.append((ts, record.state.name, ssid, status, filename, record.data_start_offset))
@@ -56,5 +53,5 @@ def get_biomeDevWifi(files_found, report_folder, seeker, wrap_text, timezone_off
 
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'SSID', 'Status', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'
 

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
 
 import os
 import blackboxprotobuf
-from datetime import *
+from datetime import timezone
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Device Plugged In",
         "description": "Parses device plugged in entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,74 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
-
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 @artifact_processor
-def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeDevplugin(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '4': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'str', 'name': ''},
+        '7': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'message', 'message_typedef': {}, 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {
+                            'type': 'message',
+                            'message_typedef': {
+                                '1': {'type': 'int', 'name': ''},
+                                '2': {'type': 'int', 'name': ''}
+                            },
+                            'name': ''
+                        },
+                        '4': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '8': {'type': 'double', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +94,6 @@ def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_o
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,17 +102,12 @@ def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_o
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 activity = (protostuff['1']['1'])
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
-                
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
-                
                 timewrite = (webkit_timestampsconv(protostuff['8']))
-                timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 con = (protostuff['4']['4'])
                 actionguid = (protostuff['5'])
@@ -72,4 +122,4 @@ def get_biomeDevplugin(files_found, report_folder, seeker, wrap_text, timezone_o
     data_headers = (('SEGB Timestamp', 'datetime'), ('Time Start', 'datetime'), ('Time End', 'datetime'),
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Status', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -86,7 +86,7 @@ def get_biomeDevplugin(context):
     }
 
     data_list = []
-    for file_found in context.files_found():
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):

--- a/scripts/artifacts/biomeHardware.py
+++ b/scripts/artifacts/biomeHardware.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Hardware Reliability",
         "description": "Parses hardware reliability entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,16 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_biomeHardware(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeHardware(context):
 
     typess = {'1': {'type': 'str', 'name': ''}}
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +36,6 @@ def get_biomeHardware(files_found, report_folder, seeker, wrap_text, timezone_of
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,12 +44,7 @@ def get_biomeHardware(files_found, report_folder, seeker, wrap_text, timezone_of
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
-                
-                #pp = pprint.PrettyPrinter(indent=4)
-                #pp.pprint(protostuff)
-                #print(types)
-                
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 hardware = (protostuff['1'])
                 
                 data_list.append((ts, record.state.name, hardware, filename, record.data_start_offset))
@@ -62,4 +54,4 @@ def get_biomeHardware(files_found, report_folder, seeker, wrap_text, timezone_of
 
     data_headers = (('SEGB Record Time', 'datetime'), 'SEGB State', 'Hardware', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - In Focus",
         "description": "Parses InFocus Events from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,18 +19,17 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeInfocus(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeInfocus(context):
 
     typess = {'10': {'name': '', 'type': 'str'}, '2': {'name': '', 'type': 'int'}, '3': {'name': '', 'type': 'int'},
               '4': {'name': '', 'type': 'double'}, '6': {'name': '', 'type': 'str'}, '9': {'name': '', 'type': 'str'}}
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -38,8 +37,6 @@ def get_biomeInfocus(files_found, report_folder, seeker, wrap_text, timezone_off
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -48,11 +45,10 @@ def get_biomeInfocus(files_found, report_folder, seeker, wrap_text, timezone_off
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 bundleid = (protostuff['6'])
                 timestart = (webkit_timestampsconv(protostuff['4']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 foreground = ('Foreground' if protostuff['3'] == 1 else 'Background')
 
                 data_list.append((ts, timestart, record.state.name, bundleid, foreground, filename, record.data_start_offset))
@@ -60,7 +56,7 @@ def get_biomeInfocus(files_found, report_folder, seeker, wrap_text, timezone_off
             elif record.state == EntryState.Deleted:
                 data_list.append((ts, None, record.state.name, None, None, filename, record.data_start_offset))
 
-    data_headers = (('Timestamp', 'datetime'), 'Bundle ID', 'Action', 'Filename', 'Offset')
+    data_headers = (('Timestamp', 'datetime'), ('Start Time', 'datetime'), 'SEGB State', 'Bundle ID', 'Action', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'
 

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -49,7 +49,7 @@ def get_biomeIntents(context):
                 typeofintent = protostuff.get('2','')
                 try:
                     typeofintent = typeofintent.decode()
-                except:
+                except (AttributeError, UnicodeDecodeError):
                     break
                 appid = typeofintent
 
@@ -58,7 +58,7 @@ def get_biomeIntents(context):
                 classname = (protostuff.get('4',''))
                 try:
                     classname = classname.decode()
-                except:
+                except (AttributeError, UnicodeDecodeError):
                     pass
 
                 if protostuff.get('5') is not None:
@@ -128,9 +128,10 @@ def get_biomeIntents(context):
                 #calls
                 elif typeofintent == 'com.apple.InCallService':
                     #print(protostuffinner)
+                    a = ''
                     try:
                         a = (protostuffinner['5']['1']['4'].decode()) #content number
-                    except:
+                    except (KeyError, TypeError, AttributeError, UnicodeDecodeError):
                         pass
                         #print(protostuffinner)
 
@@ -161,7 +162,7 @@ def get_biomeIntents(context):
                         c = (protostuffinner.get('15', ''))#senderid if not binary show dict
                         try:
                             d = (protostuffinner['2']['1']['4'])
-                        except:
+                        except (KeyError, TypeError):
                             d = ''
 
                         datos = f'Thread ID: {b}, Sender ID: {c}, Content:, {a}'
@@ -198,7 +199,7 @@ def get_biomeIntents(context):
                             a = loopy['1'].decode()
                             try:
                                 b = loopy['2']['2']['2']
-                            except:
+                            except (KeyError, TypeError):
                                 b = loopy['2']
                             datos = datos + f'{a}: {b},'
 

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -20,7 +20,7 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, get_plist_content
 
 
 @artifact_processor
@@ -144,17 +144,26 @@ def get_biomeLocationactivity(context):
                 
                 data4 = (protostuff['7'][10]['2'].get('6',''))
                 if isinstance(data4, bytes):
-                    deserialized_plist = nd.deserialize_plist_from_string(data4)
+                    #deserialized_plist = nd.deserialize_plist_from_string(data4)
+                    deserialized_plist = get_plist_content(data4)
+                    if not deserialized_plist or not isinstance(deserialized_plist, dict):
+                        data4 = None
                     data4 = (deserialized_plist['NS.relative'])
                     
                 data5 = (protostuff['7'][13]['2'].get('6',''))
                 if isinstance(data5, bytes):
-                    deserialized_plist = nd.deserialize_plist_from_string(data5)
+                    #deserialized_plist = nd.deserialize_plist_from_string(data5)
+                    deserialized_plist = get_plist_content(data5)
+                    if not deserialized_plist or not isinstance(deserialized_plist, dict):
+                        data5 = None
                     data5 = (deserialized_plist)
                     
                 data6 = (protostuff['7'][16]['2'].get('6',''))
                 if isinstance(data6, bytes):
-                    deserialized_plist = nd.deserialize_plist_from_string(data6)
+                    #deserialized_plist = nd.deserialize_plist_from_string(data6)
+                    deserialized_plist = get_plist_content(data6)
+                    if not deserialized_plist or not isinstance(deserialized_plist, dict):
+                        data6 = None
                     data6 = (deserialized_plist['NS.relative'])
                     
                 timewrite = (webkit_timestampsconv(protostuff['8']))

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -15,7 +15,6 @@ __artifacts_v2__ = {
 
 
 import os
-import nska_deserialize as nd
 from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Location Activity",
         "description": "Parses location activity entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -20,17 +20,89 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeLocationactivity(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '6': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'str', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '6': {'type': 'int', 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '5': {'type': 'fixed64', 'name': ''}, '4': {'type': 'int', 'name': ''}, '6': {'type': 'bytes', 'name': ''}, '7': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'str', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'str', 'name': ''},
+        '6': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {'type': 'str', 'name': ''},
+                '3': {'type': 'bytes', 'name': ''},
+                '6': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '7': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'message', 'message_typedef': {}, 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {
+                            'type': 'message',
+                            'message_typedef': {
+                                '1': {'type': 'int', 'name': ''},
+                                '2': {'type': 'int', 'name': ''}
+                            },
+                            'name': ''
+                        },
+                        '3': {'type': 'bytes', 'name': ''},
+                        '5': {'type': 'fixed64', 'name': ''},
+                        '4': {'type': 'int', 'name': ''},
+                        '6': {'type': 'bytes', 'name': ''},
+                        '7': {'type': 'fixed64', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '8': {'type': 'double', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -38,8 +110,6 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -48,14 +118,11 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 
                 activity = (protostuff['1']['1'])
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
-                
                 timeend = (webkit_timestampsconv(protostuff['3']))
-                timeend = convert_utc_human_to_timezone(timeend, timezone_offset)
                 
                 bundle = (protostuff['4']['3'])
                 actionguid = (protostuff['5'])
@@ -91,7 +158,6 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
                     data6 = (deserialized_plist['NS.relative'])
                     
                 timewrite = (webkit_timestampsconv(protostuff['8']))
-                timewrite = convert_utc_human_to_timezone(timewrite, timezone_offset)
                 
                 data_list.append((ts, timestart, timeend, timewrite, record.state.name, activity, bundle, bundle2,
                                   data0, data1, data2, data3, data4, data5, data6, actionguid, filename,
@@ -105,4 +171,4 @@ def get_biomeLocationactivity(files_found, report_folder, seeker, wrap_text, tim
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Bundle ID','Bundle ID 2', 'Data 0', 'Data 1',
                     'Data 2', 'Data 3', 'Data 4', 'Data 5', 'Data 6', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -147,7 +147,8 @@ def get_biomeLocationactivity(context):
                     deserialized_plist = get_plist_content(data4)
                     if not deserialized_plist or not isinstance(deserialized_plist, dict):
                         data4 = None
-                    data4 = (deserialized_plist['NS.relative'])
+                    else:
+                        data4 = (deserialized_plist.get('NS.relative'))
                     
                 data5 = (protostuff['7'][13]['2'].get('6',''))
                 if isinstance(data5, bytes):
@@ -155,7 +156,8 @@ def get_biomeLocationactivity(context):
                     deserialized_plist = get_plist_content(data5)
                     if not deserialized_plist or not isinstance(deserialized_plist, dict):
                         data5 = None
-                    data5 = (deserialized_plist)
+                    else:
+                        data5 = (deserialized_plist)
                     
                 data6 = (protostuff['7'][16]['2'].get('6',''))
                 if isinstance(data6, bytes):
@@ -163,7 +165,8 @@ def get_biomeLocationactivity(context):
                     deserialized_plist = get_plist_content(data6)
                     if not deserialized_plist or not isinstance(deserialized_plist, dict):
                         data6 = None
-                    data6 = (deserialized_plist['NS.relative'])
+                    else:
+                        data6 = (deserialized_plist.get('NS.relative'))
                     
                 timewrite = (webkit_timestampsconv(protostuff['8']))
                 

--- a/scripts/artifacts/biomeNotes.py
+++ b/scripts/artifacts/biomeNotes.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Biome/streams/restricted/NotesContent/local/*'),
         "html_columns" : ['Note'],
-        "output_types": "none",
+        "output_types": "standard",
         "function": "get_biomeNotes"
     }
 }

--- a/scripts/artifacts/biomeNotes.py
+++ b/scripts/artifacts/biomeNotes.py
@@ -3,12 +3,13 @@ __artifacts_v2__ = {
         "name": "Biome - Notes",
         "description": "Parses notes entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/NotesContent/local/*'),
+        "html_columns" : ['Note'],
         "output_types": "none",
         "function": "get_biomeNotes"
     }
@@ -18,26 +19,28 @@ __artifacts_v2__ = {
 import os
 from datetime import timezone
 import blackboxprotobuf
-from pathlib import Path
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import webkit_timestampsconv, tsv, timeline, convert_utc_human_to_timezone, convert_time_obj_to_utc
-from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data
+from scripts.ilapfuncs import webkit_timestampsconv, artifact_processor
 
+@artifact_processor
+def get_biomeNotes(context):
 
-def get_biomeNotes(files_found, report_folder, seeker, wrap_text, timezone_offset):
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Record Num', 'Identifier 1', 
+                    'Identifier 2', 'Note', 'Filename', 'Offset')
 
-    category = "Biome Notes"
-    module_name = "get_biomeNotes"
-    data_headers = ('SEGB Timestamp', 'Timestamp', 'SEGB State', 'Record Num', 'Identifier 1', 'Identifier 2', 'Note')
-    lava_data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Record Num', 'Identifier 1', 'Identifier 2', 'Note')
-
-    typess = {'1': {'type': 'str', 'name': ''}, '2': {'type': 'str', 'name': ''}, '3': {'type': 'double', 'name': ''}, '5': {'type': 'str', 'name': ''}}
+    # TODO: shouldn't it be used in decode_message?
+    # typess = {
+    #     '1': {'type': 'str', 'name': ''},
+    #     '2': {'type': 'str', 'name': ''},
+    #     '3': {'type': 'double', 'name': ''},
+    #     '5': {'type': 'str', 'name': ''}
+    # }
 
     data_list = []
+    data_list_html = []
     record_counter = 0
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -45,60 +48,28 @@ def get_biomeNotes(files_found, report_folder, seeker, wrap_text, timezone_offse
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                pass
         else:
             continue
-
-        file_data_list_html = []
-        file_data_list = []
+        
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data)
                 record_counter += 1
                 time = (webkit_timestampsconv(protostuff['3']))
-                time = convert_utc_human_to_timezone(time, timezone_offset)
                 identifier1 = protostuff['1']
                 identifier2 = protostuff['2']
                 message = protostuff['5']
                 messagehtml = (message.replace('\n', '<br>'))
-                file_data_list.append((ts, time, record.state.name, record_counter, identifier1, identifier2, message, filename, record.data_start_offset))
-                file_data_list_html.append((ts, time, record.state.name, record_counter, identifier1, identifier2, messagehtml, filename, record.data_start_offset))
-                
-                #write notes to report_folder
-                
-                output_file = Path(report_folder).joinpath(f'{record_counter}.txt')
-                output_file.write_text(message)
+                data_list.append((ts, time, record.state.name, record_counter, identifier1, identifier2, message, filename, record.data_start_offset))
+                data_list_html.append((ts, time, record.state.name, record_counter, identifier1, identifier2, messagehtml, filename, record.data_start_offset))
 
             elif record.state == EntryState.Deleted:
-                file_data_list.append((ts, None, record.state.name, None, None, None, None, filename,
+                data_list.append((ts, None, record.state.name, None, None, None, None, filename,
                                        record.data_start_offset))
-                file_data_list_html.append((ts, None, record.state.name, None, None, None, None, filename,
+                data_list_html.append((ts, None, record.state.name, None, None, None, None, filename,
                                             record.data_start_offset))
 
-        data_list.extend(file_data_list)
-        
-        if len(file_data_list) > 0:
-            description = ''
-            report = ArtifactHtmlReport(f'Biome Notes')
-            report.start_artifact_report(report_folder, f'Biome Notes - {filename}', description)
-            report.add_script()
-            report.write_artifact_data_table(data_headers, file_data_list_html, file_found, html_no_escape=['Note'])
-            report.end_artifact_report()
-            
-            tsvname = f'Biome Notes - {filename}'
-            tsv(report_folder, data_headers, file_data_list, tsvname) # TODO: _csv.Error: need to escape, but no escapechar set
-            
-            tlactivity = f'Biome Notes - {filename}'
-            timeline(report_folder, tlactivity, file_data_list, data_headers)
-
-    # Single table for LAVA output
-    table_name, object_columns, column_map = lava_process_artifact(category, module_name,
-                                                                   'Biome Notes',
-                                                                   lava_data_headers,
-                                                                   len(data_list))
-
-    lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+    return data_headers, (data_list, data_list_html), 'see Source File for more info'

--- a/scripts/artifacts/biomeNotificationsPub.py
+++ b/scripts/artifacts/biomeNotificationsPub.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Notifications",
         "description": "Parses notifications entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,28 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeNotificationsPub(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeNotificationsPub(context):
 
-    typess = {'1': {'type': 'str', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'int', 'name': ''}, '4': {'type': 'str', 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'str', 'name': ''}, '9': {'type': 'str', 'name': ''}, '11': {'type': 'int', 'name': ''}, '12': {'type': 'str', 'name': ''}, '14': {'type': 'str', 'name': ''}, '16': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {'type': 'str', 'name': ''},
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'int', 'name': ''},
+        '4': {'type': 'str', 'name': ''},
+        '5': {'type': 'str', 'name': ''},
+        '8': {'type': 'str', 'name': ''},
+        '9': {'type': 'str', 'name': ''},
+        '11': {'type': 'int', 'name': ''},
+        '12': {'type': 'str', 'name': ''},
+        '14': {'type': 'str', 'name': ''},
+        '16': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +48,6 @@ def get_biomeNotificationsPub(files_found, report_folder, seeker, wrap_text, tim
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,10 +56,9 @@ def get_biomeNotificationsPub(files_found, report_folder, seeker, wrap_text, tim
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 bundleid = (protostuff['14'])
                 data1 = (protostuff.get('8',''))
                 data2 = (protostuff.get('9',''))
@@ -71,5 +79,5 @@ def get_biomeNotificationsPub(files_found, report_folder, seeker, wrap_text, tim
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Field 1',
                     'Field 2','Field 3','Field 4','Field 5','Field 6', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'
 

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Now Playing",
         "description": "Parses Now Playing entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,35 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeNowplaying(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeNowplaying(context):
 
-    typess = {'2': {'type': 'double', 'name': ''}, '3': {'type': 'int', 'name': ''}, '5': {'type': 'str', 'name': ''}, '6': {'type': 'int', 'name': ''}, '8': {'type': 'str', 'name': ''}, '9': {'type': 'int', 'name': ''}, '10': {'type': 'str', 'name': ''}, '13': {'type': 'int', 'name': ''}, '14': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '15': {'type': 'str', 'name': ''}}
+    typess = {
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'int', 'name': ''},
+        '5': {'type': 'str', 'name': ''},
+        '6': {'type': 'int', 'name': ''},
+        '8': {'type': 'str', 'name': ''},
+        '9': {'type': 'int', 'name': ''},
+        '10': {'type': 'str', 'name': ''},
+        '13': {'type': 'int', 'name': ''},
+        '14': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'int', 'name': ''},
+                '2': {'type': 'int', 'name': ''},
+                '3': {'type': 'str', 'name': ''}
+            },
+            'name': ''
+        },
+        '15': {'type': 'str', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +55,6 @@ def get_biomeNowplaying(files_found, report_folder, seeker, wrap_text, timezone_
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,10 +63,9 @@ def get_biomeNowplaying(files_found, report_folder, seeker, wrap_text, timezone_
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 
                 timestart = (webkit_timestampsconv(protostuff['2']))
-                timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
                 bundleid = (protostuff['15'])
                 info = (protostuff.get('10',''))
                 info2 = (protostuff.get('8',''))
@@ -72,4 +87,4 @@ def get_biomeNowplaying(files_found, report_folder, seeker, wrap_text, timezone_
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Output',
                     'Media Type', 'Title', 'Artist', 'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Safari",
         "description": "Parses safari entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,86 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeSafari(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeSafari(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '6': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'str', 'name': ''}, '3': {'type': 'str', 'name': ''}, '4': {'type': 'str', 'name': ''}, '6': {'type': 'int', 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'str', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '8': {'type': 'fixed64', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'str', 'name': ''}
+            },
+            'name': ''
+        },
+        '5': {'type': 'str', 'name': ''},
+        '6': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {'type': 'str', 'name': ''},
+                '3': {'type': 'str', 'name': ''},
+                '4': {'type': 'str', 'name': ''},
+                '6': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '7': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'message', 'message_typedef': {}, 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {
+                            'type': 'message',
+                            'message_typedef': {
+                                '1': {'type': 'int', 'name': ''},
+                                '2': {'type': 'int', 'name': ''}
+                            },
+                            'name': ''
+                        },
+                        '3': {'type': 'str', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {'type': 'int', 'name': ''}
+            },
+            'name': ''
+        },
+        '8': {'type': 'fixed64', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +106,6 @@ def get_biomeSafari(files_found, report_folder, seeker, wrap_text, timezone_offs
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,7 +114,7 @@ def get_biomeSafari(files_found, report_folder, seeker, wrap_text, timezone_offs
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 activity = (protostuff['1']['1'])
                 timestart = (webkit_timestampsconv(protostuff['2']))
                 url = (protostuff['4']['3'])
@@ -67,4 +134,4 @@ def get_biomeSafari(files_found, report_folder, seeker, wrap_text, timezone_offs
         data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Activity', 'Title',
                         'URL', 'Detail', 'Detail 2', 'Detail 3', 'GUID', "Filename", "Offset")
 
-        return data_headers, data_list, report_file
+        return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeTextinputses.py
+++ b/scripts/artifacts/biomeTextinputses.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - Text Input Session",
         "description": "Parses Text Input Session entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -21,17 +21,21 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, convert_utc_human_to_timezone, convert_ts_int_to_timezone, webkit_timestampsconv
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_ts_human_to_utc
 
 
 @artifact_processor
-def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeTextinputses(context):
 
-    typess = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'str', 'name': ''}, '4': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {'type': 'double', 'name': ''},
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'str', 'name': ''},
+        '4': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -39,8 +43,6 @@ def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezon
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -49,15 +51,14 @@ def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezon
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 duration = protostuff['1']
                 # Records in "restricted" folder seem to have time in Unix time, whereas public was cocoa time
                 if 'restricted' in file_found:
-                    timestart = (convert_ts_int_to_timezone(protostuff['2'], timezone_offset))
+                    timestart = convert_ts_human_to_utc(protostuff['2'])
                 else:
                     timestart = (webkit_timestampsconv(protostuff['2']))
-                    timestart = convert_utc_human_to_timezone(timestart, timezone_offset)
 
                 bundleid = (protostuff.get('3',''))
                 
@@ -70,4 +71,4 @@ def get_biomeTextinputses(files_found, report_folder, seeker, wrap_text, timezon
     data_headers = (('SEGB Timestamp', 'datetime'), ('Time Start', 'datetime'), 'SEGB State', 'Bundle ID', 'Duration',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeTextinputses.py
+++ b/scripts/artifacts/biomeTextinputses.py
@@ -21,7 +21,7 @@ from datetime import timezone
 import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_ts_human_to_utc
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_ts_int_to_utc
 
 
 @artifact_processor
@@ -56,7 +56,7 @@ def get_biomeTextinputses(context):
                 duration = protostuff['1']
                 # Records in "restricted" folder seem to have time in Unix time, whereas public was cocoa time
                 if 'restricted' in file_found:
-                    timestart = convert_ts_human_to_utc(protostuff['2'])
+                    timestart = convert_ts_int_to_utc(protostuff['2'])
                 else:
                     timestart = (webkit_timestampsconv(protostuff['2']))
 

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -72,7 +72,7 @@ def get_biomeUseractmeta(context):
                     if type(internalbplist) != str:
                         try:
                             internalbplist = (deserialized_plist['contentAttributeSetData']['NS.data'])
-                        except Exception as ex:
+                        except (KeyError, TypeError) as ex:
                             print(ex)
                             print('Processing as bplist["container"] directly.')
                         #deserialized_plist2 = nd.deserialize_plist_from_string(internalbplist)

--- a/scripts/artifacts/biomeWifi.py
+++ b/scripts/artifacts/biomeWifi.py
@@ -3,8 +3,8 @@ __artifacts_v2__ = {
         "name": "Biome - WiFi DKEvent",
         "description": "Parses DKEvent WiFi entries from biomes",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "creation_date": "2024-10-17",
+        "last_update_date": "2025-10-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -19,17 +19,58 @@ import blackboxprotobuf
 from datetime import timezone
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeWifi(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_biomeWifi(context):
 
-    typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'message_typedef': {'8': {'type': 'fixed64', 'name': ''}}, 'name': ''}}, 'name': ''}, '5': {'type': 'bytes', 'name': ''}, '8': {'type': 'fixed64', 'name': ''}, '10': {'type': 'int', 'name': ''}}
+    typess = {
+        '1': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {'type': 'str', 'name': ''},
+                '2': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '2': {'type': 'double', 'name': ''},
+        '3': {'type': 'double', 'name': ''},
+        '4': {
+            'type': 'message',
+            'message_typedef': {
+                '1': {
+                    'type': 'message',
+                    'message_typedef': {
+                        '1': {'type': 'int', 'name': ''},
+                        '2': {'type': 'int', 'name': ''}
+                    },
+                    'name': ''
+                },
+                '3': {
+                    'type': 'bytes',
+                    'message_typedef': {
+                        '8': {'type': 'fixed64', 'name': ''}
+                    },
+                    'name': ''
+                }
+            },
+            'name': ''
+        },
+        '5': {'type': 'bytes', 'name': ''},
+        '8': {'type': 'fixed64', 'name': ''},
+        '10': {'type': 'int', 'name': ''}
+    }
 
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
@@ -37,8 +78,6 @@ def get_biomeWifi(files_found, report_folder, seeker, wrap_text, timezone_offset
         if os.path.isfile(file_found):
             if 'tombstone' in file_found:
                 continue
-            else:
-                report_file = os.path.dirname(file_found)
         else:
             continue
 
@@ -47,7 +86,7 @@ def get_biomeWifi(files_found, report_folder, seeker, wrap_text, timezone_offset
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
                 timestart = (webkit_timestampsconv(protostuff['2']))
 
@@ -65,4 +104,4 @@ def get_biomeWifi(files_found, report_folder, seeker, wrap_text, timezone_offset
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Event', 'Device', 'GUID',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, report_file
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
refactor biomes artifact to v2. 
- Most of them were already using the v2 dict but with version and date, so i just replaced that with creation_date and last_update_date and changed the artifact params to context.
- Removed timezone conversions
- Some of them also had a typess dict defined in a single line which was difficult to read. I reformatted it into a multi-line dict
- Changed the output source file to 'see Filename for more info' so it's consistent with other artifacts
- Intents and Notes still had manual report generation. I replaced it by returning the necessary values. 
- In Useractmeta, Locationactivity and Intents, replaced deserialize_plist_from_string with get_plist_content

Backlight, DeviceSync, Notifications, NowPlaying, TextInputses, UserActMeta and Intents are tested and working fine. For the rest i couldn't find any test data
