### PR TITLE
fix: Initialize alllines variable in deviceActivator function

### DIFF
--- a/scripts/artifacts/deviceActivator.py
+++ b/scripts/artifacts/deviceActivator.py
@@ -24,6 +24,7 @@ def deviceActivator(context):
     files_found = context.get_files_found()
     file_found = str(files_found[0])
     report_folder = context.get_report_folder()
+    alllines = ''
     
     with open(file_found, 'r', encoding='utf-8') as f_in:
         for line in f_in:


### PR DESCRIPTION
## Fix unbound variable error in deviceActivator artifact

Fixed `UnboundLocalError` caused by using `alllines` variable before initialization.

**Before:** Variable `alllines` was used without being initialized  
**After:** `alllines = ''` added before the loop (line 27)

This resolves the error that prevented the deviceActivator artifact from processing activation data files.

### Error Message Before Fix

UnboundLocalError: cannot access local variable `alllines` where it is not associated with a value
File `scripts/artifacts/deviceActivator.py`, line 30, in deviceActivator
alllines = alllines + line

**Files changed:**
- `scripts/artifacts/deviceActivator.py`