### PR TITLE
fix: make exception broader so it can catch DatabaseError also

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -584,10 +584,7 @@ def get_sqlite_db_records(path, query, attach_query=None):
             cursor.execute(query)
             records = cursor.fetchall()
             return records
-        except sqlite3.OperationalError as e:
-            logfunc(f"Error with {path}:")
-            logfunc(f" - {str(e)}")
-        except sqlite3.ProgrammingError as e:
+        except Exception as e:
             logfunc(f"Error with {path}:")
             logfunc(f" - {str(e)}")
     return []

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -584,7 +584,7 @@ def get_sqlite_db_records(path, query, attach_query=None):
             cursor.execute(query)
             records = cursor.fetchall()
             return records
-        except Exception as e:
+        except sqlite3.DatabaseError as e:
             logfunc(f"Error with {path}:")
             logfunc(f" - {str(e)}")
     return []


### PR DESCRIPTION
When the file was not a valid database, the code raised a <code>DatabaseError</code> that wasn’t being caught, since only <code>OperationalError</code> and <code>ProgrammingError</code> were handled. This PR broadens the exception handling to properly cover <code>DatabaseError</code> as well.

Before:
```txt
Query error, query=SELECT name FROM sqlite_master WHERE type='table' AND name='workout_activities' Error=file is not a database
Reading health_workouts artifact had errors!
Error was file is not a database
Exception Traceback: Traceback (most recent call last): File "E:\forensik\iLEAPP\ileapp.py", line 491, in crunch_artifacts plugin.method(files_found, category_folder, seeker, wrap_text, time_offset) File "E:\forensik\iLEAPP\scripts\ilapfuncs.py", line 359, in wrapper data_headers, data_list, source_path = func(Context) ^^^^^^^^^^^^^ File "E:\forensik\iLEAPP\scripts\artifacts\health.py", line 531, in health_workouts db_records = get_sqlite_db_records(data_source, query, attach_query) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "E:\forensik\iLEAPP\scripts\ilapfuncs.py", line 583, in get_sqlite_db_records cursor.execute(attach_query) sqlite3.DatabaseError: file is not a database
```

After:
```txt
Query error, query=SELECT name FROM sqlite_master WHERE type='table' AND name='workout_activities' Error=file is not a database
Error with \\?\E:\forensik\iLEAPP_Reports_2025-12-07_Sunday_001201\data\iOS_Filesystem\private\var\mobile\Library\Health\healthdb_secure.sqlite:
- file is not a database
No data found for Health - Workouts
health_workouts [health] artifact completed
```

As a result, the parsing operation can complete without the exception being thrown immediately.

ref: [https://docs.python.org/3/library/sqlite3.html](https://docs.python.org/3/library/sqlite3.html)