### PR TITLE
Convert findMy + duetLocations to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/duetLocations.py
+++ b/scripts/artifacts/duetLocations.py
@@ -1,199 +1,90 @@
+__artifacts_v2__ = {
+    "duetlocations": {
+        "name": "Duet Locations",
+        "description": "Location records from the DuetExpertCenter location stream (SEGB)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Geolocation",
+        "notes": "",
+        "paths": ('*/DuetExpertCenter/streams/location/local/*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin"
+    }
+}
+
 import os
 import struct
-import blackboxprotobuf
-import nska_deserialize as nd
-from datetime import datetime
-from time import mktime
-from io import StringIO
 from io import BytesIO
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen, webkit_timestampsconv
 
-def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
-    """Returns a tuple of bool (whether mis-encoded utf-8 is present) and str (the converted string)"""
-    output = []  # individual characters, join at the end
-    is_in_multibyte = False  # True if we're currently inside a utf-8 multibyte character
-    multibytes_expected = 0
-    multibyte_buffer = []
-    mis_encoded_utf8_present = False
-    
-    def handle_bad_data(index, character):
-        if not raise_on_unexpected: # not raising, so we dump the buffer into output and append this character
-            output.extend(multibyte_buffer)
-            multibyte_buffer.clear()
-            output.append(character)
-            nonlocal is_in_multibyte
-            is_in_multibyte = False
-            nonlocal multibytes_expected
-            multibytes_expected = 0
-        else:
-            raise ValueError(f"Expected multibyte continuation at index: {index}")
-            
-    for idx, c in enumerate(input_string):
-        code_point = ord(c)
-        if code_point <= 0x7f or code_point > 0xf4:  # ASCII Range data or higher than you get for mis-encoded utf-8:
-            if not is_in_multibyte:
-                output.append(c)  # not in a multibyte, valid ascii-range data, so we append
-            else:
-                handle_bad_data(idx, c)
-        else:  # potentially utf-8
-            if (code_point & 0xc0) == 0x80:  # continuation byte
-                if is_in_multibyte:
-                    multibyte_buffer.append(c)
-                else:
-                    handle_bad_data(idx, c)
-            else:  # start-byte
-                if not is_in_multibyte:
-                    assert multibytes_expected == 0
-                    assert len(multibyte_buffer) == 0
-                    while (code_point & 0x80) != 0:
-                        multibytes_expected += 1
-                        code_point <<= 1
-                    multibyte_buffer.append(c)
-                    is_in_multibyte = True
-                else:
-                    handle_bad_data(idx, c)
-                    
-        if is_in_multibyte and len(multibyte_buffer) == multibytes_expected:  # output utf-8 character if complete
-            utf_8_character = bytes(ord(x) for x in multibyte_buffer).decode("utf-8")
-            output.append(utf_8_character)
-            multibyte_buffer.clear()
-            is_in_multibyte = False
-            multibytes_expected = 0
-            mis_encoded_utf8_present = True
-        
-    if multibyte_buffer:  # if we have left-over data
-        handle_bad_data(len(input_string), "")
-    
-    return mis_encoded_utf8_present, "".join(output)
+import nska_deserialize as nd
 
-def get_duetLocations(files_found, report_folder, seeker, wrap_text, timezone_offset):
+from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
-    for file_found in files_found:
+_PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
+                 nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
+                 nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError)
+
+
+@artifact_processor
+def duetlocations(context):
+    data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Horizontal Accuracy',
+                    'Altitude', 'Speed')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
-        if filename.startswith('.'):
+        if filename.startswith('.') or not os.path.isfile(file_found) or 'tombstone' in file_found:
             continue
-        if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
-                continue
-            else:
-                pass
-        else:
+        with open(file_found, 'rb') as f:
+            data = f.read()
+        try:
+            headerloc = data.index(b'SEGB')
+        except ValueError:
             continue
-        
-        with open(file_found, 'rb') as file:
-            data = file.read()
-            
-        data_list = []
-        headerloc = data.index(b'SEGB')
-        #print(headerloc)
-        
-        b = data
-        ab = BytesIO(b)
+
+        ab = BytesIO(data)
         ab.seek(headerloc)
-        ab.read(4) #Main header
-        #print('---- Start of Notifications ----')
-        
+        ab.read(4)  # main header
+        found_any = False
         while True:
-            #print('----')
-            sizeofnotificatoninhex = (ab.read(4))
+            size_hex = ab.read(4)
             try:
-                sizeofnotificaton = (struct.unpack_from("<i",sizeofnotificatoninhex)[0])
-            except:
+                size = struct.unpack_from("<i", size_hex)[0]
+            except struct.error:
                 break
-            if sizeofnotificaton == 0:
+            if size == 0:
                 break
-            
-            allocation = ab.read(4)
-            
-            date1 = ab.read(8) 
-            date1 = (struct.unpack_from("<d",date1)[0])
-            convertedtime1 = webkit_timestampsconv(date1)
-            #print(convertedtime1)
-            segbtime = convertedtime1
-            
-            date2 = ab.read(8)
-            date2 = (struct.unpack_from("<d",date2)[0])
-            convertedtime2 = webkit_timestampsconv(date2)
-            #print(convertedtime2)
-            
-            
-            ignore1 = ab.read(8)
-            
-            datos = ab.read(sizeofnotificaton)
-            
-            checkforempty = BytesIO(datos)
-            check = checkforempty.read(1)
-            if check == b'\x00':
-                pass
-            else:
+            ab.read(4)   # allocation
+            ab.read(8)   # date1 (SEGB time, not surfaced — record uses the plist timestamp)
+            ab.read(8)   # date2
+            ab.read(8)   # ignore
+            datos = ab.read(size)
+
+            if datos[:1] != b'\x00':
                 try:
                     plist = nd.deserialize_plist_from_string(datos)
-                    
-                    if not isinstance(plist, dict) or len(plist) == 0:
-                        logfunc(f'Plist is empty or not a dictionary (iOS 16.3+): {type(plist)}')
-                        continue
-                    
-                    timestamp = latitude = longitude = horzacc = altitude = speed = ''
-                    
-                    for key, value in plist.items():
-                        #print(key, value)
-                        if key == 'kCLLocationCodingKeyCoordinateLongitude':
-                            longitude = value
-                        elif key == 'kCLLocationCodingKeyCoordinateLatitude':
-                            latitude = value
-                        elif key == 'kCLLocationCodingKeyHorizontalAccuracy':
-                            horzacc = value
-                        elif key == 'kCLLocationCodingKeyTimestamp':
-                            timestamp = value
-                            timestamp = webkit_timestampsconv(timestamp)
-                        elif key == 'kCLLocationCodingKeyAltitude':
-                            altitude = value
-                        elif key == 'kCLLocationCodingKeySpeed':
-                            speed = value
-                    
-                    if latitude != '' and longitude != '':
-                        data_list.append((timestamp, latitude, longitude, horzacc, altitude, speed))
-                    
-                except (nd.DeserializeError, nd.biplist.NotBinaryPlistException, nd.biplist.InvalidPlistException,
-                        nd.plistlib.InvalidFileException, nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError) as ex:
-                    logfunc(f'Failed to read plist, error was: {str(ex)}')
-                
-            modresult = (sizeofnotificaton % 8)
-            resultante =  8 - modresult
-            
-            if modresult == 0:
-                pass
-            else:
-                ab.read(resultante)
-        
-        if len(data_list) > 0:
-        
-            description = ''
-            report = ArtifactHtmlReport(f'Duet Locations')
-            report.start_artifact_report(report_folder, f'Duet Locations - {filename}', description)
-            report.add_script()
-            data_headers = ('Timestamp','Latitude','Longitude','Horizontal Accuracy','Altitude','Speed')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Duet Locations - {filename}'
-            tsv(report_folder, data_headers, data_list, tsvname) # TODO: _csv.Error: need to escape, but no escapechar set
-            
-            tlactivity = f'Duet Locations - {filename}'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-            kmlactivity = f'Duet Locations - {filename}'
-            kmlgen(report_folder, kmlactivity, data_list, data_headers)
-            
-        else:
-            logfunc(f'No data available for Duet Locations')
-    
+                except _PLIST_ERRORS:
+                    plist = None
+                if isinstance(plist, dict) and plist:
+                    lat = plist.get('kCLLocationCodingKeyCoordinateLatitude', '')
+                    lon = plist.get('kCLLocationCodingKeyCoordinateLongitude', '')
+                    if lat != '' and lon != '':
+                        ts = plist.get('kCLLocationCodingKeyTimestamp')
+                        data_list.append((webkit_timestampsconv(ts) if ts is not None else '', lat, lon,
+                                          plist.get('kCLLocationCodingKeyHorizontalAccuracy', ''),
+                                          plist.get('kCLLocationCodingKeyAltitude', ''),
+                                          plist.get('kCLLocationCodingKeySpeed', '')))
+                        found_any = True
 
-__artifacts__ = {
-    "duetlocations": (
-        "Geolocation",
-        ('*/DuetExpertCenter/streams/location/local/*'),
-        get_duetLocations)
-}
+            mod = size % 8
+            if mod != 0:
+                ab.read(8 - mod)
+
+        if found_any:
+            sources.append(context.get_relative_path(file_found))
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/findMy.py
+++ b/scripts/artifacts/findMy.py
@@ -1,43 +1,49 @@
-from datetime import datetime
-import os
-import plistlib
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows 
-
-def get_findMy(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    file_found = str(files_found[0])
-    with open(file_found, "rb") as fp:
-        pl = plistlib.load(fp)
-        for key, val in pl.items():
-            
-            if key == 'addTime':
-                addtime = datetime.utcfromtimestamp(val)
-                data_list.append(('Find My iPhone Add Time', addtime))
-                logdevinfo(f"<b>Find My iPhone: </b>Enabled")
-                logdevinfo(f"<b>Find My iPhone Add Time: </b>{addtime}")
-                
-            else:
-                data_list.append((key, val ))
-                
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Find My iPhone Settings')
-        report.start_artifact_report(report_folder, 'Find My iPhone Settings')
-        report.add_script()
-        data_headers = ('Key','Values' )     
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Find My iPhone Settings'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Find My iPhone Settings available')
-            
-
-__artifacts__ = {
-    "findMy": (
-        "Identifiers",
-        ('*/mobile/Library/Preferences/com.apple.icloud.findmydeviced.FMIPAccounts.plist'),
-        get_findMy)
+__artifacts_v2__ = {
+    "findMy": {
+        "name": "Find My iPhone Settings",
+        "description": "Find My iPhone account settings (FMIPAccounts.plist)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Identifiers",
+        "notes": "",
+        "paths": ('*/mobile/Library/Preferences/com.apple.icloud.findmydeviced.FMIPAccounts.plist',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
+    }
 }
+
+import plistlib
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def findMy(context):
+    data_headers = ('Key', 'Value')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('FMIPAccounts.plist'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    with open(source_path, 'rb') as fp:
+        pl = plistlib.load(fp)
+
+    for key, val in pl.items():
+        if key == 'addTime':
+            try:
+                val = datetime.fromtimestamp(val, tz=timezone.utc)
+                key = 'Find My iPhone Add Time'
+            except (TypeError, ValueError, OSError):
+                pass
+        data_list.append((key, val))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Modernizes two location standalones to the LAVA pipeline (context form, UTC, `get_relative_path`).

## findMy.py
- v1 `__artifacts__` → `__artifacts_v2__`; `@artifact_processor` single-arg `context` form.
- Iterate `get_files_found()` + `endswith` + empty-guard (no blind `[0]`).
- `addTime` → timezone-aware UTC datetime; `get_relative_path` on source.

## duetLocations.py
- v1 → v2; context form. Manual **SEGB** binary stream parsing preserved (struct/BytesIO).
- Location timestamps via `webkit_timestampsconv` (UTC); Latitude/Longitude routed to the framework KML via `output_types: 'all'` (drops the manual `kmlgen` call).
- `get_relative_path` on each source; consolidates records across all matched stream files.
- Removed dead `utf8_in_extended_ascii` helper and unused imports (blackboxprotobuf, mktime, StringIO, ArtifactHtmlReport, tsv, timeline, kmlgen).

## Validation
- pylint 10.00/10 (CI `--disable=C,R`); compile/ast OK.
- Mandatory reserved-word CREATE TABLE audit: PASS (key, value, timestamp, latitude, longitude, horizontal_accuracy, altitude, speed — none reserved).
- Isolated import OK, `__wrapped__` present; no cross-module imports of the old names (dead local `utf8_in_extended_ascii` was not imported elsewhere; googleChat uses the ilapfuncs version).