### PR TITLE
fix: Fix base64 decoding errors and improve error handling

### DIFF
--- a/scripts/artifacts/appleMapsSearchHistory.py
+++ b/scripts/artifacts/appleMapsSearchHistory.py
@@ -8,36 +8,59 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Locations",
         "notes": "",
-        "paths": ('*/mobile/Containers/Data/Application/*/Library/Maps/GeoHistory.mapsdata','*/GeoHistory.mapsdata',),
+        "paths": (
+            '*/mobile/Containers/Data/Application/*/Library/Maps/GeoHistory.mapsdata',
+            '*/GeoHistory.mapsdata',
+        ),
         "output_types": "standard",
     }
 }
 
 import blackboxprotobuf
 import base64
+import binascii
 import pprint
 
 from scripts.ilapfuncs import (
     artifact_processor,
-    get_plist_file_content
+    get_plist_file_content,
+    logfunc
 )
+
+
+def get_nested_value(data, path):
+    value = data
+    for key in path:
+        try:
+            value = value[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+    return value
+
 
 def longbase64proto(longstuff, longtypes):
     longstuff = longstuff.split('placeRequest=')[1]
     longstuff, _ = blackboxprotobuf.decode_message(base64.b64decode(longstuff), longtypes)
     return longstuff
 
+
 def shortbase64proto(shortstuff, shorttypes):
-    shortstuff = shortstuff.split('=')[1]
-    shortstuff, _ = blackboxprotobuf.decode_message(base64.b64decode(shortstuff), shorttypes)
-    return shortstuff
+    try:
+        shortstuff = shortstuff.split('=', 1)[1]
+        shortstuff += '=' * (-len(shortstuff) % 4)
+        shortstuff, _ = blackboxprotobuf.decode_message(base64.b64decode(shortstuff), shorttypes)
+        return shortstuff
+    except (binascii.Error, ValueError) as ex:
+        logfunc(f"Error decoding Apple Maps Search History protobuf: {ex}")
+        return None
+
 
 @artifact_processor
 def get_appleMapsSearchHistory(context):
     data_list = []
 
     shorttypes = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}}, 'name': ''}, '7': {'type': 'int', 'name': ''}, '8': {'type': 'message', 'message_typedef': {'4': {'type': 'message', 'message_typedef': {'3': {'type': 'int', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}
-    
+
     longtypes = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}}, 'name': ''}, '7': {'type': 'int', 'name': ''}, '8': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'3': {'type': 'bytes', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'5': {'type': 'double', 'name': ''}, '6': {'type': 'double', 'name': ''}, '7': {'type': 'double', 'name': ''}, '8': {'type': 'double', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}, '5': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}}, 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'int', 'name': ''}}, 'name': ''}, '12': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}}, 'name': ''}, '15': {'type': 'int', 'name': ''}, '16': {'type': 'message', 'message_typedef': {'1': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '10000': {'type': 'bytes', 'name': ''}, '10001': {'type': 'int', 'name': ''}, '10011': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '6': {'type': 'bytes', 'name': ''}}, 'name': ''}, '10019': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}
 
     for file_found in context.get_files_found():
@@ -94,8 +117,11 @@ def get_appleMapsSearchHistory(context):
                                     pass
                             try:    
                                 if protostuff.get('8'):
-                                    if (protostuff['8']['2']['1'].get('201')):
-                                        usersearchnotinproto = (protostuff['8']['2']['1']['201']['2']['2']['1'].decode())
+                                    usersearch = get_nested_value(
+                                        protostuff, ('8', '2', '1', '201', '2', '2', '1')
+                                    )
+                                    if usersearch:
+                                        usersearchnotinproto = usersearch.decode()
                             except (KeyError, AttributeError, UnicodeDecodeError):
                                 #pass
                                 try:
@@ -122,8 +148,9 @@ def get_appleMapsSearchHistory(context):
                                                     
                                                     shortstuff = shortbase64proto(mira['11']['2'].decode(), shorttypes)
                                                     
-                                                    shortlat = (shortstuff['8']['4']['4']['1']['1'])
-                                                    shortlon = (shortstuff['8']['4']['4']['1']['2'])
+                                                    if shortstuff:
+                                                        shortlat = (shortstuff['8']['4']['4']['1']['1'])
+                                                        shortlon = (shortstuff['8']['4']['4']['1']['2'])
                                                     
                                                     
                                                 except (KeyError, AttributeError, UnicodeDecodeError, TypeError):
@@ -132,15 +159,18 @@ def get_appleMapsSearchHistory(context):
                                                 if mira.get('8'):
                                                     pname = (mira.get('8')['1']['10']['3'].decode())
                                 except (KeyError, AttributeError, UnicodeDecodeError, TypeError):
-                                    currentlocation = (protostuff['8']['2']['8']['3'].decode())
+                                    currentlocation_value = get_nested_value(protostuff, ('8', '2', '8', '3'))
+                                    if currentlocation_value:
+                                        currentlocation = currentlocation_value.decode()
                                     
                             try: 
                                 if protostuff.get('7'):
                                     shortstuff = shortbase64proto(protostuff.get('7')['1']['1'][0]['2']['1']['4'][8]['11']['2'].decode(), shorttypes)
-                                    app = shortstuff['1']['1'].decode()
-                                    location = (shortstuff['8']['1']['3'].decode())
-                                    shortlat = (shortstuff['8']['4']['4']['1']['1'])
-                                    shortlon = (shortstuff['8']['4']['4']['1']['2'])
+                                    if shortstuff:
+                                        app = shortstuff['1']['1'].decode()
+                                        location = (shortstuff['8']['1']['3'].decode())
+                                        shortlat = (shortstuff['8']['4']['4']['1']['1'])
+                                        shortlon = (shortstuff['8']['4']['4']['1']['2'])
                                     
                                     if (protostuff.get('7')['1']['1'][1]['1'].get('2')):
                                         
@@ -183,9 +213,19 @@ def get_appleMapsSearchHistory(context):
                                     pp = pprint.PrettyPrinter(indent = 0)
                                     items = pp.pformat(protostuff['7']['1']['1'][0]['2']['1']['4'])
                                     
-                            data_list.append((modificationdate,app,location,shortadd,pname,shortlat,shortlon,usersearchnotinproto,usersearch1, usersearch2,geo1,geo2,geo3,geo4,geo5,geo6,guid,currentlocation,items, file_found ))
+                            data_list.append((
+                                modificationdate, app, location, shortadd, pname, shortlat,
+                                shortlon, usersearchnotinproto, usersearch1, usersearch2,
+                                geo1, geo2, geo3, geo4, geo5, geo6, guid,
+                                currentlocation, str(items), context.get_relative_path(file_found)
+                            ))
                             modificationdate = app = location = shortadd = pname = shortlat = shortlon = usersearch1 = usersearch2 = geo1 = geo2 = geo3 = geo4 = geo5 = geo6 = guid = items = currentlocation = '' 
     
-    data_headers = (('Timestamp', 'datetime'),'App','Location','Short Address','Place Name','Latitude','Longitude','Search Not in Protobuf','Search Term','Search Term','Lat1','Lon1','Lat2','Lon2','Lat2','Lon3','Record GUID','Current Location','Items', 'Source File')        
-    
-    return data_list, data_headers, 'see Source File for more info'
+    data_headers = (
+        ('Timestamp', 'datetime'), 'App', 'Location', 'Short Address', 'Place Name',
+        'Latitude', 'Longitude', 'Search Not in Protobuf', 'Search Term 1',
+        'Search Term 2', 'Lat1', 'Lon1', 'Lat2', 'Lon2', 'Lat3', 'Lon3',
+        'Record GUID', 'Current Location', 'Items', 'Source File'
+    )
+
+    return data_headers, data_list, 'see Source File for more info'


### PR DESCRIPTION
## Fix return order in appleMapsSearchHistory artifact 
Fixed multiple errors that prevented Apple Maps search history from being parsed correctly.

**Before:**
1. KeyError when accessing nested dictionary keys `protostuff['8']['2']['1']['201']['2']['2']['1']`
2. Base64 decode error with incorrect padding when processing malformed data
3. Wrong return order
4. Duplicate column names
5. Bytes objects in data causing JSON serialization errors

**After:**
1. Added safe dictionary access using `get()` with nested checks
2. Added try-except block in `shortbase64proto()`
3. Fixed return statement order
4. Renamed duplicate columns: 'Search Term' → 'Search Term 1' and 'Search Term 2', fixed 'Lat2' duplication to 'Lat3'
5. Converted `items` to string using `str(items)`

### Error Messages 
KeyError: '2'
binascii.Error: Incorrect padding
ValueError: too many values to unpack (expected 2)
sqlite3.OperationalError: duplicate column name: search_term
TypeError: Object of type bytes is not JSON serializable

**Files changed:** 
- `scripts/artifacts/appleMapsSearchHistory.py`