### PR TITLE
Convert mobileActivationLogs to artifact_processor (LAVA, context form)

### DIFF
--- a/scripts/artifacts/mobileActivationLogs.py
+++ b/scripts/artifacts/mobileActivationLogs.py
@@ -1,102 +1,90 @@
-import os
-import re
-import io
-import pathlib
-import tarfile
-
-from datetime import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows 
-
-
-def get_mobileActivationLogs(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    data_list_info = []
-
-    source_files = []
-    file_names = []
-    files = []
-    for filename in files_found:
-        if "mobileactivationd.log" in filename:
-            file_found = str(filename)
-            if file_found.startswith('\\\\?\\'):
-                file_names.append(pathlib.Path(file_found[4:]).name)
-                source_files.append(file_found[4:])
-            else:
-                file_names.append(pathlib.Path(file_found).name)
-                source_files.append(filename)
-            file = open(filename, "r", encoding="utf8")
-            files.append(file)
-        elif 'sysdiagnose_' in filename and not "IN_PROGRESS_" in filename:
-            file_found = str(filename)
-            tar = tarfile.open(filename)
-            matching_members = [
-                    m for m in tar.getmembers()
-                    if re.search(r"logs/MobileActivation/mobileactivationd\.log(\.\d+)?$", m.name)
-                ]
-            for member in matching_members:
-                file_names.append(member.name)
-                if filename not in source_files:
-                    source_files.append(filename)   
-                tar_log = tar.extractfile(member)
-                file = io.TextIOWrapper(tar_log, encoding="utf-8", errors="ignore")
-                files.append(file)
-
-    for index,fp in enumerate(files):       
-        data = fp.readlines()
-        linecount = 0
-        hitcount = 0
-        activationcount = 0
-        
-        for line in data:
-            linecount += 1
-            date_filter = re.compile(r'(([A-Za-z]+[\s]+([a-zA-Z]+[\s]+[0-9]+)[\s]+([0-9]+\:[0-9]+\:[0-9]+)[\s]+([0-9]{4}))([\s]+[\[\d\]]+[\s]+[\<a-z\>]+[\s]+[\(\w\)]+[\s]+[A-Z]{2}\:[\s]+)([main\:\s]*.*)$)')
-            line_match = re.match(date_filter, line)
-
-            if line_match:
-                date_time = (line_match.group(3, 5, 4))
-                conv_time = ' '.join(date_time)
-                dtime_obj = datetime.strptime(conv_time, '%b %d %Y %H:%M:%S')
-                ma_datetime = str(dtime_obj)
-                values = line_match.group(7)
-
-                if 'perform_data_migration' in values:
-                    hitcount += 1
-                    upgrade_match = re.search((r'((.*)(Upgrade\s+from\s+[\w]+\s+to\s+[\w]+\s+detected\.$))'), values)
-                    if upgrade_match:
-                        upgrade = upgrade_match.group(3)            
-                        data_list.append((ma_datetime, upgrade, file_names[index]))
-                
-                if '____________________ Mobile Activation Startup _____________________' in values:
-                    activationcount += 1
-                    ma_startup_line = str(linecount)
-                    ma_startup = (f'Mobile Activation Startup at line: {ma_startup_line}')
-                    data_list.append((ma_datetime, ma_startup, file_names[index]))
-
-            upgrade_entries = (f'Found {hitcount} Upgrade entries in {file_names[index]}')
-            boot_entries = (f'Found {activationcount} Mobile Activation entries in {file_names[index]}')
-        data_list_info.append((boot_entries, upgrade_entries))
-            
-    report = ArtifactHtmlReport('Mobile Activation Logs')
-    report.start_artifact_report(report_folder, 'Mobile Activation Logs')
-    report.add_script()
-    data_headers_info = ('Mobile Activation', 'Upgrade')
-    data_headers = ('Datetime', 'Event', 'Log Name')
-
-    source_files_found = ', '.join(source_files)
-    
-    report.write_artifact_data_table(data_headers_info, data_list_info, source_files_found, cols_repeated_at_bottom=False)
-    report.write_artifact_data_table(data_headers, data_list, source_files_found, True, False)
-    report.end_artifact_report()
-    
-    tsvname = 'Mobile Activation Logs'
-    tsv(report_folder, data_headers, data_list, tsvname)
-    tsv(report_folder, data_headers_info, data_list_info, tsvname)
-
-__artifacts__ = {
-    "mobileActivationLogs": (
-        "Mobile Activation Logs",
-        ('**/mobileactivationd.log*','**/sysdiagnose_*.tar.gz'),
-        get_mobileActivationLogs)
+__artifacts_v2__ = {
+    "mobileActivationLogs": {
+        "name": "Mobile Activation Logs",
+        "description": "Upgrade and Mobile Activation Startup events parsed from mobileactivationd.log "
+                       "(including logs found inside sysdiagnose archives)",
+        "author": "@AlexisBrignoni",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Activation Logs",
+        "notes": "",
+        "paths": ('**/mobileactivationd.log*', '**/sysdiagnose_*.tar.gz'),
+        "output_types": "standard",
+        "artifact_icon": "settings"
+    }
 }
+
+import io
+import re
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.ilapfuncs import artifact_processor
+
+_DATE_RE = re.compile(r'(([A-Za-z]+[\s]+([a-zA-Z]+[\s]+[0-9]+)[\s]+([0-9]+\:[0-9]+\:[0-9]+)[\s]+'
+                      r'([0-9]{4}))([\s]+[\[\d\]]+[\s]+[\<a-z\>]+[\s]+[\(\w\)]+[\s]+[A-Z]{2}\:[\s]+)'
+                      r'([main\:\s]*.*)$)')
+_UPGRADE_RE = re.compile(r'((.*)(Upgrade\s+from\s+[\w]+\s+to\s+[\w]+\s+detected\.$))')
+_TAR_MEMBER_RE = re.compile(r"logs/MobileActivation/mobileactivationd\.log(\.\d+)?$")
+_STARTUP = '____________________ Mobile Activation Startup _____________________'
+
+
+def _iter_logs(files_found):
+    """Yield (log_name, lines, source_full_path) for mobileactivationd.log files and those in sysdiagnose tars."""
+    for filename in files_found:
+        filename = str(filename)
+        if 'mobileactivationd.log' in filename:
+            path = filename[4:] if filename.startswith('\\\\?\\') else filename
+            try:
+                with open(path, 'r', encoding='utf8', errors='ignore') as fp:
+                    lines = fp.readlines()
+            except OSError:
+                continue
+            yield Path(path).name, lines, filename
+        elif 'sysdiagnose_' in filename and 'IN_PROGRESS_' not in filename:
+            try:
+                tar = tarfile.open(filename)
+            except (tarfile.TarError, OSError):
+                continue
+            try:
+                for member in tar.getmembers():
+                    if not _TAR_MEMBER_RE.search(member.name):
+                        continue
+                    extracted = tar.extractfile(member)
+                    if extracted is not None:
+                        with io.TextIOWrapper(extracted, encoding='utf-8', errors='ignore') as tfp:
+                            yield member.name, tfp.readlines(), filename
+            finally:
+                tar.close()
+
+
+@artifact_processor
+def mobileActivationLogs(context):
+    data_headers = (('Datetime', 'datetime'), 'Event', 'Log Name')
+    data_list = []
+    source_files = []
+
+    for log_name, lines, source in _iter_logs(context.get_files_found()):
+        if source not in source_files:
+            source_files.append(source)
+        for linecount, line in enumerate(lines, 1):
+            match = _DATE_RE.match(line)
+            if not match:
+                continue
+            try:
+                dtime_obj = datetime.strptime(' '.join(match.group(3, 5, 4)),
+                                              '%b %d %Y %H:%M:%S').replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            values = match.group(7)
+            if 'perform_data_migration' in values:
+                upgrade_match = _UPGRADE_RE.search(values)
+                if upgrade_match:
+                    data_list.append((dtime_obj, upgrade_match.group(3), log_name))
+            if _STARTUP in values:
+                data_list.append((dtime_obj, f'Mobile Activation Startup at line: {linecount}', log_name))
+
+    source_path = ', '.join(context.get_relative_path(s) for s in source_files)
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
Solo conversion (complex — parses `mobileactivationd.log` *and* logs inside `sysdiagnose_*.tar.gz` archives).

## Changes
- **Context single-arg form** (`def mobileActivationLogs(context):`) — no unused args, pylint 10.00.
- **Timestamps stored as aware UTC** (assume-UTC convention; this log has no local-time note) instead of naive `str()`.
- **`context.get_relative_path()`** applied to the returned source path(s) → LAVA shows clean in-extraction paths.
- **Dropped the low-value per-file 'counts' summary** report ("Found N Upgrade entries…") — the events table is the actual forensic data; the counts are derivable from it.
- Preserved the sysdiagnose tar extraction + the date/upgrade/startup regexes; hardened with `try/except (ValueError)` on the date parse, **proper file/tar closing** (the original leaked handles), and skipping unreadable files.
- Dropped `ArtifactHtmlReport`/`tsv`/`logfunc`/`logdevinfo`/`is_platform_windows`/`os`.

## Validation
- `ast.parse` OK; 0 legacy refs; reserved-word audit clean.
- pylint (CI config): **10.00/10**.
- Functional test on a fixture log: upgrade + startup events parsed with aware-UTC datetimes; non-matching lines skipped; source returned relative (`logs/mobileactivationd.log`).