### PR TITLE
Convert kik Users-in-Groups + Local Account to artifact_processor (LAVA)

### DIFF
--- a/scripts/artifacts/kikLocaladmin.py
+++ b/scripts/artifacts/kikLocaladmin.py
@@ -1,88 +1,66 @@
-import glob
-import os
-import nska_deserialize as nd
-import sqlite3
-import datetime
+__artifacts_v2__ = {
+    "kikLocaladmin": {
+        "name": "Kik Local Account",
+        "description": "Kik local account users from kik.sqlite",
+        "author": "@AlexisBrignoni",
+        "version": "1.0",
+        "date": "2026-06-22",
+        "requirements": "none",
+        "category": "Kik",
+        "notes": "",
+        "paths": ('*/kik.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "user"
+    }
+}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
-def get_kikLocaladmin(files_found, report_folder, seeker, wrap_text, timezone_offset):
+@artifact_processor
+def kikLocaladmin(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+    data_headers = ('User ID', 'Display Name', 'Username', 'Profile Pic URL', 'Member Group ID',
+                    'Administrator Group ID', 'Group Tag', 'Group Name', 'Group ID', 'Group Pic URL',
+                    'Blob', 'Additional Information')
+    data_list = []
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('kik.sqlite'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
+    if not source_path:
+        return data_headers, data_list, ''
+
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    Select ZKIKUSER.Z_PK, /*User ID*/
-        ZKIKUSER.ZDISPLAYNAME, /*Display Name*/
-        ZKIKUSER.ZUSERNAME, /*Username, if available*/
-        ZKIKUSER.ZPPURL, /*Profile Picture URL*/
-        Z_9MEMBERS.Z_9MEMBERSINVERSE, /*Group ID of group where user is a member. */
-        Z_9ADMINSINVERSE.Z_9ADMINSINVERSE, /*Group ID of group where user is an administrator. */
-        ZKIKUSEREXTRA.ZENTITYUSERDATA, /*BLOB from ZKIKUSEREXTRA that contains additional user information. */
-        ZKIKUSEREXTRA.ZROSTERENTRYDATA /*Field from ZKIKUSEREXTRA that contains additional user information*/
-    From ZKIKUSER
-        LEFT Join Z_9MEMBERS On ZKIKUSER.Z_PK = Z_9MEMBERS.Z_9MEMBERS /*(joined Z_PK from ZKIKUSER table with Z_9MEMBERS in Z_9MEMBERS table)*/
-        Left Join Z_9ADMINSINVERSE On ZKIKUSER.Z_PK = Z_9ADMINSINVERSE.Z_9ADMINS /*(matched Z_PK from ZKIKUSER table with Z_9ADMINS from Z_9ADMINSINVERSE table)*/
-        LEFT JOIN ZKIKUSEREXTRA On ZKIKUSER.Z_PK = ZKIKUSEREXTRA.ZUSER /*(matched Z_PK from ZKIKUSER with ZUSER from ZKIKUSEREXTRA)*/
+    SELECT ZKIKUSER.Z_PK,
+        ZKIKUSER.ZDISPLAYNAME,
+        ZKIKUSER.ZUSERNAME,
+        ZKIKUSER.ZPPURL,
+        Z_9MEMBERS.Z_9MEMBERSINVERSE,
+        Z_9ADMINSINVERSE.Z_9ADMINSINVERSE,
+        ZKIKUSEREXTRA.ZENTITYUSERDATA,
+        ZKIKUSEREXTRA.ZROSTERENTRYDATA
+    FROM ZKIKUSER
+        LEFT JOIN Z_9MEMBERS ON ZKIKUSER.Z_PK = Z_9MEMBERS.Z_9MEMBERS
+        LEFT JOIN Z_9ADMINSINVERSE ON ZKIKUSER.Z_PK = Z_9ADMINSINVERSE.Z_9ADMINS
+        LEFT JOIN ZKIKUSEREXTRA ON ZKIKUSER.Z_PK = ZKIKUSEREXTRA.ZUSER
     WHERE ZKIKUSER.ZFIRSTNAME OR ZKIKUSER.ZLASTNAME <> ""
     ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []
-    if usageentries > 0:
+    for row in cursor.fetchall():
+        grouptag = groupdname = zjid = zpurl = ''
+        if row[4] is not None:
+            cursor2 = db.cursor()
+            cursor2.execute('SELECT ZGROUPTAG, ZDISPLAYNAME, ZJID, ZPPURL FROM ZKIKUSER WHERE Z_PK = ?',
+                            (row[4],))
+            for rows2 in cursor2.fetchall():
+                grouptag, groupdname, zjid, zpurl = rows2[0], rows2[1], rows2[2], rows2[3]
+        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], grouptag, groupdname, zjid,
+                          zpurl, row[6], row[7]))
+    db.close()
 
-        for row in all_rows:
-            if row[4] is None:
-                grouptag = ''
-                groupdname =''
-                zjid = ''
-                zpurl = ''
-            else:
-                cursor2 = db.cursor()
-                cursor2.execute(f'''
-                SELECT ZGROUPTAG,
-                    ZDISPLAYNAME,
-                    ZJID,
-                    ZPPURL
-                FROM ZKIKUSER 
-                WHERE Z_PK = {row[4]}
-                ''')
-                
-                all_rows2 = cursor2.fetchall()
-                for rows2 in all_rows2:
-                    grouptag = rows2[0]
-                    groupdname = rows2[1]
-                    zjid = rows2[2]
-                    zpurl = rows2[3]
-            
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],grouptag,groupdname,zjid, zpurl,row[6],row[7]))
-            
-            
-        description = 'Kik Local Account.'
-        report = ArtifactHtmlReport('Kik Local Account')
-        report.start_artifact_report(report_folder, 'Kik Local Account', description)
-        report.add_script()
-        data_headers = ('User ID','Display Name','Username','Profile Pic URL','Member Group ID','Administartor Group ID','Group Tag','Group Name','Group ID','Group Pic URL','Blob','Additional Information')     
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Kik Local Account'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    
-    else:
-        logfunc('No Kik Local Account data available')
-    
-    
-__artifacts__ = {
-    "kikLocaladmin": (
-        "Kik",
-        ('*/kik.sqlite*'),
-        get_kikLocaladmin)
-}
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/kikUsersgroups.py
+++ b/scripts/artifacts/kikUsersgroups.py
@@ -1,83 +1,63 @@
-import glob
-import os
-import nska_deserialize as nd
-import sqlite3
-import datetime
+__artifacts_v2__ = {
+    "kikUsersgroups": {
+        "name": "Kik Users in Groups",
+        "description": "Kik users that are members of a group (kik.sqlite)",
+        "author": "@AlexisBrignoni",
+        "version": "1.0",
+        "date": "2026-06-22",
+        "requirements": "none",
+        "category": "Kik",
+        "notes": "",
+        "paths": ('*/kik.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "users"
+    }
+}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
-def get_kikUsersgroups(files_found, report_folder, seeker, wrap_text, timezone_offset):
+@artifact_processor
+def kikUsersgroups(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+    data_headers = ('User ID', 'Display Name', 'Username', 'Profile Pic URL', 'Member Group ID',
+                    'Group Tag', 'Group Name', 'Group ID', 'Group Pic URL', 'Blob',
+                    'Additional Information')
+    data_list = []
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('kik.sqlite'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
+    if not source_path:
+        return data_headers, data_list, ''
+
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    Select ZKIKUSER.Z_PK, /*User ID*/
-        ZKIKUSER.ZDISPLAYNAME, /*Display Name*/
-        ZKIKUSER.ZUSERNAME, /*Username, if available*/
-        ZKIKUSER.ZPPURL, /*Profile Picture URL*/
-        Z_9MEMBERS.Z_9MEMBERSINVERSE, /*Group ID of group where user is a member. */
-        ZKIKUSEREXTRA.ZENTITYUSERDATA, /*BLOB from ZKIKUSEREXTRA that contains additional user information. */
-        ZKIKUSEREXTRA.ZROSTERENTRYDATA /*Field from ZKIKUSEREXTRA that contains additional user information*/
-    From ZKIKUSER
-        INNER Join Z_9MEMBERS On ZKIKUSER.Z_PK = Z_9MEMBERS.Z_9MEMBERS /*(joined Z_PK from ZKIKUSER table with Z_9MEMBERS in Z_9MEMBERS table)*/
-        LEFT JOIN ZKIKUSEREXTRA On ZKIKUSER.Z_PK = ZKIKUSEREXTRA.ZUSER /*(matched Z_PK from ZKIKUSER with ZUSER from ZKIKUSEREXTRA)*/
-    order by Z_9MEMBERSINVERSE
+    SELECT ZKIKUSER.Z_PK,
+        ZKIKUSER.ZDISPLAYNAME,
+        ZKIKUSER.ZUSERNAME,
+        ZKIKUSER.ZPPURL,
+        Z_9MEMBERS.Z_9MEMBERSINVERSE,
+        ZKIKUSEREXTRA.ZENTITYUSERDATA,
+        ZKIKUSEREXTRA.ZROSTERENTRYDATA
+    FROM ZKIKUSER
+        INNER JOIN Z_9MEMBERS ON ZKIKUSER.Z_PK = Z_9MEMBERS.Z_9MEMBERS
+        LEFT JOIN ZKIKUSEREXTRA ON ZKIKUSER.Z_PK = ZKIKUSEREXTRA.ZUSER
+    ORDER BY Z_9MEMBERSINVERSE
     ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []
-    if usageentries > 0:
+    for row in cursor.fetchall():
+        grouptag = groupdname = zjid = zpurl = ''
+        cursor2 = db.cursor()
+        cursor2.execute('SELECT ZGROUPTAG, ZDISPLAYNAME, ZJID, ZPPURL FROM ZKIKUSER WHERE Z_PK = ?',
+                        (row[4],))
+        for rows2 in cursor2.fetchall():
+            grouptag, groupdname, zjid, zpurl = rows2[0], rows2[1], rows2[2], rows2[3]
+        data_list.append((row[0], row[1], row[2], row[3], row[4], grouptag, groupdname, zjid, zpurl,
+                          row[5], row[6]))
+    db.close()
 
-        for row in all_rows:
-        
-            cursor2 = db.cursor()
-            cursor2.execute(f'''
-            SELECT ZGROUPTAG,
-                ZDISPLAYNAME,
-                ZJID,
-                ZPPURL
-            FROM ZKIKUSER 
-            WHERE Z_PK = {row[4]}
-            ''')
-            
-            all_rows2 = cursor2.fetchall()
-            for rows2 in all_rows2:
-                grouptag = rows2[0]
-                groupdname = rows2[1]
-                zjid = rows2[2]
-                zpurl = rows2[3]
-            
-            data_list.append((row[0],row[1],row[2],row[3],row[4],grouptag,groupdname,zjid, zpurl,row[5],row[6]))
-            
-            
-        description = 'Kik users that are members of a group.'
-        report = ArtifactHtmlReport('Kik Users in Groups')
-        report.start_artifact_report(report_folder, 'Kik Users in Groups', description)
-        report.add_script()
-        data_headers = ('User ID','Display Name','Username','Profile Pic URL','Member Group ID','Group Tag','Group Name','Group ID','Group Pic URL','Blob','Additional Information')     
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Kik Users in Groups'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    
-    else:
-        logfunc('No Kik Users in Groups data available')
-    
-__artifacts__ = {
-    "kikUsersgroups": (
-        "Kik",
-        ('*/kik.sqlite*'),
-        get_kikUsersgroups)
-}
-   
-    
-        
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
First **cluster** PR of the iLEAPP modernization (following the medicalID pilot, #1552). Converts the two simple **kik.sqlite** user/group artifacts together — they share the same source and query shape, have no protobuf and no media.

| Artifact | Report |
|---|---|
| `kikUsersgroups` | Kik Users in Groups |
| `kikLocaladmin` | Kik Local Account |

`kikGroupadmins` (blackboxprotobuf decoding) and the media-bearing kik artifacts (`kikMessages`, `kikBplistmeta`) are deliberately **not** in this PR — they'll get their own.

## Changes
- v1 `__artifacts__` → `__artifacts_v2__`; `@artifact_processor` with the 5-arg iLEAPP signature (unused args underscore-prefixed → pylint 10.00, no disable header per house style).
- **Robust source selection:** iterate `files_found` + `endswith('kik.sqlite')` with an empty-guard (no `files_found[0]`).
- **Bug fix:** the per-row group sub-query left `grouptag/groupdname/zjid/zpurl` undefined when it returned no rows (NameError risk / stale carry-over) → initialized to `''` each row.
- Parameterized the sub-query (was an f-string), close the db, drop unused imports (`glob`/`os`/`nska_deserialize`/`sqlite3`/`datetime`) and the `ArtifactHtmlReport`/`tsv`/`timeline` plumbing.
- `kikLocaladmin`: fixed the `Administartor` header typo → `Administrator`.

## Validation
- `ast.parse` OK; 0 legacy refs; no cross-module imports of the functions.
- Reserved-word audit clean (incl. `Blob`).
- pylint (CI config): **10.00/10** both.
- Each module loads in isolation: valid `__artifacts_v2__`, decorated, function name = key, no legacy registry.