### PR TITLE
Convert locServicesconfig, interactionCcontacts, teamsSegment to LAVA (10 artifacts)

### DIFF
--- a/scripts/artifacts/interactionCcontacts.py
+++ b/scripts/artifacts/interactionCcontacts.py
@@ -1,27 +1,59 @@
-import glob
-import os
-import pathlib
-import plistlib
+__artifacts_v2__ = {
+    "interactionCContacts": {
+        "name": "InteractionC - Contacts",
+        "description": "Contact interactions recorded in interactionC.db",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "InteractionC",
+        "notes": "",
+        "paths": ('**/interactionC.db*',),
+        "output_types": "standard",
+        "artifact_icon": "users"
+    },
+    "interactionCAttachments": {
+        "name": "InteractionC - Attachments",
+        "description": "Attachment interactions recorded in interactionC.db",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "InteractionC",
+        "notes": "",
+        "paths": ('**/interactionC.db*',),
+        "output_types": "standard",
+        "artifact_icon": "paperclip"
+    }
+}
+
 import sqlite3
-from packaging import version #use to search per version number
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, iOS
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
 
-def get_interactionCcontacts(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    for file_found in files_found:
+
+def _find_db(context):
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
         if file_found.endswith('.db'):
-            break
-    
-    db = open_sqlite_db_readonly(file_found)
-    
-    iOSversion = iOS.get_version()
-    if version.parse(iOSversion) >= version.parse("10"):
-        cursor = db.cursor()
-        cursor.execute('''
-        select
+            return file_found
+    return ''
+
+
+@artifact_processor
+def interactionCContacts(context):
+    data_headers = (
+        ('Start Date', 'datetime'), ('End Date', 'datetime'), 'Bundle ID', 'Display Name',
+        'Identifier', 'Direction', 'Is Response', 'Recipient Count',
+        ('Zinteractions Creation Date', 'datetime'), ('Zcontacts Creation Date', 'datetime'),
+        'Content URL')
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
         datetime(zinteractions.zstartdate + 978307200, 'unixepoch'),
         datetime(zinteractions.zenddate + 978307200, 'unixepoch'),
         zinteractions.zbundleid,
@@ -33,105 +65,51 @@ def get_interactionCcontacts(files_found, report_folder, seeker, wrap_text, time
         datetime(zinteractions.zcreationdate + 978307200, 'unixepoch'),
         datetime(zcontacts.zcreationdate + 978307200, 'unixepoch'),
         zinteractions.zcontenturl
-        from
-        zinteractions 
-        left join
-        zcontacts 
-        on zinteractions.zsender = zcontacts.z_pk        
-        ''')
-        
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        data_list = []
-        
-        if version.parse(iOSversion) >= version.parse("10"):
-            for row in all_rows:
-                starttime = convert_ts_human_to_utc(row[0])
-                starttime = convert_utc_human_to_timezone(starttime,timezone_offset)
-                
-                endtime = convert_ts_human_to_utc(row[1])
-                endtime = convert_utc_human_to_timezone(endtime,timezone_offset)
-                
-                zinteractcreated = convert_ts_human_to_utc(row[8])
-                zinteractcreated = convert_utc_human_to_timezone(zinteractcreated,timezone_offset)
-                
-                zcontactscreated = row[9]
-                if zcontactscreated is None:
-                    zcontactscreated = ''
-                    
-                else:
-                    zcontactscreated = convert_ts_human_to_utc(zcontactscreated)
-                    zcontactscreated = convert_utc_human_to_timezone(zcontactscreated,timezone_offset)
-                
-                data_list.append((starttime,endtime,row[2],row[3],row[4],row[5],row[6],row[7],zinteractcreated,zcontactscreated,row[10]))
-            
-            report = ArtifactHtmlReport('InteractionC')
-            report.start_artifact_report(report_folder, 'Contacts')
-            report.add_script()
-            data_headers = ('Start Date','End Date','Bundle ID','Display Name','Identifier','Direction','Is Response','Recipient Count','Zinteractions Creation Date','Zcontacts Creation Date','Content URL')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'InteractionC Contacts'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'InteractionC Contacts'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No data available in InteractionC Contacts')
-        
-    if version.parse(iOSversion) >= version.parse("10"):
-        cursor = db.cursor()
-        cursor.execute('''
-        select
-            datetime(zinteractions.ZCREATIONDATE + 978307200, 'unixepoch'),
-            ZINTERACTIONS.zbundleid,
-            ZINTERACTIONS.ztargetbundleid,
-            ZINTERACTIONS.zuuid,
-            ZATTACHMENT.zcontenttext,
-            ZATTACHMENT.zuti,
-            ZATTACHMENT.zcontenturl
-            from zinteractions
-            inner join z_1interactions
-            on zinteractions.z_pk = z_1interactions.z_3interactions
-            inner join zattachment on z_1interactions.z_1attachments = zattachment.z_pk
-        ''')
-        
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        data_list = []
-        
-        if version.parse(iOSversion) >= version.parse("10"):
-            for row in all_rows:
-                creationdate = convert_ts_human_to_utc(row[0])
-                creationdate = convert_utc_human_to_timezone(creationdate,timezone_offset)
-                
-                data_list.append((creationdate,row[1],row[2],row[3],row[4],row[5],row[6]))
-                
-            report = ArtifactHtmlReport('InteractionC')
-            report.start_artifact_report(report_folder, 'Attachments')
-            report.add_script()
-            data_headers = ('Creation Date', 'Bundle ID', 'Target Bundle ID', 'ZUUID', 'Content Text', 'Uniform Type ID', 'Content URL')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'InteractionC Attachments'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'InteractionC Attachments'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No data available in InteractionC Attachments')
-    
+    FROM zinteractions
+    LEFT JOIN zcontacts ON zinteractions.zsender = zcontacts.z_pk
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading InteractionC contacts: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
 
-    db.close()
-    return      
-    
-__artifacts__ = {
-    "interactionCcontacts": (
-        "InteractionC",
-        ('**/interactionC.db*'),
-        get_interactionCcontacts)
-}
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def interactionCAttachments(context):
+    data_headers = (
+        ('Creation Date', 'datetime'), 'Bundle ID', 'Target Bundle ID', 'ZUUID',
+        'Content Text', 'Uniform Type ID', 'Content URL')
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(zinteractions.ZCREATIONDATE + 978307200, 'unixepoch'),
+        ZINTERACTIONS.zbundleid,
+        ZINTERACTIONS.ztargetbundleid,
+        ZINTERACTIONS.zuuid,
+        ZATTACHMENT.zcontenttext,
+        ZATTACHMENT.zuti,
+        ZATTACHMENT.zcontenturl
+    FROM zinteractions
+    INNER JOIN z_1interactions ON zinteractions.z_pk = z_1interactions.z_3interactions
+    INNER JOIN zattachment ON z_1interactions.z_1attachments = zattachment.z_pk
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading InteractionC attachments: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/locServicesconfig.py
+++ b/scripts/artifacts/locServicesconfig.py
@@ -1,108 +1,116 @@
-import os
-import plistlib
-import datetime
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
-
-def convertcocoa(timevalue):
-  if timevalue == '':
-    return ''
-  else:
-    unix = datetime.datetime(1970, 1, 1)  # UTC
-    cocoa = datetime.datetime(2001, 1, 1)
-    delta = cocoa - unix  # timedelta instance 
-    timestamp = datetime.datetime.fromtimestamp(timevalue) + delta 
-    return (timestamp.strftime('%Y-%m-%d %H:%M:%S'))
-
-def get_locServicesconfig(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    data_list_clientsplist = []
-    data_list_routinedplist= []
-    data_list_locationdplist = []
-    
-    for file_found in files_found:
-      if file_found.endswith('clients.plist'):
-        with open(file_found,'rb') as f :
-          clientsplist = plistlib.load(f)
-          
-      if file_found.endswith('com.apple.locationd.plist'):
-        with open(file_found,'rb') as f :
-          locationdplist = plistlib.load(f)
-          
-      if file_found.endswith('com.apple.routined.plist'):
-        with open(file_found,'rb') as f :
-          routinedplist = plistlib.load(f)
-          
-          
-    for key, value in clientsplist.items():
-      if key == 'com.apple.locationd.bundle-/System/Library/LocationBundles/Routine.bundle':
-        fencetimestarted = convertcocoa(value.get('FenceTimeStarted', ''))
-        comsumptionperiod = convertcocoa(value.get('ConsumptionPeriodBegin', ''))
-        receivinglocationinformationtimestopped = convertcocoa(value.get('ReceivingLocationInformationTimeStopped', ''))
-        authorization = value.get('Authorization', '')
-        locationtimestopped = convertcocoa(value.get('LocationTimeStopped', ''))
-        
-        data_list_clientsplist.append((fencetimestarted, 'FenceTimeStarted'))
-        data_list_clientsplist.append((comsumptionperiod, 'ConsumptionPeriodBegin'))
-        data_list_clientsplist.append((receivinglocationinformationtimestopped, 'ReceivingLocationInformationTimeStopped'))
-        data_list_clientsplist.append((authorization, 'Authorization'))
-        data_list_clientsplist.append((locationtimestopped, 'LocationTimeStopped'))
-        
-    for key, value in locationdplist.items():
-      data_list_locationdplist.append((key, value))
-      
-    for key, value in routinedplist.items():
-      if key != 'CloudKitAccountInfoCache':
-        data_list_routinedplist.append((value, key))
-      
-    if len(data_list_routinedplist) > 0:
-      report = ArtifactHtmlReport('LSC - com.apple.routined.plist')
-      report.start_artifact_report(report_folder, 'LSC - com.apple.routined.plist')
-      report.add_script()
-      data_headers = ('Value', 'Key')
-      report.write_artifact_data_table(data_headers, data_list_routinedplist, file_found)
-      report.end_artifact_report()
-
-      tsvname = 'LSC - com.apple.routined.plist'
-      tsv(report_folder, data_headers, data_list_routinedplist, tsvname)
-  
-      tlactivity = 'LSC - com.apple.routined.plist'
-      timeline(report_folder, tlactivity, data_list_routinedplist, data_headers)
-
-    else:
-      logfunc('No LSC - com.apple.routined.plist')
-
-    if len(data_list_locationdplist) > 0:
-      report = ArtifactHtmlReport('LSC - com.apple.locationd.plist')
-      report.start_artifact_report(report_folder, 'LSC - com.apple.locationd.plist')
-      report.add_script()
-      data_headers = ('Value', 'Key')
-      report.write_artifact_data_table(data_headers, data_list_locationdplist, file_found)
-      report.end_artifact_report()
-      
-      tsvname = 'LSC - com.apple.locationd.plist'
-      tsv(report_folder, data_headers, data_list_locationdplist, tsvname)
-      
-    else:
-      logfunc('No LSC - com.apple.locationd.plist')
-    
-    if len(data_list_clientsplist) > 0:
-      report = ArtifactHtmlReport('LSC - clients.plist')
-      report.start_artifact_report(report_folder, 'LSC - clients.plist')
-      report.add_script()
-      data_headers = ('Value', 'Key')
-      report.write_artifact_data_table(data_headers, data_list_clientsplist, file_found)
-      report.end_artifact_report()
-      
-      tsvname = 'LSC - clients.plist'
-      tsv(report_folder, data_headers, data_list_clientsplist, tsvname)
-      
-    else:
-      logfunc('No LSC - clients.plist')
-
-__artifacts__ = {
-    "locServicesconfig": (
-        "Location Services Configurations",
-        ('*/Library/Preferences/com.apple.locationd.plist','*/Library/Caches/locationd/clients.plist','*/Library/Preferences/com.apple.routined.plist'),
-        get_locServicesconfig)
+__artifacts_v2__ = {
+    "locServicesConfigClients": {
+        "name": "LSC - clients.plist",
+        "description": "Location Services configuration for the Routine bundle from clients.plist",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Location",
+        "notes": "",
+        "paths": ('*/Library/Caches/locationd/clients.plist',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
+    },
+    "locServicesConfigLocationd": {
+        "name": "LSC - com.apple.locationd.plist",
+        "description": "Location Services configuration key/values from com.apple.locationd.plist",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Location",
+        "notes": "",
+        "paths": ('*/Library/Preferences/com.apple.locationd.plist',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
+    },
+    "locServicesConfigRoutined": {
+        "name": "LSC - com.apple.routined.plist",
+        "description": "Location Services configuration key/values from com.apple.routined.plist",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Location",
+        "notes": "",
+        "paths": ('*/Library/Preferences/com.apple.routined.plist',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
+    }
 }
+
+import plistlib
+
+from scripts.ilapfuncs import artifact_processor, convert_cocoa_core_data_ts_to_utc, logfunc
+
+
+def _load_plist(context, filename):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith(filename):
+            try:
+                with open(file_found, 'rb') as f:
+                    return plistlib.load(f), context.get_relative_path(file_found)
+            except (plistlib.InvalidFileException, ValueError, OSError) as ex:
+                logfunc(f'Failed to read {file_found}: {ex}')
+                return None, context.get_relative_path(file_found)
+    return None, ''
+
+
+def _cocoa_utc_str(value):
+    """Convert a Cocoa (seconds-since-2001) timestamp to a UTC string; pass empties through."""
+    if value in ('', None):
+        return ''
+    dt = convert_cocoa_core_data_ts_to_utc(value)
+    return dt.strftime('%Y-%m-%d %H:%M:%S') if hasattr(dt, 'strftime') else str(dt)
+
+
+@artifact_processor
+def locServicesConfigClients(context):
+    data_headers = ('Value', 'Key')
+    data_list = []
+    plist, source_path = _load_plist(context, 'clients.plist')
+    if not plist:
+        return data_headers, data_list, source_path
+
+    routine_key = 'com.apple.locationd.bundle-/System/Library/LocationBundles/Routine.bundle'
+    value = plist.get(routine_key)
+    if isinstance(value, dict):
+        data_list.append((_cocoa_utc_str(value.get('FenceTimeStarted', '')), 'FenceTimeStarted'))
+        data_list.append((_cocoa_utc_str(value.get('ConsumptionPeriodBegin', '')), 'ConsumptionPeriodBegin'))
+        data_list.append((_cocoa_utc_str(value.get('ReceivingLocationInformationTimeStopped', '')),
+                          'ReceivingLocationInformationTimeStopped'))
+        data_list.append((value.get('Authorization', ''), 'Authorization'))
+        data_list.append((_cocoa_utc_str(value.get('LocationTimeStopped', '')), 'LocationTimeStopped'))
+
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def locServicesConfigLocationd(context):
+    data_headers = ('Value', 'Key')
+    data_list = []
+    plist, source_path = _load_plist(context, 'com.apple.locationd.plist')
+    if not plist:
+        return data_headers, data_list, source_path
+
+    for key, value in plist.items():
+        data_list.append((value, key))
+
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def locServicesConfigRoutined(context):
+    data_headers = ('Value', 'Key')
+    data_list = []
+    plist, source_path = _load_plist(context, 'com.apple.routined.plist')
+    if not plist:
+        return data_headers, data_list, source_path
+
+    for key, value in plist.items():
+        if key != 'CloudKitAccountInfoCache':
+            data_list.append((value, key))
+
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/teamsSegment.py
+++ b/scripts/artifacts/teamsSegment.py
@@ -1,145 +1,174 @@
+__artifacts_v2__ = {
+    "teamsSegmentLocations": {
+        "name": "Microsoft Teams - Locations",
+        "description": "Location segments logged by Microsoft Teams (DriveIQ)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Microsoft Teams",
+        "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/DriveIQ/segments/current/*.*',),
+        "output_types": ["html", "tsv", "timeline", "lava", "kml"],
+        "artifact_icon": "map-pin"
+    },
+    "teamsSegmentMotion": {
+        "name": "Microsoft Teams - Motion",
+        "description": "Motion/activity segments logged by Microsoft Teams (DriveIQ)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Microsoft Teams",
+        "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/DriveIQ/segments/current/*.*',),
+        "output_types": "standard",
+        "artifact_icon": "activity"
+    },
+    "teamsSegmentTimezone": {
+        "name": "Microsoft Teams - Timezone",
+        "description": "Timezone check segments logged by Microsoft Teams (DriveIQ)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Microsoft Teams",
+        "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/DriveIQ/segments/current/*.*',),
+        "output_types": "standard",
+        "artifact_icon": "clock"
+    },
+    "teamsSegmentPower": {
+        "name": "Microsoft Teams - Power Log",
+        "description": "Power/battery segments logged by Microsoft Teams (DriveIQ)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Microsoft Teams",
+        "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/DriveIQ/segments/current/*.*',),
+        "output_types": "standard",
+        "artifact_icon": "battery-charging"
+    },
+    "teamsSegmentStateChange": {
+        "name": "Microsoft Teams - State Change",
+        "description": "State change segments logged by Microsoft Teams (DriveIQ)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Microsoft Teams",
+        "notes": "",
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/DriveIQ/segments/current/*.*',),
+        "output_types": "standard",
+        "artifact_icon": "repeat"
+    }
+}
+
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, kmlgen, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_ts_human_to_utc, logfunc
 
-def get_teamsSegment(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list_location = []
-    data_list_motion = []
-    data_list_timecheck = []
-    data_list_power = []
-    data_list_statechange = []
-    
-    for file_found in files_found:
-        with open(file_found) as file:
-            for line in file:
-                serial = json.loads(line)
-                timestamp = serial[0].replace('T',' ')
-                #print(serial[1])
-                if serial[1] == 'location':
-                    locationtimestamp = serial[2].get('sourceTimestamp', '')
-                    locationtimestamp = locationtimestamp.replace('T',' ')
-                    longitude = serial[2].get('longitude', '')
-                    latitude = serial[2].get('latitude', '')
-                    speed = serial[2].get('speed', '')
-                    altitude = serial[2].get('altitude', '')
-                    vertacc = serial[2].get('verticalAccuracy', '')
-                    horiacc = serial[2].get('horizontalAccuracy', '')
-                    data_list_location.append((locationtimestamp, longitude, latitude, speed, altitude, vertacc, horiacc))
-                    
-                if serial[1] == 'motion':
-                    motionact = (serial[2].get('activityName', ''))
-                    data_list_motion.append((timestamp, motionact))
-                    
-                if serial[1] == 'timeCheck':
-                    tczone = serial[2].get('timezone', '')
-                    tcoffset = serial[2].get('offset', '')
-                    tcreason = serial[2].get('reason', '')
-                    data_list_timecheck.append((timestamp, tczone, tcoffset, tcreason))
-                    
-                if serial[1] == 'power':
-                    plugged = serial[2].get('isPluggedIn', '')
-                    batlvl = serial[2].get('batteryLevel', '')
-                    data_list_power.append((timestamp, plugged, batlvl))
-                    
-                if serial[1] == 'stateChange':
-                    agg = ' '
-                    for a, b in serial[2].items():
-                        agg = agg + (f'{a}: {b} ')
-                    agg = agg.lstrip()
-                    data_list_statechange.append((timestamp, agg))
 
-    if len(data_list_location) > 0:
-        report = ArtifactHtmlReport('Microsoft Teams Locations')
-        report.start_artifact_report(report_folder, 'Teams Locations')
-        report.add_script()
-        data_headers_location = ('Timestamp', 'Longitude', 'Latitude', 'Speed', 'Altitude', 'Vertical Accuracy', 'Horizontal Accuracy')   
-        report.write_artifact_data_table(data_headers_location, data_list_location, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Microsoft Teams Locations'
-        tsv(report_folder, data_headers_location, data_list_location, tsvname)
-        
-        tlactivity = 'Microsoft Teams Locations'
-        timeline(report_folder, tlactivity,  data_list_location, data_headers_location)
-        
-        kmlactivity = 'Microsoft Teams Locations'
-        kmlgen(report_folder, kmlactivity, data_list_location, data_headers_location)
-    else:
-        logfunc('No Microsoft Teams Locations data')
-    
-        
-    if len(data_list_motion) > 0:
-        report = ArtifactHtmlReport('Microsoft Teams Motion')
-        report.start_artifact_report(report_folder, 'Teams Motion')
-        report.add_script()
-        data_headers_motion = ('Timestamp', 'Activity')
-        report.write_artifact_data_table(data_headers_motion, data_list_motion, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Microsoft Teams Motion'
-        tsv(report_folder, data_headers_motion, data_list_motion, tsvname)
-        
-        tlactivity = 'Microsoft Teams Motion'
-        timeline(report_folder, tlactivity, data_list_motion, data_headers_motion)
-        
-    else:
-        logfunc('No Microsoft Teams Motion data')
-        
-    if len(data_list_timecheck) > 0:
-        report = ArtifactHtmlReport('Microsoft Teams Timezone')
-        report.start_artifact_report(report_folder, 'Teams Timezone')
-        report.add_script()
-        data_headers_timecheck = ('Timestamp', 'Timezone', 'Timezone Offset', 'Timezone reason')
-        report.write_artifact_data_table(data_headers_timecheck, data_list_timecheck, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Microsoft Teams Timezone'
-        tsv(report_folder, data_headers_timecheck, data_list_timecheck, tsvname)
-        
-        tlactivity = 'Microsoft Teams Timezone'
-        timeline(report_folder, tlactivity, data_list_timecheck, data_headers_timecheck)
-        
-    else:
-        logfunc('No Microsoft Teams Timezone data')
-        
-    if len(data_list_power) > 0:
-        report = ArtifactHtmlReport('Microsoft Teams Power Log')
-        report.start_artifact_report(report_folder, 'Teams Power Log')
-        report.add_script()
-        data_headers_power = ('Timestamp', 'Is plugged in?', 'Battery Level')
-        report.write_artifact_data_table(data_headers_power, data_list_power, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Microsoft Teams Power Log'
-        tsv(report_folder, data_headers_power, data_list_power, tsvname)
-        
-        tlactivity = 'Microsoft Teams Power Log'
-        timeline(report_folder, tlactivity, data_list_power, data_headers_power)
-        
-    else:
-        logfunc('No Microsoft Teams Power Log data')
+def _seg_ts(value):
+    """Normalize a DriveIQ ISO segment timestamp to aware UTC; pass empties/unparseable through."""
+    if not value:
+        return ''
+    cleaned = str(value).replace('T', ' ').replace('Z', '').strip()
+    try:
+        return convert_ts_human_to_utc(cleaned)
+    except (ValueError, TypeError):
+        return value
 
-    if len(data_list_statechange) > 0:
-        report = ArtifactHtmlReport('Microsoft Teams State Change')
-        report.start_artifact_report(report_folder, 'Teams State Change')
-        report.add_script()
-        data_headers_statechange = ('Timestamp', 'Change')
-        report.write_artifact_data_table(data_headers_statechange, data_list_statechange, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Microsoft Teams State Change'
-        tsv(report_folder, data_headers_statechange, data_list_statechange, tsvname)
-        
-        tlactivity = 'Microsoft Teams State Change'
-        timeline(report_folder, tlactivity, data_list_statechange, data_headers_statechange)
-        
-    else:
-        logfunc('No Microsoft Teams Power State Change')
 
-__artifacts__ = {
-    "teamsSegment": (
-        "Microsoft Teams - Logs",
-        ('*/mobile/Containers/Data/Application/*/Library/DriveIQ/segments/current/*.*'),
-        get_teamsSegment)
-}
+def _iter_records(context):
+    """Read all DriveIQ segment files and return (parsed JSON records, joined source paths)."""
+    records = []
+    sources = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        try:
+            with open(file_found, encoding='utf-8') as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError as ex:
+            logfunc(f'Failed to read {file_found}: {ex}')
+            continue
+        sources.append(context.get_relative_path(file_found))
+    return records, ', '.join(dict.fromkeys(sources))
+
+
+@artifact_processor
+def teamsSegmentLocations(context):
+    data_headers = (('Timestamp', 'datetime'), 'Longitude', 'Latitude', 'Speed', 'Altitude',
+                    'Vertical Accuracy', 'Horizontal Accuracy')
+    data_list = []
+    records, source_path = _iter_records(context)
+    for serial in records:
+        if len(serial) > 2 and serial[1] == 'location':
+            payload = serial[2]
+            data_list.append((
+                _seg_ts(payload.get('sourceTimestamp', '')),
+                payload.get('longitude', ''),
+                payload.get('latitude', ''),
+                payload.get('speed', ''),
+                payload.get('altitude', ''),
+                payload.get('verticalAccuracy', ''),
+                payload.get('horizontalAccuracy', '')))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def teamsSegmentMotion(context):
+    data_headers = (('Timestamp', 'datetime'), 'Activity')
+    data_list = []
+    records, source_path = _iter_records(context)
+    for serial in records:
+        if len(serial) > 2 and serial[1] == 'motion':
+            data_list.append((_seg_ts(serial[0]), serial[2].get('activityName', '')))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def teamsSegmentTimezone(context):
+    data_headers = (('Timestamp', 'datetime'), 'Timezone', 'Timezone Offset', 'Timezone reason')
+    data_list = []
+    records, source_path = _iter_records(context)
+    for serial in records:
+        if len(serial) > 2 and serial[1] == 'timeCheck':
+            payload = serial[2]
+            data_list.append((_seg_ts(serial[0]), payload.get('timezone', ''),
+                              payload.get('offset', ''), payload.get('reason', '')))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def teamsSegmentPower(context):
+    data_headers = (('Timestamp', 'datetime'), 'Is plugged in?', 'Battery Level')
+    data_list = []
+    records, source_path = _iter_records(context)
+    for serial in records:
+        if len(serial) > 2 and serial[1] == 'power':
+            payload = serial[2]
+            data_list.append((_seg_ts(serial[0]), payload.get('isPluggedIn', ''),
+                              payload.get('batteryLevel', '')))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def teamsSegmentStateChange(context):
+    data_headers = (('Timestamp', 'datetime'), 'Change')
+    data_list = []
+    records, source_path = _iter_records(context)
+    for serial in records:
+        if len(serial) > 2 and serial[1] == 'stateChange':
+            agg = ' '.join(f'{a}: {b}' for a, b in serial[2].items())
+            data_list.append((_seg_ts(serial[0]), agg))
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
Converts three multi-report legacy artifacts to `__artifacts_v2__`/`@artifact_processor`. Each combined report becomes its own LAVA artifact (10 total).

| Source file | New artifacts | Notes |
|---|---|---|
| locServicesconfig | 3 (clients / locationd / routined) | **Fixes local-time Cocoa timestamp bug** → UTC; corrects swapped Key/Value for locationd; guards missing plists (previously NameError) |
| interactionCcontacts | 2 (Contacts / Attachments) | Stores UTC (drops local-tz shift); robust error handling instead of iOS-version gate |
| teamsSegment | 5 (Locations / Motion / Timezone / Power / State Change) | Locations emit **KML**; ISO segment timestamps normalized to UTC |

## Conventions applied
- `creation_date` + `last_update_date` metadata; dict keys match function names.
- UTC-safe timestamps throughout.
- Globally-unique artifact names.

## Validation
- pylint 10.00/10 on all three files.
- Reserved-word + CREATE TABLE smoke test clean; no duplicate-name collisions.
- PluginLoader loads all 561 artifacts (+7 from the report splits).