### PR TITLE
Fix: Handle plist error in duetLocations

### DIFF
--- a/scripts/artifacts/duetLocations.py
+++ b/scripts/artifacts/duetLocations.py
@@ -130,6 +130,13 @@ def get_duetLocations(files_found, report_folder, seeker, wrap_text, timezone_of
             else:
                 try:
                     plist = nd.deserialize_plist_from_string(datos)
+                    
+                    if not isinstance(plist, dict) or len(plist) == 0:
+                        logfunc(f'Plist is empty or not a dictionary (iOS 16.3+): {type(plist)}')
+                        continue
+                    
+                    timestamp = latitude = longitude = horzacc = altitude = speed = ''
+                    
                     for key, value in plist.items():
                         #print(key, value)
                         if key == 'kCLLocationCodingKeyCoordinateLongitude':
@@ -145,13 +152,13 @@ def get_duetLocations(files_found, report_folder, seeker, wrap_text, timezone_of
                             altitude = value
                         elif key == 'kCLLocationCodingKeySpeed':
                             speed = value
-                            
-                    data_list.append((timestamp,latitude,longitude,horzacc,altitude,speed))
-                    timestamp = latitude = longitude = horzacc, altitude = ''
+                    
+                    if latitude != '' and longitude != '':
+                        data_list.append((timestamp, latitude, longitude, horzacc, altitude, speed))
                     
                 except (nd.DeserializeError, nd.biplist.NotBinaryPlistException, nd.biplist.InvalidPlistException,
                         nd.plistlib.InvalidFileException, nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError) as ex:
-                    logfunc(f'Failed to read plist, error was:' + str(ex))
+                    logfunc(f'Failed to read plist, error was: {str(ex)}')
                 
             modresult = (sizeofnotificaton % 8)
             resultante =  8 - modresult


### PR DESCRIPTION
This pull request enhances the robustness of the duetLocation artifact processor by adding validation checks for deserialized plist data and preventing incomplete location records from being added to the results. These improvements prevent potential runtime errors and ensure higher data quality in forensic analysis outputs.

`duetLocations` **improvements:**

1. Added Plist Validation
  - Implemented a check to verify that deserialized plist data is a non-empty dictionary before processing
  - Added informative logging when plist is empty or invalid format
2. Improved Data Completeness Checks
  - Modified variable initialization pattern for better readability
  - Added validation to only append location records when both latitude and longitude are present