### PR TITLE
Add processed files output for lava (Issue #1485)

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -16,7 +16,7 @@ from shutil import copy2
 from getpass import getpass
 from scripts.search_files import *
 from scripts.ilapfuncs import *
-from scripts.version_info import ileapp_version
+from scripts.version_info import leapp_version
 from time import process_time, gmtime, strftime, perf_counter
 from scripts.lavafuncs import *
 from scripts.context import Context
@@ -158,7 +158,7 @@ def create_casedata(path):
     return
 
 def main():
-    parser = argparse.ArgumentParser(description=f'iLEAPP v{ileapp_version}: iOS Logs, Events, And Plists Parser.')
+    parser = argparse.ArgumentParser(description=f'iLEAPP v{leapp_version}: iOS Logs, Events, And Plists Parser.')
     parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'itunes', 'file'], required=False, action="store",
                         help=("Specify the input type. "
                               "'fs' for a folder containing extracted files with normal paths and names, "
@@ -342,12 +342,11 @@ def crunch_artifacts(
     logfunc('Processing started. Please wait. This may take a few minutes...')
 
     logfunc('\n--------------------------------------------------------------------------------------')
-    logfunc(f'iLEAPP v{ileapp_version}: iOS Logs, Events, And Plists Parser')
+    logfunc(f'iLEAPP v{leapp_version}: iOS Logs, Events, And Plists Parser')
     logfunc('Objective: Triage iOS Full File System and iTunes Backup Extractions.')
     logfunc('By: Alexis Brignoni | @AlexisBrignoni | abrignoni.com')
     logfunc('By: Yogesh Khatri   | @SwiftForensics | swiftforensics.com\n')
     logdevinfo()
-
     seeker = None
     password = itunes_backup_password
     try:

--- a/ileapp.py
+++ b/ileapp.py
@@ -412,8 +412,6 @@ def crunch_artifacts(
     log.write(f'Extraction/Path selected: {input_path}<br><br>')
     log.write(f'Timezone selected: {time_offset}<br><br>')
 
-    parsed_modules = 0
-    lava_only = False
     # Special processing for iTunesBackup Info.plist as it is a seperate entity, not part of the Manifest.db. Seeker won't find it
     if extracttype == 'itunes':
         info_plist_path = os.path.join(input_path, 'Info.plist')
@@ -443,6 +441,10 @@ def crunch_artifacts(
             log.write('Info.plist not found for iTunes Backup!')
 
     # Search for the files per the arguments
+    parsed_modules = 0
+    lava_only = False
+    artifact_search_pattern_id = 0
+
     for plugin_number, plugin in enumerate(plugins, start=1):
         logfunc()
         logfunc('[{}/{}] {} [{}] artifact started'.format(plugin_number, len(plugins),
@@ -454,8 +456,6 @@ def crunch_artifacts(
             search_regexes = plugin.search
         else:
             search_regexes = [plugin.search]
-        parsed_modules += 1
-        GuiWindow.SetProgressBar(parsed_modules, len(plugins))
         files_found = []
         log.write(f'<b>For {plugin.name} module</b>')
         if search_regexes is None:
@@ -464,6 +464,10 @@ def crunch_artifacts(
             files_found = [os.path.join(out_params.output_folder_base, '_lava_artifacts.db')]
         else:
             for artifact_search_regex in search_regexes:
+                artifact_search_pattern_id += 1
+                lava_insert_sqlite_artifact_search_pattern(
+                    artifact_search_pattern_id, plugin.module_name, plugin.name, artifact_search_regex)
+                pattern_already_searched = artifact_search_regex in seeker.searched
                 found = seeker.search(artifact_search_regex)
                 if not found:
                     if plugin.name == 'logarchive' and extracttype != 'fs' and extracttype != 'file':
@@ -479,6 +483,12 @@ def crunch_artifacts(
                         if pathh.startswith('\\\\?\\'):
                             pathh = pathh[4:]
                         log.write(f'<ul><li>{pathh}</li></ul>')
+                        if seeker.file_infos.get(pathh):
+                            if not pattern_already_searched and not pathh in seeker.file_infos:
+                                lava_insert_sqlite_file_path(
+                                    id(seeker.file_infos.get(pathh)),
+                                    seeker.file_infos.get(pathh).source_path)
+                            lava_insert_sqlite_artifact_link_pattern_to_file(artifact_search_pattern_id, id(seeker.file_infos.get(pathh)))
                     log.write(f'</li></ul>')
                     files_found.extend(found)
         if files_found:
@@ -514,6 +524,9 @@ def crunch_artifacts(
         else:
             logfunc(f"No file found")
         logfunc('{} [{}] artifact completed'.format(plugin.name, plugin.module_name))
+        parsed_modules += 1
+        GuiWindow.SetProgressBar(parsed_modules, len(plugins))
+        log.flush()
     log.close()
 
     write_device_info()

--- a/ileapp.py
+++ b/ileapp.py
@@ -444,6 +444,7 @@ def crunch_artifacts(
     parsed_modules = 0
     lava_only = False
     artifact_search_pattern_id = 0
+    file_path_ids = set()
 
     for plugin_number, plugin in enumerate(plugins, start=1):
         logfunc()
@@ -484,11 +485,11 @@ def crunch_artifacts(
                             pathh = pathh[4:]
                         log.write(f'<ul><li>{pathh}</li></ul>')
                         if seeker.file_infos.get(pathh):
-                            if not pattern_already_searched and not pathh in seeker.file_infos:
-                                lava_insert_sqlite_file_path(
-                                    id(seeker.file_infos.get(pathh)),
-                                    seeker.file_infos.get(pathh).source_path)
-                            lava_insert_sqlite_artifact_link_pattern_to_file(artifact_search_pattern_id, id(seeker.file_infos.get(pathh)))
+                            file_path_id = id(seeker.file_infos.get(pathh))
+                            if not pattern_already_searched and file_path_id not in file_path_ids:
+                                lava_insert_sqlite_file_path(file_path_id,seeker.file_infos.get(pathh).source_path)
+                                file_path_ids.add(file_path_id)
+                            lava_insert_sqlite_artifact_link_pattern_to_file(artifact_search_pattern_id, file_path_id)
                     log.write(f'</li></ul>')
                     files_found.extend(found)
         if files_found:

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -11,7 +11,7 @@ import scripts.plugin_loader as plugin_loader
 
 from PIL import Image, ImageTk
 from tkinter import ttk, filedialog as tk_filedialog, messagebox as tk_msgbox
-from scripts.version_info import ileapp_version
+from scripts.version_info import leapp_version
 from scripts.search_files import *
 from scripts.ilapfuncs import *
 from scripts.tz_offset import tzvalues
@@ -502,7 +502,7 @@ theme_fgcolor = '#fdcb52'
 
 ## Main window properties
 main_window.minsize(890, 690)
-main_window.title(f'iLEAPP version {ileapp_version}')
+main_window.title(f'iLEAPP version {leapp_version}')
 main_window.configure(bg=theme_bgcolor)
 logo_icon = tk.PhotoImage(file=icon)
 main_window.iconphoto(True, logo_icon)

--- a/scripts/artifact_report.py
+++ b/scripts/artifact_report.py
@@ -3,7 +3,7 @@ import os
 import sys
 from scripts.html_parts import *
 #from scripts.ilapfuncs import is_platform_windows
-from scripts.version_info import ileapp_version
+from scripts.version_info import leapp_version
 
 class ArtifactHtmlReport:
 
@@ -23,7 +23,7 @@ class ArtifactHtmlReport:
         # artifact_file_name =  artifact_file_name.replace(" ", "_") # Replace " " with "_" in HTML filenames
         self.report_file = open(os.path.join(report_folder, f'{artifact_file_name}.temphtml'), 'w', encoding='utf8')
         self.report_file.write(page_header.format(f'iLEAPP - {self.artifact_name} report'))
-        self.report_file.write(body_start.format(f'iLEAPP {ileapp_version}'))
+        self.report_file.write(body_start.format(f'iLEAPP {leapp_version}'))
         self.report_file.write(body_sidebar_setup)
         self.report_file.write(body_sidebar_dynamic_data_placeholder) # placeholder for sidebar data
         self.report_file.write(body_sidebar_trailer)

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -27,11 +27,14 @@ Functions:
 
 import json
 import sqlite3
+import sys
 import os
+from platform import platform
 from collections import OrderedDict
 import re
 import datetime
 
+from scripts.version_info import leapp_name, leapp_version
 from scripts.context import Context
 
 # Global variables
@@ -87,11 +90,20 @@ def initialize_lava(input_path, output_path, input_type):
         input_path: The path to the input file.
         output_path: The path to the output file.
         input_type: The type of input file.
+        selected_artifacts: List of selected artifacts.
     '''
 
     global lava_data, lava_db
 
     lava_data = {
+        "parser_info": {
+            "leapp_name": leapp_name,
+            "leapp_version": leapp_version,
+            "leapp_mode": "GUI" if "leappGUI" in sys.argv[0] else "CLI", 
+            "package": "Source code" if not getattr(sys, 'frozen', False) else "Binary",
+            "OS": platform(),
+            "start_timestamp": int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        },
         "param_input": input_path,
         "param_output": output_path,
         "param_type": input_type,
@@ -625,6 +637,8 @@ def lava_finalize_output(output_path):
     # Sort artifacts within each category alphabetically
     for category in lava_data["artifacts"]:
         lava_data["artifacts"][category].sort(key=lambda x: x["name"])
+
+    lava_data["parser_info"]["end_timestamp"] = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
 
     # Save LAVA JSON output
     with open(os.path.join(output_path, lava_json_name), 'w', encoding='utf-8') as f:

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -547,7 +547,12 @@ def lava_get_full_media_info(media_ref_id):
 
 def lava_insert_sqlite_artifact_search_pattern(artifact_regex_id, module_name, artifact_name, regex):
     """
-    Docstrings to be added.
+    Inserts artifact search pattern into the _artifact_search_patterns table.
+    Args:
+        artifact_regex_id (str): Unique identifier for the artifact search pattern.
+        module_name (str): Name of the module containing the artifact.
+        artifact_name (str): Name of the artifact.
+        regex (str): The regular expression for the artifact search pattern.
     """
 
     global lava_db
@@ -567,7 +572,10 @@ def lava_insert_sqlite_artifact_search_pattern(artifact_regex_id, module_name, a
 
 def lava_insert_sqlite_file_path(file_id, file_path):
     """
-    Docstrings to be added.
+    Insert a file path record into the _file_path_list table.
+    Args:
+        file_id (int): Unique identifier for the file path entry.
+        file_path (str): Relative file path to store.
     """
 
     global lava_db
@@ -587,7 +595,10 @@ def lava_insert_sqlite_file_path(file_id, file_path):
 
 def lava_insert_sqlite_artifact_link_pattern_to_file(artifact_regex_id, file_id):
     """
-    Docstrings to be added.
+    Link an artifact search pattern to a file path entry.
+    Args:
+        artifact_regex_id (int): ID of the artifact search pattern.
+        file_id (int): ID of the related file path entry.
     """
 
     global lava_db

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -108,6 +108,20 @@ def initialize_lava(input_path, output_path, input_type):
     lava_db = sqlite3.connect(db_path)
 
     cursor = lava_db.cursor()
+    cursor.execute('''CREATE TABLE _artifact_search_patterns (
+                        id INTEGER PRIMARY KEY,
+                        module_name TEXT NOT NULL,
+                        artifact_name TEXT NOT NULL,
+                        regex TEXT NOT NULL)''')
+    cursor.execute('''CREATE TABLE _file_path_list (
+                        id INTEGER PRIMARY KEY,
+                        file_path TEXT NOT NULL)''')
+    cursor.execute('''CREATE TABLE _artifact_pattern_to_file (
+                        id INTEGER PRIMARY KEY,
+                        artifact_search_pattern_id INTEGER NOT NULL,
+                        file_path_id INTEGER NOT NULL,
+                        FOREIGN KEY (artifact_search_pattern_id) REFERENCES _artifact_search_patterns(id),
+                        FOREIGN KEY (file_path_id) REFERENCES _file_path_list(id))''')
     cursor.execute('''CREATE TABLE _lava_media_items (
                         id TEXT PRIMARY KEY,
                         source_path TEXT,
@@ -517,6 +531,66 @@ def lava_get_full_media_info(media_ref_id):
     WHERE media_ref_id = '{media_ref_id}'
     '''
     return cursor.execute(query).fetchone()
+
+
+def lava_insert_sqlite_artifact_search_pattern(artifact_regex_id, module_name, artifact_name, regex):
+    """
+    Docstrings to be added.
+    """
+
+    global lava_db
+    cursor = lava_db.cursor()
+    sql = '''INSERT INTO _artifact_search_patterns
+                ("id", "module_name", "artifact_name", "regex")
+                VALUES (?, ?, ?, ?)'''
+
+    data = (artifact_regex_id, module_name, artifact_name, regex)
+
+    try:
+        cursor.execute(sql, data)
+        lava_db.commit()
+    except sqlite3.IntegrityError as e:
+        print(str(e))
+
+
+def lava_insert_sqlite_file_path(file_id, file_path):
+    """
+    Docstrings to be added.
+    """
+
+    global lava_db
+    cursor = lava_db.cursor()
+    sql = '''INSERT INTO _file_path_list
+                ("id", "file_path")
+                VALUES (?, ?)'''
+
+    data = (file_id, file_path)
+
+    try:
+        cursor.execute(sql, data)
+        lava_db.commit()
+    except sqlite3.IntegrityError as e:
+        print(str(e))
+
+
+def lava_insert_sqlite_artifact_link_pattern_to_file(artifact_regex_id, file_id):
+    """
+    Docstrings to be added.
+    """
+
+    global lava_db
+    cursor = lava_db.cursor()
+    sql = '''INSERT INTO _artifact_pattern_to_file
+                ("artifact_search_pattern_id", "file_path_id")
+                VALUES (?, ?)'''
+
+    data = (artifact_regex_id, file_id)
+
+    try:
+        cursor.execute(sql, data)
+        lava_db.commit()
+    except sqlite3.IntegrityError as e:
+        print(str(e))
 
 
 def lava_finalize_output(output_path):

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -6,7 +6,7 @@ import shutil
 from collections import OrderedDict
 from scripts.html_parts import *
 from scripts.ilapfuncs import logfunc
-from scripts.version_info import ileapp_version, ileapp_contributors
+from scripts.version_info import leapp_version, ileapp_contributors
 from scripts.report_icons import icon_mappings, feather_icon_names
 
 def get_icon_name(category, artifact):
@@ -243,7 +243,7 @@ def create_index_html(reportfolderbase, time_in_secs, time_HMS, extraction_type,
     html_reportfolderbase.mkdir(exist_ok=True)
     with html_reportfolderbase.joinpath(filename).open('w', encoding='utf8') as f:
         f.write(page_header.format(page_title))
-        f.write(body_start.format(f"iLEAPP {ileapp_version}"))
+        f.write(body_start.format(f"iLEAPP {leapp_version}"))
         f.write(body_sidebar_setup + active_nav_list_data + body_sidebar_trailer)
         f.write(body_main_header + body_main_data_title.format(body_heading, body_description))
         f.write(content)

--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -4,7 +4,8 @@ Format = [ Name, Blog-url, Twitter-handle, Github-url]
 Leave blank if not available
 """
 
-ileapp_version = '2.5.0-dev.2'
+leapp_name = 'iLEAPP'
+leapp_version = '2.5.0-dev.2'
 
 ileapp_contributors = [
     ['Alexis Brignoni', 'https://abrignoni.com', '@AlexisBrignoni', 'https://github.com/abrignoni'],

--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -4,7 +4,7 @@ Format = [ Name, Blog-url, Twitter-handle, Github-url]
 Leave blank if not available
 """
 
-ileapp_version = '2.5.0-dev.0'
+ileapp_version = '2.5.0-dev.2'
 
 ileapp_contributors = [
     ['Alexis Brignoni', 'https://abrignoni.com', '@AlexisBrignoni', 'https://github.com/abrignoni'],


### PR DESCRIPTION
Three new tables have been added to LAVA db (_artifact_search_patterns, _file_path_list, _artifact_pattern_fo_file) to store info about artifact processed files --> Issue #1485 
More run information included in lava json file --> issue #1209
<img width="389" height="218" alt="image" src="https://github.com/user-attachments/assets/86ebb304-2af1-4491-ae53-7e74e8c588ac" />
