### PR TITLE
Convert teleguard to LAVA @artifact_processor (4-report split + media)

### DIFF
--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -1,202 +1,145 @@
-import sqlite3
-import json
-import plistlib
-import os
-import base64
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, media_to_html
-
-def get_teleguard(files_found, report_folder, seeker, wrap_text, time_offset):
-    
-    #datos =  seeker.search('**/*com.apple.mobile_container_manager.metadata.plist')
-    for file_foundm in files_found:
-        if file_foundm.endswith('.com.apple.mobile_container_manager.metadata.plist'):
-            with open(file_foundm, 'rb') as f:
-                pl = plistlib.load(f)
-                if pl['MCMMetadataIdentifier'] == 'ch.swisscows.messenger.teleguardapp':
-                    fulldir = (os.path.dirname(file_foundm))
-                    identifier = (os.path.basename(fulldir))
-                    mediafilepaths = seeker.search(f'*/{identifier}/Library/Caches/images/**')
-                    break
-                    
-    for file_found in files_found:
-        if file_found.endswith('teleguard_database.db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT
-                datetime(createDate/1000, 'unixepoch'),
-                datetime(userTime/1000, 'unixepoch'),
-                type,
-                sender,
-                receiver,
-                content,
-                metadata,
-                status,
-                isEdited
-                from messages
-            ''')
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Teleguard Messages')
-                report.start_artifact_report(report_folder, 'Teleguard Messages')
-                report.add_script()
-                data_headers = ('Timestamp', 'User Time', 'Type', 'Sender','Receiver','Content','Media','Status','Is Edited?')
-                data_list = []
-                for row in all_rows:
-                    if row[2] == 'MEDIA':
-                        mediainfo = row[6]
-                        mediainfo = json.loads(mediainfo)
-                        mediafiles = mediainfo.get('files','')
-                        if mediafiles != '':
-                            thumb = ''
-                            for key, values in mediafiles.items():
-                                #print(key,values)
-                                thumb = thumb + media_to_html(key, mediafilepaths, report_folder)
-                                thumb = thumb + f'<br>{values}</br><br></br>'
-                        else:
-                            thumb = ''
-                    else:
-                        thumb = row[6]
-                            
-                    
-                    
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], thumb, row[7], row[8]))
-        
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f'Teleguard Messages'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = 'Teleguard Messages'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Teleguard Messages data available')
-                
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT
-                datetime(createDate/1000, 'unixepoch'),
-                channelId,
-                header,
-                content,
-                type,
-                localStatus,
-                viewsCount,
-                likesCount,
-                dislikesCount,
-                metadata,
-                media
-                from posts
-            ''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10]))
-                    
-                report = ArtifactHtmlReport('Teleguard Posts')
-                report.start_artifact_report(report_folder, 'Teleguard Posts')
-                report.add_script()
-                data_headers = ('Timestamp', 'Channel ID', 'Header', 'Content','Type','Local Status','Views Count','Likes Count','Dislikes Count', 'Metadata', 'Media')
-                
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f'Teleguard Posts'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = 'Teleguard Posts'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Teleguard Posts available')
-                
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT
-                datetime(lastActivityTime/1000, 'unixepoch'),
-                serverId,
-                alias,
-                type,
-                color,
-                avatar,
-                options,
-                info,
-                datetime(lastVisitTime/1000, 'unixepoch'),
-                personalId
-                from contacts
-            ''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                data_list = []
-                for row in all_rows:
-                    if row[5] is not None:
-                        avatar = row[5]
-                        encoded_avatar = base64.b64encode(avatar).decode("utf-8")
-                        avatar = f'<img src="data:image/jpeg;base64,{encoded_avatar}" alt="image"width="300">'
-                    else:
-                        avatar = row[5]
-                        
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], avatar, row[6], row[7], row[8], row[9]))
-                    
-                report = ArtifactHtmlReport('Teleguard Contacts')
-                report.start_artifact_report(report_folder, 'Teleguard Contacts')
-                report.add_script()
-                data_headers = ('Last Activity Timestamp', 'Server ID', 'Alias', 'Type','Color','Avatar','Options','Info','Last Visit Time', 'Personal ID')
-                
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f'Teleguard Contacts'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = 'Teleguard Contacts'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Teleguard Contacts available')
-                
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT *
-                from
-                channels
-            ''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11]))
-                    
-                report = ArtifactHtmlReport('Teleguard Channels')
-                report.start_artifact_report(report_folder, 'Teleguard Channels')
-                report.add_script()
-                data_headers = ('ID', 'Alias', 'Description', 'Category','Color','Avatar ID','Subscribers Count','Admin','Posts Count', 'Is Deleted', 'Language','Type')
-                
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f'Teleguard Channels'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-            else:
-                logfunc('No Teleguard Channels available')
-    #db.close()
-
-__artifacts__ = {
-        "Teleguard": (
-                "Teleguard",
-                ('*/Shared/AppGroup/*/Library/teleguard_database.db*','*/.com.apple.mobile_container_manager.metadata.plist'),
-                get_teleguard)
+__artifacts_v2__ = {
+    "teleguardMessages": {
+        "name": "Teleguard Messages",
+        "description": "TeleGuard chat messages and shared media",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
+        "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',
+                  '*/Library/Caches/images/*'),
+        "output_types": "standard", "artifact_icon": "message-circle"
+    },
+    "teleguardPosts": {
+        "name": "Teleguard Posts",
+        "description": "TeleGuard channel posts",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
+        "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),
+        "output_types": "standard", "artifact_icon": "file-text"
+    },
+    "teleguardContacts": {
+        "name": "Teleguard Contacts",
+        "description": "TeleGuard contacts (with avatar thumbnails)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
+        "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),
+        "output_types": "standard", "artifact_icon": "users"
+    },
+    "teleguardChannels": {
+        "name": "Teleguard Channels",
+        "description": "TeleGuard channels",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Teleguard", "notes": "",
+        "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),
+        "output_types": "standard", "artifact_icon": "radio"
+    }
 }
+
+import json
+
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records, check_in_media,
+                               check_in_embedded_media)
+
+
+def _find_db(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('teleguard_database.db'):
+            return file_found
+    return ''
+
+
+@artifact_processor
+def teleguardMessages(context):
+    data_headers = (('Timestamp', 'datetime'), ('User Time', 'datetime'), 'Type', 'Sender',
+                    'Receiver', 'Content', 'Metadata', ('Media', 'media'), 'Status', 'Is Edited?')
+    data_list = []
+    db_path = _find_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(createDate/1000, 'unixepoch'),
+        datetime(userTime/1000, 'unixepoch'),
+        type, sender, receiver, content, metadata, status, isEdited
+    FROM messages
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        media_refs = []
+        if row[2] == 'MEDIA' and row[6]:
+            try:
+                files = (json.loads(row[6]) or {}).get('files') or {}
+            except (json.JSONDecodeError, TypeError, ValueError):
+                files = {}
+            for fname in files:
+                ref = check_in_media(fname)
+                if ref:
+                    media_refs.append(ref)
+        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6],
+                          media_refs or '', row[7], row[8]))
+
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def teleguardPosts(context):
+    data_headers = (('Timestamp', 'datetime'), 'Channel ID', 'Header', 'Content', 'Type',
+                    'Local Status', 'Views Count', 'Likes Count', 'Dislikes Count', 'Metadata', 'Media')
+    data_list = []
+    db_path = _find_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(createDate/1000, 'unixepoch'),
+        channelId, header, content, type, localStatus, viewsCount, likesCount,
+        dislikesCount, metadata, media
+    FROM posts
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def teleguardContacts(context):
+    data_headers = (('Last Activity Timestamp', 'datetime'), 'Server ID', 'Alias', 'Type', 'Color',
+                    ('Avatar', 'media'), 'Options', 'Info', ('Last Visit Time', 'datetime'),
+                    'Personal ID')
+    data_list = []
+    db_path = _find_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(lastActivityTime/1000, 'unixepoch'),
+        serverId, alias, type, color, avatar, options, info,
+        datetime(lastVisitTime/1000, 'unixepoch'),
+        personalId
+    FROM contacts
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        avatar = ''
+        if row[5] is not None:
+            avatar = check_in_embedded_media(db_path, row[5], f'teleguard_avatar_{row[1]}')
+        data_list.append((row[0], row[1], row[2], row[3], row[4], avatar, row[6], row[7], row[8], row[9]))
+
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def teleguardChannels(context):
+    data_headers = ('ID', 'Alias', 'Description', 'Category', 'Color', 'Avatar ID',
+                    'Subscribers Count', 'Admin', 'Posts Count', 'Is Deleted', 'Language', 'Type')
+    data_list = []
+    db_path = _find_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    for row in get_sqlite_db_records(db_path, 'SELECT * FROM channels'):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(db_path)


### PR DESCRIPTION
Modernizes TeleGuard (`teleguard_database.db`) to the LAVA pipeline. **Four reports → four processors**; context form, UTC, framework media.

## Split
`get_teleguard` → **`teleguardMessages`**, **`teleguardPosts`**, **`teleguardContacts`**, **`teleguardChannels`**.

## Media migration
- **Messages**: the original conflated metadata text and media into one `Media` column. Now a text **`Metadata`** column (raw) + a proper **`('Media','media')`** column that holds a **list of `check_in_media` refs** (the framework renders all of them) for `MEDIA`-type messages — replacing `media_to_html`. Since the `check_in_media` filename lookup is **artifact-scoped** (only indexes `files_found`), the images cache glob was added to `paths`, replacing the old metadata-plist + `seeker.search` container lookup.
- **Contacts**: avatar BLOB now rendered via **`check_in_embedded_media`** (was an inline base64 `<img>`).

## Timestamps
All `createDate`/`userTime`/`lastActivityTime`/`lastVisitTime` are epoch **milliseconds** → `datetime(x/1000,'unixepoch')` = **UTC** (marked `datetime`).

## Validation
- pylint 10.00/10; compile/ast OK; no legacy refs (`media_to_html`/`base64`/`plistlib`/`seeker.search` all gone).
- **All 4 SQL queries executed against mock schemas**; reserved-word audit PASS for all 4 tables.
- **Note:** media rendering (message-image `check_in_media` resolution + avatar `check_in_embedded_media`) follows the standard pattern but was **not exercised against live TeleGuard data** — happy to validate with a test image. `teleguardChannels` keeps the original `SELECT *` (12 columns).