### PR TITLE
Fix UnboundLocalError: Initialize 'bundleid' and 'path' in mobileInstall.py

### DIFF
--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -75,6 +75,8 @@ def get_mobileInstall(files_found, report_folder, seeker, wrap_text, timezone_of
     file_datainserts = []
     for file in files:
         for line in file:
+            bundleid = ''
+            path = ''
             counter = counter + 1
             matchObj = re.search(
                 r"(Install Successful for)", line


### PR DESCRIPTION
**Description**
This PR fixes a logic error in `scripts/artifacts/mobileInstall.py` where the variables `bundleid` and `path` could be referenced before assignment. This occurs when the regex searches inside the main loop fail to find a match, causing the script to crash with an `UnboundLocalError`.

**Errors Encountered**
When running iLEAPP against the dataset below, the plugin crashed with the following errors:

1. Error 1 (bundleid):

    Error was local variable 'bundleid' referenced before assignment File ".../mobileInstall.py", line 442, in get_mobileInstall tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path)) UnboundLocalError: local variable 'bundleid' referenced before assignment

2.  Error 2 (path) - after fixing bundleid:

    Error was local variable 'path' referenced before assignment File ".../mobileInstall.py", line 443, in get_mobileInstall tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path)) UnboundLocalError: local variable 'path' referenced before assignment

**Dataset to Reproduce**
- **Source:** Magnet 2021 CTF - iOS
- **Link:** https://digitalcorpora.s3.amazonaws.com/corpora/scenarios/magnet/2021%20CTF%20-%20iOS.zip

**The Fix**
I initialized both `bundleid` and `path` to empty strings (`''`) at the start of the log processing loop. This ensures the variables always exist even if the specific regex conditions are not met for a given line.

**Verification**
Tested locally on the Magnet 2021 CTF dataset.
- **Before fix:** Script crashed.
<img width="1508" height="148" alt="image" src="https://github.com/user-attachments/assets/0fb6abc9-d64a-4e5f-aacf-03aa13ad4f79" />

<img width="1504" height="147" alt="image" src="https://github.com/user-attachments/assets/e9e14909-409d-453f-a7b2-bd30a5bfcca7" />

- **After fix:** Script completed successfully (Processed 505 apps).

<img width="492" height="225" alt="image" src="https://github.com/user-attachments/assets/874e1f42-32f0-40d6-85f9-bd46d69fdade" />
