### PR TITLE
Convert tileApp + tileAppDb to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/tileApp.py
+++ b/scripts/artifacts/tileApp.py
@@ -1,65 +1,61 @@
-import gzip
-import re
-import os
-from datetime import datetime, timezone
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, kmlgen,tsv, is_platform_windows, convert_ts_human_to_utc, convert_utc_human_to_timezone 
-
-
-
-def get_tileApp(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('gz'):
-            x=gzip.open
-        elif file_found.endswith('log'):
-            x=open
-        
-        counter = 0
-        with x(file_found,'rt',) as f:
-            for line in f:
-                regexdate = r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}"
-                datestamp = re.search(regexdate, line)  
-                counter +=1
-                if datestamp != None:
-                    datestamp = datestamp.group(0)
-                    datestamp  = convert_ts_human_to_utc(datestamp)
-                    datestamp = convert_utc_human_to_timezone(datestamp ,timezone_offset)
-                    regexlatlong = r"<[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)>"
-                    latlong = re.search(regexlatlong, line)
-                    if latlong != None:
-                        latlong = latlong.group(0)
-                        latlong = latlong.strip('<')
-                        latlong = latlong.strip('>')
-                        lat, longi = latlong.split(',')
-                        head_tail = os.path.split(file_found) 
-                        data_list.append((datestamp, lat.lstrip(), longi.lstrip(), counter, head_tail[1]))
-
-    if len(data_list) > 0:
-        description = 'Tile app log recorded latitude and longitude coordinates.'
-        report = ArtifactHtmlReport('Locations')
-        report.start_artifact_report(report_folder, 'Tile App Geolocation Logs', description)
-        report.add_script()
-        data_headers = ('Timestamp', 'Latitude', 'Longitude', 'Row Number', 'Source File' )     
-        report.write_artifact_data_table(data_headers, data_list, head_tail[0])
-        report.end_artifact_report()
-        
-        tsvname = 'Tile App Lat Long'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Tile App Lat Long'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'Tile App Lat Long'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers)
-    
-__artifacts__ = {
-    "tileApp": (
-        "Locations",
-        ('*/mobile/Containers/Data/Application/*/Library/log/com.thetileapp.tile*'),
-        get_tileApp)
+__artifacts_v2__ = {
+    "tileApp": {
+        "name": "Tile App Geolocation Logs",
+        "description": "Latitude/longitude coordinates recorded in Tile app logs",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Locations",
+        "notes": "Log timestamps stored as UTC.",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/log/com.thetileapp.tile*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin"
+    }
 }
+
+import gzip
+import os
+import re
+
+from scripts.ilapfuncs import artifact_processor, convert_ts_human_to_utc
+
+_REGEX_DATE = r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}"
+_REGEX_LATLONG = (r"<[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*"
+                  r"[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)>")
+
+
+@artifact_processor
+def tileApp(context):
+    data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Row Number', 'Source File')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('gz'):
+            opener = gzip.open
+        elif file_found.endswith('log'):
+            opener = open
+        else:
+            continue
+
+        counter = 0
+        had_data = False
+        with opener(file_found, 'rt') as f:
+            for line in f:
+                counter += 1
+                datestamp = re.search(_REGEX_DATE, line)
+                if datestamp is None:
+                    continue
+                latlong = re.search(_REGEX_LATLONG, line)
+                if latlong is None:
+                    continue
+                lat, longi = latlong.group(0).strip('<').strip('>').split(',')
+                data_list.append((convert_ts_human_to_utc(datestamp.group(0)),
+                                  lat.lstrip(), longi.lstrip(), counter, os.path.basename(file_found)))
+                had_data = True
+        if had_data:
+            sources.append(context.get_relative_path(file_found))
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/tileAppDb.py
+++ b/scripts/artifacts/tileAppDb.py
@@ -1,91 +1,57 @@
-import glob
-import os
-import pathlib
-import sqlite3
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, kmlgen, timeline, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_tileAppDb(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('tile-TileNetworkDB.sqlite'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    datetime(ZTIMESTAMP,'unixepoch','31 years'),
-    ZNAME,
-    datetime(ZACTIVATION_TIMESTAMP,'unixepoch','31 years'),
-    datetime(ZREGISTRATION_TIMESTAMP,'unixepoch','31 years'),
-    ZALTITUDE, 
-    ZLATITUDE, 
-    ZLONGITUDE,
-    ZID,
-    ZNODE_TYPE, 
-    ZSTATUS,
-    ZIS_LOST,
-    datetime(ZLAST_LOST_TILE_COMMUNITY_CONNECTION,'unixepoch','31 years')
-    FROM ZTILENTITY_NODE INNER JOIN ZTILENTITY_TILESTATE ON ZTILENTITY_NODE.ZTILE_STATE = ZTILENTITY_TILESTATE.Z_PK
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []    
-    if usageentries > 0:
-        for row in all_rows:
-            timestamp = row[0]
-            if timestamp is None:
-                pass
-            else:
-                timestamp = convert_ts_human_to_utc(timestamp)
-                timestamp = convert_utc_human_to_timezone(timestamp,timezone_offset)
-                
-            acttimestamp = row[2]
-            if acttimestamp is None:
-                pass
-            else:
-                acttimestamp = convert_ts_human_to_utc(acttimestamp)
-                acttimestamp= convert_utc_human_to_timezone(acttimestamp,timezone_offset)
-                
-            regtimestamp = row[3]
-            if acttimestamp is None:
-                pass
-            else:
-                regtimestamp = convert_ts_human_to_utc(regtimestamp)
-                regtimestamp = convert_utc_human_to_timezone(regtimestamp,timezone_offset)
-                
-            data_list.append((timestamp, row[1], acttimestamp, regtimestamp, row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11]))
-        
-            description = ''
-            report = ArtifactHtmlReport('Tile App - Tile Information & Geolocation')
-            report.start_artifact_report(report_folder, 'Tile App DB Info & Geolocation', description)
-            report.add_script()
-            data_headers = ('Timestamp','Tile Name','Activation Timestamp','Registration Timestamp','Altitude','Latitude','Longitude','Tile ID','Tile Type','Status','Is Lost?','Last Community Connection' )     
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        tsvname = 'Tile App DB Info Geolocation'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Tile App DB Info Geolocation'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'Tile App DB Info Geolocation'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers)    
-    else:
-        logfunc('No Tile App DB data available')
-
-    db.close()
-    return 
-
-__artifacts__ = {
-    "tileAppDb": (
-        "Locations",
-        ('*/mobile/Containers/Shared/AppGroup/*/com.thetileapp.tile-TileNetworkDB.sqlite*'),
-        get_tileAppDb)
+__artifacts_v2__ = {
+    "tileAppDb": {
+        "name": "Tile App DB Info & Geolocation",
+        "description": "Tile device information and last-known geolocation from the Tile network database",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Locations",
+        "notes": "Timestamps are Cocoa/Mac absolute time (seconds since 2001-01-01 UTC), converted to UTC.",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/com.thetileapp.tile-TileNetworkDB.sqlite*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def tileAppDb(context):
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Tile Name', ('Activation Timestamp', 'datetime'),
+        ('Registration Timestamp', 'datetime'), 'Altitude', 'Latitude', 'Longitude', 'Tile ID',
+        'Tile Type', 'Status', 'Is Lost?', ('Last Community Connection', 'datetime'))
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('tile-TileNetworkDB.sqlite'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZTIMESTAMP + 978307200, 'unixepoch'),
+        ZNAME,
+        datetime(ZACTIVATION_TIMESTAMP + 978307200, 'unixepoch'),
+        datetime(ZREGISTRATION_TIMESTAMP + 978307200, 'unixepoch'),
+        ZALTITUDE,
+        ZLATITUDE,
+        ZLONGITUDE,
+        ZID,
+        ZNODE_TYPE,
+        ZSTATUS,
+        ZIS_LOST,
+        datetime(ZLAST_LOST_TILE_COMMUNITY_CONNECTION + 978307200, 'unixepoch')
+    FROM ZTILENTITY_NODE
+    INNER JOIN ZTILENTITY_TILESTATE ON ZTILENTITY_NODE.ZTILE_STATE = ZTILENTITY_TILESTATE.Z_PK
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
First of the chat/app standalones — the related **Tile** pair (Bluetooth tracker). Both simple → clustered.

## tileApp.py (Tile logs → GPS)
- v1 `__artifacts__` → `__artifacts_v2__`, context form. Parses gz/plain logs via regex for lat/long.
- **Drops `timezone_offset`** — stores UTC via `convert_ts_human_to_utc` (per the UTC rule); Latitude/Longitude → framework KML (`output_types: 'all'`).
- **Guards files that are neither `.gz` nor `.log`** (the original left the opener `x` undefined → NameError on any other matched file).
- Removed dead imports (`logdevinfo`, `packaging.version`, `is_platform_windows`, `convert_utc_human_to_timezone`, report/tsv/timeline/kmlgen). `get_relative_path` on sources.

## tileAppDb.py (Tile network DB)
- v1 → v2, context form; reads `tile-TileNetworkDB.sqlite`.
- **Fixes a latent NameError**: the original called `convert_ts_human_to_utc`/`convert_utc_human_to_timezone` but **never imported them** — it would crash on any non-null timestamp. Conversion now happens in SQL.
- **Fixes a copy-paste bug** (the `regtimestamp` branch tested `acttimestamp`).
- Replaces the approximate `datetime(...,'unixepoch','31 years')` with the **precise Cocoa offset `+ 978307200`**; NULLs pass through. `iterate+match+guard` source selection.

## Validation
- pylint 10.00/10; compile/ast OK; no legacy refs (no `timezone_offset`).
- tileAppDb query **executed against a mock Tile schema** → 12 cols, ts `700000000+978307200` → `2023-03-08 20:26:40` UTC.
- Mandatory reserved-word audit PASS for both (incl. `status`, `is_lost`, `tile_type`). No external imports of the old names.