### PR TITLE
Convert the iCloud cluster (iCloudWifi + icloudMeta + icloudSharedalbums)

### DIFF
--- a/scripts/artifacts/iCloudWifi.py
+++ b/scripts/artifacts/iCloudWifi.py
@@ -1,72 +1,60 @@
-import os
-import plistlib
+__artifacts_v2__ = {
+    "iCloudWifi": {
+        "name": "iCloud Wifi Networks",
+        "description": "Wi-Fi networks synced via iCloud (com.apple.wifid.plist)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "Wifi Connections",
+        "notes": "",
+        "paths": ('**/com.apple.wifid.plist',),
+        "output_types": "standard",
+        "artifact_icon": "wifi"
+    }
+}
 
+import plistlib
 from datetime import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows 
+from scripts.ilapfuncs import artifact_processor
 
 
-def get_iCloudWifi(files_found, report_folder, seeker, wrap_text, timezone_offset):
+@artifact_processor
+def iCloudWifi(context):
+    data_headers = ('BSSID', 'SSID', 'Added By', 'Enabled', ('Added At', 'datetime'))
     data_list = []
-    file_found = str(files_found[0])
-    with open(file_found, 'rb') as fp:
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('com.apple.wifid.plist'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    with open(source_path, 'rb') as fp:
         pl = plistlib.load(fp)
-        timestamp = ''
 
-        if 'values' in pl.keys():
-            for key, val in pl['values'].items():
-                network_name = key
+    for val in pl.get('values', {}).values():
+        if not isinstance(val, dict):
+            continue
+        info = val.get('value')
+        if not isinstance(info, dict):
+            continue
+        added_at = info.get('added_at')
+        if added_at:
+            try:
+                added_at = datetime.strptime(str(added_at), '%b  %d %Y %H:%M:%S')
+            except ValueError:
+                added_at = str(added_at)
+        else:
+            added_at = ''
+        data_list.append((str(info.get('BSSID', 'Not Available')),
+                          str(info.get('SSID_STR', 'Not Available')),
+                          str(info.get('added_by', 'Not Available')),
+                          str(info.get('enabled', 'Not Available')),
+                          added_at))
 
-                if type(val) == dict:
-                    for key2, val2 in val.items():
-                        if key2 == 'value':
-                            if type(val2) == dict:
-                                if 'BSSID' in val2:
-                                    bssid = str(val2['BSSID'])
-                                else:
-                                    bssid = 'Not Available'
-
-                                if 'SSID_STR' in val2:
-                                    ssid = str(val2['SSID_STR'])
-                                else:
-                                    ssid = 'Not Available'
-                                
-                                if 'added_by' in val2:
-                                    added_by = str(val2['added_by'])
-                                else:
-                                    added_by = 'Not Available'
-
-                                if 'enabled' in val2:
-                                    enabled = str(val2['enabled'])
-                                else:
-                                    enabled = 'Not Available'
-
-                                if 'added_at' in val2:
-                                    # Convert the value into a datetime object.
-                                    my_time2 = str(val2['added_at'])
-                                    datetime_obj = datetime.strptime(my_time2, '%b  %d %Y %H:%M:%S')
-                                    added_at = str(datetime_obj)
-                                else:
-                                    added_at = 'Not Available'
-                                data_list.append((bssid, ssid, added_by, enabled, added_at))
-
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('iCloud Wifi Networks')
-        report.start_artifact_report(report_folder, 'iCloud Wifi Networks')
-        report.add_script()
-        data_headers = ('BSSID','SSID', 'Added By', 'Enabled', 'Added At')     
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'iCloud Wifi Networks'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No data on iCloud WiFi networks')
-
-__artifacts__ = {
-    "iCloudWifi": (
-        "Wifi Connections",
-        ('**/com.apple.wifid.plist'),
-        get_iCloudWifi)
-}
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/icloudMeta.py
+++ b/scripts/artifacts/icloudMeta.py
@@ -1,70 +1,64 @@
-import json
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
-
-def get_icloudMeta(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    counter = 0
-    for file_found in files_found:
-        file_found = str(file_found)
-        counter = counter + 1
-        data_list = []
-        with open(file_found, "r") as filecontent:
-            for line in filecontent:
-                jsonconv = json.loads(line)
-                length = len(jsonconv)
-                for i in range(length):
-                    docid = (jsonconv[i].get('document_id', ''))
-                    parid = (jsonconv[i].get('parent_id', ''))
-                    name = (jsonconv[i].get('name', ''))
-                    typee = (jsonconv[i].get('type', ''))
-                    deleted= (jsonconv[i].get('deleted', ''))
-                    mtime = (jsonconv[i].get('mtime', ''))
-                    if mtime > 0:
-                        mtime = datetime.datetime.fromtimestamp(mtime/1000)
-                    else:
-                        mtime = ''
-                    ctime = (jsonconv[i].get('ctime', ''))
-                    if ctime > 0:
-                        ctime = datetime.datetime.fromtimestamp(ctime/1000)
-                    else:
-                        ctime = ''
-                    btime = (jsonconv[i].get('btime', ''))
-                    if btime > 0:
-                        btime = datetime.datetime.fromtimestamp(btime/1000)
-                    else:
-                        btime = ''
-                    size = (jsonconv[i].get('size', ''))
-                    zone = (jsonconv[i].get('zone', ''))
-                    exe = (jsonconv[i]['file_flags'].get('is_executable', ''))
-                    hid = (jsonconv[i]['file_flags'].get('is_hidden', ''))
-                    lasteditor = (jsonconv[i].get('last_editor_name', ''))
-                    if lasteditor:
-                        lasteditorname = json.loads(jsonconv[i]['last_editor_name'])
-                        lasteditorname = (lasteditorname.get('name', ''))
-                    else:
-                        lasteditorname = ''
-                    basehash = (jsonconv[i].get('basehash', ''))
-                    data_list.append((btime, ctime, mtime, name, lasteditorname, docid, parid, typee, deleted, size, zone, exe, hid))	
-            
-        
-            if len(data_list) > 0:
-                report = ArtifactHtmlReport('iCloud - File Metadata'+' '+str(counter))
-                report.start_artifact_report(report_folder, 'iCloud - File Metadata'+' '+str(counter))
-                report.add_script()
-                data_headers = ('Btime','Ctime','Mtime', 'Name', 'Last Editor Name', 'Doc ID', 'Parent ID', 'Type', 'Deleted?','Size', 'Zone', 'Executable?','Hidden?')   
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = 'iCloud - File Metadata'
-                tsv(report_folder, data_headers, data_list, tsvname)
-            else:
-                logfunc('No data available')
-
-__artifacts__ = {
-    "icloudmeta": (
-        "iCloud Returns",
-        ('*/iclouddrive/Metadata.txt'),
-        get_icloudMeta)
+__artifacts_v2__ = {
+    "icloudmeta": {
+        "name": "iCloud - File Metadata",
+        "description": "iCloud Drive file metadata parsed from Metadata.txt (iCloud Returns)",
+        "author": "",
+        "version": "2.0",
+        "date": "2026-06-23",
+        "requirements": "none",
+        "category": "iCloud Returns",
+        "notes": "btime/ctime/mtime are epoch milliseconds, stored as UTC.",
+        "paths": ('*/iclouddrive/Metadata.txt',),
+        "output_types": "standard",
+        "artifact_icon": "cloud"
+    }
 }
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+def _ms_to_utc(value):
+    """Epoch-milliseconds (UTC) to an aware UTC datetime; blank for missing/zero values."""
+    if isinstance(value, (int, float)) and value > 0:
+        return convert_unix_ts_to_utc(value)
+    return ''
+
+
+@artifact_processor
+def icloudmeta(context):
+    data_headers = (('Btime', 'datetime'), ('Ctime', 'datetime'), ('Mtime', 'datetime'), 'Name',
+                    'Last Editor Name', 'Doc ID', 'Parent ID', 'Type', 'Deleted?', 'Size', 'Zone',
+                    'Executable?', 'Hidden?')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        had_data = False
+        with open(file_found, 'r', encoding='utf-8') as filecontent:
+            for line in filecontent:
+                try:
+                    records = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                for rec in records:
+                    flags = rec.get('file_flags', {})
+                    last_editor = ''
+                    if rec.get('last_editor_name'):
+                        try:
+                            last_editor = json.loads(rec['last_editor_name']).get('name', '')
+                        except (json.JSONDecodeError, TypeError, AttributeError):
+                            last_editor = ''
+                    data_list.append((
+                        _ms_to_utc(rec.get('btime')), _ms_to_utc(rec.get('ctime')),
+                        _ms_to_utc(rec.get('mtime')), rec.get('name', ''), last_editor,
+                        rec.get('document_id', ''), rec.get('parent_id', ''), rec.get('type', ''),
+                        rec.get('deleted', ''), rec.get('size', ''), rec.get('zone', ''),
+                        flags.get('is_executable', ''), flags.get('is_hidden', '')))
+                    had_data = True
+        if had_data:
+            sources.append(context.get_relative_path(file_found))
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/icloudSharedalbums.py
+++ b/scripts/artifacts/icloudSharedalbums.py
@@ -1,168 +1,124 @@
-import plistlib
-import os
-from pathlib import Path
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows 
-
-def get_icloudSharedalbums(files_found, report_folder, seeker, wrap_text, timezone_offset):
-	data_list_sharedemails = []
-	data_list_sharedpersoninfos = []
-	data_list_sharedinfos = []
-	data_list_cloudinfo = []
-	
-	for file_found in files_found:
-		file_found = str(file_found)
-		pathedhead, pathedtail = os.path.split(file_found)
-		
-		if os.path.isfile(file_found):
-			if pathedtail == 'cloudSharedEmails.plist':
-				with open(file_found, "rb") as fp:        
-					pl = plistlib.load(fp)
-					for x, y in pl.items():
-						data_list_sharedemails.append((x, y))
-
-			elif pathedtail == 'cloudSharedPersonInfos.plist':
-				with open(file_found, "rb") as fp:        
-					pl = plistlib.load(fp)
-					for x, y in pl.items():
-						
-						email = ''
-						firstname = ''
-						lastname = ''
-						fullname = ''
-
-						for a, b in y.items():	
-							if a == 'email':
-								email = b
-							if a == 'firstName':
-								firstname = b
-							if a == 'fullName':
-								fullname = b
-							if a == 'emails':
-								email = b[0]
-							if a == 'lastName':
-								lastname = b
-						
-						file_found_persons = file_found
-						data_list_sharedpersoninfos.append((email, firstname, lastname, fullname, x))	
-		
-			elif pathedtail == 'Info.plist':
-				albumid = (os.path.basename(os.path.dirname(file_found)))
-				albumpath = file_found
-				#print(f'Info.plist album ID: {albumid}')
-				
-				cloudOwnerEmail = ''
-				
-				with open(file_found, "rb") as fp:        
-					pl = plistlib.load(fp)
-					
-					cloudOwnerEmail = ''
-					cloudownerfirstname = ''
-					cloudownerlastname  = ''
-					cloudpublicurlenabled  = ''
-					cloudsubscriptiondate = ''
-					cloudrelationshipstate  = ''
-					cloudownerhashedpersonid = ''
-					clowdoenweremail = ''
-					title = ''
-					
-					for x, y in pl.items():
-						#print(f'{x}: {y}')
-						if x == 'cloudOwnerEmail':
-							clowdoenweremail = y
-						if x == 'cloudOwnerFirstName':
-							cloudownerfirstname = y
-						if x == 'cloudOwnerLastName':
-							cloudownerlastname = y
-						if x == 'cloudPublicURLEnabled':
-							cloudpublicurlenabled = y
-						if x == 'cloudSubscriptionDate':
-							cloudsubscriptiondate = y
-						if x == 'cloudRelationshipState':
-							cloudrelationshipstate = y
-						if x == 'title':
-							albumtitle = y	
-						if x == 'cloudOwnerHashedPersonID':
-							cloudownerhashedpersonid = y
-						
-				data_list_sharedinfos.append((albumtitle, albumid, clowdoenweremail, cloudownerfirstname, cloudownerlastname, cloudpublicurlenabled, cloudsubscriptiondate, cloudrelationshipstate, cloudownerhashedpersonid, albumpath))
-
-			elif pathedtail == 'DCIM_CLOUD.plist':
-				albumid = (os.path.basename(os.path.dirname(file_found)))
-				albumpath = file_found
-				#print(f'Info.plist album ID: {albumid}')
-				with open(file_found, "rb") as fp:        
-					pl = plistlib.load(fp)
-					for x, y in pl.items():
-						if x == 'DCIMLastDirectoryNumber':
-							dcimlastdictnum = y
-						if x == 'DCIMLastFileNumber':
-							dcimlastfilenum = y
-					data_list_cloudinfo.append((albumid, dcimlastdictnum, dcimlastfilenum, albumpath))
-				
-		else:
-			pass
-			
-	if len(data_list_sharedinfos) > 0:
-		location = 'See report entry'
-		report = ArtifactHtmlReport('iCloud Shared Owner Info')
-		report.start_artifact_report(report_folder, 'iCloud Shared Owner Info')
-		report.add_script()
-		data_headers = ('Album Title','Album ID','Clowd Owner Email','Cloud Owner First Name','Clowd Owner Lastname','Cloud Public URL Enabled?','Cloud Subscription Date','Cloud Relationship State','Cloud Ownewr Hashed Person ID', 'File location' )     
-		report.write_artifact_data_table(data_headers, data_list_sharedinfos, location)
-		report.end_artifact_report()
-		
-		tsvname = 'iCloud Shared Owner Info'
-		tsv(report_folder, data_headers, data_list_sharedinfos, tsvname)
-	else:
-		logfunc('No iCloud Shared Owner Info')
-		
-	if len(data_list_cloudinfo) > 0:
-		location = 'See report entry'
-		report = ArtifactHtmlReport('iCloud Shared Album data')
-		report.start_artifact_report(report_folder, 'iCloud Shared Album Data')
-		report.add_script()
-		data_headers = ('Album Name', 'DCIM Last Directory Number','DCIM LAst File Number', 'File location' )     
-		report.write_artifact_data_table(data_headers, data_list_cloudinfo, location)
-		report.end_artifact_report()
-		
-		tsvname = 'iCloud Shared Album Data'
-		tsv(report_folder, data_headers, data_list_cloudinfo, tsvname)
-	else:
-		logfunc('No iCloud Shared Album Data')
-
-	if len(data_list_sharedpersoninfos) > 0:
-		location = file_found_persons
-		report = ArtifactHtmlReport('iCloud Shared Album Persons Info')
-		report.start_artifact_report(report_folder, 'iCloud Shared Person Info')
-		report.add_script()
-		data_headers = ('Email', 'Firstname','Lastname', 'Fullname', 'Identification' )     
-		report.write_artifact_data_table(data_headers, data_list_sharedpersoninfos, location)
-		report.end_artifact_report()
-		
-		tsvname = 'iCloud Shared Person Info'
-		tsv(report_folder, data_headers, data_list_sharedpersoninfos, tsvname)
-	else:
-		logfunc('No iCloud Shared Album Persons Info')
-		
-	if len(data_list_sharedemails) > 0:
-		location = file_found
-		report = ArtifactHtmlReport('iCloud Shared Albums Emails')
-		report.start_artifact_report(report_folder, 'iCloud Shared Emails')
-		report.add_script()
-		data_headers = ('Key', 'Value' )     
-		report.write_artifact_data_table(data_headers, data_list_sharedemails, location)
-		report.end_artifact_report()
-		
-		tsvname = 'iCloud Shared Albums Emails'
-		tsv(report_folder, data_headers, data_list_sharedemails, tsvname)
-	else:
-		logfunc('No iCloud Shared Emails')
-	
-__artifacts__ = {
-    "icloudSharedalbums": (
-        "iCloud Shared Albums",
-        ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*'),
-        get_icloudSharedalbums)
+__artifacts_v2__ = {
+    "icloudSharedOwnerInfo": {
+        "name": "iCloud Shared Albums - Owner Info",
+        "description": "iCloud shared album owner info (Info.plist)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "iCloud Shared Albums", "notes": "",
+        "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
+        "output_types": "standard", "artifact_icon": "users"
+    },
+    "icloudSharedAlbumData": {
+        "name": "iCloud Shared Albums - Album Data",
+        "description": "iCloud shared album DCIM counters (DCIM_CLOUD.plist)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "iCloud Shared Albums", "notes": "",
+        "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
+        "output_types": "standard", "artifact_icon": "image"
+    },
+    "icloudSharedPersonInfo": {
+        "name": "iCloud Shared Albums - Person Info",
+        "description": "iCloud shared album participants (cloudSharedPersonInfos.plist)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "iCloud Shared Albums", "notes": "",
+        "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
+        "output_types": "standard", "artifact_icon": "user"
+    },
+    "icloudSharedEmails": {
+        "name": "iCloud Shared Albums - Emails",
+        "description": "iCloud shared album emails (cloudSharedEmails.plist)",
+        "author": "", "version": "2.0", "date": "2026-06-23", "requirements": "none",
+        "category": "iCloud Shared Albums", "notes": "",
+        "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
+        "output_types": "standard", "artifact_icon": "mail"
+    }
 }
+
+import os
+import plistlib
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def icloudSharedOwnerInfo(context):
+    data_headers = ('Album Title', 'Album ID', 'Cloud Owner Email', 'Cloud Owner First Name',
+                    'Cloud Owner Last Name', 'Cloud Public URL Enabled?',
+                    ('Cloud Subscription Date', 'datetime'), 'Cloud Relationship State',
+                    'Cloud Owner Hashed Person ID', 'File Location')
+    data_list = []
+    sources = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.isfile(file_found) or os.path.basename(file_found) != 'Info.plist':
+            continue
+        album_id = os.path.basename(os.path.dirname(file_found))
+        with open(file_found, 'rb') as fp:
+            pl = plistlib.load(fp)
+        rel = context.get_relative_path(file_found)
+        data_list.append((pl.get('title', ''), album_id, pl.get('cloudOwnerEmail', ''),
+                          pl.get('cloudOwnerFirstName', ''), pl.get('cloudOwnerLastName', ''),
+                          pl.get('cloudPublicURLEnabled', ''), pl.get('cloudSubscriptionDate', ''),
+                          pl.get('cloudRelationshipState', ''),
+                          pl.get('cloudOwnerHashedPersonID', ''), rel))
+        sources.append(rel)
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))
+
+
+@artifact_processor
+def icloudSharedAlbumData(context):
+    data_headers = ('Album Name', 'DCIM Last Directory Number', 'DCIM Last File Number',
+                    'File Location')
+    data_list = []
+    sources = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.isfile(file_found) or os.path.basename(file_found) != 'DCIM_CLOUD.plist':
+            continue
+        album_id = os.path.basename(os.path.dirname(file_found))
+        with open(file_found, 'rb') as fp:
+            pl = plistlib.load(fp)
+        rel = context.get_relative_path(file_found)
+        data_list.append((album_id, pl.get('DCIMLastDirectoryNumber', ''),
+                          pl.get('DCIMLastFileNumber', ''), rel))
+        sources.append(rel)
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))
+
+
+@artifact_processor
+def icloudSharedPersonInfo(context):
+    data_headers = ('Email', 'First Name', 'Last Name', 'Full Name', 'Identification')
+    data_list = []
+    sources = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.isfile(file_found) or os.path.basename(file_found) != 'cloudSharedPersonInfos.plist':
+            continue
+        with open(file_found, 'rb') as fp:
+            pl = plistlib.load(fp)
+        for identifier, info in pl.items():
+            if not isinstance(info, dict):
+                continue
+            email = info.get('email', '')
+            if info.get('emails'):
+                email = info['emails'][0]
+            data_list.append((email, info.get('firstName', ''), info.get('lastName', ''),
+                              info.get('fullName', ''), identifier))
+        sources.append(context.get_relative_path(file_found))
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))
+
+
+@artifact_processor
+def icloudSharedEmails(context):
+    data_headers = ('Key', 'Value')
+    data_list = []
+    sources = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.isfile(file_found) or os.path.basename(file_found) != 'cloudSharedEmails.plist':
+            continue
+        with open(file_found, 'rb') as fp:
+            pl = plistlib.load(fp)
+        for key, value in pl.items():
+            data_list.append((key, value))
+        sources.append(context.get_relative_path(file_found))
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
Modernizes three iCloud-related old-style artifacts to LAVA. Context form, UTC. 6 processors total.

## iCloudWifi (1)
- Single report; replaced `files_found[0]` blind index with iterate+endswith+guard; `Added At` parsed to a **datetime** (was `str()`).

## icloudMeta (1)
- **Consolidated** the dynamic per-file `iCloud - File Metadata N` reports into one table across files.
- **Timestamp fix:** `btime`/`ctime`/`mtime` were naive-local `datetime.fromtimestamp(x/1000)` → **`convert_unix_ts_to_utc`** (correct aware UTC; verified `1678307200000` ms → `2023-03-08 20:26:40Z`).
- Fixed the `'' > 0` **TypeError** when a time key is absent; guarded `file_flags` and the JSON line / last-editor parse.

## icloudSharedalbums (4 → split)
- **`icloudSharedOwnerInfo`**, **`icloudSharedAlbumData`**, **`icloudSharedPersonInfo`**, **`icloudSharedEmails`** (each dispatches on its plist filename under `PhotoCloudSharingData`).
- Fixed undefined-var **NameErrors** (`albumtitle`/`dcim*` when keys absent) via `.get()`; fixed header typos (`Clowd`→`Cloud`, `Ownewr`→`Owner`, `LAst`→`Last`).

## Validation
- pylint **10.00/10**; compile/ast OK; no legacy refs (`files_found[0]`/`fromtimestamp`/`timezone_offset` gone).
- **Functional tests** for all 6 (synthetic wifid plist, Metadata.txt line, the 4 shared-album plists) — all extract correctly.
- Reserved-word audit PASS for all 6 tables. No external imports of the old names.