### PR TITLE
Label processed file log entries as artifacts

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -457,9 +457,9 @@ def crunch_artifacts(
         parsed_modules += 1
         GuiWindow.SetProgressBar(parsed_modules, len(plugins))
         files_found = []
-        log.write(f'<b>For {plugin.name} module</b>')
+        log.write(f'<b>For {plugin.name} artifact</b>')
         if search_regexes is None:
-            log.write(f'<ul><li>No search regexes provided for {plugin.name} module.')
+            log.write(f'<ul><li>No search regexes provided for {plugin.name} artifact.')
             log.write("<ul><li><i>'_lava_artifacts.db'</i> used as source file.</li></ul></li></ul>")
             files_found = [os.path.join(out_params.output_folder_base, '_lava_artifacts.db')]
         else:


### PR DESCRIPTION
## Summary
- Update `ProcessedFilesLog.html` entries to refer to each processed item as an artifact instead of a module.
- Keep the existing log structure and search-regex details unchanged.

Fixes #1264

## Validation
- `git diff --check`
- `git diff --cached --check`
- `rg -n "For {plugin.name} (module|artifact)|No search regexes provided for {plugin.name} (module|artifact)" ileapp.py`
- Not run locally
