### PR TITLE
Fix mobileBackupplist LAVA crash: 'Values' column is a SQL reserved word

### DIFF
--- a/scripts/artifacts/mobileBackupplist.py
+++ b/scripts/artifacts/mobileBackupplist.py
@@ -35,7 +35,7 @@ _SECTIONS = {
 
 @artifact_processor
 def mobilebackupplist(context):
-    data_headers = ('Key', 'Values')
+    data_headers = ('Key', 'Value')
     data_list = []
 
     source_path = ''


### PR DESCRIPTION
## Bug
Running iLEAPP, the `mobilebackupplist` artifact errors:
```
Reading mobilebackupplist artifact had errors!
Error was near "values": syntax error
sqlite3.OperationalError: near "values": syntax error
  ... lava_create_sqlite_table -> CREATE TABLE IF NOT EXISTS ... (columns_sql)
```

## Cause
The data header **`Values`** sanitizes to **`values`**, which is a **SQL reserved word** (the `VALUES` keyword). LAVA's `lava_create_sqlite_table` builds an **unquoted** `CREATE TABLE ... (key TEXT, values TEXT)`, which is a syntax error. (HTML/TSV output was unaffected — only the LAVA table creation crashed, which is why it produced records but then errored.)

## Fix
Rename the column header `Values` → **`Value`** (singular), which sanitizes to the non-reserved `value` and matches the sibling `mobileBackup` artifact. Verified: `CREATE TABLE` with `value` succeeds; with `values` it raises the same syntax error.

(Regression from #1560, where the original plural 'Values' header was preserved without re-running the reserved-word audit. `Value`/`Values` distinction now noted.)