### PR TITLE
Fix crashes in TikTok artifacts (SQL syntax error & missing tables) and logic bug

### DIFF
--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -40,9 +40,12 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text, timezone_offset):
             for table in contacts_tables:
                 contacts_subqueries.append(f'SELECT uid, customid, nickname, url1 FROM {table}')
 
-            contacts_subquery = '''
-            UNION ALL
-            '''.join(contacts_subqueries)
+            if len(contacts_subqueries) > 0:
+                contacts_subquery = '''
+                            UNION ALL
+                            '''.join(contacts_subqueries)
+            else:
+                contacts_subquery = 'SELECT null as uid, null as customid, null as nickname, null as url1 FROM sqlite_master WHERE 1=0'
 
             cursor.execute(f'''
                 select
@@ -119,7 +122,7 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text, timezone_offset):
     
     all_rows1 = cursor.fetchall()
     data_list1 = []
-    if len(all_rows) > 0:
+    if len(all_rows1) > 0:
         description = 'Timestamp corresponds to latest chat if available'
         for row in all_rows1:
             

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -47,6 +47,11 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text, timezone_offset):
             else:
                 contacts_subquery = 'SELECT null as uid, null as customid, null as nickname, null as url1 FROM sqlite_master WHERE 1=0'
 
+            cursor.execute("SELECT name FROM AwemeIM.sqlite_master WHERE type='table' and name='TIMMessageORM';")
+            if cursor.fetchone() is None:
+                logfunc("Table TIMMessageORM not found in AwemeIM.db")
+                continue
+
             cursor.execute(f'''
                 select
                     datetime(localcreatedat, 'unixepoch') as Local_Create_Time,

--- a/scripts/artifacts/tikTokReplied.py
+++ b/scripts/artifacts/tikTokReplied.py
@@ -66,6 +66,11 @@ def tiktok_replied(files_found, report_folder, seeker, wrap_text, timezone_offse
             else:
                  contacts_subquery = 'SELECT null as uid, null as customid, null as nickname, null as url1, null as t WHERE 1=0'
 
+            cursor.execute("SELECT name FROM AwemeIM.sqlite_master WHERE type='table' and name='TIMMessageKVORM';")
+            if cursor.fetchone() is None:
+                logfunc("Table TIMMessageKVORM not found in AwemeIM.db")
+                continue
+
             # wrap subquery to select only a single record per contact
             contacts_subquery = f'''
             WITH UniqueContacts AS (

--- a/scripts/artifacts/tikTokReplied.py
+++ b/scripts/artifacts/tikTokReplied.py
@@ -59,9 +59,12 @@ def tiktok_replied(files_found, report_folder, seeker, wrap_text, timezone_offse
             for table in contacts_tables:
                 contacts_subqueries.append(f'SELECT uid, customid, nickname, url1, "{table}" as t FROM AwemeIM.{table}')
 
-            contacts_subquery = '''
-                        UNION ALL
-                        '''.join(contacts_subqueries)
+            if len(contacts_subqueries) > 0:
+                contacts_subquery = '''
+                            UNION ALL
+                            '''.join(contacts_subqueries)
+            else:
+                 contacts_subquery = 'SELECT null as uid, null as customid, null as nickname, null as url1, null as t WHERE 1=0'
 
             # wrap subquery to select only a single record per contact
             contacts_subquery = f'''


### PR DESCRIPTION
### Summary
This PR fixes sqlite3.OperationalError crashes in both tikTok and tikTok_replied artifacts caused by missing tables and invalid SQL syntax generation. It also corrects a logic bug in tikTok.py that prevented contacts from being reported if no messages were found.

### Motivation and Context
When analyzing TikTok databases (AwemeIM.db) that do not contain contact tables (AwemeContactsV%) or message tables (TIMMessageORM/TIMMessageKVORM), the artifacts would crash, halting the analysis for that module.

- Current Behavior: 
  -   If no contact tables are found, the script generates invalid SQL (JOIN ()), causing a syntax error crash.
  -   If message tables are missing, it crashes with "no such table".
  -   In tikTok.py, if messages are empty but contacts exist, the contacts report is skipped due to a wrong variable check.

- New Behavior: The scripts now gracefully handle missing tables by checking for their existence and injecting dummy queries where necessary to maintain valid SQL syntax. The logic bug is fixed to correctly report contacts independent of messages.

### Technical Details
- Files Modified: scripts/artifacts/tikTok.py, scripts/artifacts/tikTokReplied.py 
- SQL Syntax Fix: Added a check for the contacts_subqueries list. If empty (no contact tables), a dummy SELECT... WHERE 1=0 subquery is injected to ensure the UNION ALL and JOIN clauses remain valid.
- Missing Table Handling: Added explicit checks for TIMMessageORM and TIMMessageKVORM. If these tables are not found in sqlite_master, the script logs the issue ("Table ... not found") and skips the file instead of crashing.
- Logic Fix: In tikTok.py, changed the report generation condition from if len(all_rows) > 0: to if len(all_rows1) > 0: to correctly reference the contacts dataset.

### Testing

- Verified against: iOS 13.4.1 Extraction where the AwemeIM.db existed but lacked the specific message and contact tables.
- Result: The modules now complete execution without crashing. The logs correctly output "Table TIMMessageORM not found" and "No TikTok Contacts available," and the tool proceeds to generate reports for other artifacts.