### PR TITLE
Fix AttributeError in sysdiagnose.py: replace missing get_model_name

### DIFF
--- a/scripts/artifacts/sysdiagnose.py
+++ b/scripts/artifacts/sysdiagnose.py
@@ -57,7 +57,7 @@ def get_sysdiag_account_devices(context):
 
         for elem in f["contextDump"]["peers"]:
             model = elem["permanentInfo"]["model_id"]
-            m_name = context.get_model_name(model)
+            m_name = context.get_device_model(model)
             os_bnum = elem["stableInfo"]["os_version"]
             os_build = os_bnum.split('(')[1].split(')')[0]
             os_ver = context.get_os_version(os_build, model)


### PR DESCRIPTION
### Summary
This PR fixes an AttributeError crash in the sysdiagnose artifact (get_sysdiag_account_devices) caused by calling a method that does not exist in the Context class.

### Motivation and Context
The artifact attempts to parse otctl_status.txt to identify devices connected to the Apple ID. However, it fails with: AttributeError: type object 'Context' has no attribute 'get_model_name'

This happens because the script calls context.get_model_name(), but the actual method defined in scripts/context.py API is get_device_model().

### Technical Details
- File Modified: scripts/artifacts/sysdiagnose.py
- Change: Replaced the invalid method call context.get_model_name(model) with the correct method context.get_device_model(model).
- Logic: The get_device_model method correctly looks up the Model ID in scripts/data/device_ids.json and returns the human-readable device name, which is the intended behavior.

### Testing

- Verified against: iOS 13.4.1 Extraction.
- Result: The artifact previously crashed immediately. After the fix, it runs successfully and logs "Found 2 records for Sysdiagnose -  Account Devices", correctly identifying the connected devices without errors.