### PR TITLE
Fix naive-datetime handling in lava_insert_sqlite_data (UTC normalization)

### DIFF
--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -404,11 +404,19 @@ def lava_insert_sqlite_data(table_name, data, object_columns, headers, column_ma
                 if isinstance(value, str):
                     try:
                         dt = datetime.datetime.fromisoformat(value)
+                        # Treat naive datetimes as UTC; otherwise int(dt.timestamp()) interprets the
+                        # value in the examiner machine's local tz, producing a wrong epoch off-UTC.
+                        if dt.tzinfo is None:
+                            dt = dt.replace(tzinfo=datetime.timezone.utc)
                         value = int(dt.timestamp())
                     except ValueError:
                         # If conversion fails, keep the original value
                         pass
                 elif isinstance(value, datetime.datetime):
+                    # Treat naive datetimes as UTC (the project convention is to store UTC) so the
+                    # subtraction below doesn't raise "can't subtract offset-naive and offset-aware".
+                    if value.tzinfo is None:
+                        value = value.replace(tzinfo=datetime.timezone.utc)
                     # Need to do it this way due to dates that could be before Epoch
                     epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
                     value = (value - epoch).total_seconds()


### PR DESCRIPTION
Fixes the reported crash **`can't subtract offset-naive and offset-aware datetimes`** (in `get_appleMapsSearchHistory`) — and a second, related timezone bug found while testing it.

## Root cause
`lava_insert_sqlite_data` converts `datetime`-typed columns to epoch seconds. Both of its branches assumed UTC-aware input:

1. **datetime object path** — subtracted the value from an *aware* epoch, so a **naive** datetime threw. Plist `<date>` values and NSDate (via `nska_deserialize`) are naive, so any artifact surfacing them in a datetime column crashed (appleMapsSearchHistory; and would crash my just-merged safariRecentWebSearches / safariTabsiCloud once those tables have rows).

2. **string path** ⚠️ *(discovered while testing)* — `int(datetime.fromisoformat(value).timestamp())` interprets a **naive ISO string in the examiner machine's local timezone**. SQL `datetime(...,'unixepoch')` returns **UTC** strings, so on any non-UTC machine **every artifact that returns a SQL-datetime string was stored with the wrong epoch, shifted by the local offset.** This silently affects a large number of artifacts (incl. most of the recent conversions) on non-UTC examiner machines.

## Fix
Both branches now normalize a naive datetime to UTC (`value.replace(tzinfo=timezone.utc)`) before converting — matching the project convention to store UTC.

```python
# object path
if value.tzinfo is None:
    value = value.replace(tzinfo=datetime.timezone.utc)
epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
value = (value - epoch).total_seconds()

# string path
dt = datetime.datetime.fromisoformat(value)
if dt.tzinfo is None:
    dt = dt.replace(tzinfo=datetime.timezone.utc)
value = int(dt.timestamp())
```

**Safety:** aware datetimes and UTC machines are unaffected; the object path crashed 100% before, so it can only fix. The string-path change *does* shift stored epochs to the correct UTC value on non-UTC machines (a correctness fix, but a visible behavior change worth calling out).

## Verified end-to-end (real `lava_insert_sqlite_data`, in-memory db)
naive object, aware object, UTC string, aware ISO string → all `1678307200`; pre-1970 naive no longer raises.

## Lint
`lavafuncs.py` sits at 9.25/10 from **pre-existing** `global-statement` warnings (unrelated to this change; the same known debt #1509 merged through). These 8 added lines introduce no new warnings.