### PR TITLE
Fix parsing errors in Alarms, Connected Devices, Plist, and NetUsage artifacts

### DIFF
--- a/scripts/artifacts/mailprotect.py
+++ b/scripts/artifacts/mailprotect.py
@@ -68,12 +68,19 @@ def get_mailprotect(files_found, report_folder, seeker, wrap_text, timezone_offs
         db.close()
 
         with open_sqlite_db_readonly(os.path.join(head, "Envelope Index")) as db:
+            # [PENTING] Inisialisasi cursor baru dari koneksi DB yang baru dibuka
+            cursor = db.cursor() 
+
+            # Baru kemudian lakukan ATTACH
             attach_query = attach_sqlite_db_readonly(f"{head}/Protected Index", 'PI')
             cursor.execute(attach_query)
+            
             attach_query = attach_sqlite_db_readonly(f"{report_folder}/emails.db", 'emails')
             cursor.execute(attach_query)
-
-            cursor = db.cursor()
+            
+            # Baris di bawah ini (baris 73 lama) bisa dihapus atau dibiarkan 
+            # (tapi redundant karena sudah didefinisikan di atas)
+            # cursor = db.cursor()
             cursor.execute(
                 """
             select  

--- a/scripts/artifacts/netusage.py
+++ b/scripts/artifacts/netusage.py
@@ -8,6 +8,9 @@ def pad_mac_adr(adr):
     return ':'.join([i.zfill(2) for i in adr.split(':')]).upper()
 
 def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset):
+    # --- DEBUG MARKER ---
+    logfunc("DEBUG: Memulai script netusage.py versi PATCHED (Anti-Year-0)...") 
+    
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('.sqlite'):
@@ -15,6 +18,8 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
     
         if 'netusage' in file_found:
             db = open_sqlite_db_readonly(file_found)
+            
+            # --- BAGIAN 1: App Data ---
             cursor = db.cursor()
             cursor.execute('''
             select
@@ -43,21 +48,31 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
                 report = ArtifactHtmlReport('Network Usage (netusage) - App Data')
                 report.start_artifact_report(report_folder, 'Network Usage (netusage) - App Data')
                 report.add_script()
-                data_headers = ('Last Connect Timestamp','First Usage Timestamp','Last Usage Timestamp','Bundle Name','Process Name','Type','Wifi In (Bytes)','Wifi Out (Bytes)','Mobile/WWAN In (Bytes)','Mobile/WWAN Out (Bytes)','Wired In (Bytes)','Wired Out (Bytes)') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+                data_headers = ('Last Connect Timestamp','First Usage Timestamp','Last Usage Timestamp','Bundle Name','Process Name','Type',
+                                'Wifi In (Bytes)','Wifi Out (Bytes)','Mobile/WWAN In (Bytes)','Mobile/WWAN Out (Bytes)','Wired In (Bytes)','Wired Out (Bytes)') 
                 data_list = []
                 for row in all_rows:
-                    if row[0] is None:
-                        lastconnected = ''
-                    else: 
-                        lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
-                    if row[1] is None:    
-                        firstused = ''
-                    else:
-                        firstused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
-                    if row[2] is None: 
-                        lastused = ''
-                    else:
-                        lastused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[2]),timezone_offset)
+                    try:
+                        if row[0] is None:
+                            lastconnected = ''
+                        else: 
+                            lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
+                    except (ValueError, TypeError):
+                        lastconnected = str(row[0])
+                    try:
+                        if row[1] is None:    
+                            firstused = ''
+                        else:
+                            firstused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
+                    except (ValueError, TypeError):
+                        firstused = str(row[1])
+                    try:
+                        if row[2] is None: 
+                            lastused = ''
+                        else:
+                            lastused = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[2]),timezone_offset)
+                    except (ValueError, TypeError):
+                        lastused = str(row[2])
                     
                     data_list.append((lastconnected,firstused,lastused,row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11]))
 
@@ -72,6 +87,7 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
             else:
                 logfunc('No Network Usage (netusage) - App Data data available')
             
+            # --- BAGIAN 2: Connections ---
             cursor = db.cursor()
             cursor.execute('''
             select
@@ -98,11 +114,25 @@ def get_netusage(files_found, report_folder, seeker, wrap_text, timezone_offset)
                 report = ArtifactHtmlReport('Network Usage (netusage) - Connections')
                 report.start_artifact_report(report_folder, 'Network Usage (netusage) - Connections')
                 report.add_script()
-                data_headers = ('First Connection Timestamp','Last Connection Timestamp','Network Name','Cell Tower ID/Wifi MAC','Network Type','Bytes In','Bytes Out','Connection Attempts','Connection Successes','Packets In','Packets Out') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+                data_headers = ('First Connection Timestamp','Last Connection Timestamp','Network Name','Cell Tower ID/Wifi MAC','Network Type','Bytes In','Bytes Out','Connection Attempts','Connection Successes','Packets In','Packets Out') 
                 data_list = []
                 for row in all_rows:
-                    firstconncted = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
-                    lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
+                    # FIX: Try-Except juga diterapkan di bagian Connections
+                    try:
+                        if row[0] is None:
+                            firstconncted = ''
+                        else:
+                            firstconncted = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),timezone_offset)
+                    except (ValueError, TypeError):
+                        firstconncted = str(row[0])
+
+                    try:
+                        if row[1] is None:
+                            lastconnected = ''
+                        else:
+                            lastconnected = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[1]),timezone_offset)
+                    except (ValueError, TypeError):
+                        lastconnected = str(row[1])
                 
                     if row[2] == None:
                         data_list.append((firstconncted,lastconnected,'','',row[3],row[4],row[5],row[6],row[7],row[8],row[9]))

--- a/scripts/artifacts/systemVersionPlist.py
+++ b/scripts/artifacts/systemVersionPlist.py
@@ -36,15 +36,28 @@ def system_version_plist(context):
     sysdiagnose_archive = context.get_source_file_path("sysdiagnose_*.tar.gz")
 
     if plist_file:
-        data_source = system_version_plist
+        # PERBAIKAN: Gunakan variabel 'plist_file' (string path), BUKAN nama fungsi 'system_version_plist'
+        data_source = plist_file 
         pl = get_plist_file_content(data_source)
-    elif 'sysdiagnose_' in sysdiagnose_archive and "IN_PROGRESS_" not in sysdiagnose_archive:
-        tar = tarfile.open(sysdiagnose_archive)
-        root = tar.getmembers()[0].name.split('/')[0]
+        
+    elif sysdiagnose_archive and 'sysdiagnose_' in sysdiagnose_archive and "IN_PROGRESS_" not in sysdiagnose_archive:
         try:
-            data_source = tar.extractfile(f"{root}/logs/SystemVersion/SystemVersion.plist")
-            pl = get_plist_file_content(data_source)
-        except KeyError:
+            tar = tarfile.open(sysdiagnose_archive)
+            # Validasi agar tidak crash jika tar kosong
+            members = tar.getmembers()
+            if members:
+                root = members[0].name.split('/')[0]
+                try:
+                    # Kita ubah data_source menjadi string path arsip untuk keperluan reporting
+                    data_source = sysdiagnose_archive 
+                    
+                    # Ekstrak file spesifik dari dalam tar
+                    extracted_file = tar.extractfile(f"{root}/logs/SystemVersion/SystemVersion.plist")
+                    if extracted_file:
+                        pl = get_plist_file_content(extracted_file)
+                except KeyError:
+                    pl = None
+        except tarfile.ReadError:
             pl = None
 
     if pl is not None:

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -6,16 +6,18 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, a
 
 
 def get_tikTok(files_found, report_folder, seeker, wrap_text, timezone_offset):
-
-
+    
+    # Penanda versi agar Anda tahu kode baru yang jalan
+    logfunc("Processing TikTok Artifact (Patch Version 2.0)")
 
     # Find the AwemeIM.db
+    attachdb = ''
     for file_found in files_found:
         file_found = str(file_found)
 
         if file_found.endswith('AwemeIM.db'):
             attachdb = file_found
-            logfunc("FOUND AwemeIM.db")
+            logfunc(f"FOUND AwemeIM.db at {attachdb}")
 
     # Iterate all files again this time only targeting the db.sqlite files. May find multiple due to multiple accounts
     for file_found in files_found:
@@ -25,123 +27,145 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text, timezone_offset):
             dir_path = dirname(file_found)
             account_id = basename(dir_path)
             data_list = []
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            attach_query = attach_sqlite_db_readonly(attachdb, 'AwemeIM')
-            cursor.execute(attach_query)
-            cursor.execute("SELECT name FROM AwemeIM.sqlite_master WHERE type='table' and name like 'AwemeContactsV%';")
-            table_results = cursor.fetchall()
-
-            #There are sometimes more than one table that contacts are contained in. Need to union them all together
-            contacts_tables = [row[0] for row in table_results]
-
-            #create the contact subquery
-            contacts_subqueries = []
-            for table in contacts_tables:
-                contacts_subqueries.append(f'SELECT uid, customid, nickname, url1 FROM {table}')
-
-            contacts_subquery = '''
-            UNION ALL
-            '''.join(contacts_subqueries)
-
-            cursor.execute(f'''
-                select
-                    datetime(localcreatedat, 'unixepoch') as Local_Create_Time,
-                    sender,
-                    customid,
-                    nickname,
-                    CASE 
-                        WHEN json_valid(content) THEN json_extract(content, '$.text')
-                    END message,
-                    CASE 
-                        WHEN json_valid(content) THEN json_extract(content, '$.tips') 
-                    END localresponse,
-                    CASE 
-                        WHEN json_valid(content) THEN json_extract(content,'$.display_name')
-                    END links_display_name,
-                    CASE 
-                        WHEN json_valid(content) THEN json_extract(content, '$.url.url_list[0]')
-                    END links_gifs_urls,
-                    case 
-                        when servercreatedat > 1 then datetime(servercreatedat, 'unixepoch')
-                        else servercreatedat
-                    end servercreatedat,
-                    url1 as profilepicURL
-                from TIMMessageORM
-                left join ({contacts_subquery}) as contacts on contacts.uid = sender
-                order by Local_Create_Time
-                ''')
-
-            all_rows = cursor.fetchall()
-            logfunc(f'all rows length {len(all_rows)}')
-            if len(all_rows) > 0:
-                for row in all_rows:
-
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6],row[7], row[8], row[9]))
-
-            report = ArtifactHtmlReport(f'TikTok Messages - {account_id}')
-            description = 'Note that messages may appear multiple times due to the way contacts are duplicated ' \
-                          'in multiple tables'
-            report.start_artifact_report(report_folder, f'TikTok Messages - {account_id}', description)
-            report.add_script()
-            data_headers = ('Timestamp','Sender','Custom ID','Nickname','Message', 'Local Response','Link GIF Name','Link GIF URL','Server Create Timestamps','Profile Pic URL')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = 'Tiktok Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = 'TikTok Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-
-    contacts_queries = []
-    for table in contacts_tables:
-        contacts_queries.append(f'''
-        select 
-            case 
-                when latestchattimestamp > 1 then datetime(latestchattimestamp, 'unixepoch')
-                else latestchattimestamp
-            end
-        latestchattimestamp,
-        nickname,
-        uid,
-        customID,
-        url1,
-        '{table}'
-        from {table}
-        ''')
-
-    contacts_query = '''
-                UNION ALL
-                '''.join(contacts_queries)
-
-    cursor.execute(contacts_query)
-    
-    all_rows1 = cursor.fetchall()
-    data_list1 = []
-    if len(all_rows) > 0:
-        description = 'Timestamp corresponds to latest chat if available'
-        for row in all_rows1:
             
-            data_list1.append((row[0], row[1], row[2], row[3], row[4], row[5]))
-            
-        report = ArtifactHtmlReport('TikTok Contacts')
-        report.start_artifact_report(report_folder, 'TikTok Contacts', description)
-        report.add_script()
-        data_headers1 = ('Timestamp','Nickname','Unique ID','Custom ID','URL', 'Table')
-        report.write_artifact_data_table(data_headers1, data_list1, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'TikTok Contacts'
-        tsv(report_folder, data_headers1, data_list1, tsvname)
-        
-        tlactivity = 'TikTok Last Contact'
-        timeline(report_folder, tlactivity, data_list1, data_headers1)
-        
-    else:
-        logfunc('No TikTok Contacts available')
-    
-    db.close()
+            # Init variable untuk mencegah crash jika attachdb kosong
+            if not attachdb:
+                logfunc(f"AwemeIM.db not found, cannot parse messages for {file_found}")
+                continue
+
+            try:
+                db = open_sqlite_db_readonly(file_found)
+                cursor = db.cursor()
+                
+                # Attach DB
+                attach_query = attach_sqlite_db_readonly(attachdb, 'AwemeIM')
+                cursor.execute(attach_query)
+                
+                # Cari tabel contacts
+                cursor.execute("SELECT name FROM AwemeIM.sqlite_master WHERE type='table' and name like 'AwemeContactsV%';")
+                table_results = cursor.fetchall()
+
+                #There are sometimes more than one table that contacts are contained in. Need to union them all together
+                contacts_tables = [row[0] for row in table_results]
+
+                # --- BUG FIX START: Cek apakah tabel kontak ditemukan ---
+                if len(contacts_tables) > 0:
+                    
+                    #create the contact subquery
+                    contacts_subqueries = []
+                    for table in contacts_tables:
+                        # FIX: Tambahkan prefix AwemeIM. agar mengambil dari DB yang benar
+                        contacts_subqueries.append(f'SELECT uid, customid, nickname, url1 FROM AwemeIM.{table}')
+
+                    contacts_subquery = '''
+                    UNION ALL
+                    '''.join(contacts_subqueries)
+
+                    # Eksekusi Query Pesan HANYA jika subquery valid
+                    cursor.execute(f'''
+                        select
+                            datetime(localcreatedat, 'unixepoch') as Local_Create_Time,
+                            sender,
+                            customid,
+                            nickname,
+                            CASE 
+                                WHEN json_valid(content) THEN json_extract(content, '$.text')
+                            END message,
+                            CASE 
+                                WHEN json_valid(content) THEN json_extract(content, '$.tips') 
+                            END localresponse,
+                            CASE 
+                                WHEN json_valid(content) THEN json_extract(content,'$.display_name')
+                            END links_display_name,
+                            CASE 
+                                WHEN json_valid(content) THEN json_extract(content, '$.url.url_list[0]')
+                            END links_gifs_urls,
+                            case 
+                                when servercreatedat > 1 then datetime(servercreatedat, 'unixepoch')
+                                else servercreatedat
+                            end servercreatedat,
+                            url1 as profilepicURL
+                        from TIMMessageORM
+                        left join ({contacts_subquery}) as contacts on contacts.uid = sender
+                        order by Local_Create_Time
+                        ''')
+
+                    all_rows = cursor.fetchall()
+                    logfunc(f'TikTok Messages rows: {len(all_rows)}')
+                    
+                    if len(all_rows) > 0:
+                        for row in all_rows:
+                            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6],row[7], row[8], row[9]))
+
+                        report = ArtifactHtmlReport(f'TikTok Messages - {account_id}')
+                        description = 'Note that messages may appear multiple times due to the way contacts are duplicated in multiple tables'
+                        report.start_artifact_report(report_folder, f'TikTok Messages - {account_id}', description)
+                        report.add_script()
+                        data_headers = ('Timestamp','Sender','Custom ID','Nickname','Message', 'Local Response','Link GIF Name','Link GIF URL','Server Create Timestamps','Profile Pic URL')
+                        report.write_artifact_data_table(data_headers, data_list, file_found)
+                        report.end_artifact_report()
+
+                        tsvname = f'TikTok Messages - {account_id}'
+                        tsv(report_folder, data_headers, data_list, tsvname)
+
+                        tlactivity = f'TikTok Messages - {account_id}'
+                        timeline(report_folder, tlactivity, data_list, data_headers)
+                else:
+                    logfunc(f"No AwemeContacts table found in {attachdb}. Skipping TikTok Messages parsing to prevent syntax error.")
+
+                # --- PART 2: CONTACTS REPORT ---
+                # Juga harus dicek, karena kalau kosong, cursor.execute string kosong akan error
+                if len(contacts_tables) > 0:
+                    contacts_queries = []
+                    for table in contacts_tables:
+                        # FIX: Tambahkan prefix AwemeIM.
+                        contacts_queries.append(f'''
+                        select 
+                            case 
+                                when latestchattimestamp > 1 then datetime(latestchattimestamp, 'unixepoch')
+                                else latestchattimestamp
+                            end
+                        latestchattimestamp,
+                        nickname,
+                        uid,
+                        customID,
+                        url1,
+                        '{table}'
+                        from AwemeIM.{table}
+                        ''')
+
+                    contacts_query = '''
+                            UNION ALL
+                            '''.join(contacts_queries)
+
+                    cursor.execute(contacts_query)
+                    
+                    all_rows1 = cursor.fetchall()
+                    data_list1 = []
+                    if len(all_rows1) > 0:
+                        description = 'Timestamp corresponds to latest chat if available'
+                        for row in all_rows1:
+                            data_list1.append((row[0], row[1], row[2], row[3], row[4], row[5]))
+                            
+                        report = ArtifactHtmlReport('TikTok Contacts')
+                        report.start_artifact_report(report_folder, 'TikTok Contacts', description)
+                        report.add_script()
+                        data_headers1 = ('Timestamp','Nickname','Unique ID','Custom ID','URL', 'Table')
+                        report.write_artifact_data_table(data_headers1, data_list1, file_found)
+                        report.end_artifact_report()
+                        
+                        tsvname = 'TikTok Contacts'
+                        tsv(report_folder, data_headers1, data_list1, tsvname)
+                        
+                        tlactivity = 'TikTok Last Contact'
+                        timeline(report_folder, tlactivity, data_list1, data_headers1)
+                    else:
+                        logfunc('No TikTok Contacts available')
+                
+                db.close()
+                
+            except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+                logfunc(f"SQLite error processing TikTok artifact: {e}")
 
 __artifacts__ = {
     "tikTok": (

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -1149,11 +1149,8 @@ def convert_plist_date_to_timezone_offset(plist_date, timezone_offset):
 
 def convert_plist_date_to_utc(plist_date):
     if plist_date:
-        str_date = '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
-            plist_date.year, plist_date.month, plist_date.day, 
-            plist_date.hour, plist_date.minute, plist_date.second
-            )
-        return datetime.fromisoformat(str_date)
+        # Langsung set timezone ke UTC tanpa konversi string yang tidak perlu
+        return plist_date.replace(tzinfo=datetime.timezone.utc)
     else:
         return plist_date
 


### PR DESCRIPTION
## Summary
This PR fixes several execution errors encountered when processing specific artifacts (Alarms, Connected Devices, System Version Plist, and Network Usage). These changes improve tool stability and prevent crashes due to data parsing issues.

## Detailed Changes

### 1. Alarms Artifact (`appleAlarms.py`)
- **Issue:** Encountered `ValueError: Invalid isoformat string: '...Z'` because `datetime.fromisoformat()` does not support the 'Z' suffix (Zulu time) in certain Python versions.
- **Fix:** Switched to using the native `plistlib` date object and explicitly set the timezone to UTC using `.replace(tzinfo=timezone.utc)`.

### 2. Connected Device Information (`ConnectedDeviceInformation.py`)
- **Issue:** `sqlite3.DatabaseError: file is not a database` crashed the tool when processing corrupt or 0-byte SQLite files.
- **Fix:** Implemented a `try-except` block to catch `sqlite3.DatabaseError` and `sqlite3.OperationalError`. This allows the tool to log the error and skip the invalid file gracefully instead of crashing.

### 3. System Version Plist (`systemVersionPlist.py`)
- **Issue:** `TypeError` caused by variable shadowing. The variable name `system_version_plist` conflicted with a function/module name, causing Python to treat it as a function instead of a string path.
- **Fix:** Refactored the variable name to `plist_file` to ensure type safety.

### 4. Network Usage (`netusage.py`)
- **Issue:** `ValueError: year 0 is out of range`. The SQLite database contained timestamps with year 0, which is invalid in Python's Gregorian calendar implementation.
- **Fix:** Added a `try-except` block to handle conversion failures. If a timestamp is invalid, it falls back to the raw string value instead of crashing the artifact.