### PR TITLE
Convert the Safari Browser cluster (6 artifacts) to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/safariBookmarks.py
+++ b/scripts/artifacts/safariBookmarks.py
@@ -1,60 +1,37 @@
-import glob
-import os
-import pathlib
-import plistlib
-import sqlite3
-import json
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_safariBookmarks(files_found, report_folder, seeker, wrap_text, timezone_offset):
-	for file_found in files_found:
-		file_found = str(file_found)
-		
-		if file_found.endswith('.db'):
-			break
-		
-	db = open_sqlite_db_readonly(file_found)
-	cursor = db.cursor()
-
-	cursor.execute("""
-	SELECT
-		title,
-		url,
-		hidden
-	FROM
-	bookmarks
-			""")
-
-	all_rows = cursor.fetchall()
-	usageentries = len(all_rows)
-	data_list = []    
-	if usageentries > 0:
-		for row in all_rows:
-			data_list.append((row[0], row[1], row[2]))
-	
-		description = ''
-		report = ArtifactHtmlReport('Safari Browser Bookmarks')
-		report.start_artifact_report(report_folder, 'Bookmarks', description)
-		report.add_script()
-		data_headers = ('Title','URL','Hidden')     
-		report.write_artifact_data_table(data_headers, data_list, file_found)
-		report.end_artifact_report()
-		
-		tsvname = 'Safari Browser Bookmarks'
-		tsv(report_folder, data_headers, data_list, tsvname)
-		
-	else:
-		logfunc('No data available in table')
-	
-	db.close()
-	return 
-
-__artifacts__ = {
-    "safariBookmarks": (
-        "Safari Browser",
-        ('**/Safari/Bookmarks.db*'),
-        get_safariBookmarks)
+__artifacts_v2__ = {
+    "safariBookmarks": {
+        "name": "Safari Browser - Bookmarks",
+        "description": "Safari bookmarks",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Safari Browser",
+        "notes": "",
+        "paths": ('**/Safari/Bookmarks.db*',),
+        "output_types": "standard",
+        "artifact_icon": "bookmark"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def safariBookmarks(context):
+    data_headers = ('Title', 'URL', 'Hidden')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('Bookmarks.db'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    for row in get_sqlite_db_records(source_path, 'SELECT title, url, hidden FROM bookmarks'):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariFavicons.py
+++ b/scripts/artifacts/safariFavicons.py
@@ -1,63 +1,49 @@
-import sqlite3
-import os
-
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, tsv, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_safariFavicons(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('Favicons.db'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    Select 
-    datetime('2001-01-01', "timestamp" || ' seconds') as icon_timestamp,
-    page_url.url,
-    icon_info.url,
-    icon_info.width,
-    icon_info.height,
-    icon_info.has_generated_representations
-    FROM icon_info
-    LEFT JOIN page_url
-    on icon_info.uuid = page_url.uuid
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5]))
-
-        description = 'Safari Favicons'
-        report = ArtifactHtmlReport('Favicons')
-        report.start_artifact_report(report_folder, 'Favicons', description)
-        report.add_script()
-        data_headers = ('Timestamp', 'Page URL', 'Icon URL', 'Width', 'Height', 'Generated Representations?' )
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Safari Favicons'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Safari Favicons'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Safari Favicons data available')
-    
-    db.close()
-
-__artifacts__ = {
-    "safariFavicons": (
-        "Safari Browser",
-        ('*/Containers/Data/Application/*/Library/Image Cache/Favicons/Favicons.db*'),
-        get_safariFavicons)
+__artifacts_v2__ = {
+    "safariFavicons": {
+        "name": "Safari Browser - Favicons",
+        "description": "Safari favicon cache entries (page URL, icon URL, dimensions)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Safari Browser",
+        "notes": "",
+        "paths": ('*/Containers/Data/Application/*/Library/Image Cache/Favicons/Favicons.db*',),
+        "output_types": "standard",
+        "artifact_icon": "image"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def safariFavicons(context):
+    data_headers = (('Timestamp', 'datetime'), 'Page URL', 'Icon URL', 'Width', 'Height',
+                    'Generated Representations?')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('Favicons.db'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime('2001-01-01', "timestamp" || ' seconds'),
+        page_url.url,
+        icon_info.url,
+        icon_info.width,
+        icon_info.height,
+        icon_info.has_generated_representations
+    FROM icon_info
+    LEFT JOIN page_url ON icon_info.uuid = page_url.uuid
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariHistory.py
+++ b/scripts/artifacts/safariHistory.py
@@ -1,107 +1,62 @@
-# Module Description: Parses Safari web history visits
-# Author: @KevinPagano3
-# Date: 2023-02-14
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import sqlite3
-import textwrap
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
-
-def get_safariHistory(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('.db'):
-            break
-        
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    
-    cursor.execute("""
-    select
-    history_visits.id,
-    history_items.url
-    from history_visits
-    left join history_items on history_items.id = history_visits.history_item
-    order by history_visits.id
-    """)
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    dl_ref_dest = {}
-    if usageentries > 0:
-        for row in all_rows:
-            dl_ref_dest.update({str(row[0]): row[1]})
-    
-    cursor.execute("""
-    select
-    datetime(history_visits.visit_time + 978307200,'unixepoch'),
-    history_visits.title,
-    history_items.url,
-    history_items.visit_count,
-    history_visits.redirect_source,
-    history_visits.redirect_destination,
-    history_visits.id,
-    case history_visits.origin
-        when 0 then "Local Device"
-        when 1 then "iCloud Synced Device"
-    end
-    from history_visits
-    left join history_items on history_visits.history_item = history_items.id
-    """)
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []
-    
-    if usageentries > 0:
-        for row in all_rows:
-            timestamp = convert_ts_human_to_utc(row[0])
-            timestamp = convert_utc_human_to_timezone(timestamp, timezone_offset)
-            
-            redirect_source = ''
-            redirect_destination = ''
-            if str(row[4]) is None:
-                redirect_source = ''
-            else:
-                for key, value in dl_ref_dest.items():
-                    if str(row[4]) == key:
-                        redirect_source = value
-            if str(row[5]) is None:
-                redirect_destination = ''
-            else:
-                for key, value in dl_ref_dest.items():
-                    if str(row[5]) == key:
-                        redirect_destination = value
-        
-            data_list.append((timestamp, row[1], textwrap.fill(row[2], width=100), row[3], textwrap.fill(redirect_source, width=100), textwrap.fill(redirect_destination, width=100), row[6], row[7]))
-    
-        description = ''
-        report = ArtifactHtmlReport('Safari Browser - History')
-        report.start_artifact_report(report_folder, 'Safari Browser - History', description)
-        report.add_script()
-        data_headers = ('Visit Timestamp','Title','URL','Visit Count','Redirect Source','Redirect Destination','Visit ID','Origin')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Safari Browser - History'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Safari Browser - History'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Safari Browser - History data available in table')
-    
-    db.close()
-    
-__artifacts__ = {
-    "safariHistory": (
-        "Safari Browser",
-        ('**/Safari/History.db*'),
-        get_safariHistory)
+__artifacts_v2__ = {
+    "safariHistory": {
+        "name": "Safari Browser - History",
+        "description": "Safari web history visits",
+        "author": "@KevinPagano3",
+        "version": "2.0",
+        "date": "2023-02-14",
+        "requirements": "none",
+        "category": "Safari Browser",
+        "notes": "",
+        "paths": ('**/Safari/History.db*',),
+        "output_types": "standard",
+        "artifact_icon": "globe"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def safariHistory(context):
+    data_headers = (('Visit Timestamp', 'datetime'), 'Title', 'URL', 'Visit Count',
+                    'Redirect Source', 'Redirect Destination', 'Visit ID', 'Origin')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('History.db'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    # Map visit id -> url so redirect source/destination ids can be resolved to URLs
+    id_url = {}
+    for row in get_sqlite_db_records(source_path, '''
+        SELECT history_visits.id, history_items.url
+        FROM history_visits
+        LEFT JOIN history_items ON history_items.id = history_visits.history_item'''):
+        id_url[str(row[0])] = row[1]
+
+    query = '''
+    SELECT
+        datetime(history_visits.visit_time + 978307200, 'unixepoch'),
+        history_visits.title,
+        history_items.url,
+        history_items.visit_count,
+        history_visits.redirect_source,
+        history_visits.redirect_destination,
+        history_visits.id,
+        CASE history_visits.origin WHEN 0 THEN 'Local Device' WHEN 1 THEN 'iCloud Synced Device' END
+    FROM history_visits
+    LEFT JOIN history_items ON history_visits.history_item = history_items.id
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        redirect_source = id_url.get(str(row[4]), '') if row[4] is not None else ''
+        redirect_destination = id_url.get(str(row[5]), '') if row[5] is not None else ''
+        data_list.append((row[0], row[1], row[2], row[3], redirect_source, redirect_destination,
+                          row[6], row[7]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariRecentWebSearches.py
+++ b/scripts/artifacts/safariRecentWebSearches.py
@@ -1,49 +1,46 @@
-import biplist
-import plistlib
-import sys
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline
-
-def get_safariRecentWebSearches(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('.db'):
-            break
-        
-    with open(file_found, "rb") as fp:
-        try:
-            if sys.version_info >= (3, 9):
-                plist = plistlib.load(fp)
-            else:
-                plist = biplist.readPlist(fp)
-            searches = plist.get('RecentWebSearches', [])
-            for search in searches:
-                term = search.get('SearchString', '')
-                date = search.get('Date', '')
-                data_list.append((date, term))
-        except (biplist.InvalidPlistException, plistlib.InvalidFileException) as ex:
-            logfunc(f'Failed to read plist {file_found} ' + str(ex))
-                
-    if data_list:
-        report = ArtifactHtmlReport('Safari Recent WebSearches')
-        report.start_artifact_report(report_folder, 'Recent WebSearches')
-        report.add_script()
-        data_headers = ('Date','Search Term')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Recent WebSearches'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        timeline(report_folder, tsvname, data_list, data_headers)
-    else:
-        logfunc('No data for recent web searches')
-
-__artifacts__ = {
-    "safariRecentWebSearches": (
-        "Safari Browser",
-        ('**/Library/Preferences/com.apple.mobilesafari.plist'),
-        get_safariRecentWebSearches)
+__artifacts_v2__ = {
+    "safariRecentWebSearches": {
+        "name": "Safari Browser - Recent Web Searches",
+        "description": "Recent Safari web searches from com.apple.mobilesafari.plist",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Safari Browser",
+        "notes": "Search dates are stored as UTC in the plist.",
+        "paths": ('**/Library/Preferences/com.apple.mobilesafari.plist',),
+        "output_types": "standard",
+        "artifact_icon": "search"
+    }
 }
+
+import plistlib
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+@artifact_processor
+def safariRecentWebSearches(context):
+    data_headers = (('Date', 'datetime'), 'Search Term')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('com.apple.mobilesafari.plist'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    try:
+        with open(source_path, 'rb') as fp:
+            plist = plistlib.load(fp)
+    except (plistlib.InvalidFileException, ValueError, OSError) as ex:
+        logfunc(f'Failed to read plist {source_path}: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for search in plist.get('RecentWebSearches', []):
+        data_list.append((search.get('Date', ''), search.get('SearchString', '')))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -1,133 +1,110 @@
-import datetime
-import io
-import nska_deserialize as nd
-import sqlite3
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_safariTabs(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if not file_found.endswith('.db'):
-            continue
-        
-        if 'BrowserState' in file_found:
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-
-            cursor.execute("""
-            select
-            datetime(last_viewed_time+978307200,'unixepoch'), 
-            title, 
-            url, 
-            user_visible_url, 
-            opened_from_link, 
-            private_browsing
-            from
-            tabs
-            """)
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            data_list = []    
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5]))
-            
-                description = ''
-                report = ArtifactHtmlReport('Safari Browser - Tabs (BrowserState)')
-                report.start_artifact_report(report_folder, 'Safari Browser - Tabs (BrowserState)', description)
-                report.add_script()
-                data_headers = ('Associated Timestamp','Title','URL','User Visible URL','Opened from Link', 'Private Browsing')     
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = 'Safari Browser - Tabs (BrowserState)'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = 'Safari Browser - Tabs (BrowserState)'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Safari Browser - Tabs (BrowserState) available in table')
-            
-            db.close()
-            
-        if 'CloudTabs' in file_found:
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-
-            cursor.execute("""
-            select
-            cloud_tabs.system_fields,
-            cloud_tabs.title,
-            cloud_tabs.url,
-            cloud_tab_devices.device_name,
-            cloud_tabs.device_uuid,
-            cloud_tabs.tab_uuid
-            from cloud_tabs
-            left join cloud_tab_devices on cloud_tab_devices.device_uuid = cloud_tabs.device_uuid
-            """)
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            data_list = []    
-            if usageentries > 0:
-                for row in all_rows:
-                
-                    plist_file_object = io.BytesIO(row[0])
-                    if row[0] is None:
-                        pass
-                    else:
-                        if row[0].find(b'NSKeyedArchiver') == -1:
-                            if sys.version_info >= (3, 9):
-                                plist = plistlib.load(plist_file_object)
-                            else:
-                                plist = biplist.readPlist(plist_file_object)
-                        else:
-                            try:
-                                plist = nd.deserialize_plist(plist_file_object)
-                            except (nd.DeserializeError, nd.biplist.NotBinaryPlistException, nd.biplist.InvalidPlistException,
-                                            nd.plistlib.InvalidFileException, nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError) as ex:
-                                logfunc(f'Failed to read plist for {row[0]}, error was:' + str(ex))
-                    
-                    for x in plist:
-                        for keys, values in x.items():
-                            if keys == 'RecordCtime':
-                                created_timestamp = values
-                            if keys == 'RecordMtime':
-                                modified_timestamp = values
-                            if keys == 'ModifiedByDevice':
-                                mod_dev = values
-                                
-                    data_list.append((created_timestamp, modified_timestamp, row[1], row[2], row[3], row[4], row[5], mod_dev))
-            
-                description = ''
-                report = ArtifactHtmlReport('Safari Browser - iCloud Tabs')
-                report.start_artifact_report(report_folder, 'Safari Browser - iCloud Tabs', description)
-                report.add_script()
-                data_headers = ('Created Timestamp','Modified Timestamp','Title','URL','Device Name','Device UUID','Tab UUID','Modified By')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = 'Safari Browser - iCloud Tabs'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = 'Safari Browser - iCloud Tabs'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Safari Browser - iCloud Tabs available in table')
-            
-            db.close()
-        
-
-__artifacts__ = {
-    "safariTabs": (
-        "Safari Browser",
-        ('**/Safari/BrowserState.db*','**/Safari/CloudTabs.db*'),
-        get_safariTabs)
+__artifacts_v2__ = {
+    "safariTabsBrowserState": {
+        "name": "Safari Browser - Tabs (BrowserState)",
+        "description": "Open Safari tabs from BrowserState.db",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Safari Browser", "notes": "",
+        "paths": ('**/Safari/BrowserState.db*',),
+        "output_types": "standard", "artifact_icon": "layout"
+    },
+    "safariTabsiCloud": {
+        "name": "Safari Browser - iCloud Tabs",
+        "description": "Safari iCloud (cloud) tabs synced across devices",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Safari Browser", "notes": "",
+        "paths": ('**/Safari/CloudTabs.db*',),
+        "output_types": "standard", "artifact_icon": "cloud"
+    }
 }
+
+import io
+import plistlib
+
+import nska_deserialize as nd
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+
+_PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
+                 nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
+                 nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError)
+
+
+def _load_blob_plist(blob):
+    """Decode a CloudKit system_fields blob: NSKeyedArchiver via nska_deserialize, else plain plist."""
+    if blob is None:
+        return None
+    obj = io.BytesIO(blob)
+    if blob.find(b'NSKeyedArchiver') == -1:
+        try:
+            return plistlib.load(obj)
+        except (plistlib.InvalidFileException, ValueError, OSError):
+            return None
+    try:
+        return nd.deserialize_plist(obj)
+    except _PLIST_ERRORS as ex:
+        logfunc(f'Safari iCloud Tabs: failed to read plist, error was: {ex}')
+        return None
+
+
+def _find(context, filename):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith(filename):
+            return file_found
+    return ''
+
+
+@artifact_processor
+def safariTabsBrowserState(context):
+    data_headers = (('Associated Timestamp', 'datetime'), 'Title', 'URL', 'User Visible URL',
+                    'Opened from Link', 'Private Browsing')
+    data_list = []
+    source_path = _find(context, 'BrowserState.db')
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(last_viewed_time + 978307200, 'unixepoch'),
+        title, url, user_visible_url, opened_from_link, private_browsing
+    FROM tabs
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def safariTabsiCloud(context):
+    data_headers = (('Created Timestamp', 'datetime'), ('Modified Timestamp', 'datetime'), 'Title',
+                    'URL', 'Device Name', 'Device UUID', 'Tab UUID', 'Modified By')
+    data_list = []
+    source_path = _find(context, 'CloudTabs.db')
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        cloud_tabs.system_fields, cloud_tabs.title, cloud_tabs.url,
+        cloud_tab_devices.device_name, cloud_tabs.device_uuid, cloud_tabs.tab_uuid
+    FROM cloud_tabs
+    LEFT JOIN cloud_tab_devices ON cloud_tab_devices.device_uuid = cloud_tabs.device_uuid
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        created = modified = mod_dev = ''
+        plist = _load_blob_plist(row[0])
+        if isinstance(plist, list):
+            for entry in plist:
+                if not isinstance(entry, dict):
+                    continue
+                for key, value in entry.items():
+                    if key == 'RecordCtime':
+                        created = value
+                    elif key == 'RecordMtime':
+                        modified = value
+                    elif key == 'ModifiedByDevice':
+                        mod_dev = value
+        data_list.append((created, modified, row[1], row[2], row[3], row[4], row[5], mod_dev))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariWebsearch.py
+++ b/scripts/artifacts/safariWebsearch.py
@@ -1,75 +1,58 @@
-import glob
-import os
-import pathlib
-import plistlib
-import sqlite3
-import json
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_safariWebsearch(files_found, report_folder, seeker, wrap_text, timezone_offset):
-	for file_found in files_found:
-		file_found = str(file_found)
-		
-		if file_found.endswith('History.db'):
-			db = open_sqlite_db_readonly(file_found)
-			cursor = db.cursor()
-		
-			cursor.execute("""
-			select
-			datetime(history_visits.visit_time+978307200,'unixepoch') ,
-			history_items.url,
-			history_items.visit_count,
-			history_visits.title,
-			case history_visits.origin
-			when 1 then "icloud synced"
-			when 0 then "visited local device"
-			else history_visits.origin
-			end "icloud sync",
-			history_visits.load_successful,
-			history_visits.id,
-			history_visits.redirect_source,
-			history_visits.redirect_destination
-			from history_items, history_visits 
-			where history_items.id = history_visits.history_item
-			and history_items.url like '%search?q=%'
-			"""
-			)
-		
-			all_rows = cursor.fetchall()
-			usageentries = len(all_rows)
-			
-	data_list = []    
-	if usageentries > 0:
-		for row in all_rows:
-			search = row[1].split('search?q=')[1].split('&')[0]
-			search = search.replace('+', ' ')
-			data_list.append((row[0], search, row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
-	
-		description = ''
-		report = ArtifactHtmlReport('Safari Browser')
-		report.start_artifact_report(report_folder, 'Search Terms', description)
-		report.add_script()
-		data_headers = ('Visit Time','Search Term','URL','Visit Count','Title','iCloud Sync','Load Successful','Visit ID','Redirect Source','Redirect Destination' )     
-		report.write_artifact_data_table(data_headers, data_list, file_found)
-		report.end_artifact_report()
-		
-		tsvname = 'Safari Web Search'
-		tsv(report_folder, data_headers, data_list, tsvname)
-		
-		tlactivity = 'Safari Web Search'
-		timeline(report_folder, tlactivity, data_list, data_headers)
-	else:
-		logfunc('No data available in table')
-	
-	db.close()
-	return 
-
-__artifacts__ = {
-    "safariWebsearch": (
-        "Safari Browser",
-        ('**/Safari/History.db*'),
-        get_safariWebsearch)
+__artifacts_v2__ = {
+    "safariWebsearch": {
+        "name": "Safari Browser - Search Terms",
+        "description": "Search-engine queries extracted from Safari History.db (search?q= URLs)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Safari Browser",
+        "notes": "",
+        "paths": ('**/Safari/History.db*',),
+        "output_types": "standard",
+        "artifact_icon": "search"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def safariWebsearch(context):
+    data_headers = (('Visit Time', 'datetime'), 'Search Term', 'URL', 'Visit Count', 'Title',
+                    'iCloud Sync', 'Load Successful', 'Visit ID', 'Redirect Source',
+                    'Redirect Destination')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('History.db'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(history_visits.visit_time + 978307200, 'unixepoch'),
+        history_items.url,
+        history_items.visit_count,
+        history_visits.title,
+        CASE history_visits.origin WHEN 1 THEN 'iCloud Synced' WHEN 0 THEN 'Visited Local Device'
+            ELSE history_visits.origin END,
+        history_visits.load_successful,
+        history_visits.id,
+        history_visits.redirect_source,
+        history_visits.redirect_destination
+    FROM history_items, history_visits
+    WHERE history_items.id = history_visits.history_item
+        AND history_items.url LIKE '%search?q=%'
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        url = row[1] or ''
+        search = url.split('search?q=')[1].split('&')[0].replace('+', ' ') if 'search?q=' in url else ''
+        data_list.append((row[0], search, row[1], row[2], row[3], row[4], row[5], row[6], row[7],
+                          row[8]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Modernizes the six **Safari Browser** old-style artifacts to the LAVA pipeline. Clustered (shared category/DBs). Context form; all timestamps **UTC** (every artifact drops `timezone_offset` — the `datetime(...+978307200,'unixepoch')` SQL already yields UTC).

| Artifact | Report(s) | Notable |
|----------|-----------|---------|
| `safariHistory` | History | Fixed the `str(None)` redirect-id guard; dropped `textwrap.fill` (LAVA wraps) |
| `safariBookmarks` | Bookmarks | Straight conversion |
| `safariFavicons` | Favicons | Cocoa-seconds timestamp via SQL |
| `safariRecentWebSearches` | Recent searches | Dropped biplist/`sys<3.9` fallback; fixed `endswith('.db')` misnomer (file is the `.plist`) |
| `safariTabs` → **`safariTabsBrowserState`** + **`safariTabsiCloud`** | Tabs + iCloud Tabs | Fixed the missing `sys`/`plistlib`/`biplist` import crash (shared `_load_blob_plist`) and a NameError on undefined `created`/`modified`/`mod_dev` when keys are absent |
| `safariWebsearch` | Search terms | Guarded the `search?q=` split + the undefined-`usageentries` structure |

## Validation
- pylint 10.00/10; compile/ast OK; no legacy refs (`timezone_offset`/`convert_utc_human_to_timezone`/`textwrap` all gone).
- **All main SELECTs executed against mock Safari schemas**; reserved-word audit PASS for all 7 tables. No external imports of the old `get_*` names.