### PR TITLE
Implement db checker and try-except block

### DIFF
--- a/scripts/artifacts/atxDatastore.py
+++ b/scripts/artifacts/atxDatastore.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, attach_sqlite_db_readonly, convert_cocoa_core_data_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, attach_sqlite_db_readonly, convert_cocoa_core_data_ts_to_utc
 
 @artifact_processor
 def atxDatastore(context):
@@ -30,39 +30,61 @@ def atxDatastore(context):
         elif file_name.endswith('Local.sqlite'):
             localdb = str(file_found)
     
+    if not atxdb:
+        logfunc("Required databases not found: ATXDataStore")
+        return data_headers, data_list, ''
+    
+    if not localdb:
+        logfunc("Required databases not found: Local")
+        return data_headers, data_list, ''
+    
     db = open_sqlite_db_readonly(atxdb)
+    if db is None:
+        logfunc(f"Error opening ATXDataStore database: {atxdb}")
+        return data_headers, data_list, ''
+    
     cursor = db.cursor()
 
     attach_query = attach_sqlite_db_readonly(localdb, 'Local')
-    cursor.execute(attach_query)
+    if attach_query:
+        cursor.execute(attach_query)
+    else:
+        logfunc(f"Error attaching Local database: {localdb}")
+        db.close()
+        return data_headers, data_list, atxdb
 
-    cursor.execute('''
-    SELECT 
-        alog.id AS Id,
-        alog.bundleId AS bundleId,
-        alogAction.actionType AS ptype,
-        Local.ZRTLEARNEDLOCATIONOFINTERESTMO.ZLOCATIONLATITUDE AS latitude, 
-        Local.ZRTLEARNEDLOCATIONOFINTERESTMO.ZLOCATIONLONGITUDE AS longitude,
-        alog.date AS date,
-        alog.appSessionStartDate AS appSessionStartDate,
-        alog.appSessionEndDate AS appSessionEndDate,
-        hex(alog.location) AS location,
-        hex(alog.prevLocation) AS prevLocation,
-        alog.motionType AS potionType,
-        alog.geohash AS geohash,
-        alog.coarseGeohash AS coarseGeohash
-    FROM alog 
-    INNER JOIN alogAction ON alogAction.id = alog.actionType
-    LEFT JOIN Local.ZRTLEARNEDLOCATIONOFINTERESTMO 
-        ON Local.ZRTLEARNEDLOCATIONOFINTERESTMO.ZIDENTIFIER = alog.location
-    ''')
+    try:
+        cursor.execute('''
+        SELECT 
+            alog.id AS Id,
+            alog.bundleId AS bundleId,
+            alogAction.actionType AS ptype,
+            Local.ZRTLEARNEDLOCATIONOFINTERESTMO.ZLOCATIONLATITUDE AS latitude, 
+            Local.ZRTLEARNEDLOCATIONOFINTERESTMO.ZLOCATIONLONGITUDE AS longitude,
+            alog.date AS date,
+            alog.appSessionStartDate AS appSessionStartDate,
+            alog.appSessionEndDate AS appSessionEndDate,
+            hex(alog.location) AS location,
+            hex(alog.prevLocation) AS prevLocation,
+            alog.motionType AS potionType,
+            alog.geohash AS geohash,
+            alog.coarseGeohash AS coarseGeohash
+        FROM alog 
+        INNER JOIN alogAction ON alogAction.id = alog.actionType
+        LEFT JOIN Local.ZRTLEARNEDLOCATIONOFINTERESTMO 
+            ON Local.ZRTLEARNEDLOCATIONOFINTERESTMO.ZIDENTIFIER = alog.location
+        ''')
 
-    all_rows = cursor.fetchall()
+        all_rows = cursor.fetchall()
+    except Exception as e:
+        logfunc(f"Error querying ATXDataStore database: {e}")
+        db.close()
+        return data_headers, data_list, atxdb
 
     for row in all_rows:
-        timestamp = convert_cocoa_core_data_ts_to_utc(row[5]) if row[5] is not None else ''
-        startdate = convert_cocoa_core_data_ts_to_utc(row[6]) if row[6] is not None else ''
-        enddate = convert_cocoa_core_data_ts_to_utc(row[7]) if row[7] is not None else ''
+        timestamp = convert_cocoa_core_data_ts_to_utc(row[5])
+        startdate = convert_cocoa_core_data_ts_to_utc(row[6])
+        enddate = convert_cocoa_core_data_ts_to_utc(row[7])
         data_list.append(
             (timestamp, startdate, enddate, row[2], row[3], row[4],row[8], row[9], row[0])
             )


### PR DESCRIPTION
This pull request improves the robustness and error handling of the `atxDatastore` artifact processor in `scripts/artifacts/atxDatastore.py`. The main focus is to ensure that missing or inaccessible databases are properly logged and handled, preventing unhandled exceptions during execution.

**Error handling and logging improvements:**

* Added checks to ensure both `ATXDataStore` and `Local` databases are present before proceeding, with clear log messages if either is missing.
* Added error handling for database opening and attachment failures, logging specific error messages and safely returning early if issues are encountered.
* Wrapped the SQL query execution in a try-except block to catch and log any exceptions during data retrieval, ensuring the database connection is closed properly on error.
* Added `logfunc` to the imports to enable logging functionality.

**Data processing adjustment:**

* Simplified timestamp conversion by removing unnecessary `None` checks, since the conversion function can handle `None` values.