### PR TITLE
fix(netusage): handle exceptions during timestamp conversion

### DIFF
--- a/scripts/artifacts/netusage.py
+++ b/scripts/artifacts/netusage.py
@@ -48,17 +48,26 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
                 for row in all_rows:
                     if row[0] is None:
                         lastconnected = ''
-                    else: 
-                        lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
-                    if row[1] is None:    
+                    else:
+                        try:
+                            lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
+                        except (ValueError, TypeError):
+                            lastconnected = 'N/A'
+                    if row[1] is None:
                         firstused = ''
                     else:
-                        firstused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
-                    if row[2] is None: 
+                        try:
+                            firstused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
+                        except (ValueError, TypeError):
+                            firstused = 'N/A'
+                    if row[2] is None:
                         lastused = ''
                     else:
-                        lastused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[2]),timezone_offset)
-                    
+                        try:
+                            lastused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[2]),timezone_offset)
+                        except (ValueError, TypeError):
+                            lastused = 'N/A'
+
                     data_list.append((lastconnected,firstused,lastused,row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11]))
 
                 report.write_artifact_data_table(data_headers, data_list, file_found)
@@ -101,9 +110,15 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
                 data_headers = ('First Connection Timestamp','Last Connection Timestamp','Network Name','Cell Tower ID/Wifi MAC','Network Type','Bytes In','Bytes Out','Connection Attempts','Connection Successes','Packets In','Packets Out') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
                 data_list = []
                 for row in all_rows:
-                    firstconncted = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
-                    lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
-                
+                    try:
+                        firstconncted = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
+                    except (ValueError, TypeError):
+                        firstconncted = 'N/A'
+                    try:
+                        lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
+                    except (ValueError, TypeError):
+                        lastconnected = 'N/A'
+
                     if row[2] == None:
                         data_list.append((firstconncted,lastconnected,'','',row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
                     else:
@@ -113,7 +128,7 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
                             id_split = row[2].rsplit('-',1)
                             netname = id_split[0]
                             id_mac = pad_mac_adr(id_split[1])
-                    
+
                             data_list.append((firstconncted,lastconnected,netname,id_mac,row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
 
                 report.write_artifact_data_table(data_headers, data_list, file_found)


### PR DESCRIPTION
This PR fixes a critical bug in netusage.py that causes the artifact parser to crash when processing `netusage.sqlite` databases containing invalid or NULL timestamps.

Previously, the parser would fail completely upon encountering a single invalid timestamp string (e.g., an empty string returned by SQLite's `datetime` function), resulting in total data loss for this artifact. This update implements defensive programming to handle these exceptions gracefully.

### Changes
*   **Added:** `try-except` blocks around `convert_ts_human_to_utc` calls in netusage.py.
*   **Logic:** If a `ValueError` or `TypeError` occurs during conversion, the timestamp is set to `'N/A'` instead of crashing the script.
*   **Result:** The parser now processes all valid rows and marks invalid timestamps clearly, ensuring maximum data extraction.

### Verification & Testing
I have created a comprehensive test suite (test_netusage_fix.py) to verify the fix and ensure no regressions.

*   **Test Suite:** 5/5 tests passed.
*   **Scenarios Covered:**
    *   Invalid Timestamp from SQLite (Empty strings/NULLs).
    *   Valid Timestamp Conversion (Regression test).
    *   None Value Handling.
    *   Full Row Processing (Simulation of the fixed loop).
    *   Comparison of Original (Crashes) vs. Fixed (Handles gracefully) code.

**Test Output Summary:**
```text
TEST SUMMARY
================================================================================
Invalid Timestamp from SQLite..................... [PASS]
Valid Timestamp Regression........................ [PASS]
None Value Handling............................... [PASS]
Full Row Processing (Fixed)....................... [PASS]
Original vs Fixed Code............................ [PASS]
================================================================================
Total: 5/5 tests passed
[SUCCESS] ALL TESTS PASSED - Fix is working correctly!
```

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified the fix with a local test script.
- [ ] The changes generate no new warnings.

### Related Issues
Closes #1389 