### PR TITLE
Convert metamask to LAVA @artifact_processor (4-report split + fixes)

### DIFF
--- a/scripts/artifacts/metamask.py
+++ b/scripts/artifacts/metamask.py
@@ -1,94 +1,115 @@
-from os.path import dirname, join
-import json
-import datetime
-import time
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
-
-
-def get_metamask(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    wallets = []
-    contacts = []
-    transactions = []
-    artifacts_from_in_app_browser = []
-
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        root = open(file_found, "r")
-        data = json.load(root)
-        if 'engine' in data:
-            json_object = json.loads(data['engine'])
-            json_browser = json.loads(data['browser'])
-            for i in json_object:
-                for accs in json_object['backgroundState']['AccountTrackerController']['accounts']:
-                    s = json_object['backgroundState']['PreferencesController']['identities'][accs]['importTime'] / 1000.0
-                    import_time = datetime.datetime.fromtimestamp(s).strftime('%Y-%m-%d %H:%M:%S.%f')
-                    balance = int(str(json_object['backgroundState']['AccountTrackerController']['accounts'][accs]['balance']), 16)
-                    wallets.append((import_time, str(json_object['backgroundState']['PreferencesController']['identities'][accs]['name']) , accs, balance/(10**18)))
-                for contactId in json_object['backgroundState']['AddressBookController']['addressBook']:
-                    for contact in json_object['backgroundState']['AddressBookController']['addressBook'][contactId]:
-                        contacts.append((str(json_object['backgroundState']['AddressBookController']['addressBook'][contactId][contact]['name']), str(json_object['backgroundState']['AddressBookController']['addressBook'][contactId][contact]['address'])))
-                for transaction in json_object['backgroundState']['TransactionController']['transactions']:
-                    s = transaction['time'] / 1000.0
-                    transaction_time = datetime.datetime.fromtimestamp(s).strftime('%Y-%m-%d %H:%M:%S.%f')
-                    transaction_value = int(str(transaction['transaction']['value']), 16) / (10**18)
-                    transactions.append((transaction_time, str(transaction['transaction']['from']),str(transaction['transaction']['to']),transaction_value , transaction['transactionHash']))
-                for history in json_browser["history"]:
-                    artifacts_from_in_app_browser.append((str(history["url"]),str(history['name'])))
-
-        description = ''
-
-        report = ArtifactHtmlReport('Meta Mask - Wallerts')
-        report.start_artifact_report(report_folder, 'Meta Mask - Wallets', description)
-        report.add_script()
-        wallet_headers = ('Import Timestamp', 'Wallet Name', 'Wallet Address','Balance (In Network Currency)')
-        report.write_artifact_data_table(wallet_headers, wallets, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Meta Mask - Wallets'
-        tsv(report_folder, wallet_headers, wallets, tsvname)
-
-        tlactivity = 'Meta Mask - Wallets'
-        timeline(report_folder, tlactivity, wallets, wallet_headers)
-        
-        report = ArtifactHtmlReport('Meta Mask - Contacts')
-        report.start_artifact_report(report_folder, 'Meta Mask - Contacts', description)
-        report.add_script()
-        contacts_headers = ('Contact Name','Wallet Address')     
-        report.write_artifact_data_table(contacts_headers, contacts, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Meta Mask - Contacts'
-        tsv(report_folder, contacts_headers, contacts, tsvname)
-        
-        report = ArtifactHtmlReport('Meta Mask - Transactions')
-        report.start_artifact_report(report_folder, 'Meta Mask - Transactions', description)
-        report.add_script()
-        transaction_headers = ('Timestamp', 'From','To', 'Value' ,'Transaction Hash')     
-        report.write_artifact_data_table(transaction_headers, transactions, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Meta Mask - Transactions'
-        tsv(report_folder, transaction_headers, transactions, tsvname)
-        
-        report = ArtifactHtmlReport('Meta Mask - Browser')
-        report.start_artifact_report(report_folder, 'Meta Mask - Browser', description)
-        report.add_script()
-        browser_headers = ('Name','URL')     
-        report.write_artifact_data_table(browser_headers, artifacts_from_in_app_browser, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Meta Mask - Browser'
-        tsv(report_folder, browser_headers, artifacts_from_in_app_browser, tsvname)
-
-        tlactivity = 'Meta Mask - Browser'
-        timeline(report_folder, tlactivity, artifacts_from_in_app_browser, browser_headers)
-    
-    
-__artifacts__ = {
-    "metamask": (
-        "Metamask",
-        ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root'),
-        get_metamask)
+__artifacts_v2__ = {
+    "metamaskWallets": {
+        "name": "MetaMask - Wallets",
+        "description": "MetaMask wallet accounts (import time, name, address, balance)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Metamask", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
+        "output_types": "standard", "artifact_icon": "credit-card"
+    },
+    "metamaskContacts": {
+        "name": "MetaMask - Contacts",
+        "description": "MetaMask address book contacts",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Metamask", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
+        "output_types": "standard", "artifact_icon": "users"
+    },
+    "metamaskTransactions": {
+        "name": "MetaMask - Transactions",
+        "description": "MetaMask transactions (time, from/to address, value, hash)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Metamask", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
+        "output_types": "standard", "artifact_icon": "repeat"
+    },
+    "metamaskBrowser": {
+        "name": "MetaMask - Browser",
+        "description": "MetaMask in-app browser history",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Metamask", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
+        "output_types": "standard", "artifact_icon": "globe"
+    }
 }
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+_WEI = 10 ** 18
+
+
+def _load_metamask(context):
+    """Return (backgroundState, browserState, source_path) from the MetaMask persist-root, or ({}, {}, '')."""
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        try:
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                data = json.load(fp)
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            continue
+        if 'engine' in data:
+            background = json.loads(data['engine']).get('backgroundState', {})
+            browser = json.loads(data['browser']) if 'browser' in data else {}
+            return background, browser, context.get_relative_path(file_found)
+    return {}, {}, ''
+
+
+def _hex_to_eth(hex_value):
+    try:
+        return int(str(hex_value), 16) / _WEI
+    except (ValueError, TypeError):
+        return hex_value
+
+
+@artifact_processor
+def metamaskWallets(context):
+    data_headers = (('Import Timestamp', 'datetime'), 'Wallet Name', 'Wallet Address',
+                    'Balance (In Network Currency)')
+    data_list = []
+    background, _, source = _load_metamask(context)
+    accounts = background.get('AccountTrackerController', {}).get('accounts', {})
+    identities = background.get('PreferencesController', {}).get('identities', {})
+    for address in accounts:
+        ident = identities.get(address, {})
+        data_list.append((convert_unix_ts_to_utc(ident.get('importTime')),
+                          str(ident.get('name', '')), address,
+                          _hex_to_eth(accounts[address].get('balance', '0x0'))))
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def metamaskContacts(context):
+    data_headers = ('Contact Name', 'Wallet Address')
+    data_list = []
+    background, _, source = _load_metamask(context)
+    address_book = background.get('AddressBookController', {}).get('addressBook', {})
+    for chain_id in address_book:
+        for contact in address_book[chain_id].values():
+            data_list.append((str(contact.get('name', '')), str(contact.get('address', ''))))
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def metamaskTransactions(context):
+    data_headers = (('Timestamp', 'datetime'), 'From Address', 'To Address', 'Value',
+                    'Transaction Hash')
+    data_list = []
+    background, _, source = _load_metamask(context)
+    for entry in background.get('TransactionController', {}).get('transactions', []):
+        tx = entry.get('transaction', {})
+        data_list.append((convert_unix_ts_to_utc(entry.get('time')), str(tx.get('from', '')),
+                          str(tx.get('to', '')), _hex_to_eth(tx.get('value', '0x0')),
+                          entry.get('transactionHash')))
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def metamaskBrowser(context):
+    data_headers = ('Name', 'URL')
+    data_list = []
+    _, browser, source = _load_metamask(context)
+    for history in browser.get('history', []):
+        data_list.append((str(history.get('name', '')), str(history.get('url', ''))))
+    return data_headers, data_list, source


### PR DESCRIPTION
Modernizes MetaMask (`persist-root` JSON store) to the LAVA pipeline. **Four reports → four processors** per the multi-report rule.

## Split
`get_metamask` (four `ArtifactHtmlReport`s) → **`metamaskWallets`**, **`metamaskContacts`**, **`metamaskTransactions`**, **`metamaskBrowser`** (context form; shared `_load_metamask` loader parses the nested `engine`/`browser` JSON once per call).

## Bugs fixed during conversion
- **Reserved-word trap**: the Transactions `From`/`To` headers sanitize to the SQL reserved words `from`/`to` (the same class of bug as the earlier `Values` crash) — renamed to **`From Address`/`To Address`**.
- **Timestamp correctness**: import/transaction times used naive `datetime.fromtimestamp` (renders in the *processing machine's* local tz). Now `convert_unix_ts_to_utc` → proper **UTC**.
- **Duplicate rows**: removed the spurious `for i in json_object:` loop that re-emitted every row once per top-level engine key.
- **Swapped Browser columns**: data was appended `(url, name)` under headers `('Name','URL')` — now aligned.
- Hardened all lookups with `.get()` so a missing controller/section no longer raises `KeyError`.

## Validation
- pylint 10.00/10; compile/ast OK; no legacy refs.
- **Functional test** with a synthetic persist-root: balances (1 ETH / 0.1 ETH) compute correctly, timestamps resolve to UTC (2021-01-01 / 2021-02-01), Browser columns aligned.
- Mandatory reserved-word audit PASS for all four tables. No external imports of `get_metamask`.