### PR TITLE
fix: avoid empty idstatus rows

### DIFF
--- a/scripts/artifacts/idstatuscache.py
+++ b/scripts/artifacts/idstatuscache.py
@@ -303,8 +303,7 @@ def get_identity_services(file_found, identifiers, report_folder, timezone_offse
     finally:
         f.close()
 
-    # row
-    if row.count(None) != len(row):
+    if data_list:
         report = ArtifactHtmlReport('Identity Lookup Service')
         report.start_artifact_report(report_folder, 'Identity Lookup Service')
         report.add_script()


### PR DESCRIPTION
Summary

- Prevent crashes when idstatuscache.plist files are empty or corrupted by only generating the Identity Lookup Service report if rows were collected.

Implementation Details

- Replace the previous row check with a direct if data_list: gate before building any reports/TSVs/timelines.
- Leaves existing parsing logic untouched; simply skips report creation when no entries exist.