### PR TITLE
Convert protonMail to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/protonMail.py
+++ b/scripts/artifacts/protonMail.py
@@ -1,263 +1,206 @@
-import os
-import plistlib
-import pgpy
+__artifacts_v2__ = {
+    "protonMail": {
+        "name": "Proton Mail - Decrypted Emails",
+        "description": "Decrypted Proton Mail emails and attachments (requires the device keychain "
+                       "in scripts/keychain/)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "pgpy, pycryptodome, ccl_bplist; a keychain plist placed in scripts/keychain/",
+        "category": "Proton Mail",
+        "notes": "Decryption requires the device keychain plist in scripts/keychain/. Email bodies and "
+                 "attachments are decrypted with the account's PGP key. Message timestamps are Cocoa "
+                 "(Mac absolute) time, stored as UTC.",
+        "paths": ('*/group.ch.protonmail.protonmail.plist', '*/ProtonMail.sqlite*',
+                  '*/Containers/Data/Application/*/tmp/*'),
+        "output_types": "standard",
+        "artifact_icon": "mail"
+    }
+}
+
 import html
 import json
-import ccl_bplist
-import sqlite3
-import hashlib
-import random
-from scripts.filetype import guess_mime
-from base64 import b64encode, b64decode
-from datetime import datetime
+import os
+import plistlib
+from base64 import b64decode
 from io import BytesIO
-from Crypto.Cipher import AES
 from pathlib import Path
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, media_to_html
 
-def get_protonMail(files_found, report_folder, seeker, wrap_text, timezone_offset):
+import ccl_bplist
+import pgpy
+from Crypto.Cipher import AES
+
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records,
+                               check_in_embedded_media, convert_cocoa_core_data_ts_to_utc, logfunc)
+
+_DECODE_ERRORS = (KeyError, ValueError, TypeError, IndexError, plistlib.InvalidFileException)
+_IV_SIZE = 16
+
+_QUERY = '''SELECT
+    ZMESSAGE.ZTIME, ZMESSAGE.ZBODY, ZMESSAGE.ZMIMETYPE, ZMESSAGE.ZTOLIST, ZMESSAGE.ZREPLYTOS,
+    ZMESSAGE.ZSENDER, ZMESSAGE.ZTITLE, ZMESSAGE.ZISENCRYPTED, ZMESSAGE.ZNUMATTACHMENTS,
+    ZATTACHMENT.ZFILESIZE, ZATTACHMENT.ZFILENAME, ZATTACHMENT.ZMIMETYPE, ZATTACHMENT.ZHEADERINFO,
+    ZATTACHMENT.ZLOCALURL, ZATTACHMENT.ZKEYPACKET
+    FROM ZMESSAGE
+    LEFT JOIN ZATTACHMENT ON ZMESSAGE.Z_PK = ZATTACHMENT.ZMESSAGE'''
+
+
+def _build_keychain_values(plist):
+    """Collect the protonmail keychain account -> v_Data entries from the keychain plist."""
+    values = {}
+    rows = plist if isinstance(plist, list) else [dd for d in plist for dd in plist[d]]
+    for dd in rows:
+        if isinstance(dd, dict) and 'svce' in dd and 'protonmail' in str(dd['svce']):
+            values[dd['acct']] = dd['v_Data']
+    return values
+
+
+@artifact_processor
+def protonMail(context):
+    data_headers = (('Timestamp', 'datetime'), 'Sender', 'To Recipients', 'Reply To', 'Title',
+                    'Body', 'Mime', 'Is encrypted?', 'File Size', ('Attachment', 'media'),
+                    'Decrypted Attachment Filename', 'Type')
     data_list = []
 
-    p = Path(__file__).parents[1]
-    
-    my_path = Path(p).joinpath('keychain')
-  
-    #platform = is_platform_windows()
-    #if platform:
-    #  my_path = my_path.replace('/', '\\')
-    
-    if len(os.listdir(my_path)) == 1:
-      logfunc("No keychain provided")
-      return
-  
-    else:
-      file = os.listdir(my_path)
-      for x in file:
-        if x.endswith('plist'):
-          keychain_plist_path = Path(my_path).joinpath(x)
-    
-    for file_found in files_found:
-      if 'group.ch.protonmail.protonmail.plist' in file_found:
-        plist_name = file_found
-      if file_found.endswith('ProtonMail.sqlite'):
-        db_name = file_found
+    keychain_dir = Path(__file__).parents[1].joinpath('keychain')
+    if not keychain_dir.exists() or len(os.listdir(keychain_dir)) <= 1:
+        logfunc("No keychain provided")
+        return data_headers, data_list, ''
+    keychain_plist_path = ''
+    for name in os.listdir(keychain_dir):
+        if name.endswith('plist'):
+            keychain_plist_path = keychain_dir.joinpath(name)
+    if not keychain_plist_path:
+        logfunc("No keychain plist found in scripts/keychain/")
+        return data_headers, data_list, ''
 
-    with open(keychain_plist_path,'rb') as f :
-      plist = plistlib.load(f)
-      
-    keychainVal={}
-    if type(plist) == list:
-      for dd in plist:
-        if type(dd) == dict:        
-          if 'svce' in dd:
-            if 'protonmail' in str(dd['svce']) :
-              #print(dd)
-              keychainVal[dd['acct']]=dd['v_Data']
-    else:
-      for d in plist:
-        for dd in plist[d]:
-          if type(dd) == dict:        
-            if 'svce' in dd:
-              if 'protonmail' in str(dd['svce']):
-                #print(dd)
-                keychainVal[dd['acct']]=dd['v_Data']
+    plist_name = db_name = ''
+    files = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        files.append(file_found)
+        if 'group.ch.protonmail.protonmail.plist' in file_found:
+            plist_name = file_found
+        elif file_found.endswith('ProtonMail.sqlite'):
+            db_name = file_found
+    if not (plist_name and db_name):
+        logfunc("Proton Mail plist or database not found")
+        return data_headers, data_list, ''
+
+    with open(keychain_plist_path, 'rb') as f:
+        keychain_values = _build_keychain_values(plistlib.load(f))
     try:
-      mainKey = keychainVal[b'NoneProtection']
-    except:
-      logfunc("No Protonmail data in the key chain")
-      return
-    IVsize = 16
-    
-    def decryptWithMainKey(encrypted):
-      iv = encrypted[:IVsize]
-      cipher = AES.new(mainKey, AES.MODE_CTR, initial_value=iv, nonce=b'')
-      return cipher.decrypt(encrypted[IVsize:])
-    
-    with open(plist_name,'rb') as p :
-      prefplist = plistlib.load(p)
-      
-      
+        main_key = keychain_values[b'NoneProtection']
+    except KeyError:
+        logfunc("No Protonmail data in the key chain")
+        return data_headers, data_list, ''
+
+    def decrypt_with_main_key(encrypted):
+        iv = encrypted[:_IV_SIZE]
+        cipher = AES.new(main_key, AES.MODE_CTR, initial_value=iv, nonce=b'')
+        return cipher.decrypt(encrypted[_IV_SIZE:])
+
+    with open(plist_name, 'rb') as p:
+        prefplist = plistlib.load(p)
     enc_val = prefplist.get('authKeychainStoreKeyProtectedWithMainKey', 'empty')
-    if enc_val != 'empty':
-      pass
-    elif keychainVal[b'authKeychainStoreKeyProtectedWithMainKey']:
-      enc_val = keychainVal[b'authKeychainStoreKeyProtectedWithMainKey']
-    else:
-      logfunc('Decryption key not found in the keychain or the application plist.')
-      return
-  
-    dec_val = decryptWithMainKey(enc_val)
-    
-    keychainStorePlist1 = ccl_bplist.load(BytesIO(dec_val))
-    keychainStorePlist = ccl_bplist.load(BytesIO(keychainStorePlist1[0]))
-    keychainStore = ccl_bplist.deserialise_NsKeyedArchiver(keychainStorePlist, parse_whole_structure=True)
-    privateKeyCoderKey = keychainStore['root']['NS.objects'][0]['privateKeyCoderKey']
-    
-    key, _ = pgpy.PGPKey.from_blob(privateKeyCoderKey)
-    pwdKey = keychainStore['root']['NS.objects'][0]['AuthCredential.Password']
-    
+    if enc_val == 'empty':
+        enc_val = keychain_values.get(b'authKeychainStoreKeyProtectedWithMainKey')
+    if not enc_val or enc_val == 'empty':
+        logfunc('Decryption key not found in the keychain or the application plist.')
+        return data_headers, data_list, ''
+
+    keychain_store_plist1 = ccl_bplist.load(BytesIO(decrypt_with_main_key(enc_val)))
+    keychain_store_plist = ccl_bplist.load(BytesIO(keychain_store_plist1[0]))
+    keychain_store = ccl_bplist.deserialise_NsKeyedArchiver(keychain_store_plist,
+                                                            parse_whole_structure=True)
+    private_key = keychain_store['root']['NS.objects'][0]['privateKeyCoderKey']
+    key, _ = pgpy.PGPKey.from_blob(private_key)
+    pwd_key = keychain_store['root']['NS.objects'][0]['AuthCredential.Password']
+
     def decrypt_message(encm):
-      if('-----BEGIN PGP MESSAGE-----') in encm:
-        with key.unlock(pwdKey):
-          assert key.is_unlocked
-          message_from_blob = pgpy.PGPMessage.from_blob(encm)
-          decm = key.decrypt(message_from_blob).message
-          #print(decm)
-          return html.unescape(decm.encode('cp1252', errors='ignore').decode('utf8', errors='ignore'))
-      else:
+        if '-----BEGIN PGP MESSAGE-----' in encm:
+            with key.unlock(pwd_key):
+                assert key.is_unlocked
+                decm = key.decrypt(pgpy.PGPMessage.from_blob(encm)).message
+                return html.unescape(decm.encode('cp1252', errors='ignore').decode('utf8', errors='ignore'))
         return encm
-    
-    def decrypt_attachment(proton_path, out_path, key, pwdKey, keyPacket, encfilename, decfilename):
-      att = None
-      for r, _, f in os.walk(proton_path):
-        for file in f:
-          if encfilename in file:
-            att=os.path.join(r,file)
-            break
-      if att:
-        with key.unlock(pwdKey):
-          assert key.is_unlocked
-          with open(att, 'rb') as attfh:
-            buf = b64decode(keyPacket)
-            buf += attfh.read()
-            att_from_blob = pgpy.PGPMessage.from_blob(buf)
-            decatt = key.decrypt(att_from_blob).message
-            itemnum = str(random.random())
-            with open(os.path.join(out_path,itemnum+decfilename),'wb') as outatt:
-              outatt.write(decatt)
-            return os.path.join(out_path,itemnum+decfilename)
-      
-      return None
-      
-    db = open_sqlite_db_readonly(db_name)
-    cursor = db.cursor()
-    cursor.execute('''SELECT
-    ZMESSAGE.ZTIME,
-    ZMESSAGE.ZBODY,
-    ZMESSAGE.ZMIMETYPE,
-    ZMESSAGE.ZTOLIST,
-    ZMESSAGE.ZREPLYTOS,
-    ZMESSAGE.ZSENDER,
-    ZMESSAGE.ZTITLE,
-    ZMESSAGE.ZISENCRYPTED,
-    ZMESSAGE.ZNUMATTACHMENTS,
-    ZATTACHMENT.ZFILESIZE,
-    ZATTACHMENT.ZFILENAME,
-    ZATTACHMENT.ZMIMETYPE,
-    ZATTACHMENT.ZHEADERINFO,
-    ZATTACHMENT.ZLOCALURL,
-    ZATTACHMENT.ZKEYPACKET
-    FROM ZMESSAGE
-    LEFT JOIN ZATTACHMENT ON ZMESSAGE.Z_PK = ZATTACHMENT.ZMESSAGE
-              ''')
-    
-    all_rows = cursor.fetchall()
-    data_list = []	
-    if len(all_rows) > 0:
-      for row in all_rows:
-        aggregatorto = ''
-        aggregatorfor = ''
-        
-        time = row[0]
-        decryptedtime = datetime.fromtimestamp(time+978307200)
-        
+
+    def decrypt_attachment_bytes(proton_path, key_packet, encfilename):
+        att = None
+        for root_dir, _, names in os.walk(proton_path):
+            for fname in names:
+                if encfilename in fname:
+                    att = os.path.join(root_dir, fname)
+                    break
+            if att:
+                break
+        if not att:
+            return None
+        with key.unlock(pwd_key):
+            assert key.is_unlocked
+            with open(att, 'rb') as attfh:
+                buf = b64decode(key_packet) + attfh.read()
+                return key.decrypt(pgpy.PGPMessage.from_blob(buf)).message
+
+    for row in get_sqlite_db_records(db_name, _QUERY):
+        aggregatorto = aggregatorfor = ''
+        decryptedtime = convert_cocoa_core_data_ts_to_utc(row[0])
         decryptedbody = decrypt_message(row[1])
-        
         mime = row[2]
-        
-        to = json.loads(plistlib.loads(decryptWithMainKey(row[3]))[0])
-        for r in to:
-          address = r['Address']
-          name = r['Name']
-          aggregatorto = f"{address} {name}"
-          
-        try: 
-          replyto = json.loads(plistlib.loads(decryptWithMainKey(row[4]))[0])
-          for r in replyto:
-            address = r['Address']
-            name = r['Name']
-            aggregatorfor = f"{address} {name}"
-        except:
-          aggregatorfor = ''
-        
+
+        to = json.loads(plistlib.loads(decrypt_with_main_key(row[3]))[0])
+        aggregatorto = '; '.join(f"{r['Address']} {r['Name']}" for r in to)
         try:
-          sender = json.loads(plistlib.loads(decryptWithMainKey(row[5]))[0])
-          name = sender['Name']
-          address = sender['Address']
-          sender_info = f'{address} {name}'
-        except:
-          sender_info = '<Not Decoded>'
-        
-        title = plistlib.loads(decryptWithMainKey(row[6]))[0]
-        
+            replyto = json.loads(plistlib.loads(decrypt_with_main_key(row[4]))[0])
+            aggregatorfor = '; '.join(f"{r['Address']} {r['Name']}" for r in replyto)
+        except _DECODE_ERRORS:
+            aggregatorfor = ''
+        try:
+            sender = json.loads(plistlib.loads(decrypt_with_main_key(row[5]))[0])
+            sender_info = f"{sender['Address']} {sender['Name']}"
+        except _DECODE_ERRORS:
+            sender_info = '<Not Decoded>'
+        try:
+            title = plistlib.loads(decrypt_with_main_key(row[6]))[0]
+        except _DECODE_ERRORS:
+            title = '<Not Decoded>'
+
         isencrypted = row[7]
-        
-        ZNUMATTACHMENTS = row[8]
-        
-        ZFILESIZE = row[9]
-        
+        file_size = row[9]
         try:
-          ZFILENAME = plistlib.loads(decryptWithMainKey(row[10]))[0]
-        except:
-          ZFILENAME = ""
-          
+            decfilename = plistlib.loads(decrypt_with_main_key(row[10]))[0]
+        except _DECODE_ERRORS:
+            decfilename = ''
         try:
-          AMIMETYPE = plistlib.loads(decryptWithMainKey(row[11]))[0]
-        except:
-          AMIMETYPE = ""
-        
-        if row[12]:
-          zheaderinfo = decryptWithMainKey(row[12])
-        
-        attpath = ''
+            att_mimetype = plistlib.loads(decrypt_with_main_key(row[11]))[0]
+        except _DECODE_ERRORS:
+            att_mimetype = ''
+
+        attachment_ref = ''
         if row[13]:
-          encfilename = plistlib.loads(row[13])['$objects'][2].split('/')[-1]
-          guidi = plistlib.loads(row[13])['$objects'][2].split('/')[-4]
-          out_path = report_folder
-        
-          for match in files_found:
-            if f'/Data/Application/{guidi}/tmp/attachments' in match:
-              proton_path = match.split('/attachments')[0]
-              break
-            elif f'\\Data\\Application\\{guidi}\\tmp\\attachments' in match:
-              proton_path = match.split('\\attachments')[0]
-          
-          attpath = decrypt_attachment(proton_path, out_path, key, pwdKey, row[14], encfilename, ZFILENAME)
-          
-          mimetype = guess_mime(attpath)
-          
-          if 'video' in mimetype:
-            attpath = f'<video width="320" height="240" controls="controls"><source src="{attpath}" type="video/mp4">Your browser does not support the video tag.</video>'
-          elif 'image' in mimetype:
-            attpath = f'<img src="{attpath}"width="300"></img>'
-          else:
-            attpath = f'<a href="{attpath}"> Link to {mimetype} </>'
-        
-        data_list.append((decryptedtime, sender_info, aggregatorto, aggregatorfor, title, decryptedbody, mime, isencrypted, ZFILESIZE, attpath, ZFILENAME, AMIMETYPE))
-        
-        encfilename = ''
-        
-    if len(data_list) > 0:
-      report = ArtifactHtmlReport('Proton Mail - Decrypted Emails')
-      report.start_artifact_report(report_folder, 'Proton Mail - Decrypted Emails')
-      report.add_script()
-      data_headers = ('Timestamp', 'Sender', 'To', 'Reply To', 'Title', 'Body', 'Mime', 'Is encrypted?', 'File Size','Attachment','Decrypted Attachment Filename', 'Type')
-      report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Sender', 'To', 'Reply To', 'Body', 'File Name', 'Type','Attachment'])
-      report.end_artifact_report()
+            try:
+                objects = plistlib.loads(row[13])['$objects']
+                encfilename = objects[2].split('/')[-1]
+                guidi = objects[2].split('/')[-4]
+            except _DECODE_ERRORS:
+                encfilename = guidi = ''
+            proton_path = ''
+            if guidi:
+                for match in files:
+                    if f'/Data/Application/{guidi}/tmp/attachments' in match:
+                        proton_path = match.split('/attachments')[0]
+                        break
+                    if f'\\Data\\Application\\{guidi}\\tmp\\attachments' in match:
+                        proton_path = match.split('\\attachments')[0]
+                        break
+            if proton_path and encfilename:
+                decbytes = decrypt_attachment_bytes(proton_path, row[14], encfilename)
+                if decbytes:
+                    attachment_ref = check_in_embedded_media(db_name, bytes(decbytes),
+                                                             decfilename or encfilename)
 
-      tsvname = 'Proton Mail - Decrypted Emails'
-      tsv(report_folder, data_headers, data_list, tsvname)
-  
-      tlactivity = 'Proton Mail - Decrypted Emails'
-      timeline(report_folder, tlactivity, data_list, data_headers)
+        data_list.append((decryptedtime, sender_info, aggregatorto, aggregatorfor, title,
+                          decryptedbody, mime, isencrypted, file_size, attachment_ref, decfilename,
+                          att_mimetype))
 
-    else:
-      logfunc('No Proton Mail - Decrypted Emails')
-
-__artifacts__ = {
-    "protonMail": (
-        "Proton Mail",
-        ('*/group.ch.protonmail.protonmail.plist','*/ProtonMail.sqlite*','*/Containers/Data/Application/*/tmp/*'),
-        get_protonMail)
-}
+    return data_headers, data_list, context.get_relative_path(db_name)


### PR DESCRIPTION
Modernizes the Proton Mail email decryptor to the LAVA pipeline. Solo PR — crypto-sensitive. The **PGP/AES/ccl_bplist decryption flow is kept byte-identical**; only registration, plumbing, the timestamp, and media handling changed.

## Changes
- v1 `__artifacts__` → `__artifacts_v2__`; context form (`protonMail`).
- **Reserved-word trap fixed:** the `To` header sanitizes to the SQL reserved word `to` → renamed **`To Recipients`**.
- **Timestamp correctness:** was `datetime.fromtimestamp(ZTIME+978307200)` — a naive **local wall-clock** value (which the framework's naive→UTC normalization would then *mislabel* as UTC). Now `convert_cocoa_core_data_ts_to_utc` → correct aware **UTC**.
- **Attachments:** decrypted bytes → `check_in_embedded_media` (was decrypt-to-disk with a random filename + inline `<img>/<video>/<a>`); `('Attachment','media')` column.
- The five bare `except:` blocks → specific exception tuples (lint-clean). Aggregates **all** To/Reply-To recipients (was last-wins). Guarded the To/Title decode and attachment-objects parse. Dropped dead imports/vars.

## Validation
- pylint **10.00/10** (PGPy/pycryptodome/ccl_bplist are in requirements, so no import-errors); compile/ast OK; reserved-word audit PASS; no legacy refs; no external imports of `get_protonMail`.
- ⚠️ **The decryption + attachment media paths were NOT exercised against live keychain/ProtonMail data** — like the keychain/Waze/secretCalculator cases, this needs a real keychain (`scripts/keychain/`) + ProtonMail.sqlite to verify end-to-end. Happy to validate with test data.