### PR TITLE
Convert notificationsDuet + notificationsXII to artifact_processor (LAVA, context form)

### DIFF
--- a/scripts/artifacts/notificationsDuet.py
+++ b/scripts/artifacts/notificationsDuet.py
@@ -1,133 +1,91 @@
 __artifacts_v2__ = {
     "get_notificationsDuet": {
         "name": "Notification Duet",
-        "description": "Parses battery percentage entries from biomes",
+        "description": "Parses Duet/proactive userNotificationEvents SEGB records",
         "author": "@JohnHyla",
-        "version": "0.0.2",
-        "date": "2024-10-17",
+        "version": "0.0.3",
+        "date": "2026-06-23",
         "requirements": "none",
         "category": "Notifications",
         "notes": "",
-        "paths": ('*/userNotificationEvents/local/*'),
-        "output_types": "none",
-        "function": "get_notificationsDuet"
+        "paths": ('*/userNotificationEvents/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "bell"
     }
 }
 
-
 import os
-import blackboxprotobuf
 from datetime import timezone
+
+import blackboxprotobuf
+
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
-from scripts.ilapfuncs import webkit_timestampsconv, convert_utc_human_to_timezone, tsv
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
+
+_TYPEDEF = {
+    '1': {'type': 'message',
+          'message_typedef': {'1': {'type': 'double', 'name': ''},
+                              '2': {'type': 'str', 'name': ''},
+                              '3': {'type': 'str', 'name': ''},
+                              '4': {'type': 'str', 'name': ''},
+                              '5': {'type': 'str', 'name': ''},
+                              '6': {'type': 'int', 'name': ''},
+                              '8': {'type': 'str', 'name': ''},
+                              '9': {'type': 'message', 'message_typedef': {}, 'name': ''},
+                              '10': {'type': 'str', 'name': ''},
+                              '12': {'type': 'str', 'name': ''},
+                              '13': {'type': 'str', 'name': ''},
+                              '14': {'type': 'int', 'name': ''},
+                              '15': {'type': 'int', 'name': ''},
+                              '16': {'type': 'int', 'name': ''},
+                              '17': {'type': 'int', 'name': ''},
+                              '19': {'type': 'fixed64', 'name': ''},
+                              '20': {'type': 'str', 'name': ''}},
+          'name': ''},
+    '2': {'type': 'int', 'name': ''},
+    '3': {'type': 'double', 'name': ''},
+    '4': {'type': 'str', 'name': ''},
+    '5': {'type': 'int', 'name': ''}}
 
 
-def get_notificationsDuet(files_found, report_folder, seeker, wrap_text, timezone_offset):
-
-    category = "Notifications Duet"
-    module_name = "get_notificationsDuet"
-
-    data_headers = ('SEGB Timestamp', 'Notification Time', 'Notification Time 2', 'SEGB State', 'GUID', 'Title',
-                    'Subtitle','Body', 'Bundle ID', 'Bundle ID 2', 'Optional Data', 'Person Identifier', 'Person Info',
-                    'GUID 2', 'Filename', 'Offset')
-    lava_data_headers = (('SEGB Timestamp', 'datetime'), ('Notification Time', 'datetime'),
-                         ('Notification Time 2', 'datetime'), 'SEGB State', 'GUID', 'Title', 'Subtitle', 'Body',
-                         'Bundle ID', 'Bundle ID 2', 'Optional Data', 'Person Identifier', 'Person Info', 'GUID 2',
-                         'Filename', 'Offset')
-
-    typess = {'1': {'type': 'message',
-                    'message_typedef': {'1': {'type': 'double', 'name': ''},
-                                        '2': {'type': 'str', 'name': ''},
-                                        '3': {'type': 'str', 'name': ''},
-                                        '4': {'type': 'str', 'name': ''},
-                                        '5': {'type': 'str', 'name': ''},
-                                        '6': {'type': 'int', 'name': ''},
-                                        '8': {'type': 'str', 'name': ''},
-                                        '9': {'type': 'message', 'message_typedef': {}, 'name': ''},
-                                        '10': {'type': 'str', 'name': ''},
-                                        '12': {'type': 'str', 'name': ''},
-                                        '13': {'type': 'str', 'name': ''},
-                                        '14': {'type': 'int', 'name': ''},
-                                        '15': {'type': 'int', 'name': ''},
-                                        '16': {'type': 'int', 'name': ''},
-                                        '17': {'type': 'int', 'name': ''},
-                                        '19': {'type': 'fixed64', 'name': ''},
-                                        '20': {'type': 'str', 'name': ''}},
-                    'name': ''},
-              '2': {'type': 'int', 'name': ''},
-              '3': {'type': 'double', 'name': ''},
-              '4': {'type': 'str', 'name': ''},
-              '5': {'type': 'int', 'name': ''}}
-
+@artifact_processor
+def get_notificationsDuet(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Notification Time', 'datetime'),
+                    ('Notification Time 2', 'datetime'), 'SEGB State', 'GUID', 'Title', 'Subtitle',
+                    'Body', 'Bundle ID', 'Bundle ID 2', 'Optional Data', 'Person Identifier',
+                    'Person Info', 'GUID 2', 'Filename', 'Offset')
     data_list = []
-    report_file = 'Unknown'
-    for file_found in files_found:
+    sources = []
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
-        if filename.startswith('.'):
+        if filename.startswith('.') or not os.path.isfile(file_found) or 'tombstone' in file_found:
             continue
-        if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
-                continue
-            else:
-                report_file = os.path.dirname(file_found)
-        else:
-            continue
+        rel = context.get_relative_path(file_found)
+        if rel not in sources:
+            sources.append(rel)
 
-        file_data_list = []
         for record in read_segb_file(file_found):
-
-            segb_time = record.timestamp1
-            segb_time = segb_time.replace(tzinfo=timezone.utc)
-
+            segb_time = record.timestamp1.replace(tzinfo=timezone.utc)
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
-                proto_time = webkit_timestampsconv(protostuff['1'].get('1'))
-                proto_time2 = webkit_timestampsconv(protostuff.get('3'))
-                guid = protostuff['1'].get('2')
-                title = protostuff['1'].get('3')
-                subtitle = protostuff['1'].get('4')
-                body = (protostuff['1'].get('5'))
-                bundle_id = protostuff['1'].get('8')
-                bundle_id2 = protostuff['1'].get('12')
-                optional_data = protostuff['1'].get('10')
-                guid2 = protostuff.get('4')
-                person_identifier = protostuff['1'].get('13')
-                person_info = protostuff['1'].get('20')
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, _TYPEDEF)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    continue  # malformed/variant record
+                p1 = protostuff.get('1') or {}
+                person_info = p1.get('20')
                 if isinstance(person_info, list):
                     person_info = ', '.join(person_info)
-
-                file_data_list.append((segb_time, proto_time, proto_time2, record.state.name, guid,title,subtitle, body,
-                                       bundle_id, bundle_id2, optional_data, person_identifier, person_info, guid2,
-                                       filename, record.data_start_offset))
-
+                data_list.append((segb_time, webkit_timestampsconv(p1.get('1')),
+                                  webkit_timestampsconv(protostuff.get('3')), record.state.name,
+                                  p1.get('2'), p1.get('3'), p1.get('4'), p1.get('5'), p1.get('8'),
+                                  p1.get('12'), p1.get('10'), p1.get('13'), person_info,
+                                  protostuff.get('4'), filename, record.data_start_offset))
             elif record.state == EntryState.Deleted:
-                file_data_list.append((segb_time, None, None, record.state.name, None, None,None,None, None,None, None,
-                                       None, None, None, filename, record.data_start_offset))
+                data_list.append((segb_time, None, None, record.state.name, None, None, None, None,
+                                  None, None, None, None, None, None, filename,
+                                  record.data_start_offset))
 
-        data_list.extend(file_data_list)
-
-        if len(file_data_list) > 0:
-            description = ''
-            report = ArtifactHtmlReport(f'Notifications Duet')
-            report.start_artifact_report(report_folder, f'Notifications Duet - {filename}', description)
-            report.add_script()
-            report.write_artifact_data_table(data_headers, file_data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Notifications Duet - {filename}'
-            tsv(report_folder, data_headers, file_data_list, tsvname)  # TODO: _csv.Error: need to escape, but no escapechar set
-
-    # Single table for LAVA output
-    table_name, object_columns, column_map = lava_process_artifact(category, module_name,
-                                                                   'Notifications Duet',
-                                                                   lava_data_headers,
-                                                                   len(data_list))
-
-    lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
-
-
-
+    return data_headers, data_list, ', '.join(sources)

--- a/scripts/artifacts/notificationsXII.py
+++ b/scripts/artifacts/notificationsXII.py
@@ -1,112 +1,90 @@
-import os
+__artifacts_v2__ = {
+    "notificationsXII": {
+        "name": "Notifications",
+        "description": "iOS 12+ delivered notifications (DeliveredNotifications.plist)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Notifications",
+        "notes": "",
+        "paths": ('*/mobile/Library/UserNotifications*',),
+        "output_types": "standard",
+        "artifact_icon": "bell"
+    }
+}
+
 import glob
+import os
+from datetime import datetime, timezone
+
 import nska_deserialize as nd
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_bundle_id_and_names_from_plist(library_plist_file_path):
-    '''Parses Library.plist and returns a dictionary where Key=Bundle_ID, Value=Bundle_Name'''
-    bundle_info = {}
-    f = open(library_plist_file_path, 'rb')
-    plist = nd.deserialize_plist(f)
-    for k, v in plist.items():
-        bundle_info[v] = k
-    f.close()
-    return bundle_info
 
-def get_bundle_info(files_found):
-
-    for file_path in files_found:
-        file_path = str(file_path)
-        if file_path.endswith('Library.plist') and os.path.dirname(file_path).endswith('UserNotificationsServer'):
-            bundle_info = get_bundle_id_and_names_from_plist(file_path)
-            return bundle_info
-        # If this is fs search, then only top level folder will be present, so append path and search it too
-        if file_path.endswith('UserNotificationsServer'):
-            plist_file_path = os.path.join(file_path, 'Library.plist')
-            if os.path.exists(plist_file_path):
-                bundle_info = get_bundle_id_and_names_from_plist(plist_file_path)
-                return bundle_info
+def _bundle_info(plist_files):
+    """Map bundle_id -> bundle_name from UserNotificationsServer/Library.plist (if present)."""
+    for fp in plist_files:
+        if fp.endswith('Library.plist') and os.path.dirname(fp).endswith('UserNotificationsServer'):
+            try:
+                with open(fp, 'rb') as f:
+                    plist = nd.deserialize_plist(f)
+                return {v: k for k, v in plist.items()}
+            except (OSError, ValueError, nd.DeserializeError):
+                return {}
     return {}
 
-def get_notificationsXII(files_found, report_folder, seeker, wrap_text, timezone_offset):
 
-    bundle_info = get_bundle_info(files_found)
+@artifact_processor
+def notificationsXII(context):
+    data_headers = (('Creation Time', 'datetime'), 'Bundle', 'Title[Subtitle]', 'Message',
+                    'Other Details')
     data_list = []
-    exportedbplistcount = 0
+    sources = []
 
-    pathfound = str(files_found[0])
-    # logfunc(f'Posix to string is: {pathfound}')
-    for filepath in glob.iglob(pathfound + "/**", recursive=True):
-        # create directory where script is running from
-        if os.path.isfile(filepath):  # filter dirs
-            file_name = os.path.splitext(os.path.basename(filepath))[0]
-            # create directory
-            if filepath.endswith('DeliveredNotifications.plist'):
-                bundle_id = os.path.basename(os.path.dirname(filepath))
-                # open the plist
-                p = open(filepath, "rb")
+    plist_files = []
+    for fp in context.get_files_found():
+        fp = str(fp)
+        if os.path.isdir(fp):
+            plist_files.extend(str(x) for x in glob.iglob(os.path.join(fp, '**'), recursive=True))
+        else:
+            plist_files.append(fp)
+
+    bundle_info = _bundle_info(plist_files)
+
+    for filepath in plist_files:
+        if not (os.path.isfile(filepath) and filepath.endswith('DeliveredNotifications.plist')):
+            continue
+        try:
+            with open(filepath, 'rb') as p:
                 plist = nd.deserialize_plist(p)
-                
-                # Empty plist will be { 'root': None }
-                if isinstance(plist, dict):
-                    continue # skip it, it's empty
-                
-                # Good plist will be a list of dicts
-                for item in plist:
-                    creation_date = ''
-                    title = ''
-                    subtitle = ''
-                    message = ''
-                    other_dict = {}
-                    bundle_name = bundle_info.get(bundle_id, bundle_id)
-                    #if bundle_name == 'com.apple.ScreenTimeNotifications':
-                    #    pass # has embedded plist!
-                    for k, v in item.items():
-                        if k == 'AppNotificationCreationDate': creation_date = str(v)
-                        elif k == 'AppNotificationMessage': message = v
-                        elif k == 'AppNotificationTitle': title = v
-                        elif k == 'AppNotificationSubtitle': subtitle = v
-                        else:
-                            if isinstance(v, bytes):
-                                logfunc(f'Found binary data, look into this one later k={k}!')
-                            elif isinstance(v, dict):
-                                pass # recurse look for plists #TODO
-                            elif isinstance(v, list):
-                                pass # recurse look for plists #TODO
-                            other_dict[k] = str(v)
-                    if subtitle:
-                        title += f'[{subtitle}]'
-                    data_list.append((creation_date, bundle_name, title, message, str(other_dict)))
-                p.close()
-                
-            elif "AttachmentsList" in file_name:
-                pass  # future development
+        except (OSError, ValueError, nd.DeserializeError):
+            continue
+        if isinstance(plist, dict):
+            continue  # empty plist is {'root': None}
 
-    if data_list:
-        description = 'iOS > 12 Notifications'
-        report = ArtifactHtmlReport('iOS Notificatons')
-        report.start_artifact_report(report_folder, 'iOS Notifications', description)
-        report.add_script()
-        data_headers = ('Creation Time', 'Bundle', 'Title[Subtitle]', 'Message', 'Other Details')
-        report.write_artifact_data_table(data_headers, data_list, filepath)
-        report.end_artifact_report()
+        sources.append(context.get_relative_path(filepath))
+        bundle_id = os.path.basename(os.path.dirname(filepath))
+        bundle_name = bundle_info.get(bundle_id, bundle_id)
 
-        logfunc("Total notifications processed:" + str(len(data_list)))
-        #logfunc("Total exported bplists from notifications:" + str(exportedbplistcount))
-        
-        tsvname = 'Notifications'
-        tsv(report_folder, data_headers, data_list, tsvname)
+        for item in plist:
+            creation_date = ''
+            title = subtitle = message = ''
+            other_dict = {}
+            for k, v in item.items():
+                if k == 'AppNotificationCreationDate':
+                    creation_date = v.replace(tzinfo=timezone.utc) if isinstance(v, datetime) else v
+                elif k == 'AppNotificationMessage':
+                    message = v
+                elif k == 'AppNotificationTitle':
+                    title = v
+                elif k == 'AppNotificationSubtitle':
+                    subtitle = v
+                else:
+                    other_dict[k] = str(v)
+            if subtitle:
+                title = f'{title}[{subtitle}]'
+            data_list.append((creation_date, bundle_name, title, message, str(other_dict)))
 
-        tlactivity = 'Notifications'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc("No notifications found.")
-
-__artifacts__ = {
-    "notificationsXII": (
-        "Notifications",
-        ('*/mobile/Library/UserNotifications*'),
-        get_notificationsXII)
-}
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary
Notifications cluster (2 artifacts) → `@artifact_processor`, context form.

- **notificationsDuet** — was a **hybrid** (v2 header + an undecorated function that built a per-file `ArtifactHtmlReport` *and* called `lava_process_artifact`/`lava_insert_sqlite_data` by hand). Now decorated (context form), `'function'` key dropped, `output_types` set to `standard` (was `none`), single datetime-marked header set, wrapper emits everything. Hardened the `blackboxprotobuf` decode + `.get()` fallbacks on the proto message.
- **notificationsXII** — v1 `__artifacts__` → v2, context form. Robust file discovery (iterate `files_found`, glob dirs) instead of `files_found[0]+glob`; `AppNotificationCreationDate` returned as **aware-UTC datetime**; guarded plist deserialize; merged the two bundle-name helpers.
- Both: `context.get_relative_path()` on the source; **reserved-word audit run on both header sets**; pylint 10.00.

## Validation
- `ast.parse` OK; 0 legacy refs; no cross-module imports.
- Reserved-word audit: both header sets create SQLite tables cleanly.
- pylint (CI config): **10.00/10** both.
- Both load: decorated, key matches function name, context-form, no legacy/`function` registry.