### PR TITLE
AAPL file sometimes uses ASTC instead of astc tag

### DIFF
--- a/scripts/ktx/ios_ktx2png.py
+++ b/scripts/ktx/ios_ktx2png.py
@@ -139,7 +139,7 @@ class KTX_reader:
                 self.aapl_data_pos = f.tell() + 4
                 self.aapl_data_size = item_size - 4
                 self.aapl_is_compressed = True
-            elif item_identifier == b'astc':
+            elif item_identifier in (b'astc', b'ASTC'):
                 self.aapl_data_pos = f.tell() + 4
                 self.aapl_data_size = item_size - 4
             next_header_pos += 8 + item_size

--- a/scripts/ktx/ios_ktx2png.py
+++ b/scripts/ktx/ios_ktx2png.py
@@ -31,7 +31,7 @@
     See main 
 """
 
-import astc_decomp_faster 
+import astc_decomp_faster # pylint: disable=unused-import
 import liblzfse
 import os
 import struct


### PR DESCRIPTION
The folder mobile/Library/Caches/com.apple.chrono contains .snapshot files wich can decode to a small tile of a widget.

E.g. in iOS_16_Public_Image (iPhone 11, iOS 16) (Binary Hick) the file systemSmall--169.00w--169.00h--23.00r--0f--0.00t-0.00l-0.00b0.00t--0.dark.private.snapshot md5:1c7a02f80fc0bde931b95094f392195e
contains a small map-tile.

These files use a capitallized tag ASTC