### PR TITLE
fix(system_version_plist): correct data source assignment

### DIFF
--- a/scripts/artifacts/systemVersionPlist.py
+++ b/scripts/artifacts/systemVersionPlist.py
@@ -36,7 +36,7 @@ def system_version_plist(context):
     sysdiagnose_archive = context.get_source_file_path("sysdiagnose_*.tar.gz")
 
     if plist_file:
-        data_source = system_version_plist
+        data_source = plist_file
         pl = get_plist_file_content(data_source)
     elif 'sysdiagnose_' in sysdiagnose_archive and "IN_PROGRESS_" not in sysdiagnose_archive:
         tar = tarfile.open(sysdiagnose_archive)


### PR DESCRIPTION
This PR fixes a critical bug in systemVersionPlist.py that causes the artifact parser to crash with a `TypeError`.

The crash was caused by passing the function object `system_version_plist` to the plist parser instead of the file path string `plist_file`. This occurred due to a variable naming error where the function name was used in an assignment statement instead of the local variable holding the path.

### Changes
*   **Corrected:** Changed assignment on line 39 to use `plist_file` instead of `system_version_plist`.
*   **Result:** The `get_plist_file_content` function now receives a valid string path, allowing the artifact to parse successfully and extract iOS version information.

### Verification & Testing
I have created a reproduction script (test_sysversion_fix.py) to verify the fix.

*   **Test Suite:** 6/6 tests passed.
*   **Scenarios Covered:**
    *   Plist File Path Type Validation.
    *   Function Object vs String Comparison.
    *   `get_plist_file_content` Argument Type validation.
    *   `data_source` Assignment Validation.
    *   Comparison of Original (Buggy) vs. Fixed patterns.
    *   Complete Workflow Integration.

**Test Output Summary:**
```text
TEST SUMMARY
================================================================================
Plist File Path Type Validation................... [PASS]
Function Object vs String Comparison.............. [PASS]
get_plist_file_content Argument Type.............. [PASS]
data_source Assignment Validation................. [PASS]
Original Bug vs Fixed Code........................ [PASS]
Complete Workflow Integration..................... [PASS]
================================================================================
Total: 6/6 tests passed
[SUCCESS] ALL TESTS PASSED - Fix is working correctly!
```

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified the fix with a local test script.
- [ ] The changes generate no new warnings.

### Related Issues
Closes #1390 