### PR TITLE
Harden the 3 naive-datetime artifacts to emit aware UTC (defense in depth)

### DIFF
--- a/scripts/artifacts/appleMapsSearchHistory.py
+++ b/scripts/artifacts/appleMapsSearchHistory.py
@@ -20,6 +20,7 @@ import blackboxprotobuf
 import base64
 import binascii
 import pprint
+from datetime import datetime, timezone
 
 from scripts.ilapfuncs import (
     artifact_processor,
@@ -90,7 +91,8 @@ def get_appleMapsSearchHistory(context):
                     for g, h in f.items():
                         
                         if g == 'modificationDate':
-                            modificationdate = h
+                            modificationdate = (h.replace(tzinfo=timezone.utc)
+                                                if isinstance(h, datetime) and h.tzinfo is None else h)
                         if g == 'contents':
                             
                             protostuff, _ = blackboxprotobuf.decode_message(h)

--- a/scripts/artifacts/safariRecentWebSearches.py
+++ b/scripts/artifacts/safariRecentWebSearches.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
 }
 
 import plistlib
+from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, logfunc
 
@@ -41,6 +42,9 @@ def safariRecentWebSearches(context):
         return data_headers, data_list, context.get_relative_path(source_path)
 
     for search in plist.get('RecentWebSearches', []):
-        data_list.append((search.get('Date', ''), search.get('SearchString', '')))
+        date = search.get('Date', '')
+        if isinstance(date, datetime) and date.tzinfo is None:
+            date = date.replace(tzinfo=timezone.utc)
+        data_list.append((date, search.get('SearchString', '')))
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
 
 import io
 import plistlib
+from datetime import datetime, timezone
 
 import nska_deserialize as nd
 
@@ -27,6 +28,13 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
 _PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
                  nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
                  nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError)
+
+
+def _aware_utc(value):
+    """Tag a naive datetime as UTC (RecordCtime/RecordMtime deserialize naive); pass others through."""
+    if isinstance(value, datetime) and value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
 
 
 def _load_blob_plist(blob):
@@ -105,6 +113,7 @@ def safariTabsiCloud(context):
                         modified = value
                     elif key == 'ModifiedByDevice':
                         mod_dev = value
-        data_list.append((created, modified, row[1], row[2], row[3], row[4], row[5], mod_dev))
+        data_list.append((_aware_utc(created), _aware_utc(modified), row[1], row[2], row[3],
+                          row[4], row[5], mod_dev))
 
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Follow-up to the framework fix [#1582](https://github.com/abrignoni/iLEAPP/pull/1582). With `lava_insert_sqlite_data` now normalizing naive→UTC centrally, these three already work — this PR makes them emit **aware** UTC datetimes at the source so they're correct independent of framework version (the belt-and-suspenders half of the agreed plan).

| Artifact | Naive source | Fix |
|----------|--------------|-----|
| `appleMapsSearchHistory` | `modificationDate` (plist `<date>`) | `.replace(tzinfo=utc)` when naive |
| `safariRecentWebSearches` | `RecentWebSearches[].Date` (plist `<date>`) | same |
| `safariTabsiCloud` | `RecordCtime`/`RecordMtime` (NSDate via `nska_deserialize`) | small `_aware_utc()` helper |

## Validation
- pylint **10.00/10** on all three (appleMapsSearchHistory was clean at 10.00 and stays there).
- **Functional test**: a plist `<date>` fed through `safariRecentWebSearches` now returns a **tz-aware** datetime; `_aware_utc` verified for naive/aware/empty inputs.
- Non-datetime/empty values pass through untouched.