### PR TITLE
Convert slack to LAVA @artifact_processor (8-function split)

### DIFF
--- a/scripts/artifacts/slack.py
+++ b/scripts/artifacts/slack.py
@@ -1,488 +1,342 @@
-from os.path import dirname, join
-import sqlite3
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
-
-
-def get_slack(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('main_db') or file_found.endswith('db.sqlite'):
-            break
-        
-        else:
-            continue
-    
-    deprecated = 0
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute("SELECT name FROM sqlite_master WHERE type='table'") 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    
-    if 'ModelDatabase' in file_found:
-        squery = ('''
-        select
-        datetime(ZCOREDATAMESSAGE.ZTIMESTAMP,'unixepoch'),
-        ZCOREDATAMESSAGE.ZUSERID as "Sender User ID",
-        ZCOREDATAUSER.ZREALNAME as "Sender Display Name",
-        ZCOREDATACONVERSATION.ZNAME as "Channel Name",
-        ZCOREDATAMESSAGE.ZTEXT as "Message",
-        ZCOREDATAMESSAGE.ZCONVERSATIONID as "Conversation ID",
-        ZCOREDATACONVERSATION.ZCONTEXTTEAMID as "Group ID"
-        from ZCOREDATAMESSAGE
-        left outer join ZCOREDATAUSER on ZCOREDATAMESSAGE.ZUSERID = ZCOREDATAUSER.ZTSID
-        left outer join ZCOREDATACONVERSATION ON ZCOREDATAMESSAGE.ZCONVERSATIONID = ZCOREDATACONVERSATION.ZTSID
-        ''')
-        
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
-                
-            description = 'Slack Messages'
-            report = ArtifactHtmlReport('Slack Messages')
-            report.start_artifact_report(report_folder, 'Slack Messages', description)
-            report.add_script()
-            data_headers = ('Timestamp', 'From', 'From Name', 'Channel Name', 'Message', 'Conversation ID','Group ID')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'Slack Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Slack Messages data available')
-    
-        squery = ('''
-        select
-        datetime(ZSERVERVERSION,'unixepoch'),
-        ZREALNAME,
-        ZFIRSTNAME,
-        ZLASTNAME,
-        ZNAME,
-        ZEMAIL,
-        ZPHONE,
-        ZTEAMID,
-        ZWORKSPACEORENTERPRISEID,
-        ZTSID,
-        CASE ZISME
-            WHEN 0 THEN ''
-            WHEN 1 THEN 'Yes'
-        END as "Local User",
-        CASE ZISOWNER
-            WHEN 0 THEN ''
-            WHEN 1 THEN 'Yes'
-        END as "Owner",
-        CASE ZISADMIN
-            WHEN 0 THEN ''
-            WHEN 1 THEN 'Yes'
-        END as "Admin",
-        CASE ZISBOT
-        WHEN 0 THEN ''
-            WHEN 1 THEN 'Yes'
-        END as "Bot",
-        ZTIMEZONE,
-        ZTIMEZONETITLE,
-        ZTIMEZONEOFFSET/3600 as "Timezone Offset (Hours)",
-        ZAVATARHASH,
-        ZCOLORSTRING
-        from ZCOREDATAUSER
-        ''')
-        
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14] , row[15] , row[16] , row[17], row[18] ))
-
-            description = 'Slack User Data'
-            report = ArtifactHtmlReport('Slack User Data')
-            report.start_artifact_report(report_folder, 'Slack User Data', description)
-            report.add_script()
-            data_headers = ('User Sync Timestamp','Real Name','First Name','Last Name','User Name','Email','Phone','Team ID','Workspace ID','User ID','Local User','Owner','Admin','Bot','Timezone','Timezone Title','Timezone Offset (Hours)','Avatar Hash','Color String')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack User Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Slack User data available')
-        
-        squery = ('''
-        select
-        datetime(ZCOREDATACONVERSATION.ZCREATED,'unixepoch') as "Created Timestamp",
-        datetime(ZCOREDATACONVERSATION.ZFIRSTMESSAGETIMESTAMP,'unixepoch') as "First Message Timestamp",
-        ZCOREDATACONVERSATION.ZCREATORID as "Creator ID",
-        ZCOREDATAUSER.ZREALNAME as "Creator Name",
-        ZCOREDATACONVERSATION.ZNAME as "Channel Name",
-        ZCOREDATACONVERSATION.ZTSID as "Channel ID",
-        ZCOREDATACONVERSATION.ZIMUSERID as "DM User ID",
-        ZCOREDATACONVERSATION.ZPURPOSETEXT as "Channel Description",
-        case ZCOREDATACONVERSATION.ZTYPE
-            when 0 then 'Channel'
-            when 2 then 'Direct Message'
-        end
-        from ZCOREDATACONVERSATION
-        left outer join ZCOREDATAUSER on ZCOREDATACONVERSATION.ZCREATORID = ZCOREDATAUSER.ZTSID
-        ''')
-        
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
-
-            description = 'Slack Channel Data'
-            report = ArtifactHtmlReport('Slack Channel Data')
-            report.start_artifact_report(report_folder, 'Slack Channel Data', description)
-            report.add_script()
-            data_headers = ('Created Timestamp','First Message Timestamp','Creator ID','Creator Name','Channel Name','Channel ID','DM User ID','Channel Description','Channel Type')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack Channel Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Slack Channel Data available')
-    
-    else:
-        for row in all_rows:
-            if 'ZSLKDEPRECATEDMESSAGE' in row[0]:
-                deprecated = 1
-                
-        if deprecated == 1:
-            squery = ('''
-            select distinct
-            datetime(ZSLKDEPRECATEDMESSAGE.ZTIMESTAMP, 'unixepoch') as MessageTimeStamp,
-            ZSLKDEPRECATEDMESSAGE.ZUSERID as MessageGeneratedFrom,
-            ZSLKDEPRECATEDCOREDATAUSER.ZREALNAME as MessageGeneratedFromName,
-            ZSLKDEPRECATEDBASECHANNEL.ZNAME as MessageSentToChannelName,
-            ZSLKDEPRECATEDMESSAGE.ZTEXT,
-            json_extract(ZFILEIDS, '$[0]') as HasSharedFile,
-            ZSLKDEPRECATEDMESSAGE.ZCHANNELID,
-            ZSLKDEPRECATEDBASECHANNEL.ZTSID,
-            ZSLKDEPRECATEDBASECHANNEL.ZTSID1,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTSID
-            from ZSLKDEPRECATEDMESSAGE, ZSLKDEPRECATEDBASECHANNEL,ZSLKDEPRECATEDCOREDATAUSER
-            where  ZSLKDEPRECATEDCOREDATAUSER.ZTSID = ZSLKDEPRECATEDMESSAGE.ZUSERID and 
-            (ZSLKDEPRECATEDBASECHANNEL.ZTSID = ZSLKDEPRECATEDMESSAGE.ZCHANNELID or ZSLKDEPRECATEDBASECHANNEL.ZTSID1 = ZSLKDEPRECATEDMESSAGE.ZCHANNELID)
-            order by ZSLKDEPRECATEDMESSAGE.ZTIMESTAMP
-            ''')
-        else:
-            squery = ('''
-            select distinct 
-            datetime(ZSLKMESSAGE.ZTIMESTAMP, 'unixepoch') as MessageTimeStamp,
-            ZSLKMESSAGE.ZUSERID as MessageGeneratedFrom,
-            ZSLKCOREDATAUSER.ZREALNAME as MessageGeneratedFromName,
-            ZSLKBASECHANNEL.ZNAME as MessageSentToChannelName,
-            ZSLKMESSAGE.ZTEXT,
-            json_extract(ZFILEIDS, '$[0]') as HasSharedFile,
-            ZSLKMESSAGE.ZCHANNELID,
-            ZSLKBASECHANNEL.ZTSID,
-            ZSLKBASECHANNEL.ZTSID1,
-            ZSLKCOREDATAUSER.ZTSID
-            from ZSLKMESSAGE, ZSLKBASECHANNEL,ZSLKCOREDATAUSER
-            where  ZSLKCOREDATAUSER.ZTSID = ZSLKMESSAGE.ZUSERID and 
-            (ZSLKBASECHANNEL.ZTSID = ZSLKMESSAGE.ZCHANNELID or ZSLKBASECHANNEL.ZTSID1 = ZSLKMESSAGE.ZCHANNELID)
-            order by ZSLKMESSAGE.ZTIMESTAMP
-            ''')
-            
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9] ))
-                
-            description = 'Slack Messages'
-            report = ArtifactHtmlReport('Slack Messages')
-            report.start_artifact_report(report_folder, 'Slack Messages', description)
-            report.add_script()
-            data_headers = ('Timestamp', 'From', 'From Name', 'Channel Name', 'Message', 'Shared File', 'Channel ID','Channel SID', 'Channel SID1','User SID' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'Slack Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Slack Messages data available')
-            
-        if deprecated == 1:
-            squery = ('''
-            select 
-            ZSLKDEPRECATEDCOREDATAUSER.ZADMIN,
-            ZSLKDEPRECATEDCOREDATAUSER.ZOWNER,
-            ZSLKDEPRECATEDCOREDATAUSER.ZREALNAME,
-            ZSLKDEPRECATEDCOREDATAUSER.ZFIRSTNAME,
-            ZSLKDEPRECATEDCOREDATAUSER.ZLASTNAME,
-            ZSLKDEPRECATEDCOREDATAUSER.ZDISPLAYNAME,
-            ZSLKDEPRECATEDCOREDATAUSER.ZNAME,
-            ZSLKDEPRECATEDCOREDATAUSER.ZPHONE,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTIMEZONE,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTIMEZONEOFFSET,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTIMEZONETITLE,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTITLE,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTSID,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTEAMID
-            from ZSLKDEPRECATEDCOREDATAUSER
-            ''')
-        else:
-            squery = ('''
-            select 
-            ZSLKCOREDATAUSER.ZADMIN,
-            ZSLKCOREDATAUSER.ZOWNER,
-            ZSLKCOREDATAUSER.ZREALNAME,
-            ZSLKCOREDATAUSER.ZFIRSTNAME,
-            ZSLKCOREDATAUSER.ZLASTNAME,
-            ZSLKCOREDATAUSER.ZDISPLAYNAME,
-            ZSLKCOREDATAUSER.ZNAME,
-            ZSLKCOREDATAUSER.ZPHONE,
-            ZSLKCOREDATAUSER.ZTIMEZONE,
-            ZSLKCOREDATAUSER.ZTIMEZONEOFFSET,
-            ZSLKCOREDATAUSER.ZTIMEZONETITLE,
-            ZSLKCOREDATAUSER.ZTITLE,
-            ZSLKCOREDATAUSER.ZTSID,
-            ZSLKCOREDATAUSER.ZTEAMID
-            from ZSLKCOREDATAUSER
-            ''')
-            
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13] ))
-
-            description = 'Slack User Data'
-            report = ArtifactHtmlReport('Slack User Data')
-            report.start_artifact_report(report_folder, 'Slack User Data', description)
-            report.add_script()
-            data_headers = ('Admin', 'Owner', 'Real Name', 'First Name', 'Last Name', 'Display Name', 'Name','Phone', 'Timezone','Timezone Offset', 'Timezone Title', 'Title', 'SID', 'Team ID' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack User Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Slack User data available')
-
-        if deprecated == 1:
-            squery = ('''
-            select distinct
-            datetime(ZSLKDEPRECATEDMESSAGE.ZTIMESTAMP, 'unixepoch') as MessageTimeStamp,   
-            ZSLKDEPRECATEDMESSAGE.ZUSERID as MessageGeneratedFrom,
-            ZSLKDEPRECATEDCOREDATAUSER.ZREALNAME as MessageGeneratedFromName,
-            ZSLKDEPRECATEDBASECHANNEL.ZNAME as MessageSentToChannelName,
-            ZSLKDEPRECATEDMESSAGE.ZTEXT,
-            json_extract(ZFILEIDS, '$[0]') as HasSharedFile,
-            ZSLKDEPRECATEDFILE.ZMODESTRING,
-            ZSLKDEPRECATEDFILE.ZTITLE,
-            ZSLKDEPRECATEDFILE.ZTYPESTRING,
-            datetime(ZSLKDEPRECATEDFILE.ZTIMESTAMPNUMBER, 'unixepoch') as FileTimeStamp,
-            ZSLKDEPRECATEDFILE.ZPREVIEW,
-            ZSLKDEPRECATEDFILE.ZSIZE, 
-            ZSLKDEPRECATEDFILE.ZPRIVATEDOWNLOADURL,
-            ZSLKDEPRECATEDFILE.ZPERMALINKURL,  
-            ZSLKDEPRECATEDMESSAGE.ZCHANNELID,
-            ZSLKDEPRECATEDBASECHANNEL.ZTSID,
-            ZSLKDEPRECATEDBASECHANNEL.ZTSID1,
-            ZSLKDEPRECATEDCOREDATAUSER.ZTSID
-            from ZSLKDEPRECATEDMESSAGE, ZSLKDEPRECATEDBASECHANNEL,ZSLKDEPRECATEDCOREDATAUSER, ZSLKDEPRECATEDFILE
-            where  ZSLKDEPRECATEDCOREDATAUSER.ZTSID = ZSLKDEPRECATEDMESSAGE.ZUSERID and
-            (ZSLKDEPRECATEDBASECHANNEL.ZTSID = ZSLKDEPRECATEDMESSAGE.ZCHANNELID or ZSLKDEPRECATEDBASECHANNEL.ZTSID1 = ZSLKDEPRECATEDMESSAGE.ZCHANNELID) and
-            HasSharedFile = ZSLKDEPRECATEDFILE.ZTSID 
-            order by ZSLKDEPRECATEDMESSAGE.ZTIMESTAMP
-            ''')
-        else:
-            squery = ('''
-            select distinct 
-            datetime(ZSLKMESSAGE.ZTIMESTAMP, 'unixepoch') as MessageTimeStamp, 
-            ZSLKMESSAGE.ZUSERID as MessageGeneratedFrom,
-            ZSLKCOREDATAUSER.ZREALNAME as MessageGeneratedFromName,
-            ZSLKBASECHANNEL.ZNAME as MessageSentToChannelName,
-            ZSLKMESSAGE.ZTEXT,
-            json_extract(ZFILEIDS, '$[0]') as HasSharedFile,
-            ZSLKFILE.ZMODESTRING,
-            ZSLKFILE.ZTITLE,
-            ZSLKFILE.ZTYPESTRING,
-            datetime(ZSLKFILE.ZTIMESTAMP, 'unixepoch') as FileTimeStamp,
-            ZSLKFILE.ZPREVIEW,
-            ZSLKFILE.ZSIZE, 
-            ZSLKFILE.ZPRIVATEDOWNLOADURL,
-            ZSLKFILE.ZPERMALINKURL,  
-            ZSLKMESSAGE.ZCHANNELID,
-            ZSLKBASECHANNEL.ZTSID,
-            ZSLKBASECHANNEL.ZTSID1,
-            ZSLKCOREDATAUSER.ZTSID
-            from ZSLKMESSAGE, ZSLKBASECHANNEL,ZSLKCOREDATAUSER, ZSLKFILE
-            where  ZSLKCOREDATAUSER.ZTSID = ZSLKMESSAGE.ZUSERID and
-            (ZSLKBASECHANNEL.ZTSID = ZSLKMESSAGE.ZCHANNELID or ZSLKBASECHANNEL.ZTSID1 = ZSLKMESSAGE.ZCHANNELID) and
-            HasSharedFile = ZSLKFILE.ZTSID 
-            order by ZSLKMESSAGE.ZTIMESTAMP
-            ''')
-            
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17] ))
-                
-            description = 'Slack Attachments'
-            report = ArtifactHtmlReport('Slack Attachments')
-            report.start_artifact_report(report_folder, 'Slack Attachments', description)
-            report.add_script()
-            data_headers = ('Timestamp', 'From', 'From Name', 'Channel Name', 'Message', 'Shared File', 'Mode', 'Title', 'Type', 'File Timestamp', 'Preview', 'Size', 'Private Download URL', 'Permalink URL', 'Channel ID','Channel SID', 'Channel SID1','User SID' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack Attachments'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'Slack Attachments'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('No Slack User data available')
-        
-        if deprecated == 1:
-            squery = ('''
-            select
-            datetime(ZSLKDEPRECATEDBASECHANNEL.ZCREATED, 'unixepoch') as CreatedTime,
-            datetime(ZSLKDEPRECATEDBASECHANNEL.ZPURPOSELASTSET, 'unixepoch') as PurposeLastSet,
-            datetime(ZSLKDEPRECATEDBASECHANNEL.ZTOPICLASTSET, 'unixepoch') as TopicLastSet,
-            datetime(ZSLKDEPRECATEDBASECHANNEL.ZLATEST, 'unixepoch') as Latest,
-            ZSLKDEPRECATEDBASECHANNEL.ZNAME as ChannelNames,
-            ZSLKDEPRECATEDBASECHANNEL.ZTSID as DMChannels,
-            ZSLKDEPRECATEDBASECHANNEL.ZTSID1 as OtherChannels,
-            ZSLKDEPRECATEDBASECHANNEL.ZUSERID,
-            ZSLKDEPRECATEDBASECHANNEL.ZCREATORID,
-            ZSLKDEPRECATEDBASECHANNEL.ZPURPOSECREATORID,
-            ZSLKDEPRECATEDBASECHANNEL.ZPURPOSETEXT,
-            ZSLKDEPRECATEDBASECHANNEL.ZTOPICCREATORID,
-            ZSLKDEPRECATEDBASECHANNEL.ZTOPICTEXT
-            from ZSLKDEPRECATEDBASECHANNEL
-            ''')
-        else:
-            squery = ('''
-            select
-            datetime(ZSLKBASECHANNEL.ZCREATED, 'unixepoch') as CreatedTime,
-            datetime(ZSLKBASECHANNEL.ZPURPOSELASTSET, 'unixepoch') as PurposeLastSet,
-            datetime(ZSLKBASECHANNEL.ZTOPICLASTSET, 'unixepoch') as TopicLastSet,
-            datetime(ZSLKBASECHANNEL.ZLATEST, 'unixepoch') as Latest,
-            ZSLKBASECHANNEL.ZNAME as ChannelNames,
-            ZSLKBASECHANNEL.ZTSID as DMChannels,
-            ZSLKBASECHANNEL.ZTSID1 as OtherChannels,
-            ZSLKBASECHANNEL.ZUSERID,
-            ZSLKBASECHANNEL.ZCREATORID,
-            ZSLKBASECHANNEL.ZPURPOSECREATORID,
-            ZSLKBASECHANNEL.ZPURPOSETEXT,
-            ZSLKBASECHANNEL.ZTOPICCREATORID,
-            ZSLKBASECHANNEL.ZTOPICTEXT
-            from ZSLKBASECHANNEL
-            ''')
-            
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12] ))
-                
-            description = 'Slack Channel Data'
-            report = ArtifactHtmlReport('Slack Channel Data')
-            report.start_artifact_report(report_folder, 'Slack Channel Data', description)
-            report.add_script()
-            data_headers = ('Timestamp Created', 'Purpose Last Set', 'Topic Last Set', 'Latest', 'Channel Names','DM Channels', 'Other Channels', 'User ID', 'Creator ID', 'Purpose Creator ID', 'Purpose Text', 'Topic Creator ID', 'Topic Text' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Slack Channel Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'Slack Channel Data'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-            
-        else:
-            logfunc('No Slack Channel Data available')
-            
-        if deprecated == 1:
-            squery = ('''
-            select
-            ZSLKDEPRECATEDTEAM.ZNAME,
-            ZSLKDEPRECATEDTEAM.ZDOMAIN,
-            ZSLKDEPRECATEDTEAM.ZAUTHUSERID,
-            ZSLKDEPRECATEDTEAM.ZTSID
-            from ZSLKDEPRECATEDTEAM
-            ''')
-        else:
-            squery = ('''
-            select
-            ZSLKTEAM.ZNAME,
-            ZSLKTEAM.ZDOMAIN,
-            ZSLKTEAM.ZAUTHUSERID,
-            ZSLKTEAM.ZTSID
-            from ZSLKTEAM
-            ''')
-            
-        cursor.execute(squery) 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3] ))
-                
-            description = 'Slack Team Data'
-            report = ArtifactHtmlReport('Slack Team Data')
-            report.start_artifact_report(report_folder, 'Slack Team Data', description)
-            report.add_script()
-            data_headers = ('Name', 'Domain Name', 'Author User ID', 'SID' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Team Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Slack Workspace Data available')
-    
-__artifacts__ = {
-    "slack": (
-        "Slack",
-        ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*','*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*'),
-        get_slack)
+__artifacts_v2__ = {
+    "slackModelMessages": {
+        "name": "Slack - Messages (ModelDatabase)",
+        "description": "Slack chat messages from the newer ModelDatabase (ZCOREDATA*) schema",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
+        "output_types": "standard", "artifact_icon": "message-circle"
+    },
+    "slackModelUsers": {
+        "name": "Slack - User Data (ModelDatabase)",
+        "description": "Slack users from the newer ModelDatabase (ZCOREDATAUSER) schema",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
+        "output_types": "standard", "artifact_icon": "users"
+    },
+    "slackModelChannels": {
+        "name": "Slack - Channel Data (ModelDatabase)",
+        "description": "Slack channels/DMs from the newer ModelDatabase schema",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
+        "output_types": "standard", "artifact_icon": "hash"
+    },
+    "slackMessages": {
+        "name": "Slack - Messages",
+        "description": "Slack chat messages from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
+        "output_types": "standard", "artifact_icon": "message-circle"
+    },
+    "slackUsers": {
+        "name": "Slack - User Data",
+        "description": "Slack users from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
+        "output_types": "standard", "artifact_icon": "users"
+    },
+    "slackAttachments": {
+        "name": "Slack - Attachments",
+        "description": "Slack messages with shared file attachments (main_db)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
+        "output_types": "standard", "artifact_icon": "paperclip"
+    },
+    "slackChannels": {
+        "name": "Slack - Channel Data",
+        "description": "Slack channels from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
+        "output_types": "standard", "artifact_icon": "hash"
+    },
+    "slackTeams": {
+        "name": "Slack - Team Data",
+        "description": "Slack workspaces/teams from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "Slack", "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
+        "output_types": "standard", "artifact_icon": "briefcase"
+    }
 }
-    
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, does_table_exist_in_db
+
+
+def _find_model_db(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if 'ModelDatabase' in file_found and file_found.endswith('db.sqlite'):
+            return file_found
+    return ''
+
+
+def _find_main_db(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('main_db'):
+            return file_found
+    return ''
+
+
+def _slack_prefix(db_path):
+    """main_db tables are ZSLK*; older databases use ZSLKDEPRECATED*. Return the live prefix or None."""
+    if does_table_exist_in_db(db_path, 'ZSLKDEPRECATEDMESSAGE'):
+        return 'ZSLKDEPRECATED'
+    if does_table_exist_in_db(db_path, 'ZSLKMESSAGE'):
+        return 'ZSLK'
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ModelDatabase (newer ZCOREDATA* schema)
+# ---------------------------------------------------------------------------
+@artifact_processor
+def slackModelMessages(context):
+    data_headers = (('Timestamp', 'datetime'), 'Sender ID', 'Sender Name', 'Channel Name',
+                    'Message', 'Conversation ID', 'Group ID')
+    data_list = []
+    db_path = _find_model_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZCOREDATAMESSAGE.ZTIMESTAMP, 'unixepoch'),
+        ZCOREDATAMESSAGE.ZUSERID,
+        ZCOREDATAUSER.ZREALNAME,
+        ZCOREDATACONVERSATION.ZNAME,
+        ZCOREDATAMESSAGE.ZTEXT,
+        ZCOREDATAMESSAGE.ZCONVERSATIONID,
+        ZCOREDATACONVERSATION.ZCONTEXTTEAMID
+    FROM ZCOREDATAMESSAGE
+    LEFT OUTER JOIN ZCOREDATAUSER ON ZCOREDATAMESSAGE.ZUSERID = ZCOREDATAUSER.ZTSID
+    LEFT OUTER JOIN ZCOREDATACONVERSATION ON ZCOREDATAMESSAGE.ZCONVERSATIONID = ZCOREDATACONVERSATION.ZTSID
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def slackModelUsers(context):
+    data_headers = (('User Sync Timestamp', 'datetime'), 'Real Name', 'First Name', 'Last Name',
+                    'User Name', 'Email', 'Phone', 'Team ID', 'Workspace ID', 'User ID',
+                    'Local User', 'Owner', 'Admin', 'Bot', 'Timezone', 'Timezone Title',
+                    'Timezone Offset (Hours)', 'Avatar Hash', 'Color String')
+    data_list = []
+    db_path = _find_model_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZSERVERVERSION, 'unixepoch'),
+        ZREALNAME, ZFIRSTNAME, ZLASTNAME, ZNAME, ZEMAIL, ZPHONE, ZTEAMID,
+        ZWORKSPACEORENTERPRISEID, ZTSID,
+        CASE ZISME WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE ZISOWNER WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE ZISADMIN WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE ZISBOT WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        ZTIMEZONE, ZTIMEZONETITLE, ZTIMEZONEOFFSET/3600, ZAVATARHASH, ZCOLORSTRING
+    FROM ZCOREDATAUSER
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def slackModelChannels(context):
+    data_headers = (('Created Timestamp', 'datetime'), ('First Message Timestamp', 'datetime'),
+                    'Creator ID', 'Creator Name', 'Channel Name', 'Channel ID', 'DM User ID',
+                    'Channel Description', 'Channel Type')
+    data_list = []
+    db_path = _find_model_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZCOREDATACONVERSATION.ZCREATED, 'unixepoch'),
+        datetime(ZCOREDATACONVERSATION.ZFIRSTMESSAGETIMESTAMP, 'unixepoch'),
+        ZCOREDATACONVERSATION.ZCREATORID,
+        ZCOREDATAUSER.ZREALNAME,
+        ZCOREDATACONVERSATION.ZNAME,
+        ZCOREDATACONVERSATION.ZTSID,
+        ZCOREDATACONVERSATION.ZIMUSERID,
+        ZCOREDATACONVERSATION.ZPURPOSETEXT,
+        CASE ZCOREDATACONVERSATION.ZTYPE WHEN 0 THEN 'Channel' WHEN 2 THEN 'Direct Message' END
+    FROM ZCOREDATACONVERSATION
+    LEFT OUTER JOIN ZCOREDATAUSER ON ZCOREDATACONVERSATION.ZCREATORID = ZCOREDATAUSER.ZTSID
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+# ---------------------------------------------------------------------------
+# main_db (ZSLK* / ZSLKDEPRECATED* schema)
+# ---------------------------------------------------------------------------
+@artifact_processor
+def slackMessages(context):
+    data_headers = (('Timestamp', 'datetime'), 'Sender ID', 'Sender Name', 'Channel Name',
+                    'Message', 'Shared File', 'Channel ID', 'Channel SID', 'Channel SID1', 'User SID')
+    data_list = []
+    db_path = _find_main_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    p = _slack_prefix(db_path)
+    if not p:
+        return data_headers, data_list, context.get_relative_path(db_path)
+
+    query = f'''
+    SELECT DISTINCT
+        datetime({p}MESSAGE.ZTIMESTAMP, 'unixepoch'),
+        {p}MESSAGE.ZUSERID,
+        {p}COREDATAUSER.ZREALNAME,
+        {p}BASECHANNEL.ZNAME,
+        {p}MESSAGE.ZTEXT,
+        json_extract(ZFILEIDS, '$[0]'),
+        {p}MESSAGE.ZCHANNELID,
+        {p}BASECHANNEL.ZTSID,
+        {p}BASECHANNEL.ZTSID1,
+        {p}COREDATAUSER.ZTSID
+    FROM {p}MESSAGE, {p}BASECHANNEL, {p}COREDATAUSER
+    WHERE {p}COREDATAUSER.ZTSID = {p}MESSAGE.ZUSERID
+        AND ({p}BASECHANNEL.ZTSID = {p}MESSAGE.ZCHANNELID
+             OR {p}BASECHANNEL.ZTSID1 = {p}MESSAGE.ZCHANNELID)
+    ORDER BY {p}MESSAGE.ZTIMESTAMP
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def slackUsers(context):
+    data_headers = ('Admin', 'Owner', 'Real Name', 'First Name', 'Last Name', 'Display Name',
+                    'Name', 'Phone', 'Timezone', 'Timezone Offset', 'Timezone Title', 'Title',
+                    'SID', 'Team ID')
+    data_list = []
+    db_path = _find_main_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    p = _slack_prefix(db_path)
+    if not p:
+        return data_headers, data_list, context.get_relative_path(db_path)
+
+    query = f'''
+    SELECT
+        {p}COREDATAUSER.ZADMIN, {p}COREDATAUSER.ZOWNER, {p}COREDATAUSER.ZREALNAME,
+        {p}COREDATAUSER.ZFIRSTNAME, {p}COREDATAUSER.ZLASTNAME, {p}COREDATAUSER.ZDISPLAYNAME,
+        {p}COREDATAUSER.ZNAME, {p}COREDATAUSER.ZPHONE, {p}COREDATAUSER.ZTIMEZONE,
+        {p}COREDATAUSER.ZTIMEZONEOFFSET, {p}COREDATAUSER.ZTIMEZONETITLE, {p}COREDATAUSER.ZTITLE,
+        {p}COREDATAUSER.ZTSID, {p}COREDATAUSER.ZTEAMID
+    FROM {p}COREDATAUSER
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def slackAttachments(context):
+    data_headers = (('Timestamp', 'datetime'), 'Sender ID', 'Sender Name', 'Channel Name',
+                    'Message', 'Shared File', 'Mode', 'Title', 'Type', ('File Timestamp', 'datetime'),
+                    'Preview', 'Size', 'Private Download URL', 'Permalink URL', 'Channel ID',
+                    'Channel SID', 'Channel SID1', 'User SID')
+    data_list = []
+    db_path = _find_main_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    p = _slack_prefix(db_path)
+    if not p:
+        return data_headers, data_list, context.get_relative_path(db_path)
+    file_ts = 'ZTIMESTAMPNUMBER' if p == 'ZSLKDEPRECATED' else 'ZTIMESTAMP'
+
+    query = f'''
+    SELECT DISTINCT
+        datetime({p}MESSAGE.ZTIMESTAMP, 'unixepoch'),
+        {p}MESSAGE.ZUSERID,
+        {p}COREDATAUSER.ZREALNAME,
+        {p}BASECHANNEL.ZNAME,
+        {p}MESSAGE.ZTEXT,
+        json_extract(ZFILEIDS, '$[0]') as HasSharedFile,
+        {p}FILE.ZMODESTRING,
+        {p}FILE.ZTITLE,
+        {p}FILE.ZTYPESTRING,
+        datetime({p}FILE.{file_ts}, 'unixepoch'),
+        {p}FILE.ZPREVIEW,
+        {p}FILE.ZSIZE,
+        {p}FILE.ZPRIVATEDOWNLOADURL,
+        {p}FILE.ZPERMALINKURL,
+        {p}MESSAGE.ZCHANNELID,
+        {p}BASECHANNEL.ZTSID,
+        {p}BASECHANNEL.ZTSID1,
+        {p}COREDATAUSER.ZTSID
+    FROM {p}MESSAGE, {p}BASECHANNEL, {p}COREDATAUSER, {p}FILE
+    WHERE {p}COREDATAUSER.ZTSID = {p}MESSAGE.ZUSERID
+        AND ({p}BASECHANNEL.ZTSID = {p}MESSAGE.ZCHANNELID
+             OR {p}BASECHANNEL.ZTSID1 = {p}MESSAGE.ZCHANNELID)
+        AND HasSharedFile = {p}FILE.ZTSID
+    ORDER BY {p}MESSAGE.ZTIMESTAMP
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def slackChannels(context):
+    data_headers = (('Timestamp Created', 'datetime'), ('Purpose Last Set', 'datetime'),
+                    ('Topic Last Set', 'datetime'), ('Latest', 'datetime'), 'Channel Names',
+                    'DM Channels', 'Other Channels', 'User ID', 'Creator ID', 'Purpose Creator ID',
+                    'Purpose Text', 'Topic Creator ID', 'Topic Text')
+    data_list = []
+    db_path = _find_main_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    p = _slack_prefix(db_path)
+    if not p:
+        return data_headers, data_list, context.get_relative_path(db_path)
+
+    query = f'''
+    SELECT
+        datetime({p}BASECHANNEL.ZCREATED, 'unixepoch'),
+        datetime({p}BASECHANNEL.ZPURPOSELASTSET, 'unixepoch'),
+        datetime({p}BASECHANNEL.ZTOPICLASTSET, 'unixepoch'),
+        datetime({p}BASECHANNEL.ZLATEST, 'unixepoch'),
+        {p}BASECHANNEL.ZNAME, {p}BASECHANNEL.ZTSID, {p}BASECHANNEL.ZTSID1,
+        {p}BASECHANNEL.ZUSERID, {p}BASECHANNEL.ZCREATORID, {p}BASECHANNEL.ZPURPOSECREATORID,
+        {p}BASECHANNEL.ZPURPOSETEXT, {p}BASECHANNEL.ZTOPICCREATORID, {p}BASECHANNEL.ZTOPICTEXT
+    FROM {p}BASECHANNEL
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)
+
+
+@artifact_processor
+def slackTeams(context):
+    data_headers = ('Name', 'Domain Name', 'Author User ID', 'SID')
+    data_list = []
+    db_path = _find_main_db(context)
+    if not db_path:
+        return data_headers, data_list, ''
+    p = _slack_prefix(db_path)
+    if not p:
+        return data_headers, data_list, context.get_relative_path(db_path)
+
+    query = f'''
+    SELECT {p}TEAM.ZNAME, {p}TEAM.ZDOMAIN, {p}TEAM.ZAUTHUSERID, {p}TEAM.ZTSID
+    FROM {p}TEAM
+    '''
+    for row in get_sqlite_db_records(db_path, query):
+        data_list.append(tuple(row))
+    return data_headers, data_list, context.get_relative_path(db_path)


### PR DESCRIPTION
Modernizes Slack (the largest old-style artifact, 488 lines) to the LAVA pipeline. Solo PR — genuinely complex.

## Why 8 functions
Slack ships **two different schemas**: the newer **ModelDatabase** (`ZCOREDATA*`) and the older **main_db** (`ZSLK*`, with a `ZSLKDEPRECATED*` variant). The legacy `get_slack` branched on these and reused report *names* with **different column shapes** (e.g. "Slack Messages" = 7 cols on ModelDatabase vs 10 on main_db) — which can't be one LAVA table. So it splits into one `@artifact_processor` per (DB, report):

- **ModelDatabase:** `slackModelMessages`, `slackModelUsers`, `slackModelChannels`
- **main_db:** `slackMessages`, `slackUsers`, `slackAttachments`, `slackChannels`, `slackTeams`

Each is scoped to its own DB path glob, so it only fires for its schema.

## Fixes / cleanups
- **Reserved-word trap:** the `From`/`From Name` headers (sanitize to the SQL reserved word `from`) → **`Sender ID`/`Sender Name`** in all three message/attachment reports.
- **Deprecated duplication collapsed:** every main_db query existed twice (`ZSLK` vs `ZSLKDEPRECATED`). A `_slack_prefix()` helper picks the live prefix by table presence; the one differing column (FILE timestamp `ZTIMESTAMPNUMBER` vs `ZTIMESTAMP`) is handled explicitly.
- `datetime(...,'unixepoch')` values are UTC; `get_relative_path` on source.

## Validation (exhaustive)
- pylint **10.00/10**; compile/ast OK; no legacy refs.
- **All 13 query shapes executed against real mock databases** with sample rows — 3 ModelDatabase + 5 main_db × **both** `ZSLK`/`ZSLKDEPRECATED` prefixes — each returns the **exact column count** matching its headers.
- Reserved-word audit PASS for all 8 tables. No external imports of `get_slack`.