### PR TITLE
Convert mobileInstall to artifact_processor (LAVA, context form); 729 lines -> 4 functions

### DIFF
--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -1,730 +1,206 @@
-import os
-import textwrap
-import datetime
-import sys
-import re
-import io
-import string
-import sqlite3
-import tarfile
-from html import escape
+_NOTE = "All timestamps are in LOCAL device time (the log records local time), not UTC."
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def month_converter(month):
-    months = [
-        "Jan",
-        "Feb",
-        "Mar",
-        "Apr",
-        "May",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Oct",
-        "Nov",
-        "Dec",
-    ]
-    month = months.index(month) + 1
-    if month < 10:
-        month = f"{month:02d}"
-    return month
-
-def day_converter(day):
-    day = int(day)
-    if day < 10:
-        day = f"{day:02d}"
-    return day
-
-def get_mobileInstall(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    counter = 0
-    filescounter = 0
-    tsv_tml_data_list = []
-
-    mibdatabase = os.path.join(report_folder, 'mib.db')
-    db = sqlite3.connect(mibdatabase)
-    cursor = db.cursor()
-    cursor.execute(
-        """
-    CREATE TABLE dimm(time_stamp TEXT, action TEXT, bundle_id TEXT, path TEXT)
-    """
-    )
-
-    db.commit()
-    files = []
-
-    for filename in files_found:
-        if "mobile_installation" in filename:
-            file = open(filename, "r", encoding="utf8")
-            filescounter = filescounter + 1
-            files.append(file)
-        elif 'sysdiagnose_' in filename and not "IN_PROGRESS_" in filename:
-            tar = tarfile.open(filename)
-
-            matching_members = [
-                    m for m in tar.getmembers()
-                    if re.search(r"logs/MobileInstallation/mobile_installation\.log(\.\d+)?$", m.name)
-                ]
-            for member in matching_members:   
-                tar_log = tar.extractfile(member)
-                file = io.TextIOWrapper(tar_log, encoding="utf-8", errors="ignore")
-                files.append(file)
-                filescounter = filescounter + 1
-    file_datainserts = []
-    for file in files:
-        for line in file:
-            bundleid = ''
-            path = ''
-            counter = counter + 1
-            matchObj = re.search(
-                r"(Install Successful for)", line
-            )  # Regex for installed applications
-            if matchObj:
-                actiondesc = "Install successful"
-                matchObj1 = re.search(
-                    r"(?<= for \(Placeholder:)(.*)(?=\))", line
-                )  # Regex for bundle id
-                matchObj2 = re.search(
-                    r"(?<= for \(Customer:)(.*)(?=\))", line
-                )  # Regex for bundle id
-                matchObj3 = re.search(
-                    r"(?<= for \(System:)(.*)(?=\))", line
-                )  # Regex for bundle id
-                matchObj4 = re.search(
-                    r"(?<= for \()(.*)(?=\))", line
-                )  # Regex for bundle id
-                if matchObj1:
-                    bundleid = matchObj1.group(1)
-                elif matchObj2:
-                    bundleid = matchObj2.group(1)
-                elif matchObj3:
-                    bundleid = matchObj3.group(1)
-                elif matchObj4:
-                    bundleid = matchObj4.group(1)
-
-                matchObj = re.search(r"(?<=^)(.*?)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                # logfunc(inserttime, actiondesc, bundleid)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    "",
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-                path = ''
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-
-                # logfunc()
-            
-            matchObj = re.search(
-                r"(Destroying container )", line
-            )  # Regex for destroyed containers
-            if matchObj:
-                actiondesc = "Destroying container"
-                # logfunc(actiondesc)
-                # logfunc("Destroyed containers:")
-                matchObj = re.search(
-                    r"(?<=identifier )(.*)(?= at )", line
-                )  # Regex for bundle id
-                if matchObj:
-                    bundleid = matchObj.group(1)
-                    # logfunc ("Bundle ID: ", bundleid )
-                
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-                
-                matchObj = re.search(r"(?<= at )(.*)(?=$)", line)  # Regex for path
-                if matchObj:
-                    path = matchObj.group(1)
-                    # logfunc ("Path: ", matchObj.group(1))
-                
-                # logfunc(inserttime, actiondesc, bundleid, path)
-                
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    path,
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-            
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-                # logfunc()
-            
-            matchObj = re.search(
-                r"(Destroying container with identifier)", line
-            )  # Regex for destroyed containers
-            if matchObj:
-                actiondesc = "Destroying container"
-                # logfunc(actiondesc)
-                # logfunc("Destroyed containers:")
-                matchObj = re.search(
-                    r"(?<=identifier )(.*)(?= at )", line
-                )  # Regex for bundle id
-                if matchObj:
-                    bundleid = matchObj.group(1)
-                    # logfunc ("Bundle ID: ", bundleid )
-
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                matchObj = re.search(r"(?<= at )(.*)(?=$)", line)  # Regex for path
-                if matchObj:
-                    path = matchObj.group(1)
-                    # logfunc ("Path: ", matchObj.group(1))
-
-                # logfunc(inserttime, actiondesc, bundleid, path)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    path,
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-                # logfunc()
-
-            matchObj = re.search(
-                r"(Data container for)", line
-            )  # Regex Moved data containers
-            if matchObj:
-                actiondesc = "Data container moved"
-                # logfunc(actiondesc)
-                # logfunc("Data container moved:")
-                matchObj = re.search(
-                    r"(?<=for )(.*)(?= is now )", line
-                )  # Regex for bundle id
-                if matchObj:
-                    bundleid = matchObj.group(1)
-                    # logfunc ("Bundle ID: ", bundleid )
-
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                matchObj = re.search(r"(?<= at )(.*)(?=$)", line)  # Regex for path
-                if matchObj:
-                    path = matchObj.group(1)
-                    # logfunc ("Path: ", matchObj.group(1))
-
-                # logfunc(inserttime, actiondesc, bundleid, path)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    path,
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-                # logfunc()
-
-            matchObj = re.search(
-                r"(Made container live for)", line
-            )  # Regex for made container
-            if matchObj:
-                actiondesc = "Made container live"
-                # logfunc(actiondesc)
-                # logfunc("Made container:")
-                matchObj = re.search(
-                    r"(?<=for )(.*)(?= at)", line
-                )  # Regex for bundle id
-                if matchObj:
-                    bundleid = matchObj.group(1)
-                    # logfunc ("Bundle ID: ", bundleid )
-
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                matchObj = re.search(r"(?<= at )(.*)(?=$)", line)  # Regex for path
-                if matchObj:
-                    path = matchObj.group(1)
-                    # logfunc ("Path: ", matchObj.group(1))
-                # logfunc(inserttime, actiondesc, bundleid, path)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    path,
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-
-            matchObj = re.search(
-                r"(Uninstalling identifier )", line
-            )  # Regex for made container
-            if matchObj:
-                actiondesc = "Uninstalling identifier"
-                # logfunc(actiondesc)
-                # logfunc("Uninstalling identifier")
-                matchObj = re.search(
-                    r"(?<=Uninstalling identifier )(.*)", line
-                )  # Regex for bundle id
-                if matchObj:
-                    bundleid = matchObj.group(1)
-                    # logfunc ("Bundle ID: ", bundleid )
-
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    "",
-                )
-                # cursor.execute( 
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, ''))
-
-            matchObj = re.search(r"(main: Reboot detected)", line)  # Regex for reboots
-            if matchObj:
-                actiondesc = "Reboot detected"
-                # logfunc(actiondesc)
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    "",
-                    "",
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-
-            matchObj = re.search(
-                r"(Attempting Delta patch update of )", line
-            )  # Regex for Delta patch
-            if matchObj:
-                actiondesc = "Attempting Delta patch"
-                # logfunc(actiondesc)
-                # logfunc("Made container:")
-                matchObj = re.search(
-                    r"(?<=Attempting Delta patch update of )(.*)(?= from)", line
-                )  # Regex for bundle id
-                if matchObj:
-                    bundleid = matchObj.group(1)
-                    # logfunc ("Bundle ID: ", bundleid )
-
-                matchObj = re.search(r"(?<=^)(.*)(?= \[)", line)  # Regex for timestamp
-                if matchObj:
-                    timestamp = matchObj.group(1)
-                    weekday, month, day, time, year = str.split(timestamp)
-                    day = day_converter(day)
-                    month = month_converter(month)
-                    inserttime = (
-                            str(year) + "-" + str(month) + "-" + str(day) + " " + str(time)
-                    )
-                    # logfunc(inserttime)
-                    # logfunc(month)
-                    # logfunc(day)
-                    # logfunc(year)
-                    # logfunc(time)
-                    # logfunc ("Timestamp: ", timestamp)
-
-                matchObj = re.search(r"(?<= from )(.*)", line)  # Regex for path
-                if matchObj:
-                    path = matchObj.group(1)
-                    # logfunc ("Path: ", matchObj.group(1))
-                # logfunc(inserttime, actiondesc, bundleid, path)
-
-                # insert to database
-                cursor = db.cursor()
-                datainsert = (
-                    inserttime,
-                    actiondesc,
-                    bundleid,
-                    path,
-                )
-                # cursor.execute(
-                #     "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                #     datainsert,
-                # )
-                # db.commit()
-                file_datainserts.append(datainsert)
-
-                tsv_tml_data_list.append((inserttime, actiondesc, bundleid, path))
-                # logfunc()
-        # end for line in file:
-        if file_datainserts:
-            cursor.executemany(
-                "INSERT INTO dimm (time_stamp, action, bundle_id, path)  VALUES(?,?,?,?)",
-                file_datainserts,
-            )
-            db.commit()
-        else:
-            print("Had no commits to do...")
-
-    logfunc(f"Logs processed: {filescounter}")
-    logfunc(f"Lines processed: {counter}")
-    logfunc("")
-    file.close
-
-    # Initialize counters
-    totalapps = 0
-    installedcount = 0
-    uninstallcount = 0
-    historicalcount = 0
-    sysstatecount = 0
-
-    # created folders for reports for App history
-    os.makedirs(os.path.join(report_folder, "Apps_Historical"), exist_ok=True)
-
-    data_list_installed = []
-    data_list_uninstalled = []
-
-    # Initialize database connection
-    db = sqlite3.connect(mibdatabase)
-    cursor = db.cursor()
-    # Query to create installed and uninstalled app reports
-    cursor.execute("""SELECT distinct bundle_id from dimm""")
-    all_rows = cursor.fetchall()
-    for row in all_rows:
-        # logfunc(row[0])
-        distinctbundle = row[0]
-        cursor.execute(
-            """SELECT * from dimm where bundle_id=? order by time_stamp desc limit 1""",
-            (distinctbundle,),
-        )
-        all_rows_iu = cursor.fetchall()
-        for row in all_rows_iu:
-            # logfunc(row[0], row[1], row[2], row[3])
-            if row[2] == "":
-                continue
-            elif row[1] == "Destroying container":
-                # logfunc(row[0], row[1], row[2], row[3])
-                uninstallcount = uninstallcount + 1
-                totalapps = totalapps + 1
-                # tofile1 = row[0] + ' ' + row[1] + ' ' + row[2] + ' ' + row[3] + '\n'
-                data_list_uninstalled.append((row[0], row[2],))
-                # logfunc()
-            elif row[1] == "Uninstalling identifier":
-                # logfunc(row[0], row[1], row[2], row[3])
-                uninstallcount = uninstallcount + 1
-                totalapps = totalapps + 1
-                # tofile1 = row[0] + ' ' + row[1] + ' ' + row[2] + ' ' + row[3] + '\n'
-                data_list_uninstalled.append((row[0], row[2],))
-                # logfunc()
-            else:
-                # logfunc(row[0], row[1], row[2], row[3])
-                data_list_installed.append((row[0], row[2],))
-                installedcount = installedcount + 1
-                totalapps = totalapps + 1
-
-    location = f'{filename}'
-    description = 'List of Uninstalled apps. All timestamps are in Local Time'
-    report = ArtifactHtmlReport('Apps - Uninstalled')
-    report.start_artifact_report(report_folder, 'Apps - Uninstalled', description)
-    report.add_script()
-    data_headers = ('Last Uninstalled', 'Bundle ID',)
-    report.write_artifact_data_table(data_headers, data_list_uninstalled, location)
-    report.end_artifact_report()
-
-    location = f'{filename}'
-    description = 'List of Installed apps.'
-    report = ArtifactHtmlReport('Apps - Installed')
-    report.start_artifact_report(report_folder, 'Apps - Installed', description)
-    report.add_script()
-    data_headers = ('Last Installed', 'Bundle ID',)
-    report.write_artifact_data_table(data_headers, data_list_installed, location)
-    report.end_artifact_report()
-
-    # Query to create historical report per app
-
-    cursor.execute("""SELECT distinct bundle_id from dimm""")
-    all_rows = cursor.fetchall()
-    for row in all_rows:
-        # logfunc(row[0])
-        distinctbundle = row[0]
-        if row[0] == "":
-            continue
-        else:
-            f3 = open(os.path.join(report_folder, "Apps_Historical", distinctbundle + ".txt"),
-                    "w+",
-                    encoding="utf8"
-                    )  # Create historical app report per app
-            cursor.execute(
-                """SELECT * from dimm where bundle_id=? order by time_stamp DESC""",
-                (distinctbundle,),
-            )  # Query to create app history per bundle_id
-            all_rows_hist = cursor.fetchall()
-            for row in all_rows_hist:
-                # logfunc(row[0], row[1], row[2], row[3])
-                tofile3 = row[0] + " " + row[1] + " " + row[2] + " " + row[3] + "\n"
-                f3.write(tofile3)
-        f3.close()
-        historicalcount = historicalcount + 1
-
-    list = []
-    data_list = []
-    path = os.path.join(report_folder, "Apps_Historical")
-    files = os.listdir(path)
-    for name in files:
-        bun = (f'{name}')
-        appendval = (
-            f'<a href = "./Mobile Installation Logs/Apps_Historical/{name}" style = "color:blue" target="content">Report</a>')
-        data_list.append((bun, appendval))
-
-    location = f'{filename}'
-    description = 'Historical App report from the Mobile Installation Logs. All timestamps are in Local Time'
-    report = ArtifactHtmlReport('Apps - Historical')
-    report.start_artifact_report(report_folder, 'Apps - Historical', description)
-    report.add_script()
-    data_headers = ('Bundle ID', 'Report Link')
-    tsv_data_headers = ('Bundle ID', 'Report Link')
-    report.write_artifact_data_table(data_headers, data_list, location, html_escape=False)
-    report.end_artifact_report()
-
-    tsvname = 'Mobile Installation Logs - History'
-    tsv(report_folder, tsv_data_headers, tsv_tml_data_list, tsvname)
-    tlactivity = 'Mobile Installation Logs - History'
-    tml_data_headers = ('Timestamp', 'Event', 'Bundle ID', 'Event Path')
-    timeline(report_folder, tlactivity, tsv_tml_data_list, tml_data_headers)
-
-    # All event historical in html report
-    description = 'Historical App report from the Mobile Installation Logs. All timestamps are in Local Time'
-    report = ArtifactHtmlReport('Apps - Historical')
-    report.start_artifact_report(report_folder, 'Apps - Historical Combined', description)
-    report.add_script()
-    data_headers = ('Timestamp', 'Event', 'Bundle ID', 'Event Path')
-    report.write_artifact_data_table(data_headers, tsv_tml_data_list, location)
-    report.end_artifact_report()
-
-    # Query to create system events
-    data_list_reboots = []
-    cursor.execute(
-        """SELECT * from dimm where action ='Reboot detected' order by time_stamp DESC"""
-    )
-    all_rows = cursor.fetchall()
-    for row in all_rows:
-        # logfunc(row[0])
-        # logfunc(row[0], row[1], row[2], row[3])
-        data_list_reboots.append((row[0], row[1]))
-        sysstatecount = sysstatecount + 1
-
-    if len(all_rows) > 0:
-        location = f'{filename}'
-        description = 'Reboots detected in Local Time.'
-        report = ArtifactHtmlReport('State - Reboots')
-        report.start_artifact_report(report_folder, 'State - Reboots', description)
-        report.add_script()
-        data_headers_reboots = ('Timestamp (Local Time)', 'Description')
-        report.write_artifact_data_table(data_headers_reboots, data_list_reboots, location)
-        report.end_artifact_report()
-
-        tsvname = 'Mobile Installation Logs - Reboots'
-        tsv(report_folder, data_headers_reboots, data_list_reboots, tsvname)
-
-    logfunc(f"Total apps: {totalapps}")
-    logfunc(f"Total installed apps: {installedcount}")
-    logfunc(f"Total uninstalled apps: {uninstallcount}")
-    logfunc(f"Total historical app reports: {historicalcount}")
-    logfunc(f"Total system state events: {sysstatecount}")
-
-    '''
-    data_headers_reboots = ('Timestamp (Local Time)', 'Description')
-    tsv_data_headers = ('Timestamp (Local Time)', 'Action', 'Bundle ID', 'Path')
-    
-    tsvname = 'Mobile Installation Logs - Reboots'
-    tsv(report_folder, data_headers_reboots, data_list_reboots, tsvname)
-    
-    tlactivity = 'Mobile Installation Logs - Reboots'
-    timeline(report_folder, tlactivity, data_list_reboots, data_headers_reboots)
-    
-    tsvname = 'Mobile Installation Logs - History'
-    tsv(report_folder, tsv_data_headers, tsv_tml_data_list, tsvname)
-    
-    tlactivity = 'Mobile Installation Logs - History'
-    timeline(report_folder, tlactivity, tsv_tml_data_list, tsv_data_headers)
-    '''
-
-
-'''    
-    
-    x = 0
-    data_list =[]
-    for file_found in files_found:
-        x = x + 1
-        sx = str(x)
-        journalName = os.path.basename(file_found)
-        outputpath = os.path.join(report_folder, sx+'_'+journalName+'.txt') # name of file in txt
-        #linkpath = os.path.basename(
-        level2, level1 = (os.path.split(outputpath))
-        level2 = (os.path.split(level2)[1])
-        final = level2+'/'+level1
-        with open(outputpath, 'w') as g:
-            for s in strings(file_found):
-                g.write(s)
-                g.write('\n')
-        
-        out = (f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>') 
-        
-        data_list.append((out, file_found))
-
-    location =''
-    description = 'ASCII and Unicode strings extracted from SQLite journaing files.'
-    report = ArtifactHtmlReport('Strings - SQLite Journal')
-    report.start_artifact_report(report_folder, 'Strings - SQLite Journal', description)
-    report.add_script()
-    data_headers = ('Report', 'Location')
-    report.write_artifact_data_table(data_headers, data_list, location, html_escape=False)
-    report.end_artifact_report()
-'''
-
-__artifacts__ = {
-    "mobileInstall": (
-        "Mobile Installation Logs",
-        ('**/mobile_installation.log.*','**/sysdiagnose_*.tar.gz'),
-        get_mobileInstall)
+__artifacts_v2__ = {
+    "mobileInstall_installed": {
+        "name": "Apps - Installed",
+        "description": "Apps whose most recent mobile_installation.log event is an install/update",
+        "author": "@AlexisBrignoni",
+        "version": "3.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Installation Logs",
+        "notes": _NOTE,
+        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "download"
+    },
+    "mobileInstall_uninstalled": {
+        "name": "Apps - Uninstalled",
+        "description": "Apps whose most recent mobile_installation.log event is an uninstall/destroy",
+        "author": "@AlexisBrignoni",
+        "version": "3.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Installation Logs",
+        "notes": _NOTE,
+        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "trash-2"
+    },
+    "mobileInstall_historical": {
+        "name": "Apps - Historical Combined",
+        "description": "All app install/update/uninstall/container/reboot events from mobile_installation.log",
+        "author": "@AlexisBrignoni",
+        "version": "3.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Installation Logs",
+        "notes": _NOTE,
+        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "list"
+    },
+    "mobileInstall_reboots": {
+        "name": "State - Reboots",
+        "description": "Reboot events detected in mobile_installation.log",
+        "author": "@AlexisBrignoni",
+        "version": "3.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Mobile Installation Logs",
+        "notes": _NOTE,
+        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "refresh-cw"
+    }
 }
+
+import io
+import re
+import tarfile
+
+from scripts.ilapfuncs import artifact_processor
+
+_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+_UNINSTALL_ACTIONS = ('Destroying container', 'Uninstalling identifier')
+_TAR_MEMBER_RE = re.compile(r"logs/MobileInstallation/mobile_installation\.log(\.\d+)?$")
+
+
+def _first_group(line, *patterns):
+    for pat in patterns:
+        match = re.search(pat, line)
+        if match:
+            return match.group(1)
+    return ''
+
+
+def _parse_timestamp(line):
+    """Convert the leading 'Wed Jan 15 10:30:00 2024' prefix into a local 'YYYY-MM-DD HH:MM:SS' string."""
+    match = re.search(r"^(.*?)(?= \[)", line)
+    if not match:
+        return None
+    parts = match.group(1).split()
+    if len(parts) != 5:
+        return None
+    _weekday, month, day, time, year = parts
+    try:
+        month_num = _MONTHS.index(month) + 1
+        return f'{year}-{month_num:02d}-{int(day):02d} {time}'
+    except (ValueError, IndexError):
+        return None
+
+
+def _parse_events(lines):
+    """Return a list of (timestamp_local, action, bundle_id, path) events from mobile_installation.log lines."""
+    events = []
+    for line in lines:
+        ts = _parse_timestamp(line)
+        if ts is None:
+            continue
+        if 'Install Successful for' in line:
+            bundle = _first_group(line, r"(?<= for \(Placeholder:)(.*)(?=\))",
+                                  r"(?<= for \(Customer:)(.*)(?=\))",
+                                  r"(?<= for \(System:)(.*)(?=\))", r"(?<= for \()(.*)(?=\))")
+            events.append((ts, 'Install successful', bundle, ''))
+        if 'Destroying container ' in line:
+            events.append((ts, 'Destroying container', _first_group(line, r"(?<=identifier )(.*)(?= at )"),
+                           _first_group(line, r"(?<= at )(.*)$")))
+        if 'Data container for' in line:
+            events.append((ts, 'Data container moved', _first_group(line, r"(?<=for )(.*)(?= is now )"),
+                           _first_group(line, r"(?<= at )(.*)$")))
+        if 'Made container live for' in line:
+            events.append((ts, 'Made container live', _first_group(line, r"(?<=for )(.*)(?= at)"),
+                           _first_group(line, r"(?<= at )(.*)$")))
+        if 'Uninstalling identifier ' in line:
+            events.append((ts, 'Uninstalling identifier',
+                           _first_group(line, r"(?<=Uninstalling identifier )(.*)"), ''))
+        if 'main: Reboot detected' in line:
+            events.append((ts, 'Reboot detected', '', ''))
+        if 'Attempting Delta patch update of ' in line:
+            events.append((ts, 'Attempting Delta patch',
+                           _first_group(line, r"(?<=Attempting Delta patch update of )(.*)(?= from)"),
+                           _first_group(line, r"(?<= from )(.*)$")))
+    return events
+
+
+def _iter_log_lines(files_found):
+    """Yield (lines, source_full_path) for mobile_installation.log files and those inside sysdiagnose tars."""
+    for filename in files_found:
+        filename = str(filename)
+        if 'mobile_installation' in filename:
+            try:
+                with open(filename, 'r', encoding='utf8', errors='ignore') as fp:
+                    yield fp.readlines(), filename
+            except OSError:
+                continue
+        elif 'sysdiagnose_' in filename and 'IN_PROGRESS_' not in filename:
+            try:
+                tar = tarfile.open(filename)
+            except (tarfile.TarError, OSError):
+                continue
+            try:
+                for member in tar.getmembers():
+                    if not _TAR_MEMBER_RE.search(member.name):
+                        continue
+                    extracted = tar.extractfile(member)
+                    if extracted is not None:
+                        with io.TextIOWrapper(extracted, encoding='utf-8', errors='ignore') as tfp:
+                            yield tfp.readlines(), filename
+            finally:
+                tar.close()
+
+
+def _events_and_source(context):
+    events = []
+    sources = []
+    for lines, source in _iter_log_lines(context.get_files_found()):
+        rel = context.get_relative_path(source)
+        if rel not in sources:
+            sources.append(rel)
+        events.extend(_parse_events(lines))
+    return events, ', '.join(sources)
+
+
+def _latest_per_bundle(events):
+    """Most recent event per (non-empty) bundle id; local timestamp strings sort chronologically."""
+    latest = {}
+    for event in events:
+        bundle = event[2]
+        if not bundle:
+            continue
+        if bundle not in latest or event[0] > latest[bundle][0]:
+            latest[bundle] = event
+    return latest
+
+
+@artifact_processor
+def mobileInstall_installed(context):
+    data_headers = ('Last Installed', 'Bundle ID')
+    events, source = _events_and_source(context)
+    data_list = [(ev[0], ev[2]) for ev in _latest_per_bundle(events).values()
+                 if ev[1] not in _UNINSTALL_ACTIONS]
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def mobileInstall_uninstalled(context):
+    data_headers = ('Last Uninstalled', 'Bundle ID')
+    events, source = _events_and_source(context)
+    data_list = [(ev[0], ev[2]) for ev in _latest_per_bundle(events).values()
+                 if ev[1] in _UNINSTALL_ACTIONS]
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def mobileInstall_historical(context):
+    data_headers = ('Timestamp', 'Event', 'Bundle ID', 'Event Path')
+    events, source = _events_and_source(context)
+    return data_headers, events, source
+
+
+@artifact_processor
+def mobileInstall_reboots(context):
+    data_headers = ('Timestamp (Local Time)', 'Description')
+    events, source = _events_and_source(context)
+    data_list = [(ev[0], ev[1]) for ev in events if ev[1] == 'Reboot detected']
+    return data_headers, data_list, source


### PR DESCRIPTION
## Summary
The big pre-iOS-17 `mobile_installation.log` parser (729 lines). Was a single old-style function building **6 HTML reports** via a temp SQLite db (`mib.db`) and per-bundle linked `.txt` files. Rewritten into **four clean `@artifact_processor` functions**.

| Function | Artifact |
|---|---|
| mobileInstall_installed | Apps - Installed |
| mobileInstall_uninstalled | Apps - Uninstalled |
| mobileInstall_historical | Apps - Historical Combined |
| mobileInstall_reboots | State - Reboots |

## What changed
- **Installed/Uninstalled** = most-recent event per bundle id, partitioned by whether the latest action is a destroy/uninstall — computed **in Python** (no temp `mib.db`).
- **Historical Combined** = all parsed events. This is exactly the flat data the old per-bundle **HTML-linked** "Apps - Historical" report indexed, so that linked report (and the `.txt` files it wrote into the report folder) is **dropped**.
- **Context form**; pylint 10.00.
- **LOCAL time** (you flagged these): timestamps stored as-is, local-time stated in every `notes`; `output_types` excludes `timeline`.
- **`context.get_relative_path()`** on the returned source.
- Preserved all **7 event-type regexes** (dropped the redundant `Destroying container with identifier` block that double-matched the plain one) and the sysdiagnose-tar extraction; hardened timestamp parsing + file/tar closing.
- Removed the **dead/commented `Strings - SQLite Journal`** report and ~500 lines of commented-out temp-db INSERTs/debug logging.

## Validation
- `ast.parse` OK; 0 legacy refs (no sqlite3/mib.db); no cross-module imports; all 4 reserved-word audits clean.
- pylint (CI config): **10.00/10**.
- Functional test on a fixture log: an app installed-then-uninstalled correctly appears only in Uninstalled (latest event wins), a still-installed app in Installed, all events in Historical, reboot in Reboots; source returned relative.