### PR TITLE
Fix: Add backward-compatible handling for missing score column in parsecdCache module

### DIFF
--- a/scripts/artifacts/parsecdCache.py
+++ b/scripts/artifacts/parsecdCache.py
@@ -19,7 +19,6 @@ from scripts.ilapfuncs import artifact_processor, convert_utc_human_to_timezone
 
 @artifact_processor
 def get_parseCDCache(files_found, report_folder, seeker, wrap_text, timezone_offset):
-
     data_list = []
     report_file = 'Unknown'
     for file_found in files_found:
@@ -30,15 +29,26 @@ def get_parseCDCache(files_found, report_folder, seeker, wrap_text, timezone_off
         db = open_sqlite_db_readonly(file_found)
 
         cursor = db.cursor()
-        cursor.execute('''
-        select 
+        
+        cursor.execute("PRAGMA table_info(completion_cache_engagement);")
+        columns = [i[1] for i in cursor.fetchall()]
+        
+        if 'score' in columns:
+            score_column = 'score'
+        else:
+            score_column = 'NULL as score'
+        
+        query = f'''
+        SELECT 
             datetime(engagement_date + 978307200,'unixepoch') as engagement_date, 
             input, 
             completion, 
             transformed, 
-            score
+            {score_column}
         FROM completion_cache_engagement
-        ''')
+        '''
+        
+        cursor.execute(query)
 
         all_rows = cursor.fetchall()
 


### PR DESCRIPTION
**Description**

This pull request improves the parsecdCache.py artifact parser by adding backward-compatible handling for older ParseCD Cache databases that do not contain the score column.
The updated logic dynamically inspects table schema via PRAGMA table_info and safely substitutes NULL AS score when the column is absent. This prevents SQLite errors when processing legacy datasets.

**Errors Encountered**

When running iLEAPP against the 2020 CTF – iOS dataset, the following error occurred:

<img width="1522" height="156" alt="1cf6666a-0dea-4b11-a426-950931950abe" src="https://github.com/user-attachments/assets/78a1872a-fcd4-41a0-ae62-d4b7bb120f78" />

It originated from the completion_cache_engagement table, which lacks the score field in older iOS datasets.

**Dataset to Reproduce**

Source: 2020 CTF – iOS forensic dataset (EngagedCompletions/Cache.db)

Relevant table: completion_cache_engagement

Issue: Table schema does not include the score column

Running get_parseCDCache on this dataset reliably reproduces the error.

The Fix

- Added a schema check using PRAGMA table_info(completion_cache_engagement);
- If score exists, it is selected normally.
- If not present, the query uses NULL AS score to preserve output format.
- Ensures output headers remain consistent regardless of dataset version.
- No changes to downstream code or artifact structure.
- This provides full backward compatibility with older ParseCD Cache databases.

**Verification (Before/After)**

Before Fix:
iLEAPP aborts artifact processing with sqlite3.OperationalError: no such column: score
No report generated for this artifact.

After Fix:
Artifact runs without errors.

<img width="1907" height="906" alt="acc6f75c-26ba-4cf8-8b3f-283c88f76206" src="https://github.com/user-attachments/assets/6a938455-e534-488e-b5ee-c99094e9077f" />

Rows from older ParseCD Cache files are parsed successfully.
The “Score” column is populated with NULL for datasets that lack the field.
Output verified using the 2020 CTF – iOS Cache.db dataset.