### PR TITLE
Convert geodApplications + geodPDPlaceCache to artifact_processor (LAVA, context form)

### DIFF
--- a/scripts/artifacts/geodApplications.py
+++ b/scripts/artifacts/geodApplications.py
@@ -1,59 +1,45 @@
-import base64
-import json
-import sqlite3
-import os
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, does_table_exist_in_db
-
-
-def get_geodApplications(files_found, report_folder, seeker, wrap_text, timezone_offset):
-	for file_found in files_found:
-		file_found = str(file_found)
-		
-		if file_found.endswith('.db'):
-			break
-	
-	db = open_sqlite_db_readonly(file_found)
-	cursor = db.cursor()
-	
-	if does_table_exist_in_db(file_found, 'mkcount'):
-		query = "SELECT count_type, app_id, createtime FROM mkcount"
-	elif does_table_exist_in_db(file_found, 'dailycounts'):
-		query = "SELECT count_type, app_id, createtime FROM dailycounts"
-
-	cursor.execute(query)
-
-	all_rows = cursor.fetchall()
-	
-	usageentries = len(all_rows)
-	data_list = []
-	if usageentries > 0:
-		for row in all_rows:
-			data_list.append((row[2], row[0], row[1] ))
-			description = ''
-		report = ArtifactHtmlReport('Geolocation')
-		report.start_artifact_report(report_folder, 'Applications', description)
-		report.add_script()
-		data_headers = ("Creation Time", "Count ID", "Application")
-		report.write_artifact_data_table(data_headers, data_list, file_found, html_escape = False)
-		report.end_artifact_report()
-
-		tsvname = 'Geolocation Applications'
-		tsv(report_folder, data_headers, data_list, tsvname)
-		
-		tlactivity = 'Geolocation Applications'
-		timeline(report_folder, tlactivity, data_list, data_headers)
-
-	else:
-		logfunc('No data available for Geolocation Applications')
-
-	db.close()
-	return
-	
-__artifacts__ = {
-    "geodapplications": (
-        "Location",
-        ('**/AP.db*'),
-        get_geodApplications)
+__artifacts_v2__ = {
+    "geodapplications": {
+        "name": "Geolocation - Applications",
+        "description": "Per-application location count entries from the geod AP.db (mkcount/dailycounts)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Location",
+        "notes": "createtime assumed to be Mac absolute time (Cocoa, seconds since 2001-01-01 UTC).",
+        "paths": ('**/AP.db*',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
+    }
 }
+
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records, does_table_exist_in_db,
+                               convert_cocoa_core_data_ts_to_utc)
+
+
+@artifact_processor
+def geodapplications(context):
+    data_headers = (('Creation Time', 'datetime'), 'Count ID', 'Application')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('.db'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    table = ''
+    if does_table_exist_in_db(source_path, 'mkcount'):
+        table = 'mkcount'
+    elif does_table_exist_in_db(source_path, 'dailycounts'):
+        table = 'dailycounts'
+
+    if table:
+        for row in get_sqlite_db_records(source_path, f'SELECT count_type, app_id, createtime FROM {table}'):
+            data_list.append((convert_cocoa_core_data_ts_to_utc(row[2]), row[0], row[1]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/geodPDPlaceCache.py
+++ b/scripts/artifacts/geodPDPlaceCache.py
@@ -1,62 +1,45 @@
-import base64
-import json
-import sqlite3
-import os
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, strings, open_sqlite_db_readonly, does_table_exist_in_db
-
-
-def get_geodPDPlaceCache(files_found, report_folder, seeker, wrap_text, timezone_offset):
-	for file_found in files_found:
-		file_found = str(file_found)
-		
-		if file_found.endswith('.db'):
-			break
-		
-	db = open_sqlite_db_readonly(file_found)
-	if does_table_exist_in_db(file_found, 'pdplacelookup'):
-		query = ("""
-	SELECT requestkey, pdplacelookup.pdplacehash, datetime('2001-01-01', "lastaccesstime" || ' seconds') as lastaccesstime, datetime('2001-01-01', "expiretime" || ' seconds') as expiretime, pdplace
-	FROM pdplacelookup
-	INNER JOIN pdplaces on pdplacelookup.pdplacehash = pdplaces.pdplacehash
-	""")
-	else:
-		logfunc()
-	cursor = db.cursor()
-	cursor.execute(query)
-	
-
-	all_rows = cursor.fetchall()
-	usageentries = len(all_rows)
-	data_list = []
-	if usageentries > 0:
-		for row in all_rows:
-			pd_place = ''.join(f'{row}<br>' for row in set(strings(row[4])))
-			data_list.append((row[2], row[0], row[1], row[3], pd_place))
-		description = ''
-		report = ArtifactHtmlReport('Geolocation')
-		report.start_artifact_report(report_folder, 'PD Place Cache', description)
-		report.add_script()
-		data_headers = ( "last access time", "requestkey", "pdplacehash", "expire time", "pd place")
-		report.write_artifact_data_table(data_headers, data_list, file_found, html_escape = False)
-		report.end_artifact_report()
-
-		tsvname = 'Geolocation PD Place Caches'
-		tsv(report_folder, data_headers, data_list, tsvname)
-		
-		tlactivity = 'Geolocation PD Place Caches'
-		timeline(report_folder, tlactivity, data_list, data_headers)
-
-	else:
-		logfunc('No data available for Geolocation PD Place Caches')
-
-	db.close()
-	return
-	
-__artifacts__ = {
-    "geodpdplacecache": (
-        "Location",
-        ('**/PDPlaceCache.db*'),
-        get_geodPDPlaceCache)
+__artifacts_v2__ = {
+    "geodpdplacecache": {
+        "name": "Geolocation - PD Place Cache",
+        "description": "Cached place lookups from the geod PDPlaceCache.db",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Location",
+        "notes": "lastaccesstime/expiretime are Mac absolute time (Cocoa, seconds since 2001-01-01 UTC).",
+        "paths": ('**/PDPlaceCache.db*',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
+    }
 }
+
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records, does_table_exist_in_db,
+                               convert_cocoa_core_data_ts_to_utc, strings)
+
+
+@artifact_processor
+def geodpdplacecache(context):
+    data_headers = (('Last Access Time', 'datetime'), 'Request Key', 'PD Place Hash',
+                    ('Expire Time', 'datetime'), 'PD Place')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('.db'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    if does_table_exist_in_db(source_path, 'pdplacelookup'):
+        query = '''SELECT requestkey, pdplacelookup.pdplacehash, lastaccesstime, expiretime, pdplace
+            FROM pdplacelookup
+            INNER JOIN pdplaces ON pdplacelookup.pdplacehash = pdplaces.pdplacehash'''
+        for row in get_sqlite_db_records(source_path, query):
+            pd_place = '\n'.join(sorted(set(strings(row[4]))))
+            data_list.append((convert_cocoa_core_data_ts_to_utc(row[2]), row[0], row[1],
+                              convert_cocoa_core_data_ts_to_utc(row[3]), pd_place))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary
geod/location cluster — two simple AP.db / PDPlaceCache.db artifacts.

| Artifact | Source |
|---|---|
| Geolocation - Applications | AP.db (mkcount/dailycounts) |
| Geolocation - PD Place Cache | PDPlaceCache.db |

## Changes
- v1 `__artifacts__` → v2; **context form**; pylint 10.00.
- **Timestamps → aware UTC** via `convert_cocoa_core_data_ts_to_utc` (Mac absolute time, seconds since 2001). PDPlaceCache already used the Cocoa epoch in SQL; AP.db `createtime` assumed Cocoa (same geod family, noted in `notes`). Time columns marked `('datetime')`.
- `get_sqlite_db_records` + `does_table_exist_in_db` helpers instead of manual cursors.
- geodPDPlaceCache: place strings now joined with newlines (was `<br>` + `html_escape=False`).
- `context.get_relative_path()` on the source.

## Validation
- `ast.parse` OK; 0 legacy refs; no cross-module imports; names unique.
- **Reserved-word audit:** both header sets create SQLite tables cleanly.
- pylint (CI config): **10.00/10** both.
- Functional test on fixture DBs: Cocoa→UTC conversion verified (725846400 → 2024-01-02), place strings extracted + sorted, source relative.