### PR TITLE
fix: fix duplicate column name error in chromeLoginData artifact

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1231,7 +1231,7 @@ def chromeLoginData(files_found, report_folder, seeker, wrap_text, timezone_offs
 
     lava_data_headers[0] = (lava_data_headers[0], 'datetime')
 
-    all_data_headers = lava_data_headers + ['Browser Name']
+    all_data_headers = lava_data_headers
 
     report_file = 'Unknown'
     for file_found in files_found:


### PR DESCRIPTION
This PR removes a duplicate column name in chromeLoginData artifact

The chromeLoginData function was adding 'Browser Name' to all_data_headers even though it was already present in data_headers, causing a SQLite error: 'duplicate column name: browser_name' when creating the LAVA table.

Before:

```line 181, in lava_create_sqlite_table cursor.execute(f"CREATE TABLE IF NOT EXISTS {sanitized_table_name} ({columns_sql})") sqlite3.OperationalError: duplicate column name: browser_name ```

After:
```[1/1] last_build [lastBuild] artifact started
iOS version: 15.3.1
Product: iPhone OS
Found 9 records for iOS Information
last_build [lastBuild] artifact completed 
```
Tested with iOS 15 Public Image