### PR TITLE
Add initial Claude iOS artifact discovery parser

### DIFF
--- a/scripts/artifacts/claude.py
+++ b/scripts/artifacts/claude.py
@@ -18,8 +18,6 @@ __artifacts_v2__ = {
 }
 
 import os
-import json
-import plistlib
 from scripts.ilapfuncs import artifact_processor
 
 @artifact_processor

--- a/scripts/artifacts/claude.py
+++ b/scripts/artifacts/claude.py
@@ -1,0 +1,43 @@
+__artifacts_v2__ = {
+    "get_claude": {
+        "name": "Claude",
+        "description": "Parses Claude iOS app artifacts",
+        "author": "Dielle De Noon",
+        "creation_date": "2026-06-08",
+        "last_updated": "2026-06-08",
+        "requirements": "none",
+        "category": "Claude",
+        "notes": "",
+        "paths": (
+            "*/mobile/Containers/Data/Application/*/Documents/*",
+            "*/mobile/Containers/Shared/AppGroup/*/*claude*",
+            "*/mobile/Containers/Shared/AppGroup/*/*anthropic*",
+        ),
+        "output_types": "standard",
+    }
+}
+
+import os
+import json
+import plistlib
+from scripts.ilapfuncs import artifact_processor
+
+@artifact_processor
+def get_claude(context):
+    data_list = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+
+        if not os.path.isfile(file_found):
+            continue
+
+        lower = file_found.lower()
+        if "claude" not in lower and "anthropic" not in lower:
+            continue
+
+        data_list.append((os.path.basename(file_found), file_found))
+
+    data_headers = ("File Name", "Source File")
+    return data_headers, data_list, "Claude iOS app related files"
+


### PR DESCRIPTION
This pull request adds an initial artifact module for the Claude iOS application.

The artifact is intended as a discovery and research parser that identifies Claude/Anthropic-related files within iOS filesystem extractions. The parser searches for Claude-specific application paths and reports matching files to assist with future reverse engineering and artifact development.

**Current Functionality:**
Identifies Claude/Anthropic-related files within iOS filesystem extractions
Reports discovered file names and source paths
Provides a foundation for future Claude conversation and metadata parsing

**Testing:**

Tested against an iOS filesystem extraction using iLEAPP.

**Results:**

Artifact loaded successfully
Artifact executed without errors
Future Enhancements

**Potential future improvements include:**

Conversation metadata extraction
Message history parsing
Account information extraction
Attachment and uploaded file analysis
Claude project and workspace artifact parsing