### PR TITLE
Convert kijijiConversations to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/kijijiConversations.py
+++ b/scripts/artifacts/kijijiConversations.py
@@ -1,103 +1,72 @@
-# Kijiji Conversations
-# Author:  Terry Chabot (Krypterry)
-# Version: 1.0.0
-# Kijiji iOS App Version Tested: v15.24.0 (2022-06)
-# Requirements:  None
-#
-#   Description:
-#   Obtains individual chat messages that were sent and received using the Kijiji application.
-#
-#   Additional Info:
-#       Kijiji.ca is a Canadian online classified advertising website and part of eBay Classifieds Group, with over 16 million unique visitors per month.
-#
-#       Kijiji, May 2022 <https://help.kijiji.ca/helpdesk/basics/what-is-kijiji>
-#       Wikipedia - The Free Encyclopedia, May 2022, <https://en.wikipedia.org/wiki/Kijiji>
-import json
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
-
-LOCAL_USER = 'Local User'
-UNIX_EPOCH = 978307200
-
-def get_kijijiConversations(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list_conversation = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        logfunc(f'JSON file {file_found} is being deserialized...')
-        with open(file_found, mode='r', encoding="UTF-8") as json_content:
-            data_list_conversation = []
-            data = json.load(json_content)
-
-            for conversation in data['data']:
-                counterPartyName = conversation['counterParty']['name']
-                counterPartyId = conversation['counterParty']['identifier']
-                conversationId = conversation['conversationId']
-                advertTitle = conversation['ad']['displayTitle']
-                advertId = conversation['ad']['identifier']
-                messages = conversation['messages']
-                #advertThumbnailUrl = conversation['ad']['thumbnailUrl']
-                AppendMessageRowsToDataList(data_list_conversation,
-                    conversationId,
-                    advertId,
-                    advertTitle,
-                    counterPartyId,
-                    counterPartyName,
-                    messages)
-
-            if len(data_list_conversation) > 0:
-                report = ArtifactHtmlReport('Kijiji Conversations')
-                report.start_artifact_report(report_folder, 'Kijiji Conversations')
-                report.add_script()
-                data_headers = ('Timestamp (Local Time)', 'Conversation ID', 'Ad ID', 'Ad Title', 'Message ID', 'Sender ID', 'Sender Name', 'Recipient ID', 'Recipient Name', 'State', 'Message')
-                report.write_artifact_data_table(data_headers, data_list_conversation, file_found)
-                report.end_artifact_report()
-                
-                tsvname = 'Kijiji Conversations'
-                tsv(report_folder, data_headers, data_list_conversation, tsvname)                
-            else:
-                logfunc('No Kijiji Conversations data found.')
-
-            return True
-
-# Appends a row for each message sent in a unique conversation thread.
-def AppendMessageRowsToDataList(data_list, 
-    conversationId, 
-    advertId,
-    advertTitle,    
-    conversationPartyId,
-    conversationPartyName, 
-    messages):
-    for message in messages:
-        # Determine sender (local user or counter party)
-        if message['sender'] == 0:
-            senderId = ''
-            senderName = LOCAL_USER
-            recipientId = conversationPartyId
-            recipientName = conversationPartyName
-        else:            
-            senderId = conversationPartyId
-            senderName = conversationPartyName
-            recipientId = ''
-            recipientName = LOCAL_USER
-
-        messageTimestamp = (datetime.datetime.fromtimestamp(int(message['sentDate']) + UNIX_EPOCH).strftime('%Y-%m-%d %H:%M:%S'))
-
-        data_list.append((messageTimestamp, 
-            conversationId, 
-            advertId, 
-            advertTitle, 
-            message['messageId'], 
-            senderId, senderName, 
-            recipientId, 
-            recipientName, 
-            message['messageStatus'], 
-            message['text']))
-
-__artifacts__ = {
-    "kijijiConversations": (
-        "Kijiji Conversations",
-        ('*/Library/Caches/conversation_cache'),
-        get_kijijiConversations)
+__artifacts_v2__ = {
+    "kijijiConversations": {
+        "name": "Kijiji Conversations",
+        "description": "Chat messages sent and received using the Kijiji application",
+        "author": "Terry Chabot (Krypterry)",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Kijiji Conversations",
+        "notes": "Kijiji.ca is a Canadian online classified advertising site. Message timestamps are "
+                 "Cocoa/Mac absolute time (seconds since 2001-01-01 UTC), converted to UTC.",
+        "paths": ('*/Library/Caches/conversation_cache',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle"
+    }
 }
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_cocoa_core_data_ts_to_utc, logfunc
+
+_LOCAL_USER = 'Local User'
+
+
+def _message_rows(conversation):
+    """Yield one output row per message in a single Kijiji conversation thread."""
+    counter_party_name = conversation['counterParty']['name']
+    counter_party_id = conversation['counterParty']['identifier']
+    conversation_id = conversation['conversationId']
+    advert_title = conversation['ad']['displayTitle']
+    advert_id = conversation['ad']['identifier']
+    for message in conversation['messages']:
+        if message['sender'] == 0:
+            sender_id, sender_name = '', _LOCAL_USER
+            recipient_id, recipient_name = counter_party_id, counter_party_name
+        else:
+            sender_id, sender_name = counter_party_id, counter_party_name
+            recipient_id, recipient_name = '', _LOCAL_USER
+        yield (convert_cocoa_core_data_ts_to_utc(int(message['sentDate'])), conversation_id,
+               advert_id, advert_title, message['messageId'], sender_id, sender_name,
+               recipient_id, recipient_name, message['messageStatus'], message['text'])
+
+
+@artifact_processor
+def kijijiConversations(context):
+    data_headers = (('Timestamp', 'datetime'), 'Conversation ID', 'Ad ID', 'Ad Title', 'Message ID',
+                    'Sender ID', 'Sender Name', 'Recipient ID', 'Recipient Name', 'State', 'Message')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        try:
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                data = json.load(fp)
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError) as ex:
+            logfunc(f'Kijiji: could not parse {file_found}: {ex}')
+            continue
+
+        had_data = False
+        for conversation in data.get('data', []):
+            try:
+                rows = list(_message_rows(conversation))
+            except (KeyError, TypeError, ValueError) as ex:
+                logfunc(f'Kijiji: skipping malformed conversation: {ex}')
+                continue
+            data_list.extend(rows)
+            had_data = had_data or bool(rows)
+        if had_data:
+            sources.append(context.get_relative_path(file_found))
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
Modernizes Kijiji chat messages (`conversation_cache` JSON) to the LAVA pipeline. Single report, context form.

## Changes
- v1 `__artifacts__` → `__artifacts_v2__`; `get_kijijiConversations` → `kijijiConversations`.
- **Timestamp correctness**: the original used naive `datetime.fromtimestamp(int(sentDate) + 978307200)`, which renders in the *processing machine's* local timezone and was mislabeled `Timestamp (Local Time)`. Since `sentDate` is Cocoa/Mac absolute time, it now uses `convert_cocoa_core_data_ts_to_utc` → proper **UTC**.
- Now processes **all** `conversation_cache` files (the original `return`ed after the first).
- Per-conversation `try/except` so one malformed thread is skipped rather than aborting the artifact. Preserved author **Terry Chabot (Krypterry)**.

## Validation
- pylint 10.00/10; compile/ast OK; no legacy refs.
- **Functional test**: sender 0 → 'Local User' as sender / counterparty as recipient; sender 1 → reversed; timestamps resolve to UTC (Cocoa 700000000 → 2023-03-08 20:26:40Z).
- Mandatory reserved-word audit PASS (incl. `state`, `message`). No external imports of `get_kijijiConversations`.