### PR TITLE
Implement column checker

### DIFF
--- a/scripts/artifacts/Ph51PossOptimizedAssetsIntResouData.py
+++ b/scripts/artifacts/Ph51PossOptimizedAssetsIntResouData.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, open_sqlite_db_readonly, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, open_sqlite_db_readonly, get_sqlite_db_records, logfunc, iOS, does_column_exist_in_db
 
 @artifact_processor
 def Ph51PossibleOptimizedAssetsIntResouPhDaPsql(files_found, report_folder, seeker, wrap_text, timezone_offset):
@@ -38,6 +38,17 @@ def Ph51PossibleOptimizedAssetsIntResouPhDaPsql(files_found, report_folder, seek
 	if version.parse(iosversion) <= version.parse("13.7"):
 		logfunc("Unsupported version for PhotoData-Photos.sqlite from iOS " + iosversion)
 		return (), [], source_path
+	
+	    
+	if (version.parse(iosversion) >= version.parse("16")):
+		required_columns = ['ZDUPLICATEDETECTORPERCEPTUALPROCESSINGSTATE']
+		missing_columns = [col for col in required_columns if not does_column_exist_in_db(source_path, 'ZADDITIONALASSETATTRIBUTES', col)]
+
+		if missing_columns:
+			logfunc(f'Missing columns in ZADDITIONALASSETATTRIBUTES table: {", ".join(missing_columns)}')
+			return (), [], source_path
+    
+
 	if (version.parse(iosversion) >= version.parse("14")) & (version.parse(iosversion) < version.parse("15")):
 		source_path = get_file_path(files_found, "Photos.sqlite")
 		if source_path is None or not os.path.exists(source_path):


### PR DESCRIPTION
This pull request improves the handling of database schema differences for iOS versions 16 and above in the `Ph51PossibleOptimizedAssetsIntResouPhDaPsql` artifact processor. The main change is the addition of a check to ensure required columns exist in the `ZADDITIONALASSETATTRIBUTES` table before proceeding, which helps prevent errors when processing databases with missing columns.

**Database schema validation for iOS 16+:**

* Added a check using `does_column_exist_in_db` to verify that the `ZDUPLICATEDETECTORPERCEPTUALPROCESSINGSTATE` column exists in the `ZADDITIONALASSETATTRIBUTES` table for iOS versions 16 and above, logging a message and exiting early if the column is missing.
* Imported the `does_column_exist_in_db` utility from `scripts.ilapfuncs` to support the new column existence check.