### PR TITLE
Convert kikBplistmeta to artifact_processor (LAVA) + embedded media check-in

### DIFF
--- a/scripts/artifacts/kikBplistmeta.py
+++ b/scripts/artifacts/kikBplistmeta.py
@@ -1,86 +1,94 @@
-#!/usr/bin/env python3
-from pathlib import Path
+__artifacts_v2__ = {
+    "kikBplistmeta": {
+        "name": "Kik Attachments Bplist Metadata",
+        "description": "Metadata from the Kik attachments directory bplist files, with the embedded thumbnail",
+        "author": "@AlexisBrignoni",
+        "version": "1.0",
+        "date": "2026-06-22",
+        "requirements": "none",
+        "category": "Kik",
+        "notes": "",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/cores/private/*/attachments/*',),
+        "output_types": "standard",
+        "artifact_icon": "paperclip"
+    }
+}
+
 import os
+
 import biplist
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media
 
 
-def get_kikBplistmeta(files_found, report_folder, seeker, wrap_text, timezone_offset):
-	data_list = []
-	for file_found in files_found:
-		file_found = str(file_found)
-		isDirectory = os.path.isdir(file_found)
-		if isDirectory:
-			pass
-		else:
-			sha1org = sha1scaled = blockhash = appname = layout = allowforward = filesize = filename = thumb = appid = id = ''
-			with open(file_found, 'rb') as f:
-				plist = biplist.readPlist(f)
-				for key,val in plist.items():
-					if key == 'id':
-						id = val
-					elif key == 'hashes':
-						for x in val:
-							if x['name'] == 'sha1-original':
-								sha1org = x.get('value', '')
-							if x['name'] == 'sha1-scaled':
-								sha1scaled = x.get('value', '')
-							if x['name'] == 'blockhash-scaled':
-								blockhash = x.get('value', '')
-					elif key == 'string':
-						for x in val:
-							if x['name'] == 'app-name':
-								appname = x.get('value', '')
-							if x['name'] == 'layout':
-								layout = x.get('value', '')
-							if x['name'] == 'allow-forward':
-								allowforward = x.get('value', '')
-							if x['name'] == 'file-size':
-								filesize = x.get('value', '')
-							if x['name'] == 'file-name':
-								filename = x.get('value', '')
-					elif key == 'image':
-						thumbfilename = id
-						
-						complete = Path(report_folder).joinpath('Kik')
-						if not complete.exists():
-							Path(f'{complete}').mkdir(parents=True, exist_ok=True)
-						
-						file = open(f'{complete}{thumbfilename}', "wb")
-						file.write(val[0]['value'])
-						file.close()
-						
-						imagetofind = []
-						imagetofind.append(f'{complete}{thumbfilename}')
-						thumb = media_to_html(id, imagetofind, report_folder)
-					
-					
-					elif key == 'app-id':
-						appid = val
-						
-				data_list.append((id, filename, filesize, allowforward, layout, appname, appid, sha1org, sha1scaled, blockhash, thumb  ))
-				aggregate = ''
-				
-	if len(data_list) > 0:
-		head_tail = os.path.split(file_found)
-		description = 'Metadata from Kik media directory. Source are bplist files.'
-		report = ArtifactHtmlReport('Kik Attachments Bplist Metadata')
-		report.start_artifact_report(report_folder, 'Kik Media Metadata', description)
-		report.add_script()
-		data_headers = ('Content ID ', 'Filename', 'File Size', 'Allow Forward', 'Layout','App Name','App ID', 'SHA1 Original','SHA1 Scaled','Blockhash Scaled', 'Internal Thumbnail')
-		report.write_artifact_data_table(data_headers, data_list, head_tail[0],html_escape=False)
-		report.end_artifact_report()
-		
-		tsvname = 'Kik Attachments Bplist Metadata'
-		tsv(report_folder, data_headers, data_list, tsvname)
-	else:
-		logfunc('No data on Kik Attachments Bplist MetadataD')
+@artifact_processor
+def kikBplistmeta(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+    data_headers = ('Content ID', 'Filename', 'File Size', 'Allow Forward', 'Layout', 'App Name',
+                    'App ID', 'SHA1 Original', 'SHA1 Scaled', 'Blockhash Scaled',
+                    ('Internal Thumbnail', 'media'))
+    data_list = []
+    source_path = ''
 
-__artifacts__ = {
-    "kikBplistmeta": (
-        "Kik",
-        ('*/mobile/Containers/Shared/AppGroup/*/cores/private/*/attachments/*'),
-        get_kikBplistmeta)
-}
+    for file_found in files_found:
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        try:
+            with open(file_found, 'rb') as f:
+                plist = biplist.readPlist(f)
+        except Exception:  # pylint: disable=broad-exception-caught
+            continue  # not a (readable) binary plist
+        if not isinstance(plist, dict):
+            continue
+        source_path = source_path or file_found
+
+        content_id = appid = filename = filesize = allowforward = layout = appname = ''
+        sha1org = sha1scaled = blockhash = ''
+        image_data = None
+
+        for key, val in plist.items():
+            if key == 'id':
+                content_id = val
+            elif key == 'app-id':
+                appid = val
+            elif key == 'hashes':
+                for x in val:
+                    if x.get('name') == 'sha1-original':
+                        sha1org = x.get('value', '')
+                    elif x.get('name') == 'sha1-scaled':
+                        sha1scaled = x.get('value', '')
+                    elif x.get('name') == 'blockhash-scaled':
+                        blockhash = x.get('value', '')
+            elif key == 'string':
+                for x in val:
+                    name = x.get('name')
+                    if name == 'app-name':
+                        appname = x.get('value', '')
+                    elif name == 'layout':
+                        layout = x.get('value', '')
+                    elif name == 'allow-forward':
+                        allowforward = x.get('value', '')
+                    elif name == 'file-size':
+                        filesize = x.get('value', '')
+                    elif name == 'file-name':
+                        filename = x.get('value', '')
+            elif key == 'image':
+                try:
+                    image_data = val[0]['value']
+                except (KeyError, IndexError, TypeError):
+                    image_data = None
+
+        thumb = ''
+        if image_data:
+            force_type = force_extension = None
+            if image_data[:3] == b'\xff\xd8\xff':
+                force_type, force_extension = 'image/jpeg', 'jpg'
+            elif image_data[:8] == b'\x89PNG\r\n\x1a\n':
+                force_type, force_extension = 'image/png', 'png'
+            thumb = check_in_embedded_media(file_found, image_data, name=str(content_id),
+                                            force_type=force_type, force_extension=force_extension) or ''
+
+        data_list.append((content_id, filename, filesize, allowforward, layout, appname, appid,
+                          sha1org, sha1scaled, blockhash, thumb))
+
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
Converts `kikBplistmeta` and migrates its embedded-thumbnail handling to the LAVA pipeline.

## Changes
- v1 `__artifacts__` → `__artifacts_v2__`; `@artifact_processor` 5-arg signature (unused args underscore-prefixed → pylint 10.00).
- **Embedded media migration:** the thumbnail lives *inside* the bplist (`image` → bytes). The original wrote those bytes into a hand-made `Kik/` folder and rendered an inline `<img>` via `media_to_html`. Replaced with **`check_in_embedded_media`** in an `('Internal Thumbnail','media')` column, with magic-byte JPEG/PNG type detection so it renders correctly in HTML and LAVA — no more manual `mkdir`/file writes into the report folder.
- **Defensive:** guard `biplist.readPlist` (try/except), verify the result is a dict, `.get()` for nested hash/string entries, and resolve the embedded image *after* the loop so the Content ID (media name) is finalized first.
- Fixed the `Content ID ` header trailing space; dropped the dead `aggregate` var and unused `Path`/`ArtifactHtmlReport`/`tsv`/`is_platform_windows` imports.

## Validation
- `ast.parse` OK; 0 legacy/old-media refs; no cross-module imports.
- Reserved-word audit: all 11 columns unique.
- pylint (CI config): **10.00/10**.
- Loads in isolation: decorated, function = key, no legacy registry, `media` header present.