### PR TITLE
Convert bumble + googleDuo + imoHD_Chat to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/bumble.py
+++ b/scripts/artifacts/bumble.py
@@ -1,183 +1,131 @@
-# Module Description: Parses Bumble chat messages and some local user account details
-# Author: @KevinPagano3
-# Date: 2022-04-16
-# Artifact version: 0.0.1
-# Requirements: none
-
-import datetime
-import io
-import nska_deserialize as nd
-import sqlite3
-
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, kmlgen, tsv, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_bumble(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('Chat.sqlite'):
-            chat_db = file_found
-        if file_found.endswith('yap-database.sqlite'):
-            account_db = file_found
-        
-    db = open_sqlite_db_readonly(chat_db)
-    cursor = db.cursor()
-    cursor.execute('''
-    select
-    database2.data,
-    case secondaryIndex_isReadIndex.isIncoming
-        when 0 then 'Outgoing'
-        when 1 then 'Incoming'
-    end as "Direction",
-    case secondaryIndex_isReadIndex.isRead
-        when 0 then ''
-        when 1 then 'Yes'
-    end as "Message Read"
-    from database2
-    join secondaryIndex_isReadIndex on database2.rowid = secondaryIndex_isReadIndex.rowid
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []
-    bumble_datecreated = ''
-    bumble_datemodified = ''
-    bumble_message = ''
-    bumble_receiver = ''
-    bumble_sender = ''
-    
-    if usageentries > 0:
-        for row in all_rows:
-
-            plist_file_object = io.BytesIO(row[0])
-            if row[0] is None:
-                pass
-            else:
-                if row[0].find(b'NSKeyedArchiver') == -1:
-                    if sys.version_info >= (3, 9):
-                        plist = plistlib.load(plist_file_object)
-                    else:
-                        plist = biplist.readPlist(plist_file_object)
-                else:
-                    try:
-                        plist = nd.deserialize_plist(plist_file_object)
-                    except (nd.DeserializeError, nd.biplist.NotBinaryPlistException, nd.biplist.InvalidPlistException,
-                        nd.plistlib.InvalidFileException, nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError) as ex:
-                        logfunc(f'Failed to read plist for {row[0]}, error was:' + str(ex))
-                  
-            if 'self.dateCreated' in plist:
-                bumble_datecreated = datetime.datetime.utcfromtimestamp(plist['self.dateCreated'])
-                bumble_datemodified = datetime.datetime.utcfromtimestamp(plist['self.dateModified'])
-                bumble_sender = plist.get('self.fromPersonUid','')
-                bumble_receiver = plist.get('self.toPersonUid','')
-                bumble_message = plist.get('self.messageText','')
-            
-                data_list.append((bumble_datecreated, bumble_datemodified, bumble_sender, bumble_receiver, bumble_message, row[1], row[2]))
-            else: pass
-                
-        description = 'Bumble - Messages'
-        report = ArtifactHtmlReport('Bumble - Messages')
-        report.start_artifact_report(report_folder, 'Bumble - Messages')
-        report.add_script()
-        data_headers = (
-            'Created Timestamp','Modified Timestamp','Sender ID','Receiver ID','Message','Message Direction','Message Read')  # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        
-        report.write_artifact_data_table(data_headers, data_list, chat_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Bumble - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Bumble - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('Bumble - Messages data available')
-    
-    db = open_sqlite_db_readonly(account_db)
-    cursor = db.cursor()
-    cursor.execute('''
-    select
-    data,
-    key
-    from database2
-    where key = 'lastLocation' or key = 'appVersion' or key = 'userName' or key = 'userId'
-    ''')
-    
-    all_rows1 = cursor.fetchall()
-    usageentries = len(all_rows1)
-    data_list_account = []
-    
-    if usageentries > 0:
-        for row in all_rows1:
-
-            plist_file_object = io.BytesIO(row[0])
-            if row[0] is None:
-                pass
-            else:
-                if row[0].find(b'NSKeyedArchiver') == -1:
-                    if sys.version_info >= (3, 9):
-                        plist = plistlib.load(plist_file_object)
-                    else:
-                        plist = biplist.readPlist(plist_file_object)
-                else:
-                    try:
-                        plist = nd.deserialize_plist(plist_file_object)
-                    except (nd.DeserializeError, nd.biplist.NotBinaryPlistException, nd.biplist.InvalidPlistException,
-                        nd.plistlib.InvalidFileException, nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError) as ex:
-                        logfunc(f'Failed to read plist for {row[0]}, error was:' + str(ex))
-            
-            if row[1] == 'userId':
-                bumble_userId = plist.get('root','')
-                data_list_account.append(('User ID',str(bumble_userId)))
-                
-            elif row[1] == 'userName':
-                bumble_userName = plist.get('root','')
-                data_list_account.append(('User Name',str(bumble_userName)))
-                
-            elif row[1] == 'lastLocation':
-                bumble_timestamp = datetime.datetime.utcfromtimestamp(int(plist['kCLLocationCodingKeyTimestamp']) + 978307200)
-                bumble_lastlat = plist.get('kCLLocationCodingKeyRawCoordinateLatitude','')
-                bumble_lastlong = plist.get('kCLLocationCodingKeyRawCoordinateLongitude','') 
-                
-                data_list_account.append(('Timestamp',str(bumble_timestamp)))
-                data_list_account.append(('Last Latitude',bumble_lastlat))
-                data_list_account.append(('Last Longitude',bumble_lastlong))
-                
-            elif row[1] == 'appVersion':
-                bumble_appVersion = plist.get('root','')
-                data_list_account.append(('App Version',str(bumble_appVersion)))
-            
-            else: pass
-            
-        description = 'Bumble - Account Details'
-        report = ArtifactHtmlReport('Bumble - Account Details')
-        report.start_artifact_report(report_folder, 'Bumble - Account Details')
-        report.add_script()
-        data_headers_account = (
-            'Key', 'Values')  # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        
-        report.write_artifact_data_table(data_headers_account, data_list_account, account_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Bumble - Account Details'
-        tsv(report_folder, data_headers_account, data_list_account, tsvname)
-        
-        tlactivity = f'Bumble - Account Details'
-        timeline(report_folder, tlactivity, data_list_account, data_headers_account)
-        
-    else:
-        logfunc('No Bumble - Account Details data available')
-    
-    db.close()
-
-__artifacts__ = {
-    "bumble": (
-        "Bumble",
-        ('**/Library/Caches/Chat.sqlite*','**/Documents/yap-database.sqlite*'),
-        get_bumble)
+__artifacts_v2__ = {
+    "bumbleMessages": {
+        "name": "Bumble - Messages",
+        "description": "Bumble chat messages",
+        "author": "@KevinPagano3",
+        "version": "2.0",
+        "date": "2022-04-16",
+        "requirements": "none",
+        "category": "Bumble",
+        "notes": "",
+        "paths": ('**/Library/Caches/Chat.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle"
+    },
+    "bumbleAccount": {
+        "name": "Bumble - Account Details",
+        "description": "Bumble local user account details (user id/name, app version, last location)",
+        "author": "@KevinPagano3",
+        "version": "2.0",
+        "date": "2022-04-16",
+        "requirements": "none",
+        "category": "Bumble",
+        "notes": "Last location timestamp is Cocoa/Mac absolute time, converted to UTC.",
+        "paths": ('**/Documents/yap-database.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "user"
+    }
 }
+
+import io
+import plistlib
+
+import nska_deserialize as nd
+
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records, logfunc,
+                               convert_unix_ts_to_utc, convert_cocoa_core_data_ts_to_utc)
+
+_PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
+                 nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
+                 nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError)
+
+
+def _load_blob_plist(blob):
+    """Decode a YapDatabase value blob: NSKeyedArchiver via nska_deserialize, otherwise plain plist."""
+    if blob is None:
+        return None
+    obj = io.BytesIO(blob)
+    if blob.find(b'NSKeyedArchiver') == -1:
+        try:
+            return plistlib.load(obj)
+        except (plistlib.InvalidFileException, ValueError, OSError):
+            return None
+    try:
+        return nd.deserialize_plist(obj)
+    except _PLIST_ERRORS as ex:
+        logfunc(f'Bumble: failed to read plist, error was: {ex}')
+        return None
+
+
+@artifact_processor
+def bumbleMessages(context):
+    data_headers = (('Created Timestamp', 'datetime'), ('Modified Timestamp', 'datetime'),
+                    'Sender ID', 'Receiver ID', 'Message', 'Message Direction', 'Message Read')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('Chat.sqlite'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        database2.data,
+        CASE secondaryIndex_isReadIndex.isIncoming WHEN 0 THEN 'Outgoing' WHEN 1 THEN 'Incoming' END,
+        CASE secondaryIndex_isReadIndex.isRead WHEN 0 THEN '' WHEN 1 THEN 'Yes' END
+    FROM database2
+    JOIN secondaryIndex_isReadIndex ON database2.rowid = secondaryIndex_isReadIndex.rowid
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        plist = _load_blob_plist(row[0])
+        if not isinstance(plist, dict) or 'self.dateCreated' not in plist:
+            continue
+        data_list.append((convert_unix_ts_to_utc(plist['self.dateCreated']),
+                          convert_unix_ts_to_utc(plist.get('self.dateModified')),
+                          plist.get('self.fromPersonUid', ''), plist.get('self.toPersonUid', ''),
+                          plist.get('self.messageText', ''), row[1], row[2]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def bumbleAccount(context):
+    data_headers = ('Key', 'Value')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('yap-database.sqlite'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT data, key FROM database2
+    WHERE key IN ('lastLocation', 'appVersion', 'userName', 'userId')
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        plist = _load_blob_plist(row[0])
+        if not isinstance(plist, dict):
+            continue
+        key = row[1]
+        if key == 'userId':
+            data_list.append(('User ID', str(plist.get('root', ''))))
+        elif key == 'userName':
+            data_list.append(('User Name', str(plist.get('root', ''))))
+        elif key == 'appVersion':
+            data_list.append(('App Version', str(plist.get('root', ''))))
+        elif key == 'lastLocation':
+            ts = plist.get('kCLLocationCodingKeyTimestamp')
+            if ts is not None:
+                data_list.append(('Timestamp', str(convert_cocoa_core_data_ts_to_utc(int(ts)))))
+            data_list.append(('Last Latitude', plist.get('kCLLocationCodingKeyRawCoordinateLatitude', '')))
+            data_list.append(('Last Longitude', plist.get('kCLLocationCodingKeyRawCoordinateLongitude', '')))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -1,169 +1,122 @@
-import os
-import shutil
-import sqlite3
+__artifacts_v2__ = {
+    "googleDuoContacts": {
+        "name": "Google Duo - Contacts",
+        "description": "Google Duo contacts",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Google Duo", "notes": "",
+        "paths": ('*/Application Support/DataStore*',),
+        "output_types": "standard", "artifact_icon": "users"
+    },
+    "googleDuoCallHistory": {
+        "name": "Google Duo - Call History",
+        "description": "Google Duo call history",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Google Duo", "notes": "",
+        "paths": ('*/Application Support/DataStore*',),
+        "output_types": "standard", "artifact_icon": "phone"
+    },
+    "googleDuoClips": {
+        "name": "Google Duo - Clips",
+        "description": "Google Duo media clips (with thumbnails from ClipsCache)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Google Duo", "notes": "",
+        "paths": ('*/Application Support/DataStore*', '*/Application Support/ClipsCache/*.png'),
+        "output_types": "standard", "artifact_icon": "film"
+    }
+}
 
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, check_in_media
 
-def get_googleDuo(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
+
+def _find_datastore(context):
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        if not file_found.endswith('DataStore'):
-            continue
-        
-        db = open_sqlite_db_readonly(file_found)
-        cursor = db.cursor()
-            
-        cursor.execute('''
-        select
+        if file_found.endswith('DataStore'):
+            return file_found
+    return ''
+
+
+@artifact_processor
+def googleDuoContacts(context):
+    data_headers = (('Registration Date', 'datetime'), 'Name', 'ID', 'Number Label',
+                    ('Sync Date', 'datetime'))
+    data_list = []
+    db_path = _find_datastore(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
         datetime(contact_reg_data_timestamp/1000000, 'unixepoch'),
         contact_name,
         contact_id,
         contact_number_label,
         datetime(contact_sync_date/1000000, 'unixepoch')
-        from contact
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            description = 'Google Duo - Contacts'
-            report = ArtifactHtmlReport('Google Duo - Contacts')
-            report.start_artifact_report(report_folder, 'Google Duo - Contacts')
-            report.add_script()
-            data_headers = ('Registration Date','Name','ID','Number Label','Sync Date') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4]))
+    FROM contact
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Duo - Contacts'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Duo - Contacts'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('Google Duo - Contacts data available')
-            
-        cursor.execute('''
-        select
+
+@artifact_processor
+def googleDuoCallHistory(context):
+    data_headers = (('Timestamp', 'datetime'), 'Local User ID', 'Remote User ID', 'Contact Name',
+                    'Call Duration', 'Call Direction', 'Video Call?')
+    data_list = []
+    db_path = _find_datastore(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
         datetime(call_history.call_history_timestamp, 'unixepoch'),
         call_history.call_history_local_user_id,
         call_history.call_history_other_user_id,
         contact.contact_name,
-        strftime('%H:%M:%S',call_history.call_history_duration, 'unixepoch'),
-        case call_history.call_history_is_outgoing_call
-            when 0 then 'Incoming'
-            when 1 then 'Outgoing'
-        end,
-        case call_history.call_history_is_video_call
-            when 0 then ''
-            when 1 then 'Yes'
-        end
-        from call_history
-        left join contact on call_history.call_history_other_user_id = contact.contact_id
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            description = 'Google Duo - Call History'
-            report = ArtifactHtmlReport('Google Duo - Call History')
-            report.start_artifact_report(report_folder, 'Google Duo - Call History')
-            report.add_script()
-            data_headers = ('Timestamp','Local User ID','Remote User ID','Contact Name','Call Duration','Call Direction','Video Call?') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+        strftime('%H:%M:%S', call_history.call_history_duration, 'unixepoch'),
+        CASE call_history.call_history_is_outgoing_call WHEN 0 THEN 'Incoming' WHEN 1 THEN 'Outgoing' END,
+        CASE call_history.call_history_is_video_call WHEN 0 THEN '' WHEN 1 THEN 'Yes' END
+    FROM call_history
+    LEFT JOIN contact ON call_history.call_history_other_user_id = contact.contact_id
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Duo - Call History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Duo - Call History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('Google Duo - Call History data available')
-            
-        cursor.execute('''
-        select
+
+@artifact_processor
+def googleDuoClips(context):
+    data_headers = (('Creation Date', 'datetime'), ('Message Date', 'datetime'),
+                    ('Viewed Date', 'datetime'), 'Local User ID', 'Clip Direction',
+                    'Text Representation', 'Message ID', 'MD5 Checksum', 'Content Size',
+                    'Transferred Size', ('Clip', 'media'))
+    data_list = []
+    db_path = _find_datastore(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    files = [str(f) for f in context.get_files_found()]
+
+    query = '''
+    SELECT
         datetime(media_clip_creation_date/1000000, 'unixepoch'),
         datetime(media_clip_message_date/1000000, 'unixepoch'),
         datetime(media_clip_viewed_date/1000000, 'unixepoch'),
         media_clip_local_id,
-        case media_clip_source
-            when 0 then 'Received'
-            when 1 then 'Sent'
-        end,
+        CASE media_clip_source WHEN 0 THEN 'Received' WHEN 1 THEN 'Sent' END,
         media_clip_text_representation,
         media_clip_message_id,
         media_clip_md5_checksum,
         media_clip_content_size,
         media_clip_transferred_size
-        from media_clip_v2
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                
-                clip_creation = row[0]
-                clip_message = row[1]
-                clip_viewed = row[2]
-                local_id = row[3]
-                clip_direction = row[4]
-                text_rep = row[5]
-                message_id = row[6]
-                content_size = row[7]
-                transferred_size = row[8]
-                thumb = ''
-                
-                clip_name = str(message_id) + '.png'
-                print(clip_name)    
-                #Check for Clips
-                for match in files_found:
-                    if clip_name in match:
-                        shutil.copy2(match, report_folder)
-                        data_file_name = os.path.basename(match)
-                        thumb = f'<img src="{report_folder}/{data_file_name}" width="300"></img>'
-      
-                data_list.append((clip_creation, clip_message, clip_viewed, local_id, clip_direction ,text_rep, message_id, content_size, transferred_size, thumb))
-            
-            description = 'Google Duo - Clips'
-            report = ArtifactHtmlReport('Google Duo - Clips')
-            report.start_artifact_report(report_folder, 'Google Duo - Clips')
-            report.add_script()
-            data_headers = (
-                'Creation Date', 'Message Date', 'Viewed Date', 'Local User ID', 'Clip Direction','Text Representation', 'Message ID','Content Size', 'Transferred Size', 'Clip')  # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Clip'])
-            report.end_artifact_report()
-            
-            tsvname = f'Google Duo - Clips'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Duo - Clips'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('Google Duo - Clips data available')    
-            
-        db.close()
-        return
-
-__artifacts__ = {
-    "googleduo": (
-        "Google Duo",
-        ('*/Application Support/DataStore*','*/Application Support/ClipsCache/*.png'),
-        get_googleDuo)
-}
+    FROM media_clip_v2
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        clip_name = f'{row[6]}.png'
+        media_ref = ''
+        for match in files:
+            if clip_name in match:
+                media_ref = check_in_media(match)
+                break
+        data_list.append((*tuple(row), media_ref))
+    return data_headers, data_list, context.get_relative_path(db_path)

--- a/scripts/artifacts/imoHD_Chat.py
+++ b/scripts/artifacts/imoHD_Chat.py
@@ -1,154 +1,123 @@
-import sqlite3
+__artifacts_v2__ = {
+    "imoHDChatMessages": {
+        "name": "IMO HD Chat - Messages",
+        "description": "IMO HD chat messages and attachments",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "IMO HD Chat", "notes": "",
+        "paths": ('*/IMODb2.sqlite*',
+                  '*/mobile/Containers/Data/Application/*/Library/Caches/videos/*.webp'),
+        "output_types": "standard", "artifact_icon": "message-circle"
+    },
+    "imoHDChatContacts": {
+        "name": "IMO HD Chat - Contacts",
+        "description": "IMO HD chat contacts",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "IMO HD Chat", "notes": "",
+        "paths": ('*/IMODb2.sqlite*',),
+        "output_types": "standard", "artifact_icon": "users"
+    }
+}
+
 import io
-import json
-import os
-import shutil
+import plistlib
+
 import nska_deserialize as nd
 
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, kmlgen, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, check_in_media, logfunc
+
+_PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
+                 nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
+                 nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError)
 
 
-def get_imoHD_Chat(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
+def _load_blob_plist(blob):
+    """Decode a ZIMDATA value blob: NSKeyedArchiver via nska_deserialize, otherwise plain plist."""
+    if blob is None:
+        return None
+    obj = io.BytesIO(blob)
+    if blob.find(b'NSKeyedArchiver') == -1:
+        try:
+            return plistlib.load(obj)
+        except (plistlib.InvalidFileException, ValueError, OSError):
+            return None
+    try:
+        return nd.deserialize_plist(obj)
+    except _PLIST_ERRORS as ex:
+        logfunc(f'IMO HD Chat: failed to read plist, error was: {ex}')
+        return None
+
+
+def _find_db(context):
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        if file_found.endswith('.sqlite'):
-            break
-        
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    select
-    case ZIMOCHATMSG.ZTS
-        when 0 then ''
-        else datetime(ZTS/1000000000,'unixepoch')
-    end  as "Timestamp",
-    ZIMOCONTACT.ZDISPLAY as "Sender Display Name",
-    ZIMOCHATMSG.ZALIAS as "Sender Alias",
-    ZIMOCONTACT.ZDIGIT_PHONE,
-    ZIMOCHATMSG.ZTEXT as "Message",
-    case ZIMOCHATMSG.ZISSENT
-        when 0 then 'Received'
-        when 1 then 'Sent'
-    end as "Message Status",
-    ZIMOCHATMSG.ZIMDATA
-    from ZIMOCHATMSG
-    left join ZIMOCONTACT ON ZIMOCONTACT.ZBUID = ZIMOCHATMSG.ZA_UID
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
+        if file_found.endswith('IMODb2.sqlite'):
+            return file_found
+    return ''
+
+
+@artifact_processor
+def imoHDChatMessages(context):
+    data_headers = (('Timestamp', 'datetime'), 'Sender Name', 'Sender Alias', 'Sender Phone',
+                    'Message', 'Message Status', 'Item Action', 'Attachment URL',
+                    ('Attachment', 'media'))
     data_list = []
-    
-    if usageentries > 0:
-        for row in all_rows:
-            
-            plist = ''
-            timestamp = row[0]
-            senderName = row[1]
-            senderAlias = row[2]
-            senderPhone = row[3]
-            message = row[4]
-            messageStatus = row[5]
-            itemAction = ''
-            attachmentURL = ''
-            thumb = ''
-            
-            plist_file_object = io.BytesIO(row[6])
-            if row[6] is None:
-                pass
-            else:
-                if row[6].find(b'NSKeyedArchiver') == -1:
-                    if sys.version_info >= (3, 9):
-                        plist = plistlib.load(plist_file_object)
-                    else:
-                        plist = biplist.readPlist(plist_file_object)
-                else:
-                    try:
-                        plist = nd.deserialize_plist(plist_file_object)
-                    except (nd.DeserializeError, nd.biplist.NotBinaryPlistException, nd.biplist.InvalidPlistException,
-                        nd.plistlib.InvalidFileException, nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError) as ex:
-                        logfunc(f'Failed to read plist for {row[0]}, error was:' + str(ex))
-                    
-                itemAction = plist['type']
-                
-                #Check for Attachments
-                if plist.get('objects') is not None:
-                    attachmentName = plist['objects'][0]['object_id']
-                    attachmentURL = "https://cdn.imoim.us/s/object/" + attachmentName + "/"
-                    
-                    for match in files_found:
-                        if attachmentName in match:
-                            shutil.copy2(match, report_folder)
-                            data_file_name = os.path.basename(match)
-                            thumb = f'<img src="{report_folder}/{data_file_name}"  width="300"></img>'
-                    
-                else:
-                    attachmentURL = ''
-                    
-            data_list.append((timestamp, senderName, senderAlias, senderPhone, message, messageStatus, itemAction, attachmentURL, thumb))
-        
-        description = 'IMO HD Chat - Messages'
-        report = ArtifactHtmlReport('IMO HD Chat - Messages')
-        report.start_artifact_report(report_folder, 'IMO HD Chat - Messages')
-        report.add_script()
-        data_headers = (
-            'Timestamp', 'Sender Name', 'Sender Alias', 'Sender Phone', 'Message', 'Message Status', 'Item Action',
-            'Attachment URL', 'Attachment')  # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Attachment'])
-        report.end_artifact_report()
-        
-        tsvname = f'IMO HD Chat - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'IMO HD Chat - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('IMO HD Chat - Messages data available')
-        
-    cursor.execute('''
-    select
-    ZPH_NAME,
-    ZALIAS,
-    ZPHONE,
-    "https://cdn.imoim.us/s/object/" || ZICON_ID || "/" as "Profile Pic",
-    ZBUID
-    from ZIMOCONTACT
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        description = 'IMO HD Chat - Contacts'
-        report = ArtifactHtmlReport('IMO HD Chat - Contacts')
-        report.start_artifact_report(report_folder, 'IMO HD Chat - Contacts')
-        report.add_script()
-        data_headers = ('Contact Name','Contact Alias','Contact Phone','Profile Pic URL','User ID') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
+    db_path = _find_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    files = [str(f) for f in context.get_files_found()]
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'IMO HD Chat - Contacts'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'IMO HD Chat - Contacts'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('IMO HD Chat - Contacts data available')
-        
-    db.close()
+    query = '''
+    SELECT
+        CASE ZIMOCHATMSG.ZTS WHEN 0 THEN '' ELSE datetime(ZTS/1000000000, 'unixepoch') END,
+        ZIMOCONTACT.ZDISPLAY,
+        ZIMOCHATMSG.ZALIAS,
+        ZIMOCONTACT.ZDIGIT_PHONE,
+        ZIMOCHATMSG.ZTEXT,
+        CASE ZIMOCHATMSG.ZISSENT WHEN 0 THEN 'Received' WHEN 1 THEN 'Sent' END,
+        ZIMOCHATMSG.ZIMDATA
+    FROM ZIMOCHATMSG
+    LEFT JOIN ZIMOCONTACT ON ZIMOCONTACT.ZBUID = ZIMOCHATMSG.ZA_UID
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        item_action = ''
+        attachment_url = ''
+        media_ref = ''
+        plist = _load_blob_plist(row[6])
+        if isinstance(plist, dict):
+            item_action = plist.get('type', '')
+            objects = plist.get('objects')
+            if objects and isinstance(objects[0], dict):
+                attachment_name = objects[0].get('object_id')
+                if attachment_name:
+                    attachment_url = f'https://cdn.imoim.us/s/object/{attachment_name}/'
+                    for match in files:
+                        if attachment_name in match:
+                            media_ref = check_in_media(match)
+                            break
+        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], item_action,
+                          attachment_url, media_ref))
 
-__artifacts__ = {
-    "imoHD_Chat": (
-        "IMO HD Chat",
-        ('*/IMODb2.sqlite*','*/mobile/Containers/Data/Application/*/Library/Caches/videos/*.webp'),
-        get_imoHD_Chat)
-}
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def imoHDChatContacts(context):
+    data_headers = ('Contact Name', 'Contact Alias', 'Contact Phone', 'Profile Pic URL', 'User ID')
+    data_list = []
+    db_path = _find_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        ZPH_NAME,
+        ZALIAS,
+        ZPHONE,
+        'https://cdn.imoim.us/s/object/' || ZICON_ID || '/',
+        ZBUID
+    FROM ZIMOCONTACT
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(db_path)


### PR DESCRIPTION
Modernizes three messaging/comms apps to the LAVA pipeline. Each multi-report artifact is **split into one processor per report**; context form, UTC, framework media via `check_in_media`. Clustered as they're the same class of app.

## bumble → `bumbleMessages` + `bumbleAccount`
- **Reserved-word trap fixed**: the account header `('Key','Values')` sanitizes `Values`→ the SQL reserved word (same class as the #1565 `Values` crash) — renamed to **`Value`**.
- **Latent crash fixed**: the non-NSKeyedArchiver branch used `sys`/`plistlib`/`biplist` that were **never imported**. Now a shared `_load_blob_plist` (plistlib + nska_deserialize). Timestamps → aware **UTC**; guarded the `io.BytesIO(None)` ordering.

## googleDuo → `googleDuoContacts` + `googleDuoCallHistory` + `googleDuoClips`
- Clips media: `shutil.copy2` + inline `<img>` → **`check_in_media`** (`('Clip','media')`).
- **Off-by-one column bug fixed**: the original selected `media_clip_md5_checksum` but labeled it `Content Size`, shifting Content/Transferred and **dropping `transferred_size`**. Now MD5 Checksum / Content Size / Transferred Size are all mapped.
- Removed a stray debug `print()`.

## imoHD_Chat → `imoHDChatMessages` + `imoHDChatContacts`
- Same missing `sys`/`plistlib`/`biplist` import crash fixed via `_load_blob_plist`.
- Attachment media: `shutil.copy2` + inline `<img>` → **`check_in_media`**; guarded `plist['type']` (was an unguarded index on a failed/empty parse).

## Validation
- pylint 10.00/10; compile/ast OK; no legacy refs.
- **All 7 SQL queries executed against mock schemas** (syntax + column names valid).
- Mandatory reserved-word audit PASS for all 7 tables. No external imports of the old `get_*` names.