### PR TITLE
Fix Multiple Artifacts Processing Errors

### DIFF
--- a/scripts/artifacts/FitnessWorkoutsLocationData.py
+++ b/scripts/artifacts/FitnessWorkoutsLocationData.py
@@ -28,7 +28,7 @@ def get_Health(files_found, report_folder, seeker, wrap_text, timezone_offset):
     
     cursor = db.cursor()
 
-    if  does_table_exist_in_db(healthdb_secure, 'location_series_data') == True:
+    if  does_table_exist_in_db(healthdb_secure, 'location_series_data') == True and does_table_exist_in_db(healthdb_secure, 'associations') == True:
     
     # Fitness Workouts Location Data Analysis
 

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1231,7 +1231,7 @@ def chromeLoginData(files_found, report_folder, seeker, wrap_text, timezone_offs
 
     lava_data_headers[0] = (lava_data_headers[0], 'datetime')
 
-    all_data_headers = lava_data_headers + ['Browser Name']
+    all_data_headers = lava_data_headers
 
     report_file = 'Unknown'
     for file_found in files_found:

--- a/scripts/artifacts/cloudkitSharing.py
+++ b/scripts/artifacts/cloudkitSharing.py
@@ -61,18 +61,38 @@ def get_cloudkitServerSharedData(file_found, report_folder, seeker, wrap_text):
         for item in deserialized_plist:
             if 'Participants' in item:
                 for participant in item['Participants']:
-                    record_id = participant['UserIdentity']['UserRecordID']['RecordName']
-                    email_address = participant['UserIdentity']['LookupInfo']['EmailAddress']
-                    phone_number = participant['UserIdentity']['LookupInfo']['PhoneNumber']
-                    first_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.givenName']
-                    middle_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.middleName']
-                    last_name = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.familyName']
-                    name_prefix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.namePrefix']
-                    name_suffix = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nameSuffix']
-                    nickname = participant['UserIdentity']['NameComponents']['NS.nameComponentsPrivate']['NS.nickname']
-
-                    user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name,
-                                                  middle_name, last_name, name_suffix, nickname]
+                    try:
+                        if not isinstance(participant, dict) or 'UserIdentity' not in participant:
+                            continue
+                        
+                        # must be dict and have UserIdentity
+                        user_identity = participant.get('UserIdentity', {})
+                        if not isinstance(user_identity, dict):
+                            continue
+                        
+                        user_record_id = user_identity.get('UserRecordID', {})
+                        if not isinstance(user_record_id, dict):
+                            continue
+                        
+                        record_id = user_record_id.get('RecordName', '')
+                        lookup_info = user_identity.get('LookupInfo', {})
+                        email_address = lookup_info.get('EmailAddress', '') if isinstance(lookup_info, dict) else ''
+                        phone_number = lookup_info.get('PhoneNumber', '') if isinstance(lookup_info, dict) else ''
+                        
+                        name_components = user_identity.get('NameComponents', {})
+                        name_private = name_components.get('NS.nameComponentsPrivate', {}) if isinstance(name_components, dict) else {}
+                        first_name = name_private.get('NS.givenName', '') if isinstance(name_private, dict) else ''
+                        middle_name = name_private.get('NS.middleName', '') if isinstance(name_private, dict) else ''
+                        last_name = name_private.get('NS.familyName', '') if isinstance(name_private, dict) else ''
+                        name_prefix = name_private.get('NS.namePrefix', '') if isinstance(name_private, dict) else ''
+                        name_suffix = name_private.get('NS.nameSuffix', '') if isinstance(name_private, dict) else ''
+                        nickname = name_private.get('NS.nickname', '') if isinstance(name_private, dict) else ''
+                        
+                        if record_id:  # Only add valid entries
+                            user_dictionary[record_id] = [record_id, email_address, phone_number, name_prefix, first_name, middle_name, last_name, name_suffix, nickname]
+                    except (KeyError, TypeError, AttributeError) as e:
+                        logfunc(f'Error processing participant data: {str(e)}')
+                        continue
     db.close()
 
     # Build the array after dealing with all the files 

--- a/scripts/artifacts/health.py
+++ b/scripts/artifacts/health.py
@@ -533,19 +533,31 @@ def health_workouts(context):
     for record in db_records:
         start_timestamp = convert_cocoa_core_data_ts_to_utc(record[0])
         end_timestamp = convert_cocoa_core_data_ts_to_utc(record[1])
-        added_timestamp = convert_cocoa_core_data_ts_to_utc(record[26])
-        device_model = context.get_device_model(record[22])
+        
+        # Check if record has enough elements to avoid IndexError
+        added_timestamp = convert_cocoa_core_data_ts_to_utc(record[26]) if len(record) > 26 else ''
+        device_model = context.get_device_model(record[22]) if len(record) > 22 else ''
 
-        if record[16]:
+        celcius_temp = ''
+        if len(record) > 16 and record[16]:
             celcius_temp = round(((record[16] - 32) * (5 / 9)), 2)
 
+        # safe access
         data_list.append(
-            (start_timestamp, end_timestamp, str(record[2]).title(), record[3],
-             record[4], record[5], record[6], record[7], record[8], record[9],
-             record[10], record[11], record[12], record[13], record[14],
-             record[15], celcius_temp, record[16], record[17], record[18],
-             record[19], record[20], record[21], record[22], device_model,
-             record[23], record[24], record[25], added_timestamp)
+            (start_timestamp, end_timestamp, str(record[2]).title() if len(record) > 2 else '',
+            record[3] if len(record) > 3 else '', record[4] if len(record) > 4 else '',
+            record[5] if len(record) > 5 else '', record[6] if len(record) > 6 else '',
+            record[7] if len(record) > 7 else '', record[8] if len(record) > 8 else '',
+            record[9] if len(record) > 9 else '', record[10] if len(record) > 10 else '',
+            record[11] if len(record) > 11 else '', record[12] if len(record) > 12 else '',
+            record[13] if len(record) > 13 else '', record[14] if len(record) > 14 else '',
+            record[15] if len(record) > 15 else '', celcius_temp,
+            record[16] if len(record) > 16 else '', record[17] if len(record) > 17 else '',
+            record[18] if len(record) > 18 else '', record[19] if len(record) > 19 else '',
+            record[20] if len(record) > 20 else '', record[21] if len(record) > 21 else '',
+            record[22] if len(record) > 22 else '', device_model,
+            record[23] if len(record) > 23 else '', record[24] if len(record) > 24 else '',
+            record[25] if len(record) > 25 else '', added_timestamp)
             )
 
     return data_headers, data_list, data_source


### PR DESCRIPTION
### Summary
This PR fixes 5 errors that caused artifact processing to fail during iOS data extraction. All fixes have been tested successfully with iOS 15 Public Image

### Artifacts Fixed
1. chromeLoginData - Duplicate Column Error
The all_data_headers was adding 'Browser Name' even though it already exist in data_header.
Before:
`all_data_headers = lava_data_headers + ['Browser Name']`
After:
`all_data_headers = lava_data_headers`
2. cloudkitParticipants - Type Error
Code assumed participant['UserIdentity'] was always a dictionary, but it could be a string
Fix: Added type checking and safe dictionary access

3. cloudkitSharing - Type Error
Same issue as cloudkitParticipants - participant data structure varied.

4. FitnessWorkoutsLocationData - Missing Table
Code queried associations table without checking if it exists.
Fix: Added table existence check

5. health - Index Out of Range
Query returns varying column counts depending on database schema, but code assumed all indices exist.
Fix: Added bound checking
