### PR TITLE
Convert ooklaSpeedtestData, hikvision, notes to LAVA

### DIFF
--- a/scripts/artifacts/hikvision.py
+++ b/scripts/artifacts/hikvision.py
@@ -1,187 +1,198 @@
-""""
+"""
 Developed by Evangelos D. (@theAtropos4n6)
 
-Research for this artifact was conducted by Evangelos Dragonas, Costas Lambrinoudakis and Michael Kotsis. 
-For more information read their research paper here: Link_to_be_uploaded
+Research for this artifact was conducted by Evangelos Dragonas, Costas Lambrinoudakis
+and Michael Kotsis.
 
-Updated:27-03-2023
-
-Hikvision is a well-known app that is used to remotely access/operate CCTV systems. Currently the following information can be interpreted:
-
--Hikvision - CCTV Channels: retrieves info for the available CCTV record channels 
--Hikvision - CCTV Info: Information about the CCTV system
--Hikvision - CCTV Activity: User Interaction with the app. Unfortunately it is not easy to attribute user actions but indirectly can indicate remote live view/play back from CCTV footage.
--Hikvision - User Created Media: The media files the user created while viewing footage from the CCTV
-
+Hikvision is a well-known app used to remotely access/operate CCTV systems. The
+following information can be interpreted:
+- Hikvision - CCTV Channels: the available CCTV record channels.
+- Hikvision - CCTV Info: information about the CCTV system.
+- Hikvision - CCTV Activity: user interaction with the app. User actions are not easy
+  to attribute but can indirectly indicate remote live view/play back of CCTV footage.
+- Hikvision - User Created Media: media files the user created while viewing CCTV footage.
 """
-import sqlite3
+__artifacts_v2__ = {
+    "hikvisionChannels": {
+        "name": "Hikvision - CCTV Channels",
+        "description": "Available CCTV record channels from the Hikvision app",
+        "author": "Evangelos D. (@theAtropos4n6)",
+        "creation_date": "2023-03-27",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Hikvision",
+        "notes": "",
+        "paths": ('*/Documents/database.hik*',),
+        "output_types": "standard",
+        "artifact_icon": "video"
+    },
+    "hikvisionInfo": {
+        "name": "Hikvision - CCTV Info",
+        "description": "Information about the CCTV system from the Hikvision app",
+        "author": "Evangelos D. (@theAtropos4n6)",
+        "creation_date": "2023-03-27",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Hikvision",
+        "notes": "",
+        "paths": ('*/Documents/database.hik*',),
+        "output_types": "standard",
+        "artifact_icon": "info"
+    },
+    "hikvisionActivity": {
+        "name": "Hikvision - CCTV Activity",
+        "description": "User interaction with the Hikvision app (live view / play back)",
+        "author": "Evangelos D. (@theAtropos4n6)",
+        "creation_date": "2023-03-27",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Hikvision",
+        "notes": "",
+        "paths": ('*/Documents/DCLOG/YSDCLogItem.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "activity"
+    },
+    "hikvisionMedia": {
+        "name": "Hikvision - User Created Media",
+        "description": "Media files the user created while viewing CCTV footage",
+        "author": "Evangelos D. (@theAtropos4n6)",
+        "creation_date": "2023-03-27",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Hikvision",
+        "notes": "Media are stored under Documents/YYYY/MM/DD within the app container.",
+        "paths": ('*/Documents/*/*/*/*.jpg', '*/Documents/*/*/*/*.mov', '*/Documents/*/*/*/*.mp4'),
+        "output_types": "standard",
+        "artifact_icon": "film"
+    }
+}
+
 import os
-import textwrap
+import re
+import sqlite3
+
+from scripts.ilapfuncs import artifact_processor, check_in_media, get_sqlite_db_records, logfunc
 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly,media_to_html
+def _find(context, filename):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) == filename:
+            return file_found
+    return ''
 
-def get_hikvision(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    separator_1 = '/'
-    separator_2 = "\\"
-    media_data_list = []
-    for file_found in files_found:
+
+@artifact_processor
+def hikvisionChannels(context):
+    data_headers = ('Device ID', 'Channel No.', 'Channel Name', 'Status')
+    data_list = []
+    source_path = _find(context, 'database.hik')
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        nDeviceID,
+        nChannelNo,
+        chChannelName,
+        CASE nEnable WHEN '0' THEN 'Disabled' WHEN '1' THEN 'Enabled' END
+    FROM ChannelInfo
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Hikvision channels: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hikvisionInfo(context):
+    data_headers = ('ID', 'Name/IP', 'Serial Number', 'Port', 'Channels', 'DDNS Address', 'DDNS Port')
+    data_list = []
+    source_path = _find(context, 'database.hik')
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        nDeviceID,
+        chDeviceName,
+        chDeviceSerialNo,
+        nDevicePort,
+        nChannelNum,
+        chDDNSAddr,
+        nDDNSPort
+    FROM DeviceInfo
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Hikvision info: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hikvisionActivity(context):
+    data_headers = (('Timestamp', 'datetime'), 'Record Type', 'Activity')
+    data_list = []
+    source_path = _find(context, 'YSDCLogItem.sqlite')
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(time/1000, 'unixepoch'),
+        systemName,
+        data
+    FROM YSDCLogItem
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Hikvision activity: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hikvisionMedia(context):
+    data_headers = ('File Path', 'File Name', ('File Content', 'media'))
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         file_name = os.path.basename(file_found)
-        if file_name == 'database.hik':
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            
-            #CCTV Available Channels
-            cursor.execute('''
-                select 
-                nDeviceID,
-                nChannelNo,
-                chChannelName,
-                case  nEnable
-                    when '0' then 'Disabled'
-                    when '1' then 'Enabled'
-                end
-                from ChannelInfo 
-                ''')
+        if not file_name.endswith(('.jpg', '.mov', '.mp4')):
+            continue
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Hikvision - CCTV Channels')
-                report.start_artifact_report(report_folder, 'Hikvision - CCTV Channels')
-                report.add_script()
-                data_headers = ('Device ID','Channel No.','Channel Name','Status') 
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3]))
+        # Ensure the media file belongs to the app: Documents/YYYY/MM/DD/<file>
+        parts = re.split(r'[\\/]', file_found)
+        if len(parts) <= 5:
+            continue
+        if (parts[-5] != 'Documents'
+                or not (parts[-4].isdigit() and len(parts[-4]) == 4)
+                or not (parts[-3].isdigit() and len(parts[-3]) == 2)
+                or not (parts[-2].isdigit() and len(parts[-2]) == 2)):
+            continue
 
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Hikvision - CCTV Channels'
-                tsv(report_folder, data_headers, data_list, tsvname)
-            
-            else:
-                logfunc(f'No Hikvision - CCTV Channels data available')
-            
-            #CCTV Info
-            cursor.execute('''
-                select 
-                    nDeviceID,
-                    chDeviceName,
-                    chDeviceSerialNo,
-                    nDevicePort,
-                    nChannelNum,
-                    chDDNSAddr,
-                    nDDNSPort
-                from DeviceInfo
-            ''')
+        media_ref = check_in_media(file_found, file_name)
+        rel_path = context.get_relative_path(file_found)
+        data_list.append((rel_path, file_name, media_ref))
+        sources.append(rel_path)
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Hikvision - CCTV Info')
-                report.start_artifact_report(report_folder, 'Hikvision - CCTV Info')
-                report.add_script()
-                data_headers = ('ID','Name/IP','Serial Number','Port','Channels','DDNS Address','DDNS Port') 
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Hikvision - CCTV Info'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-            else:
-                logfunc(f'No Hikvision - CCTV Info data available')
-
-            db.close()
-
-        if file_name == 'YSDCLogItem.sqlite':
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            
-            #CCTV Activity
-            cursor.execute('''
-            SELECT
-            datetime(time/1000,'unixepoch'),
-            datetime(time/1000,'unixepoch','localtime'),
-            systemName as 'Record Type',
-            data
-            FROM YSDCLogItem
-                ''')
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Hikvision - CCTV Activity')
-                report.start_artifact_report(report_folder, 'Hikvision - CCTV Activity')
-                report.add_script()
-                data_headers = ('Timestamp (UTC)','Timestamp (Local)','Record Type','Activity') 
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3]))
-
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Hikvision - CCTV Activity'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Hikvision - CCTV Activity'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc(f'No Hikvision - CCTV Activity data available')
-
-        #CCTV - User Created Media - Collecting Files
-        if file_name.endswith(".jpg") or file_name.endswith(".mov") or file_name.endswith(".mp4"):
-            #The files found grep input returns many files are not part of the app (false positives). This block of code ensures that each media file collected is part of the app's data
-            if separator_1 in file_found:
-                media_file_path = file_found.split(separator_1)
-            else:
-                media_file_path = file_found.split(separator_2)
-
-            if len(media_file_path) > 5:
-                doc_in_path = "True" if media_file_path[-5] == "Documents" else "False"
-                year_in_path = "True" if media_file_path[-4].isdigit() and len(media_file_path[-4]) == 4 else "False"
-                month_in_path = "True" if media_file_path[-3].isdigit() and len(media_file_path[-3]) == 2 else "False"
-                day_in_path = "True" if media_file_path[-2].isdigit() and len(media_file_path[-2]) == 2 else "False"
-                path_flags = [doc_in_path,year_in_path,month_in_path,day_in_path]
-
-                if "False" not in path_flags:
-                    temp_tuple = ()
-                    temp_tuple = (file_found,file_name,file_name)
-                    media_data_list.append(temp_tuple)
-            
-    #CCTV - User Created Media - Reporting Files
-    media_files =  len(media_data_list)
-    if media_files > 0:
-        report = ArtifactHtmlReport('Hikvision - User Created Media')
-        report.start_artifact_report(report_folder, 'Hikvision - User Created Media')
-        report.add_script()
-        data_headers = ('File Path','File Name', 'File Content') 
-        data_list = []
-        for mfile in media_data_list:          
-            if mfile[2] is not None:
-                media = media_to_html(mfile[2], files_found, report_folder)
-            data_list.append((mfile[0],mfile[1],media))
-        media_files_dir = "*/mobile/Containers/Data/Application/[Application-GUID]/Documents/YYYY/MM/DD" #Generic path of the media files. Each file is stored within seperate dirs based on its creation date
-        report.write_artifact_data_table(data_headers, data_list, media_files_dir, html_escape = False)
-        report.end_artifact_report()
-
-        tsvname = f'Hikvision - User Created Media'
-        tsv(report_folder, data_headers, data_list, tsvname)
-            
-    else:
-        logfunc(f'No Hikvision - User Created Media data available')
-
-__artifacts__ = {
-        "hikvision": (
-                "Hikvision",
-                ('*/Documents/DCLOG/YSDCLogItem.sqlite*','*/Documents/database.hik*','*/Documents/*/*/*/*.jpg','*/Documents/*/*/*/*.mov','*/Documents/*/*/*/*.mp4'),
-                get_hikvision)
-}
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/notes.py
+++ b/scripts/artifacts/notes.py
@@ -1,254 +1,82 @@
-# Parts of this script have been modified from code 
-# found in Yogesh Khatri's mac_apt project Notes plugin (https://github.com/ydkhatri/mac_apt) 
+# Parts of this script have been modified from code
+# found in Yogesh Khatri's mac_apt project Notes plugin (https://github.com/ydkhatri/mac_apt)
 # and used under terms of the MIT License.
+__artifacts_v2__ = {
+    "notes": {
+        "name": "Notes",
+        "description": "Apple Notes including decoded note body text and embedded attachments",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Notes",
+        "notes": "Note body text is decompressed and parsed from the protobuf blob. "
+                 "Password-protected note contents are not decoded.",
+        "paths": ('*/NoteStore.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "file-text"
+    }
+}
 
-from os.path import basename, dirname, join
-from PIL import Image
-import imghdr
-import zlib
 import binascii
 import os
+import zlib
+from os.path import dirname, join
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, does_column_exist_in_db
+from scripts.ilapfuncs import (artifact_processor, check_in_embedded_media,
+                               does_column_exist_in_db, get_sqlite_db_records, logfunc)
 
 
-def get_notes(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
+def _build_query(creation_col, account_col):
+    """Notes schema varies by iOS version; only the creation-date and account columns differ."""
+    return f'''
+    SELECT
+        DATETIME(TabA.{creation_col}+978307200,'UNIXEPOCH'),
+        TabA.ZTITLE1,
+        TabA.ZSNIPPET,
+        TabB.ZTITLE2,
+        TabC.ZNAME,
+        DATETIME(TabA.ZMODIFICATIONDATE1+978307200,'UNIXEPOCH'),
+        CASE TabA.ZISPASSWORDPROTECTED WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
+        TabA.ZPASSWORDHINT,
+        CASE TabA.ZMARKEDFORDELETION WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
+        CASE TabA.ZISPINNED WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
+        TabE.ZFILENAME,
+        TabE.ZIDENTIFIER,
+        TabD.ZFILESIZE,
+        TabD.ZTYPEUTI,
+        DATETIME(TabD.ZCREATIONDATE+978307200,'UNIXEPOCH'),
+        DATETIME(TabD.ZMODIFICATIONDATE+978307200,'UNIXEPOCH'),
+        TabF.ZDATA
+    FROM ZICCLOUDSYNCINGOBJECT TabA
+    INNER JOIN ZICCLOUDSYNCINGOBJECT TabB on TabA.ZFOLDER = TabB.Z_PK
+    INNER JOIN ZICCLOUDSYNCINGOBJECT TabC on TabA.{account_col} = TabC.Z_PK
+    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabD on TabA.Z_PK = TabD.ZNOTE
+    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabE on TabD.Z_PK = TabE.ZATTACHMENT1
+    LEFT JOIN ZICNOTEDATA TabF on TabF.ZNOTE = TabA.Z_PK
+    '''
 
-        if file_found.endswith('.sqlite'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            
-            if does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT','ZACCOUNT4') == True and does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT','ZCREATIONDATE3') == True:
-                        
-                cursor.execute('''
-                    SELECT 
-                    DATETIME(TabA.ZCREATIONDATE3+978307200,'UNIXEPOCH'), 
-                    TabA.ZTITLE1,
-                    TabA.ZSNIPPET,
-                    TabB.ZTITLE2,
-                    TabC.ZNAME,
-                    DATETIME(TabA.ZMODIFICATIONDATE1+978307200,'UNIXEPOCH'),
-                    case TabA.ZISPASSWORDPROTECTED
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    TabA.ZPASSWORDHINT,
-                    case TabA.ZMARKEDFORDELETION
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    case TabA.ZISPINNED
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    TabE.ZFILENAME,
-                    TabE.ZIDENTIFIER,
-                    TabD.ZFILESIZE,
-                    TabD.ZTYPEUTI,
-                    DATETIME(TabD.ZCREATIONDATE+978307200,'UNIXEPOCH') as "Attachment Created",
-                    DATETIME(TabD.ZMODIFICATIONDATE+978307200,'UNIXEPOCH') as "Attachment Modified",
-                    TabF.ZDATA
-                    FROM ZICCLOUDSYNCINGOBJECT TabA
-                    INNER JOIN ZICCLOUDSYNCINGOBJECT TabB on TabA.ZFOLDER = TabB.Z_PK
-                    INNER JOIN ZICCLOUDSYNCINGOBJECT TabC on TabA.ZACCOUNT4 = TabC.Z_PK
-                    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabD on TabA.Z_PK = TabD.ZNOTE
-                    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabE on TabD.Z_PK = TabE.ZATTACHMENT1
-                    LEFT JOIN ZICNOTEDATA TabF on TabF.ZNOTE = TabA.Z_PK
-                    ''')
 
-            elif does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT','ZACCOUNT4') == True and does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT','ZCREATIONDATE3') == False:
-                cursor.execute('''
-                    SELECT 
-                    DATETIME(TabA.ZCREATIONDATE1+978307200,'UNIXEPOCH'), 
-                    TabA.ZTITLE1,
-                    TabA.ZSNIPPET,
-                    TabB.ZTITLE2,
-                    TabC.ZNAME,
-                    DATETIME(TabA.ZMODIFICATIONDATE1+978307200,'UNIXEPOCH'),
-                    case TabA.ZISPASSWORDPROTECTED
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    TabA.ZPASSWORDHINT,
-                    case TabA.ZMARKEDFORDELETION
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    case TabA.ZISPINNED
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    TabE.ZFILENAME,
-                    TabE.ZIDENTIFIER,
-                    TabD.ZFILESIZE,
-                    TabD.ZTYPEUTI,
-                    DATETIME(TabD.ZCREATIONDATE+978307200,'UNIXEPOCH') as "Attachment Created",
-                    DATETIME(TabD.ZMODIFICATIONDATE+978307200,'UNIXEPOCH') as "Attachment Modified",
-                    TabF.ZDATA
-                    FROM ZICCLOUDSYNCINGOBJECT TabA
-                    INNER JOIN ZICCLOUDSYNCINGOBJECT TabB on TabA.ZFOLDER = TabB.Z_PK
-                    INNER JOIN ZICCLOUDSYNCINGOBJECT TabC on TabA.ZACCOUNT3 = TabC.Z_PK
-                    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabD on TabA.Z_PK = TabD.ZNOTE
-                    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabE on TabD.Z_PK = TabE.ZATTACHMENT1
-                    LEFT JOIN ZICNOTEDATA TabF on TabF.ZNOTE = TabA.Z_PK
-                    ''')
+def _query_for_db(file_found):
+    if does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT', 'ZACCOUNT4'):
+        if does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT', 'ZCREATIONDATE3'):
+            return _build_query('ZCREATIONDATE3', 'ZACCOUNT4')
+        return _build_query('ZCREATIONDATE1', 'ZACCOUNT3')
+    return _build_query('ZCREATIONDATE1', 'ZACCOUNT2')
 
-            else:
-                cursor.execute('''
-                    SELECT 
-                    DATETIME(TabA.ZCREATIONDATE1+978307200,'UNIXEPOCH'), 
-                    TabA.ZTITLE1,
-                    TabA.ZSNIPPET,
-                    TabB.ZTITLE2,
-                    TabC.ZNAME,
-                    DATETIME(TabA.ZMODIFICATIONDATE1+978307200,'UNIXEPOCH'),
-                    case TabA.ZISPASSWORDPROTECTED
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    TabA.ZPASSWORDHINT,
-                    case TabA.ZMARKEDFORDELETION
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    case TabA.ZISPINNED
-                    when 0 then "No"
-                    when 1 then "Yes"
-                    end,
-                    TabE.ZFILENAME,
-                    TabE.ZIDENTIFIER,
-                    TabD.ZFILESIZE,
-                    TabD.ZTYPEUTI,
-                    DATETIME(TabD.ZCREATIONDATE+978307200,'UNIXEPOCH') as "Attachment Created",
-                    DATETIME(TabD.ZMODIFICATIONDATE+978307200,'UNIXEPOCH') as "Attachment Modified",
-                    TabF.ZDATA
-                    FROM ZICCLOUDSYNCINGOBJECT TabA
-                    INNER JOIN ZICCLOUDSYNCINGOBJECT TabB on TabA.ZFOLDER = TabB.Z_PK
-                    INNER JOIN ZICCLOUDSYNCINGOBJECT TabC on TabA.ZACCOUNT2 = TabC.Z_PK
-                    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabD on TabA.Z_PK = TabD.ZNOTE
-                    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabE on TabD.Z_PK = TabE.ZATTACHMENT1
-                    LEFT JOIN ZICNOTEDATA TabF on TabF.ZNOTE = TabA.Z_PK
-                    ''')
-            
-            all_rows = cursor.fetchall()
-            analyzed_file = file_found
 
-    if len(all_rows) > 0:
-        for row in all_rows:
-            
-            if row[6] == 'No' and row[16] is not None:
-                data = GetUncompressedData(row[16])
-                text_content = ProcessNoteBodyBlob(data)
-            else:
-                text_content = ''
-            
-            if row[10] is not None and row[11] is not None:
-                attachment_file = join(dirname(analyzed_file), 'Accounts/LocalAccount/Media', row[11], row[10])
-                attachment_storage_path = dirname(attachment_file)
-
-                if not os.path.exists(attachment_file):
-                    thumbnail = 'Attachment file not found.'
-                else:
-                    try:
-                        filetype = imghdr.what(attachment_file)
-                    except OSError:
-                        filetype = None
-
-                    if filetype in ('jpeg', 'jpg', 'png'):
-                        thumbnail_path = join(report_folder, 'thumbnail_' + basename(attachment_file))
-                        try:
-                            save_original_attachment_as_thumbnail(attachment_file, thumbnail_path)
-                            thumbnail = f'<img src="{thumbnail_path}">'
-                        except OSError:
-                            thumbnail = 'Attachment present but thumbnail creation failed.'
-                    else:
-                        thumbnail = 'File is not an image or the filetype is not supported'
-            else:
-                thumbnail = ''
-                attachment_storage_path = ''
-
-            if row[12] is not None:
-                filesize = '.'.join(str(row[12])[i:i+3] for i in range(0, len(str(row[12])), 3))
-            else:
-                filesize = ''
-
-            data_list.append((row[0], row[1], row[2], text_content, row[3], row[4], row[5], row[6], row[7], row[8], row[9], thumbnail, row[10], attachment_storage_path, filesize, row[13], row[14], row[15]))
-
-        report = ArtifactHtmlReport('Notes')
-        report.start_artifact_report(report_folder, 'Notes')
-        report.add_script()
-        data_headers = ('Creation Date', 'Note Title', 'Snippet', 'Note Contents', 'Folder', 'Storage Place', 'Last Modified',
-                        'Password Protected', 'Password Hint', 'Marked for Deletion', 'Pinned', 'Attachment Thumbnail',
-                        'Attachment Original Filename', 'Attachment Storage Folder', 'Attachment Size in KB',
-                        'Attachment Type', 'Attachment Creation Date', 'Attachment Last Modified')
-        report.write_artifact_data_table(data_headers, data_list, analyzed_file, html_no_escape=['Attachment Thumbnail'])
-        report.end_artifact_report()
-
-        tsvname = 'Notes'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = 'Notes'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Notes available')
-
-    db.close()
-
-def GetUncompressedData(compressed):
-    if compressed == None:
+def get_uncompressed_data(compressed):
+    if compressed is None:
         return None
-    data = None
     try:
-        data = zlib.decompress(compressed, 15 + 32)
+        return zlib.decompress(compressed, 15 + 32)
     except zlib.error:
-        print('Zlib Decompression failed!')
-    return data
+        logfunc('Notes: zlib decompression failed')
+        return None
 
-def ProcessNoteBodyBlob(blob):
-    data = b''
-    if blob == None: return data
-    try:
-        pos = 0
-        if blob[0:3] != b'\x08\x00\x12': # header
-            print('Unexpected bytes in header pos 0 - ' + binascii.hexlify(blob[0:3]) + '  Expected 080012')
-            return ''
-        pos += 3
-        length, skip = ReadLengthField(blob[pos:])
-        pos += skip
 
-        if blob[pos:pos+3] != b'\x08\x00\x10': # header 2
-            print('Unexpected bytes in header pos {0}:{0}+3'.format(pos))
-            return '' 
-        pos += 3
-        length, skip = ReadLengthField(blob[pos:])
-        pos += skip
-
-        # Now text data begins
-        if blob[pos] != 0x1A:
-            print('Unexpected byte in text header pos {} - byte is 0x{:X}'.format(pos, blob[pos]))
-            return ''
-        pos += 1
-        length, skip = ReadLengthField(blob[pos:])
-        pos += skip
-        # Read text tag next
-        if blob[pos] != 0x12:
-            print('Unexpected byte in pos {} - byte is 0x{:X}'.format(pos, blob[pos]))
-            return ''
-        pos += 1
-        length, skip = ReadLengthField(blob[pos:])
-        pos += skip
-        data = blob[pos : pos + length].decode('utf-8', 'backslashreplace')
-        # Skipping the formatting Tags
-    except (IndexError, ValueError):
-        print('Error processing note data blob')
-    return data
-
-def ReadLengthField(blob):
-    '''Returns a tuple (length, skip) where skip is number of bytes read'''
+def read_length_field(blob):
+    '''Return a tuple (length, skip) where skip is the number of bytes read.'''
     length = 0
     skip = 0
     try:
@@ -264,15 +92,90 @@ def ReadLengthField(blob):
     return length, skip
 
 
-def save_original_attachment_as_thumbnail(file, store_path):
-    image = Image.open(file)
-    thumbnail_max_size = (350, 350)
-    image.thumbnail(thumbnail_max_size)
-    image.save(store_path)
+def process_note_body_blob(blob):
+    if blob is None:
+        return ''
+    try:
+        pos = 0
+        if blob[0:3] != b'\x08\x00\x12':  # header
+            logfunc(f'Unexpected bytes in note header: {binascii.hexlify(blob[0:3])}')
+            return ''
+        pos += 3
+        _, skip = read_length_field(blob[pos:])
+        pos += skip
+        if blob[pos:pos + 3] != b'\x08\x00\x10':  # header 2
+            logfunc(f'Unexpected bytes in note header 2 at pos {pos}')
+            return ''
+        pos += 3
+        _, skip = read_length_field(blob[pos:])
+        pos += skip
+        if blob[pos] != 0x1A:  # text header
+            logfunc(f'Unexpected byte in note text header at pos {pos}')
+            return ''
+        pos += 1
+        _, skip = read_length_field(blob[pos:])
+        pos += skip
+        if blob[pos] != 0x12:  # text tag
+            logfunc(f'Unexpected byte at pos {pos}')
+            return ''
+        pos += 1
+        length, skip = read_length_field(blob[pos:])
+        pos += skip
+        return blob[pos:pos + length].decode('utf-8', 'backslashreplace')
+    except (IndexError, ValueError):
+        logfunc('Error processing note data blob')
+        return ''
 
-__artifacts__ = {
-    "notes": (
-        "Notes",
-        ('*/NoteStore.sqlite*'),
-        get_notes)
-}
+
+@artifact_processor
+def notes(context):
+    data_headers = (
+        ('Creation Date', 'datetime'), 'Note Title', 'Snippet', 'Note Contents', 'Folder',
+        'Storage Place', ('Last Modified', 'datetime'), 'Password Protected', 'Password Hint',
+        'Marked for Deletion', 'Pinned', ('Attachment', 'media'), 'Attachment Original Filename',
+        'Attachment Storage Folder', 'Attachment Size in KB', 'Attachment Type',
+        ('Attachment Creation Date', 'datetime'), ('Attachment Last Modified', 'datetime'))
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.sqlite'):
+            continue
+
+        rows = get_sqlite_db_records(file_found, _query_for_db(file_found))
+        if not rows:
+            continue
+
+        for row in rows:
+            if row[6] == 'No' and row[16] is not None:
+                text_content = process_note_body_blob(get_uncompressed_data(row[16]))
+            else:
+                text_content = ''
+
+            media_ref = None
+            attachment_storage = ''
+            filename, identifier = row[10], row[11]
+            if filename and identifier:
+                attachment_file = join(dirname(file_found), 'Accounts/LocalAccount/Media',
+                                       identifier, filename)
+                attachment_storage = context.get_relative_path(dirname(attachment_file))
+                if os.path.exists(attachment_file):
+                    try:
+                        with open(attachment_file, 'rb') as af:
+                            media_ref = check_in_embedded_media(file_found, af.read(), filename)
+                    except OSError as ex:
+                        logfunc(f'Failed to read Notes attachment {attachment_file}: {ex}')
+
+            if row[12] is not None:
+                filesize = '.'.join(str(row[12])[i:i + 3] for i in range(0, len(str(row[12])), 3))
+            else:
+                filesize = ''
+
+            data_list.append((row[0], row[1], row[2], text_content, row[3], row[4], row[5],
+                              row[6], row[7], row[8], row[9], media_ref, row[10],
+                              attachment_storage, filesize, row[13], row[14], row[15]))
+
+        sources.append(context.get_relative_path(file_found))
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/ooklaSpeedtestData.py
+++ b/scripts/artifacts/ooklaSpeedtestData.py
@@ -1,181 +1,120 @@
-import glob
-import os
-import pathlib
+__artifacts_v2__ = {
+    "ooklaSpeedtestData": {
+        "name": "Ookla Speedtest",
+        "description": "Ookla Speedtest results including network details and test location",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Applications",
+        "notes": "",
+        "paths": ('**/speedtest.sqlite*',),
+        "output_types": ["html", "tsv", "timeline", "lava", "kml"],
+        "artifact_icon": "wifi"
+    }
+}
+
 import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+
+_QUERY = '''
+SELECT
+    datetime(("ZDATE") + strftime('%s', '2001-01-01 00:00:00'), 'unixepoch'),
+    "ZEXTERNALIP",
+    "ZINTERNALIP",
+    "ZCARRIERNAME",
+    "ZISP",
+    "ZWIFISSID",
+    "ZWANTYPE",
+    CASE "ZDEVICEMODEL"
+        WHEN "iPad3,1" THEN "iPad 3rd Gen (Wi-Fi Only)"
+        WHEN "iPad3,2" THEN "iPad 3rd Gen (Wi-Fi/Cellular Verizon/GPS)"
+        WHEN "iPad3,3" THEN "iPad 3rd Gen (Wi-Fi/Cellular AT&T/GPS)"
+        WHEN "iPad3,4" THEN "iPad 4th Gen (Wi-Fi Only)"
+        WHEN "iPad3,5" THEN "iPad 4th Gen (Wi-Fi/AT&T/GPS)"
+        WHEN "iPad3,6" THEN "iPad 4th Gen (Wi-Fi/Verizon & Sprint/GPS)"
+        WHEN "iPad6,11" THEN "iPad 9.7 5th Gen (Wi-Fi Only)"
+        WHEN "iPad6,12" THEN "iPad 9.7 5th Gen (Wi-Fi/Cellular)"
+        WHEN "iPad7,5" THEN "iPad 9.7 6th Gen (Wi-Fi Only)"
+        WHEN "iPad7,6" THEN "iPad 9.7 6th Gen (Wi-Fi/Cellular)"
+        WHEN "iPad7,11" THEN "iPad 10.2 7th Gen (Wi-Fi Only)"
+        WHEN "iPad7,12" THEN "iPad 10.2 7th Gen (Wi-Fi/Cellular Global)"
+        WHEN "iPad11,3" THEN "iPad Air 3rd Gen (Wi-Fi Only)"
+        WHEN "iPad11,4" THEN "iPad Air 3rd Gen (Wi-Fi+Cell)"
+        WHEN "iPad2,5" THEN "iPad mini Wi-Fi Only/1st Gen"
+        WHEN "iPad2,6" THEN "iPad mini Wi-Fi/AT&T/GPS - 1st Gen"
+        WHEN "iPad2,7" THEN "iPad mini Wi-Fi/VZ & Sprint/GPS - 1st Gen"
+        WHEN "iPad4,4" THEN "iPad mini 2 (Retina/2nd Gen Wi-Fi Only)"
+        WHEN "iPad4,5" THEN "iPad mini 2 (Retina/2nd Gen Wi-Fi/Cellular)"
+        WHEN "iPad4,7" THEN "iPad mini 3 (Wi-Fi Only)"
+        WHEN "iPad4,8" THEN "iPad mini 3 (Wi-Fi/Cellular)"
+        WHEN "iPad5,1" THEN "iPad mini 4 (Wi-Fi Only)"
+        WHEN "iPad5,2" THEN "iPad mini 4 (Wi-Fi/Cellular)"
+        WHEN "iPad11,1" THEN "iPad mini 5th Gen (Wi-Fi Only)"
+        WHEN "iPad11,2" THEN "iPad mini 5th Gen (Wi-Fi+Cell)"
+        WHEN "iPad6,7" THEN "iPad Pro 12.9 (Wi-Fi Only)"
+        WHEN "iPad6,8" THEN "iPad Pro 12.9 (Wi-Fi/Cellular)"
+        WHEN "iPad6,3" THEN "iPad Pro 9.7 (Wi-Fi Only)"
+        WHEN "iPad6,4" THEN "iPad Pro 9.7 (Wi-Fi/Cellular)"
+        WHEN "iPad7,3" THEN "iPad Pro 10.5 (Wi-Fi Only)"
+        WHEN "iPad7,4" THEN "iPad Pro 10.5 (Wi-Fi/Cellular)"
+        WHEN "iPad7,1" THEN "iPad Pro 12.9 (Wi-Fi Only - 2nd Gen)"
+        WHEN "iPad7,2" THEN "iPad Pro 12.9 (Wi-Fi/Cell - 2nd Gen)"
+        WHEN "iPad8,9" THEN "iPad Pro 11 (Wi-Fi Only - 2nd Gen)"
+        WHEN "iPad8,10" THEN "iPad Pro 11 (Wi-Fi/Cell - 2nd Gen)"
+        WHEN "iPad8,11" THEN "iPad Pro 12.9 (Wi-Fi Only - 4th Gen)"
+        WHEN "iPad8,12" THEN "iPad Pro 12.9 (Wi-Fi/Cell - 4th Gen)"
+        WHEN "iPhone8,4" THEN "iPhone SE (United States/A1662)"
+        WHEN "iPhone9,1" THEN "iPhone 7 (Verizon/Sprint/China/A1660)"
+        WHEN "iPhone9,3" THEN "iPhone 7 (AT&T/T-Mobile/A1778)"
+        WHEN "iPhone9,2" THEN "iPhone 7 Plus (Verizon/Sprint/China/A1661)"
+        WHEN "iPhone9,4" THEN "iPhone 7 Plus (AT&T/T-Mobile/A1784)"
+        WHEN "iPhone10,1" THEN "iPhone 8 (Verizon/Sprint/China/A1863)"
+        WHEN "iPhone10,4" THEN "iPhone 8 (AT&T/T-Mobile/Global/A1905)"
+        WHEN "iPhone10,2" THEN "iPhone 8 Plus (Verizon/Sprint/China/A1864)"
+        WHEN "iPhone10,5" THEN "iPhone 8 Plus (AT&T/T-Mobile/Global/A1897)"
+        WHEN "iPhone10,3" THEN "iPhone X (Verizon/Sprint/China/A1865)"
+        WHEN "iPhone10,6" THEN "iPhone X (AT&T/T-Mobile/Global/A1901)"
+        WHEN "iPhone11,2" THEN "iPhone Xs (A1920/A2097/A2098/A2100)"
+        WHEN "iPhone11,6" THEN "iPhone Xs Max (A1921/A2101/A2101/A2104)"
+        WHEN "iPhone11,8" THEN "iPhone XR (A1984/A2105/A2106/A2108)"
+        WHEN "iPhone12,1" THEN "iPhone 11 (A2111/A2221/A2223)"
+        WHEN "iPhone12,3" THEN "iPhone 11 Pro (A2160/A2215/A2217)"
+        WHEN "iPhone12,5" THEN "iPhone 11 Pro Max (A2161/A2218/A2220)"
+        ELSE "ZDEVICEMODEL"
+    END,
+    "ZLATITUDE",
+    "ZLONGITUDE",
+    "ZHORIZONTALACCURACY"
+FROM ZSPEEDTESTRESULT
+ORDER BY "ZDATE" DESC
+'''
 
 
-def get_ooklaSpeedtestData(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    for file_found in files_found:
+@artifact_processor
+def ooklaSpeedtestData(context):
+    data_headers = (('Timestamp', 'datetime'), 'External IP Address', 'Internal IP Address',
+                    'Carrier Name', 'ISP', 'Wifi SSID', 'WAN Type', 'Device Model',
+                    'Latitude', 'Longitude', 'Accuracy in Meters')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
         if file_found.endswith('speedtest.sqlite'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-        datetime(("ZDATE")+strftime('%s', '2001-01-01 00:00:00'), 'unixepoch') as 'Date',
-        "ZEXTERNALIP" as 'External IP Address',
-        "ZINTERNALIP" as 'Internal IP Address',
-        "ZCARRIERNAME" as 'Carrier Name',
-        "ZISP" as 'ISP',
-        "ZWIFISSID" as 'Wifi SSID',
-        "ZWANTYPE" as 'WAN Type',
-        CASE "ZDEVICEMODEL" 
-            WHEN "iPad3,1"
-                THEN "iPad 3rd Gen (Wi-Fi Only)"
-            WHEN "iPad3,2"
-                THEN "iPad 3rd Gen (Wi-Fi/Cellular Verizon/GPS)"
-            WHEN "iPad3,3"
-                THEN "iPad 3rd Gen (Wi-Fi/Cellular AT&T/GPS)"
-            WHEN "iPad3,4"
-                THEN "iPad 4th Gen (Wi-Fi Only)"
-            WHEN "iPad3,5"
-                THEN "iPad 4th Gen (Wi-Fi/AT&T/GPS)"
-            WHEN "iPad3,6"
-                THEN "iPad 4th Gen (Wi-Fi/Verizon & Sprint/GPS)"
-            WHEN "iPad6,11"
-                THEN "iPad 9.7 5th Gen (Wi-Fi Only)"
-            WHEN "iPad6,12"
-                THEN "iPad 9.7 5th Gen (Wi-Fi/Cellular)"
-            WHEN "iPad7,5"
-                THEN "iPad 9.7 6th Gen (Wi-Fi Only)"
-            WHEN "iPad7,6"
-                THEN "iPad 9.7 6th Gen (Wi-Fi/Cellular)"
-            WHEN "iPad7,11"
-                THEN "iPad 10.2 7th Gen (Wi-Fi Only)"
-            WHEN "iPad7,12"
-                THEN "iPad 10.2 7th Gen (Wi-Fi/Cellular Global)"
-            WHEN "iPad11,3"
-                THEN "iPad Air 3rd Gen (Wi-Fi Only)"
-            WHEN "iPad11,4"
-                THEN "iPad Air 3rd Gen (Wi-Fi+Cell)"
-            WHEN "iPad2,5"
-                THEN "iPad mini Wi-Fi Only/1st Gen"
-            WHEN "iPad2,6"
-                THEN "iPad mini Wi-Fi/AT&T/GPS - 1st Gen"
-            WHEN "iPad2,7"
-                THEN "iPad mini Wi-Fi/VZ & Sprint/GPS - 1st Gen"
-            WHEN "iPad4,4"
-                THEN "iPad mini 2 (Retina/2nd Gen Wi-Fi Only)"
-            WHEN "iPad4,5"
-                THEN "iPad mini 2 (Retina/2nd Gen Wi-Fi/Cellular)"
-            WHEN "iPad4,7"
-                THEN "iPad mini 3 (Wi-Fi Only)"
-            WHEN "iPad4,8"
-                THEN "iPad mini 3 (Wi-Fi/Cellular)"
-            WHEN "iPad5,1"
-                THEN "iPad mini 4 (Wi-Fi Only)"
-            WHEN "iPad5,2"
-                THEN "iPad mini 4 (Wi-Fi/Cellular)"
-            WHEN "iPad11,1"
-                THEN "iPad mini 5th Gen (Wi-Fi Only)"
-            WHEN "iPad11,2"
-                THEN "iPad mini 5th Gen (Wi-Fi+Cell)"
-            WHEN "iPad6,7" 
-                THEN "iPad Pro 12.9 (Wi-Fi Only)"
-            WHEN "iPad6,8" 
-                THEN "iPad Pro 12.9 (Wi-Fi/Cellular)"
-            WHEN "iPad6,3" 
-                THEN "iPad Pro 9.7 (Wi-Fi Only)"
-            WHEN "iPad6,4" 
-                THEN "iPad Pro 9.7 (Wi-Fi/Cellular)"
-            WHEN "iPad7,3" 
-                THEN "iPad Pro 10.5 (Wi-Fi Only)"
-            WHEN "iPad7,4" 
-                THEN "iPad Pro 10.5 (Wi-Fi/Cellular)"
-            WHEN "iPad7,1" 
-                THEN "iPad Pro 12.9 (Wi-Fi Only - 2nd Gen)"
-            WHEN "iPad7,2" 
-                THEN "iPad Pro 12.9 (Wi-Fi/Cell - 2nd Gen)"
-            WHEN "iPad8,9" 
-                THEN "iPad Pro 11 (Wi-Fi Only - 2nd Gen)"
-            WHEN "iPad8,10" 
-                THEN "iPad Pro 11 (Wi-Fi/Cell - 2nd Gen)"
-            WHEN "iPad8,11" 
-                THEN "iPad Pro 12.9 (Wi-Fi Only - 4th Gen)"
-            WHEN "iPad8,12" 
-                THEN "iPad Pro 12.9 (Wi-Fi/Cell - 4th Gen)"
-            WHEN "iPhone8,4" 
-                THEN "iPhone SE (United States/A1662)"
-            WHEN "iPhone9,1" 
-                THEN "iPhone 7 (Verizon/Sprint/China/A1660)"
-            WHEN "iPhone9,3" 
-                THEN "iPhone 7 (AT&T/T-Mobile/A1778)"
-            WHEN "iPhone9,2" 
-                THEN "iPhone 7 Plus (Verizon/Sprint/China/A1661)"
-            WHEN "iPhone9,4" 
-                THEN "iPhone 7 Plus (AT&T/T-Mobile/A1784)"
-            WHEN "iPhone10,1" 
-                THEN "iPhone 8 (Verizon/Sprint/China/A1863)"
-            WHEN "iPhone10,4" 
-                THEN "iPhone 8 (AT&T/T-Mobile/Global/A1905)"
-            WHEN "iPhone10,2" 
-                THEN "iPhone 8 Plus (Verizon/Sprint/China/A1864)"
-            WHEN "iPhone10,5" 
-                THEN "iPhone 8 Plus (AT&T/T-Mobile/Global/A1897)"
-            WHEN "iPhone10,3" 
-                THEN "iPhone X (Verizon/Sprint/China/A1865)"
-            WHEN "iPhone10,6" 
-                THEN "iPhone X (AT&T/T-Mobile/Global/A1901)"
-            WHEN "iPhone11,2" 
-                THEN "iPhone Xs (A1920/A2097/A2098/A2100)"
-            WHEN "iPhone11,6" 
-                THEN "iPhone Xs Max (A1921/A2101/A2101/A2104)"
-            WHEN "iPhone11,8" 
-                THEN "iPhone XR (A1984/A2105/A2106/A2108)"
-            WHEN "iPhone12,1" 
-                THEN "iPhone 11 (A2111/A2221/A2223)"
-            WHEN "iPhone12,3" 
-                THEN "iPhone 11 Pro (A2160/A2215/A2217)"
-            WHEN "iPhone12,5" 
-                THEN "iPhone 11 Pro Max (A2161/A2218/A2220)"
-                    ELSE "ZDEVICEMODEL"
-            END 'Device Model',
-        "ZLATITUDE" as 'Latitude',
-        "ZLONGITUDE" as 'Longitude',
-        "ZHORIZONTALACCURACY" as 'Accuracy in Meters'
-        FROM ZSPEEDTESTRESULT
-        
-        ORDER BY "ZDATE" DESC	
-    ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10]))
-        
-            description = ''
-            report = ArtifactHtmlReport('Applications')
-            report.start_artifact_report(report_folder, 'Ookla Speedtest', description)
-            report.add_script()
-            data_headers = ('Timestamp','External IP Address','Internal IP Address','Carrier Name','ISP','Wifi SSID','WAN Type','Device Model','Latitude','Longitude','Accuracy in Meters' )     
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = 'Ookla Speedtest Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-            tlactivity = 'Ookla Speedtest Data'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-            kmlactivity = 'Ookla Speedtest Data'
-            kmlgen(report_folder, kmlactivity, data_list, data_headers)
-        else:
-            logfunc('No Ookla Speedtest Application data available')
-        
-        db.close()
-        return 
+    if not source_path:
+        return data_headers, data_list, ''
 
-__artifacts__ = {
-    "ooklaSpeedtestData": (
-        "Applications",
-        ('**/speedtest.sqlite*'),
-        get_ooklaSpeedtestData)
-}
+    try:
+        rows = get_sqlite_db_records(source_path, _QUERY)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Ookla Speedtest data: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary
Converts three legacy artifacts to `__artifacts_v2__`/`@artifact_processor`.

| Source | Result | Notable |
|---|---|---|
| ooklaSpeedtestData | 1 artifact | Renamed generic **'Applications' → 'Ookla Speedtest'**; emits KML; fixes report-regenerated-inside-loop bug |
| hikvision | 4 artifacts (Channels/Info/Activity/User Media) | 🔴 **Drops the machine-localtime column** from CCTV Activity (SQLite `localtime` = examiner's machine TZ, not the device's) — keeps UTC; media via `check_in_media`; preserves researcher attribution |
| notes | 1 artifact | Embeds real attachments as media (`check_in_embedded_media`, dropping PIL/imghdr); **fixes a latent bytes+str crash** in the blob parser; now reads every NoteStore.sqlite (was last-only) |

## Conventions applied
- `creation_date` + `last_update_date` metadata; dict keys match function names.
- UTC-safe timestamps; globally-unique artifact names.

## Validation
- pylint 10.00/10 on all three files.
- Reserved-word + CREATE TABLE smoke test clean; no duplicate-name collisions.
- PluginLoader loads all 564 artifacts (+3 from the hikvision split).