### PR TITLE
Fix timestamp parsing errors in keyboard.py (ValueError & AttributeError)

### DIFF
--- a/scripts/artifacts/keyboard.py
+++ b/scripts/artifacts/keyboard.py
@@ -41,6 +41,7 @@ import plistlib
 import sqlite3
 import string
 from os.path import dirname
+from datetime import datetime
 
 from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, artifact_processor, convert_plist_date_to_timezone_offset
 
@@ -79,9 +80,17 @@ def keyboardAppUsage(files_found, report_folder, seeker, wrap_text, timezone_off
                 plist_content = plistlib.load(plist_file)
                 for app in plist_content:
                     for entry in plist_content[app]:
-                        start_date = convert_plist_date_to_timezone_offset(entry['startDate'], timezone_offset)
-                        data_list.append((start_date, app, entry['appTime'], ', '.join(map(str, entry['keyboardTimes']))))
-    
+                        raw_date = str(entry['startDate'])
+                        if raw_date.endswith('Z'):
+                            raw_date = raw_date.replace('Z', '+00:00')
+                        try:
+                            dt_obj = datetime.fromisoformat(raw_date)
+                            start_date = dt_obj.strftime('%Y-%m-%d %H:%M:%S')
+                        except ValueError:
+                            start_date = raw_date
+
+                        data_list.append((start_date, app, entry['appTime'], ', '.join(map(str, entry['keyboardTimes'])))) 
+                           
     data_headers = (('Date', 'datetime'), 'Application Name', 'Application Time Used in Seconds', 'Keyboard Times Used in Seconds')
     return data_headers, data_list, files_found[0]
 


### PR DESCRIPTION
**Description**
This PR fixes a crash in scripts/artifacts/keyboard.py caused by timestamp parsing issues. The script failed to handle timestamps ending in 'Z' (Zulu/UTC time) when running on Python versions where `datetime.fromisoformat` requires +00:00. Additionally, attempting to fix the string format introduced a secondary AttributeError because the helper function expected a Plist object, not a string.

**Errors Encountered**
When running iLEAPP against the dataset below, the plugin crashed with the following errors:

1. Error 1 (ValueError - Original):

    Reading keyboardAppUsage artifact had errors!
    Error was Invalid isoformat string: '2021-03-14T00:00:00Z'
    File ".../scripts/artifacts/keyboard.py", line 85, in keyboardAppUsage
    start_date = convert_plist_date_to_timezone_offset(raw_date, timezone_offset)
    ValueError: Invalid isoformat string: '2021-03-14T00:00:00Z'

2. Error 2 (AttributeError - After partial fix):

    Reading keyboardAppUsage artifact had errors!
    Error was 'str' object has no attribute 'year'
    File ".../scripts/artifacts/keyboard.py", line 84, in keyboardAppUsage
    start_date = convert_plist_date_to_timezone_offset(raw_date, timezone_offset)
    File ".../scripts/ilapfuncs.py", line 1142, in convert_plist_date_to_timezone_offset
    plist_date.year, plist_date.month, plist_date.day,
    AttributeError: 'str' object has no attribute 'year'

**Dataset to Reproduce**
- Source: Magnet 2021 CTF - iOS
- Link: https://digitalcorpora.s3.amazonaws.com/corpora/scenarios/magnet/2021%20CTF%20-%20iOS.zip

**The Fix** 
I modified the keyboardAppUsage function to handle date parsing locally within the script, bypassing the ilapfuncs helper function to avoid the attribute error:
  1. Imported datetime from the standard library.
  2. Converted the input to a string and replaced the 'Z' suffix with '+00:00'.
  3. Parsed the string using datetime.fromisoformat directly and formatted it for the report.
  4. Added a try-except block to ensure the script falls back to the raw string if parsing fails, preventing future crashes.

**Verification** 
Tested locally on the Magnet 2021 CTF dataset.

Before fix: Script crashed.
<img width="1510" height="211" alt="image" src="https://github.com/user-attachments/assets/b0134eef-65d1-4147-b24a-3c913c8e4d58" />
<img width="1517" height="198" alt="image" src="https://github.com/user-attachments/assets/f78b12db-b5a6-4569-9ad7-aeb35e98fe41" />


After fix: Script completed successfully (Found 1 record for Keyboard Application Usage).
<img width="506" height="84" alt="image" src="https://github.com/user-attachments/assets/f3b209db-fb69-47e2-9750-237bb8ffada0" />

