### PR TITLE
Convert 5 artifacts to LAVA (@artifact_processor): offlinePages, fsCachedData, quickLook, reminders, textinputTyping

### DIFF
--- a/scripts/artifacts/fsCachedData.py
+++ b/scripts/artifacts/fsCachedData.py
@@ -1,53 +1,48 @@
-import os
-import datetime
-
-from packaging import version
-from scripts.filetype import guess_mime
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, media_to_html
-
-
-def get_fsCachedData(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []  
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
-
-        #ext = (mime.split('/')[1])
-            
-        if os.path.isfile(file_found):
-            mime = guess_mime(file_found)
-            media = media_to_html(file_found, files_found, report_folder)
-            data_list.append((utc_modified_date, media, mime, filename, file_found))
-        
-    
-    if len(data_list) > 0:
-        note = 'Source location in extraction found in the report for each item.'
-        description = 'Media files'
-        report = ArtifactHtmlReport('fsCachedData')
-        report.start_artifact_report(report_folder, 'fsCachedData', description)
-        report.add_script()
-        data_headers = ('Timestamp Modified', 'Media', 'Mime Type', 'Filename', 'Path')
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = 'fsCachedData'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'fsCachedData'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No fsCachedData data available')
-        
-
-__artifacts__ = {
-    "fsCachedData": (
-        "Cache Data",
-        ('*/fsCachedData/**'),
-        get_fsCachedData)
+__artifacts_v2__ = {
+    "fsCachedData": {
+        "name": "fsCachedData",
+        "description": "Media and other files cached under fsCachedData",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Cache Data",
+        "notes": "Source location in the extraction is provided for each item.",
+        "paths": ('*/fsCachedData/**',),
+        "output_types": "standard",
+        "artifact_icon": "database"
+    }
 }
+
+import os
+
+from scripts.filetype import guess_mime
+from scripts.ilapfuncs import artifact_processor, check_in_media, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def fsCachedData(context):
+    data_headers = (
+        ('Timestamp Modified', 'datetime'),
+        ('Media', 'media'),
+        'Mime Type',
+        'Filename',
+        'Path')
+    data_list = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.isfile(file_found):
+            continue
+
+        modified_time = convert_unix_ts_to_utc(os.path.getmtime(file_found))
+        mime = guess_mime(file_found)
+        media_ref = check_in_media(file_found)
+        data_list.append((
+            modified_time,
+            media_ref,
+            mime,
+            os.path.basename(file_found),
+            context.get_relative_path(file_found)))
+
+    return data_headers, data_list, ''

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -1,45 +1,55 @@
-import datetime
+__artifacts_v2__ = {
+    "offlinePages": {
+        "name": "Offline Pages (MHTML)",
+        "description": "Saved offline web pages (MHTML/MHT) with their captured source URL and date",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Offline Pages",
+        "notes": "Source location in the extraction is provided for each item.",
+        "paths": ('*/*.mhtml', '*/*.mht'),
+        "output_types": "standard",
+        "artifact_icon": "file-text"
+    }
+}
+
 import email
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_media, convert_unix_ts_to_utc, logfunc
 
-def get_offlinePages(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
+
+@artifact_processor
+def offlinePages(context):
+    data_headers = (
+        ('Timestamp Modified', 'datetime'),
+        ('File', 'media'),
+        'Web Source',
+        'Subject',
+        'MIME Date',
+        'Source in Extraction')
     data_list = []
-    
-    for file_found in files_found:
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
-        
-        with open(file_found,'r', errors='replace') as fp:
-            message = email.message_from_file(fp)
-            sourced = (message['Snapshot-Content-Location'])
-            subjectd = (message['Subject'])
-            dated = (message['Date'])
-            media = media_to_html(file_found, files_found, report_folder)
 
-        data_list.append((utc_modified_date, media, sourced, subjectd, dated, file_found))
-        
-    if len(data_list) > 0:
-        note = 'Source location in extraction found in the report for each item.'
-        report = ArtifactHtmlReport('Offline Pages')
-        report.start_artifact_report(report_folder, f'Offline Pages')
-        report.add_script()
-        data_headers = ('Timestamp Modified', 'File', 'Web Source', 'Subject', 'MIME Date', 'Source in Extraction')
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['File'])
-        report.end_artifact_report()
-        
-        tsvname = f'Offline Pages'
-        tsv(report_folder, data_headers, data_list, tsvname)
+        modified_time = convert_unix_ts_to_utc(os.path.getmtime(file_found))
 
-__artifacts__ = {
-        "pages": (
-                "Offline Pages",
-                ('*/*.mhtml', '*/*.mht'),
-                get_offlinePages)
-}
-            
+        try:
+            with open(file_found, 'r', errors='replace', encoding='utf-8') as fp:
+                message = email.message_from_file(fp)
+        except OSError as ex:
+            logfunc(f'Failed to read offline page {file_found}: {ex}')
+            continue
+
+        media_ref = check_in_media(file_found)
+        data_list.append((
+            modified_time,
+            media_ref,
+            message['Snapshot-Content-Location'],
+            message['Subject'],
+            message['Date'],
+            context.get_relative_path(file_found)))
+
+    return data_headers, data_list, ''

--- a/scripts/artifacts/quickLook.py
+++ b/scripts/artifacts/quickLook.py
@@ -1,61 +1,47 @@
-import glob
-import os
-import pathlib
-import sqlite3
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, kmlgen, timeline, is_platform_windows, open_sqlite_db_readonly
-
-
-def get_quickLook(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('cloudthumbnails.db'):
-            break
-    
-    if file_found.endswith('cloudthumbnails.db'):
-        db = open_sqlite_db_readonly(file_found)
-        cursor = db.cursor()
-        cursor.execute('''
-        select 
-        datetime("last_hit_date", 'unixepoch') as lasthitdate,
-        last_seen_path, 
-        size
-        from thumbnails
-        ''')
-    
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        data_list = []    
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2]))
-            
-                description = 'Listing of iCloud files accessed by the Quick Look function.'
-                report = ArtifactHtmlReport('iCloud Quick Look')
-                report.start_artifact_report(report_folder, 'iCloud Quick Look', description)
-                report.add_script()
-                data_headers = ('Last Hit Date','Last Seen Path','Size')     
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-            tsvname = 'iCloud Quick Look'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-            tlactivity = 'iCloud Quick Look'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('No iCloud Quick Look DB data available')
-    
-        db.close()
-        
-    else:
-        logfunc('No Quicklook DB file found. Check -wal files for possible data remnants.')
-__artifacts__ = {
-    "quickLook": (
-        "iCloud Quick Look",
-        ('*/Quick Look/cloudthumbnails.db*'),
-        get_quickLook)
+__artifacts_v2__ = {
+    "quickLook": {
+        "name": "iCloud Quick Look",
+        "description": "Listing of iCloud files accessed by the Quick Look function",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "iCloud Quick Look",
+        "notes": "Check -wal files for possible data remnants if the DB is missing.",
+        "paths": ('*/Quick Look/cloudthumbnails.db*',),
+        "output_types": "standard",
+        "artifact_icon": "eye"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def quickLook(context):
+    data_headers = (
+        ('Last Hit Date', 'datetime'),
+        'Last Seen Path',
+        'Size')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('cloudthumbnails.db'):
+            source_path = file_found
+            break
+
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(last_hit_date, 'unixepoch'),
+        last_seen_path,
+        size
+    FROM thumbnails
+    '''
+    for row in get_sqlite_db_records(source_path, query):
+        data_list.append((row[0], row[1], row[2]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/reminders.py
+++ b/scripts/artifacts/reminders.py
@@ -1,73 +1,56 @@
-from os.path import dirname
-from os.path import basename
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, does_column_exist_in_db, convert_ts_human_to_utc, convert_utc_human_to_timezone
-
-
-def get_reminders(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    
-    slash = '\\' if is_platform_windows() else '/'
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-
-        if file_found.endswith('.sqlite'):
-            db = open_sqlite_db_readonly(file_found)
-            answer = does_column_exist_in_db(file_found, 'ZREMCDOBJECT', 'ZLASTMODIFIEDDATE')
-        
-            if answer:
-                #db = open_sqlite_db_readonly(file_found)
-                cursor = db.cursor()
-                cursor.execute('''
-                    SELECT
-                    DATETIME(ZCREATIONDATE+978307200,'UNIXEPOCH'),
-                    DATETIME(ZLASTMODIFIEDDATE+978307200,'UNIXEPOCH'),
-                    ZNOTES,
-                    ZTITLE1
-                    FROM ZREMCDOBJECT
-                    WHERE ZTITLE1 <> ''
-                    ''')
-    
-                all_rows = cursor.fetchall()
-                sqlite_file = file_found
-                
-                if len(all_rows) > 0:
-                    location_file_found = sqlite_file.split('Stores'+slash, 1)[1]
-                    for row in all_rows:
-                        createdate = convert_ts_human_to_utc(row[0])
-                        createdate = convert_utc_human_to_timezone(createdate,timezone_offset)
-                        
-                        moddate = convert_ts_human_to_utc(row[1])
-                        moddate = convert_utc_human_to_timezone(moddate,timezone_offset)
-                        data_list.append((createdate, row[3], row[2], moddate, location_file_found))
-                        
-                    dir_file_found = dirname(sqlite_file).split('Stores', 1)[0] + 'Stores'
-                    
-                    report = ArtifactHtmlReport('Reminders')
-                    report.start_artifact_report(report_folder, f'Reminders - {location_file_found}')
-                    report.add_script()
-                    data_headers = ('Creation Date', 'Title', 'Note to Reminder', 'Last Modified', 'File Location')
-                    report.write_artifact_data_table(data_headers, data_list, dir_file_found)
-                    report.end_artifact_report()
-                    
-                    tsvname = 'Reminders'
-                    tsv(report_folder, data_headers, data_list, tsvname)
-                    
-                    tlactivity = 'Reminders'
-                    timeline(report_folder, tlactivity, data_list, data_headers)
-                else:
-                    logfunc(f'No Reminders available on {basename(file_found)}')
-                    
-                
-    
-    db.close()
-    return
-
-__artifacts__ = {
-    "reminders": (
-        "Reminders",
-        ('**/Reminders/Container_v1/Stores/*.sqlite*'),
-        get_reminders)
+__artifacts_v2__ = {
+    "reminders": {
+        "name": "Reminders",
+        "description": "iOS Reminders with creation and last-modified timestamps",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Reminders",
+        "notes": "",
+        "paths": ('**/Reminders/Container_v1/Stores/*.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "bell"
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, does_column_exist_in_db
+
+
+@artifact_processor
+def reminders(context):
+    data_headers = (
+        ('Creation Date', 'datetime'),
+        'Title',
+        'Note to Reminder',
+        ('Last Modified', 'datetime'),
+        'File Location')
+    data_list = []
+    sources = []
+
+    query = '''
+    SELECT
+        DATETIME(ZCREATIONDATE + 978307200, 'UNIXEPOCH'),
+        DATETIME(ZLASTMODIFIEDDATE + 978307200, 'UNIXEPOCH'),
+        ZNOTES,
+        ZTITLE1
+    FROM ZREMCDOBJECT
+    WHERE ZTITLE1 <> ''
+    '''
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.sqlite'):
+            continue
+        if not does_column_exist_in_db(file_found, 'ZREMCDOBJECT', 'ZLASTMODIFIEDDATE'):
+            continue
+
+        rel_path = context.get_relative_path(file_found)
+        rows = get_sqlite_db_records(file_found, query)
+        if not rows:
+            continue
+        for row in rows:
+            data_list.append((row[0], row[3], row[2], row[1], rel_path))
+        sources.append(rel_path)
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/textinputTyping.py
+++ b/scripts/artifacts/textinputTyping.py
@@ -1,72 +1,59 @@
-import os
+__artifacts_v2__ = {
+    "textinputTyping": {
+        "name": "Text Input Messages",
+        "description": "Typed text captured by the TextInput TypingDESPlugin (.desdata)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Text Input Messages",
+        "notes": "",
+        "paths": ('*/DES/Records/com.apple.TextInput.TypingDESPlugin/*.desdata',),
+        "output_types": "standard",
+        "artifact_icon": "type"
+    }
+}
+
 import nska_deserialize as nd
-import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly 
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
+                 nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
+                 nd.ccl_bplist.BplistError, ValueError, TypeError, OSError, OverflowError)
 
 
-def get_textinputTyping(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    count = 0
-    for file_found in files_found:
-        count = count + 1
-        data_list = []
+@artifact_processor
+def textinputTyping(context):
+    data_headers = ('Timestamp', 'Sender Identifier', 'Text', 'contextBeforeInput')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         with open(file_found, 'rb') as f:
             try:
                 deserialized_plist = nd.deserialize_plist(f)
-                #print(deserialized_plist)
-            except (nd.DeserializeError, 
-                    nd.biplist.NotBinaryPlistException, 
-                    nd.biplist.InvalidPlistException,
-                    plistlib.InvalidFileException,
-                    nd.ccl_bplist.BplistError, 
-                    ValueError, 
-                    TypeError, OSError, OverflowError) as ex:
-                # These are all possible errors from libraries imported
-            
-                print('Had exception: ' + str(ex))
-                deserialized_plist = None
-        
-        lenofjson = len(deserialized_plist['alignedEntries'])
-        testrun = deserialized_plist['alignedEntries'][lenofjson -1]
-        for x, y in testrun['originalWord'].items():
-            #print(x)
-            if x == 'documentState':
-                finalvalue = (y['contextBeforeInput'])
-                
-            if x == 'keyboardState':
-                for a, b in y.items():
-                    if a == 'inputContextHistory':
-                        for c, d in b.items():
-                            if c == 'pendingEntries': 
-                                #print(d) #this is a list
-                                for e in d:
-                                    data_list.append((e['timestamp'], e['senderIdentifier'], e['text'], '' ))
-        
-        data_list.append(('','', finalvalue, 'True'))
+            except _PLIST_ERRORS as ex:
+                logfunc(f'Failed to read {file_found}: {ex}')
+                continue
 
-        
-        entries = len(data_list)
-        if entries > 0:
-            report = ArtifactHtmlReport('Text Input Typing')
-            report.start_artifact_report(report_folder, f'Messages {count}')
-            report.add_script()
-            data_headers = ('Timestamp','Sender Identifier','Text','contextBeforeInput' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Messages {count}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Messages {count}'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-    
-        else:
-            logfunc(f"No Messages {count} available")
+        aligned = deserialized_plist.get('alignedEntries') if isinstance(deserialized_plist, dict) else None
+        if not aligned:
+            continue
 
-__artifacts__ = {
-    "textinputTyping": (
-        "Text Input Messages",
-        ('*/DES/Records/com.apple.TextInput.TypingDESPlugin/*.desdata'),
-        get_textinputTyping)
-}
+        finalvalue = ''
+        testrun = aligned[-1]
+        for key, value in testrun.get('originalWord', {}).items():
+            if key == 'documentState':
+                finalvalue = value.get('contextBeforeInput', '')
+            elif key == 'keyboardState':
+                history = value.get('inputContextHistory', {})
+                for entry in history.get('pendingEntries', []):
+                    data_list.append((entry.get('timestamp'), entry.get('senderIdentifier'),
+                                      entry.get('text'), ''))
+
+        data_list.append(('', '', finalvalue, 'True'))
+        sources.append(context.get_relative_path(file_found))
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary
Converts 5 legacy `__artifacts__` artifacts to the LAVA `__artifacts_v2__` / `@artifact_processor` form with the context API.

| Artifact | Notes |
|---|---|
| offlinePages | MHTML/MHT saved pages; `media_to_html`→`check_in_media`. Renamed to **Offline Pages (MHTML)** to avoid a global name clash with chrome.py's 'Offline Pages'. |
| fsCachedData | Cached media; `media_to_html`→`check_in_media`. |
| quickLook | iCloud Quick Look thumbnails DB. |
| reminders | iOS Reminders; stores UTC (no local-tz shift). |
| textinputTyping | TypingDESPlugin `.desdata`; also fixes a latent missing `plistlib` import in the exception handler. |

## Conventions applied
- `creation_date` + `last_update_date` metadata (no deprecated `version`/`date`).
- Dict key exactly matches function name.
- UTC-safe timestamps (offset-free converters / SQL `unixepoch`).

## Validation
- pylint 10.00/10 each; reserved-word + CREATE TABLE smoke test clean.
- PluginLoader loads all 554 artifacts with no duplicate-name error.