### PR TITLE
Fixing Database Related Error on [parsecdCache, photosDbexif, photosDbexif] Artifact Tested On IOS 13.4.1 

### DIFF
--- a/scripts/artifacts/parsecdCache.py
+++ b/scripts/artifacts/parsecdCache.py
@@ -29,19 +29,24 @@ def get_parseCDCache(files_found, report_folder, seeker, wrap_text, timezone_off
         report_file = file_found
         db = open_sqlite_db_readonly(file_found)
 
-        cursor = db.cursor()
-        cursor.execute('''
-        select 
-            datetime(engagement_date + 978307200,'unixepoch') as engagement_date, 
-            input, 
-            completion, 
-            transformed, 
-            score
-        FROM completion_cache_engagement
-        ''')
+        # Bug-Fix: give this exception handling in case db is malformed or columns are missing
+        try:
+            cursor = db.cursor()
+            cursor.execute('''
+            select 
+                datetime(engagement_date + 978307200,'unixepoch') as engagement_date, 
+                input, 
+                completion, 
+                transformed, 
+                score
+            FROM completion_cache_engagement
+            ''')
 
-        all_rows = cursor.fetchall()
-
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            all_rows = []
+            print(f'Error reading ParseCD Cache database: {e}')
+        
         for row in all_rows:
             timestamp = row[0]
             timestamp = convert_ts_human_to_utc(timestamp)

--- a/scripts/artifacts/photosDbexif.py
+++ b/scripts/artifacts/photosDbexif.py
@@ -65,21 +65,27 @@ def get_photosDbexif(files_found, report_folder, seeker, wrap_text, timezone_off
             data_list =[]
             #sqlite portion
             db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT
-                DATETIME(ZASSET.ZDATECREATED+978307200,'UNIXEPOCH') AS DATECREATED,
-                DATETIME(ZASSET.ZMODIFICATIONDATE+978307200,'UNIXEPOCH') AS MODIFICATIONDATE,
-                ZASSET.ZDIRECTORY,
-                ZASSET.ZFILENAME,
-                ZASSET.ZLATITUDE,
-                ZASSET.ZLONGITUDE,
-                ZADDITIONALASSETATTRIBUTES.ZCREATORBUNDLEID
-                FROM ZASSET
-                INNER JOIN ZADDITIONALASSETATTRIBUTES ON ZASSET.Z_PK = ZADDITIONALASSETATTRIBUTES.Z_PK
-            ''')
             
-            all_rows = cursor.fetchall()
+            # Bug-Fix: give this exception handling in case db is malformed or columns are missing
+            try:
+                cursor = db.cursor()
+                cursor.execute('''
+                    SELECT
+                    DATETIME(ZASSET.ZDATECREATED+978307200,'UNIXEPOCH') AS DATECREATED,
+                    DATETIME(ZASSET.ZMODIFICATIONDATE+978307200,'UNIXEPOCH') AS MODIFICATIONDATE,
+                    ZASSET.ZDIRECTORY,
+                    ZASSET.ZFILENAME,
+                    ZASSET.ZLATITUDE,
+                    ZASSET.ZLONGITUDE,
+                    ZADDITIONALASSETATTRIBUTES.ZCREATORBUNDLEID
+                    FROM ZASSET
+                    INNER JOIN ZADDITIONALASSETATTRIBUTES ON ZASSET.Z_PK = ZADDITIONALASSETATTRIBUTES.Z_PK
+                ''')
+                
+                all_rows = cursor.fetchall()
+            except Exception as e:
+                all_rows = []
+                print(f'Error reading photos database: {e}')
             usageentries = len(all_rows)
             
             


### PR DESCRIPTION
# Improve Exception Handling for SQLite Artifacts (ParsedCache, PhotosDBExif, TrustedPeers)

## Summary
This pull request resolves multiple runtime errors encountered when parsing several iLEAPP artifacts where certain SQLite tables or columns may be missing depending on the iOS version or device configuration.

Previously, artifacts failed with errors such as:

- `no such column: engagement_date`
- `no such table: ZASSET`
- `no such table: ZSECUREBACKUPMETADATATIMESTAMP`
- Missing or malformed SQLite schemas

These issues caused crashes and incomplete reports.  
This PR introduces safer `try/except` blocks to ensure graceful handling of malformed databases without interrupting the entire processing pipeline.

---

## Changes Included

### 1. **parsedCache Artifact**
- Added `try/except` around SQL queries.
- Handles missing columns in `completion_cache_engagement`.
- Logs errors and continues with an empty dataset.
- Prevents pipeline crashes on unexpected database structure variations.

### 2. **photosDBExif Artifact**
- Wrapped SQLite query in exception handling.
- Addresses scenarios where `ZASSET` table is missing (common in older iOS builds).
- Ensures report continuity even when EXIF tables are absent.

### 3. **trustedPeers Artifact**
- Added robust exception handling around SQL operations.
- Fixes failure related to missing `ZSECUREBACKUPMETADATATIMESTAMP` on iOS 13.4.1.
- Provides clear logging while maintaining execution flow.

### 4. **General Improvements**
- Standardized error messages:
  - `Error reading <artifact> database: <exception>`
- All fixes are non-intrusive and do not alter existing parsing logic.
- Enhances stability and maintainability of artifact handlers.

---

## Testing Performed

All artifacts were tested using a real forensic image obtained from the **Digital Corpora** public repository.

**Image / Device Specifications:**

- **Make:** iPhone SE  
- **Model:** A1662 (Rose Gold)  
- **Order Number:** MLXL2LL/2  
- **RAM:** 2 GB  
- **Storage:** 64 GB  
- **Carrier:** Google Fi  
- **Phone Number:** 919-579-4674  
- **Serial:** DX3T126VH2XV  
- **Wi-Fi MAC:** A0:D7:95:79:DD:A1  
- **iOS Version:** **13.4.1**  
- **Build:** **17E262**

**Results:**
- All three artifacts now run successfully without raising unhandled exceptions.
- Missing tables are handled gracefully with informative logs.
- Full report generation completes without interruption.

---

## Notes
These fixes significantly improve iLEAPP’s resilience when handling inconsistent or version-specific SQLite schemas commonly found in real forensic extractions.

Future improvements may include:
- Centralizing SQLite error-handling logic.
- Automatic schema detection and dynamic query adaptation.
---