### PR TITLE
Small fix for app snapshots

### DIFF
--- a/scripts/artifacts/appSnapshots.py
+++ b/scripts/artifacts/appSnapshots.py
@@ -79,7 +79,7 @@ def applicationSnapshots(context): #files_found, report_folder, seeker, wrap_tex
         if not media_item:
             continue
             
-        last_modified_date = convert_unix_ts_to_utc(lava_get_full_media_info(media_item)[-2])
+        last_modified_date = convert_unix_ts_to_utc(lava_get_full_media_info(media_item)['updated_at'])
         data_list.append([last_modified_date, app_name, file_found, media_item])
     
     data_headers = (('Date Modified', 'datetime'), 'App Name', 'Source Path', ('Snapshot', 'media'))

--- a/scripts/artifacts/appSnapshots.py
+++ b/scripts/artifacts/appSnapshots.py
@@ -79,7 +79,7 @@ def applicationSnapshots(context): #files_found, report_folder, seeker, wrap_tex
         if not media_item:
             continue
             
-        last_modified_date = convert_unix_ts_to_utc(lava_get_full_media_info(media_item)[-1])
+        last_modified_date = convert_unix_ts_to_utc(lava_get_full_media_info(media_item)[-2])
         data_list.append([last_modified_date, app_name, file_found, media_item])
     
     data_headers = (('Date Modified', 'datetime'), 'App Name', 'Source Path', ('Snapshot', 'media'))

--- a/scripts/artifacts/appSnapshots.py
+++ b/scripts/artifacts/appSnapshots.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
             Dates and times shown are from file modified timestamps",
         "author": "@ydkhatri",
         "creation_date": "2020-07-23",
-        "last_update_date": "2025-05-13",
+        "last_update_date": "2026-06-18",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",


### PR DESCRIPTION
Since `_lava_media_info.updated_at` is the second to last column in the result of the query used in function `lava_get_full_media_info`, the list item used for variable `last_modified_date` should be updated from -1 to -2. (The query was updated in commit 28ea00e9cbe3d8e87192adbe3dda84a08fef603f.)