### PR TITLE
Convert mobileBackup + mobileContainerManager to artifact_processor (LAVA)

### DIFF
--- a/scripts/artifacts/mobileBackup.py
+++ b/scripts/artifacts/mobileBackup.py
@@ -1,53 +1,52 @@
-import os
+__artifacts_v2__ = {
+    "mobileBackup": {
+        "name": "Mobile Backup",
+        "description": "Backup/restore info from com.apple.MobileBackup.plist (backup version, "
+                       "iOS version at recovery, recovery date, and whether restored from iCloud)",
+        "author": "@AlexisBrignoni",
+        "version": "1.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Backup",
+        "notes": "",
+        "paths": ('*/Preferences/com.apple.MobileBackup.plist',),
+        "output_types": "standard",
+        "artifact_icon": "save"
+    }
+}
+
 import plistlib
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows 
+from scripts.ilapfuncs import artifact_processor
 
 
-# Backup version of iOS, iOS version installed at the time of recovery, 
-# recovery date, and whether the backup was restored from iCloud.
-def get_mobileBackup(files_found, report_folder, seeker, wrap_text, timezone_offset):
+@artifact_processor
+def mobileBackup(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+    data_headers = ('Key', 'Value')
     data_list = []
-    file_found = str(files_found[0])
-    
-    with open(file_found, 'rb') as fp:
+
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('com.apple.MobileBackup.plist'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    with open(source_path, 'rb') as fp:
         pl = plistlib.load(fp)
-        
-        if 'BackupStateInfo' in pl.keys():
-            for key, val in pl['BackupStateInfo'].items():
-                if key == 'isCloud':
-                    data_list.append((key, val))
-                if key == 'date':
-                    data_list.append((key, val))
-        else:
-            pass
 
-        if 'RestoreInfo' in pl.keys():
-            for key, val in pl['RestoreInfo'].items():
-                if key == 'BackupBuildVersion':
-                    data_list.append((key, val))
-                if key == 'DeviceBuildVersion':
-                    data_list.append((key, val))
-                if key == 'WasCloudRestore':
-                    data_list.append((key, val))
-                if key == 'RestoreDate':
-                    data_list.append((key, val))
+    state = pl.get('BackupStateInfo', {})
+    if isinstance(state, dict):
+        for key in ('isCloud', 'date'):
+            if key in state:
+                data_list.append((key, state[key]))
 
-            
-    report = ArtifactHtmlReport('Mobile Backup')
-    report.start_artifact_report(report_folder, 'Mobile Backup')
-    report.add_script()
-    data_headers = ('Key', 'Value')     
-    report.write_artifact_data_table(data_headers, data_list, file_found)
-    report.end_artifact_report()
-    
-    tsvname = 'Mobile Backup'
-    tsv(report_folder, data_headers, data_list, tsvname)
+    restore = pl.get('RestoreInfo', {})
+    if isinstance(restore, dict):
+        for key in ('BackupBuildVersion', 'DeviceBuildVersion', 'WasCloudRestore', 'RestoreDate'):
+            if key in restore:
+                data_list.append((key, restore[key]))
 
-__artifacts__ = {
-    "mobileBackup": (
-        "Mobile Backup",
-        ('*/Preferences/com.apple.MobileBackup.plist'),
-        get_mobileBackup)
-}
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/mobileContainerManager.py
+++ b/scripts/artifacts/mobileContainerManager.py
@@ -1,57 +1,54 @@
-import plistlib
-import re
+__artifacts_v2__ = {
+    "mobileContainerManager": {
+        "name": "Mobile Container Manager",
+        "description": "Group container removals logged by containermanagerd (last reference removed)",
+        "author": "@AlexisBrignoni",
+        "version": "1.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Container Manager",
+        "notes": "",
+        "paths": ('**/containermanagerd.log.*',),
+        "output_types": "standard",
+        "artifact_icon": "trash-2"
+    }
+}
 
 from datetime import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_mobileContainerManager(files_found, report_folder, seeker, wrap_text, timezone_offset):
+_MARKER = ('[MCMGroupManager _removeGroupContainersIfNeededforUser:groupContainerClass:identifiers:'
+           'referenceCounts:]: Last reference to group container')
 
+
+@artifact_processor
+def mobileContainerManager(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+    data_headers = (('Datetime', 'datetime'), 'Removed', 'Line')
     data_list = []
+    source_path = ''
 
     for file_found in files_found:
+        file_found = str(file_found)
+        source_path = source_path or file_found
+        try:
+            with open(file_found, 'r', encoding='utf-8', errors='ignore') as fp:
+                lines = fp.readlines()
+        except OSError:
+            continue
 
-        linecount = 0
-        hitcount = 0
-        with open(file_found, 'r') as fp:
-            data = fp.readlines()
+        for linecount, line in enumerate(lines, 1):
+            if _MARKER not in line:
+                continue
+            txts = line.split()
+            try:
+                # log prefix: <dow> <Mon> <day> <HH:MM:SS> <year> ... <group at index 15>
+                month_number = datetime.strptime(txts[1], '%b').month
+                dtime_obj = datetime.strptime(f'{txts[4]}-{month_number}-{txts[2]} {txts[3]}',
+                                              '%Y-%m-%d %H:%M:%S')
+                group = txts[15]
+            except (ValueError, IndexError):
+                continue
+            data_list.append((dtime_obj, group, linecount))
 
-            for line in data:
-                linecount += 1
-                
-                if '[MCMGroupManager _removeGroupContainersIfNeededforUser:groupContainerClass:identifiers:referenceCounts:]: Last reference to group container' in line:
-                    hitcount += 1
-                    txts = line.split()
-                    dayofweek = txts[0]
-                    month = txts[1]
-                    day = txts[2]
-                    time = txts[3]
-                    year = txts[4]
-                    group = txts[15]
-
-                    datetime_object = datetime.strptime(month, "%b")
-                    month_number = datetime_object.month
-                    concat_date = year + "-" + str(month_number) + "-" + day + " " + time 
-                    dtime_obj = datetime.strptime(concat_date, '%Y-%m-%d %H:%M:%S')
-                    
-                    data_list.append((str(dtime_obj), group, str(linecount)))
-
-    
-    report = ArtifactHtmlReport('Mobile Container Manager')
-    report.start_artifact_report(report_folder, 'Mobile Container Manager')
-    report.add_script()
-    data_headers = ('Datetime', 'Removed', 'Line')
-
-    report.write_artifact_data_table(data_headers, data_list, file_found)
-    report.end_artifact_report()
-        
-    tsvname = 'Mobile Container Manager'
-    tsv(report_folder, data_headers, data_list, tsvname)
-
-__artifacts__ = {
-    "mobileContainerManager": (
-        "Mobile Container Manager",
-        ('**/containermanagerd.log.*'),
-        get_mobileContainerManager)
-}
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
First `mobile*` cluster — two simple single-report artifacts converted together.

| Artifact | Source |
|---|---|
| `mobileBackup` | com.apple.MobileBackup.plist |
| `mobileContainerManager` | containermanagerd.log (group container removals) |

## Changes
- v1 `__artifacts__` → `__artifacts_v2__`; `@artifact_processor` 5-arg signature (unused args underscore-prefixed → pylint 10.00).
- **Robust source selection** (iterate + `endswith`/per-file + empty-guard, no `files_found[0]`); defensive `.get()`/`isinstance` for the plist sections.
- `mobileContainerManager`: returns the parsed log time as a real `datetime` object (marked `'datetime'`) instead of `str()`, and **hardens the date parse** with `try/except (ValueError, IndexError)` so a malformed log line is skipped rather than crashing the artifact; dropped the unused `re` import.
- Dropped `os`/`logdevinfo`/`is_platform_windows`/`ArtifactHtmlReport`/`tsv` plumbing.

## Validation
- `ast.parse` OK; 0 legacy refs; no cross-module imports.
- Reserved-word audit clean (Key/Value, Datetime/Removed/Line).
- pylint (CI config): **10.00/10** both.
- Both load in isolation: decorated, function = key, no legacy registry.