### PR TITLE
Fix: Handle missing columns in Health Source Devices

### DIFF
--- a/scripts/artifacts/health.py
+++ b/scripts/artifacts/health.py
@@ -253,8 +253,8 @@ __artifacts_v2__ = {
 }
 
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
-    attach_sqlite_db_readonly, does_table_exist_in_db, convert_cocoa_core_data_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, does_column_exist_in_db, get_sqlite_db_records, \
+    attach_sqlite_db_readonly, does_table_exist_in_db, convert_cocoa_core_data_ts_to_utc, logfunc
 
 
 @artifact_processor
@@ -1178,6 +1178,14 @@ def health_source_devices(context):
         "0x2024": "AirPods Pro (2nd generation) (USB-C)",
     }
 
+    required_column = ['creation_date', 'name', 'manufacturer', 'model', 'hardware',
+                       'firmware', 'software', 'localIdentifier', 'sync_provenance', 'sync_identity']
+    missing_column = [column for column in required_column if not does_column_exist_in_db(data_source, 'source_devices', column)]
+
+    if missing_column:
+        logfunc(f'Missing column in {data_source}: {", ".join(missing_column)}')
+        return ([], [], data_source)
+    
     query = '''
     SELECT
         creation_date,


### PR DESCRIPTION
This pull request improves the robustness of the `health_source_devices` artifact processor in `scripts/artifacts/health.py` by adding a check for required columns in the `source_devices` table before executing the main query. If any columns are missing, the function logs the missing columns and returns early, preventing possible runtime errors.

**Health source devices extraction improvements:**

* Added a check for required columns in the `source_devices` table using the new `does_column_exist_in_db` function; if any are missing, logs the missing columns and returns early to avoid runtime errors.
* Updated imports to include `does_column_exist_in_db` and `logfunc`, supporting the new column existence check and logging functionality.