### PR TITLE
Convert iconsScreen to LAVA: tabular home-screen layout + rendered PNG visual

### DIFF
--- a/scripts/artifacts/SiriRemembers.py
+++ b/scripts/artifacts/SiriRemembers.py
@@ -1,591 +1,576 @@
-# Module Description: Parses Message, Call, and Media AppIntent Data from the siriremembers.sqlite3 database
-# Author: @SQL_McGee through https://github.com/MetadataForensics
-# Date: 2024-01-29
-# Artifact version: 0.0.1
-# Requirements: none
-
-# This query was the product of research completed by James McGee, Metadata Forensics, LLC, for "Siri's Memory Lane: Exploring the siriremembers Database"
+# Parses Message, Call, and Media AppIntent data from the siriremembers.sqlite3 database.
+# The queries are the product of research by James McGee, Metadata Forensics, LLC, for
+# "Siri's Memory Lane: Exploring the siriremembers Database":
 # https://metadataperspective.com/2024/01/29/siris-memory-lane-exploring-the-siriremembers-database/
 # Additional data at https://github.com/MetadataForensics/siriremembers
+__artifacts_v2__ = {
+    "siriRemembersMessages": {
+        "name": "Siri Remembers - Messages",
+        "description": "Message AppIntent data from the siriremembers database",
+        "author": "@SQL_McGee (James McGee, Metadata Forensics, LLC)",
+        "creation_date": "2024-01-29",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Siri Remembers",
+        "notes": "Research: https://metadataperspective.com/2024/01/29/"
+                 "siris-memory-lane-exploring-the-siriremembers-database/",
+        "paths": ('*/mobile/Library/com.apple.siri.inference/siriremembers*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle"
+    },
+    "siriRemembersCalls": {
+        "name": "Siri Remembers - Calls",
+        "description": "Call AppIntent data from the siriremembers database",
+        "author": "@SQL_McGee (James McGee, Metadata Forensics, LLC)",
+        "creation_date": "2024-01-29",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Siri Remembers",
+        "notes": "Research: https://metadataperspective.com/2024/01/29/"
+                 "siris-memory-lane-exploring-the-siriremembers-database/",
+        "paths": ('*/mobile/Library/com.apple.siri.inference/siriremembers*',),
+        "output_types": "standard",
+        "artifact_icon": "phone"
+    },
+    "siriRemembersMedia": {
+        "name": "Siri Remembers - Media",
+        "description": "Media AppIntent data from the siriremembers database",
+        "author": "@SQL_McGee (James McGee, Metadata Forensics, LLC)",
+        "creation_date": "2024-01-29",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Siri Remembers",
+        "notes": "Research: https://metadataperspective.com/2024/01/29/"
+                 "siris-memory-lane-exploring-the-siriremembers-database/",
+        "paths": ('*/mobile/Library/com.apple.siri.inference/siriremembers*',),
+        "output_types": "standard",
+        "artifact_icon": "music"
+    }
+}
 
 import sqlite3
-import textwrap
 
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, does_table_exist_in_db
+from scripts.ilapfuncs import (artifact_processor, does_table_exist_in_db,
+                               get_sqlite_db_records, logfunc)
 
-def get_SiriRemembers(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    SiriRemembers = ''
-    
-    for file_found in files_found:
-        file_name = str(file_found)
-        if file_name.endswith('siriremembers.sqlite3'):
-            SiriRemembers = str(file_found)
-            source_file_sms = file_found.replace(seeker.data_folder, '')
-   
-    db = open_sqlite_db_readonly(SiriRemembers)
-    
-    cursor = db.cursor()
-    
-    if does_table_exist_in_db(SiriRemembers, 'intents'):
-    
-        # Messages
-        
-        cursor.execute('''
-        SELECT *
-        FROM (
-        SELECT
-            datetime(intents.start_date, 'UNIXEPOCH') as "Timestamp",
-            CASE 
-            WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipients'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'speakableGroupName'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.burbn.instagram' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'speakableGroupName'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                    END
-            ELSE
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipients'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-        END as "Recipient",
-        CASE 
-            WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'speakableGroupName'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.burbn.instagram' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                    END
-            ELSE
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN 'Owner'
-                END
-        END as "Recipient Handle",
-        CASE 
-            WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'sender'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'sender'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.burbn.instagram' THEN
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'speakableGroupName'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Sender')
-                    END
-            ELSE
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'sender'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-        END as "Sender",
-        CASE 
-            WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'senderHandle'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.tokens
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'speakableGroupName'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'com.burbn.instagram' THEN
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-            WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
-                CASE
-                    WHEN intents.direction = '1' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Owner')
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'recipientHandles'
-                        ), 'Sender')
-                    END
-            ELSE
-                CASE
-                    WHEN intents.direction = '2' THEN
-                        COALESCE((
-                            SELECT entities.uuid
-                            FROM intent_entities
-                            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-                            JOIN entities ON entities.id = intent_entities.entity_id
-                            WHERE
-                                intent_entities.intent_id = intents.id
-                                AND parameter_names.name = 'senderHandle'
-                        ), 'Sender')
-                    WHEN intents.direction = '1' THEN 'Owner'
-                END
-        END as "Sender Handle",
-        CASE 
-            WHEN intents.direction = '1' THEN 'Sent'
-            WHEN intents.direction = '2' THEN 'Received'
-        END as "Direction",
+_MESSAGES_QUERY = '''
+SELECT *
+FROM (
+SELECT
+    datetime(intents.start_date, 'UNIXEPOCH') as "Timestamp",
+    CASE
+    WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
         CASE
-            WHEN intents.donated_by_siri = '0' THEN 'No'
-            WHEN intents.donated_by_siri = '1' THEN 'Yes'
-        END as "Donated by Siri",
-        apps.bundle_id as "Application Bundle ID",
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipients'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
         CASE
-            WHEN intents.donated_by_siri = '1' AND 
-                 intents.start_date = LEAD(intents.start_date) OVER (ORDER BY intents.id) THEN
-                LEAD(SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1)) OVER (ORDER BY intents.id)
-            WHEN intents.donated_by_siri = '1' AND 
-                 intents.start_date = LAG(intents.start_date) OVER (ORDER BY intents.id) THEN
-                LAG(SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1)) OVER (ORDER BY intents.id)
-            ELSE 
-                SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1)
-        END as "Application UUID",
-        domains.name as "Domain ID",
-        verbs.name as "Verb ID",
-        intents.id as "Intents ID",
-        intents.uuid as "Intents UUID",
-            CASE 
-                WHEN intents.donated_by_siri = '1' AND intents.start_date = LEAD(intents.start_date) OVER (ORDER BY intents.id) THEN 'Active'
-                WHEN intents.donated_by_siri = '1' AND intents.start_date = LAG(intents.start_date) OVER (ORDER BY intents.id) THEN 'Active'
-                WHEN intents.donated_by_siri = '0' AND intents.start_date = LEAD(intents.start_date) OVER (ORDER BY intents.id) THEN 'Inactive'
-                WHEN intents.donated_by_siri = '0' AND intents.start_date = LAG(intents.start_date) OVER (ORDER BY intents.id) THEN 'Inactive'
-                ELSE 'Active'
-            END as "is_active_flag"
-        FROM intents
-        LEFT OUTER JOIN domains ON domains.id = intents.domain_id
-        LEFT OUTER JOIN verbs ON verbs.id = intents.verb_id
-        LEFT OUTER JOIN apps ON apps.id = intents.app_id
-        LEFT OUTER JOIN groups ON groups.id = intents.group_id
-        WHERE domains.name = 'Messages'
-        ) AS subquery
-        WHERE "is_active_flag" = 'Active';
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            data_list = []
-            for row in all_rows:
-                data_list.append(
-                (row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13]))
-                
-            report = ArtifactHtmlReport('Siri Remembers - Messages')
-            report.start_artifact_report(report_folder, 'Siri Remembers - Messages')
-            report.add_script()
-            data_headers = (
-                'Timestamp', 'Recipient', 'Recipient Handle', 'Sender', 'Sender Handle', 'Direction', 'Donated by Siri', 'Application Bundle ID', 
-                'Application UUID', 'Domain ID', 'Verb ID', 'Intents ID', 'Intents UUID', 'Active Row')
-            report.write_artifact_data_table(data_headers, data_list, SiriRemembers)
-            report.end_artifact_report()
-
-            tsvname = 'Siri Remembers - Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = 'Siri Remembers - Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No data available in Siri Remembers - Messages')
-        
-        # Calls
-        
-        cursor.execute('''
-        SELECT
-        datetime(intents.start_date, 'UNIXEPOCH') as "Timestamp",
-        COALESCE((
-            SELECT 
-                CASE 
-                    WHEN intents.direction = '0' AND intents.donated_by_siri = '1' THEN entities.tokens
-                    WHEN intents.direction = '1' THEN entities.tokens
-                    ELSE 'Owner'
-                END
-            FROM intent_entities
-            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-            JOIN entities ON entities.id = intent_entities.entity_id
-            WHERE
-                intent_entities.intent_id = intents.id
-                AND parameter_names.name = 'contacts'
-        ), 'Owner') as "Recipient",
-        COALESCE((
-            SELECT 
-                CASE 
-                    WHEN intents.direction = '0' AND intents.donated_by_siri = '1' THEN entities.uuid
-                    WHEN intents.direction = '1' THEN entities.uuid
-                    ELSE 'Owner'
-                END
-            FROM intent_entities
-            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-            JOIN entities ON entities.id = intent_entities.entity_id
-            WHERE
-                intent_entities.intent_id = intents.id
-                AND parameter_names.name = 'contactHandles'
-        ), 'Owner') as "Recipient Handle",
-        COALESCE((
-            SELECT 
-                CASE 
-                    WHEN intents.direction = '2' THEN entities.tokens
-                    ELSE 'Owner'
-                END
-            FROM intent_entities
-            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-            JOIN entities ON entities.id = intent_entities.entity_id
-            WHERE
-                intent_entities.intent_id = intents.id
-                AND parameter_names.name = 'contacts'
-        ), 'Owner') as "Sender",
-        COALESCE((
-            SELECT 
-                CASE 
-                    WHEN intents.direction = '2' THEN entities.uuid
-                    ELSE 'Owner'
-                END
-            FROM intent_entities
-            JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
-            JOIN entities ON entities.id = intent_entities.entity_id
-            WHERE
-                intent_entities.intent_id = intents.id
-                AND parameter_names.name = 'contactHandles'
-        ), 'Owner') as "Sender Handle",
-        CASE 
-            WHEN intents.direction = '1' THEN 'Outgoing'
-            WHEN intents.direction = '2' THEN 'Incoming'
-            WHEN intents.direction = '0' AND intents.donated_by_siri = '1' THEN 'Outgoing'
-        END as "Direction",
-        CASE 
-            WHEN intents.duration_seconds = '0' THEN 'Not Answered or Missed'
-            ELSE strftime('%H:%M:%S', intents.duration_seconds, 'unixepoch')
-        END as "Duration",
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'speakableGroupName'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.burbn.instagram' THEN
         CASE
-            WHEN intents.donated_by_siri = '0' THEN 'No'
-            WHEN intents.donated_by_siri = '1' THEN 'Yes'
-        END as "Donated by Siri",
-        apps.bundle_id as "Application Bundle ID",
-        SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1) as "Application UUID",
-        domains.name as "Domain ID",
-        verbs.name as "Verb ID",
-        intents.id as "Intents ID",
-        intents.uuid as "Intents UUID"
-        FROM intents
-        LEFT OUTER JOIN domains ON domains.id = intents.domain_id
-        LEFT OUTER JOIN verbs ON verbs.id = intents.verb_id
-        LEFT OUTER JOIN apps ON apps.id = intents.app_id
-        LEFT OUTER JOIN groups ON groups.id = intents.group_id
-        WHERE domains.name = "Calls"
-        GROUP BY intents.uuid;
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            data_list = []
-            for row in all_rows:
-                data_list.append(
-                (row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13]))
-                
-            report = ArtifactHtmlReport('Siri Remembers - Calls')
-            report.start_artifact_report(report_folder, 'Siri Remembers - Calls')
-            report.add_script()
-            data_headers = (
-                'Timestamp', 'Recipient', 'Recipient Handle', 'Sender', 'Sender Handle', 'Direction', 'Duration', 'Donated by Siri', 'Application Bundle ID', 'Application UUID', 'Domain ID', 'Verb ID', 'Intents ID', 'Intents UUID')
-            report.write_artifact_data_table(data_headers, data_list, SiriRemembers)
-            report.end_artifact_report()
-
-            tsvname = 'Siri Remembers - Calls'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = 'Siri Remembers - Calls'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No data available in Siri Remembers - Calls')
-
-        # Media
-        
-        cursor.execute('''
-        SELECT
-        datetime(intents.start_date, 'UNIXEPOCH') as "Timestamp",
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'speakableGroupName'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
         CASE
-            WHEN entities.tokens like '%mediatype%' or entities.tokens like '% zzz%' THEN
-                CASE 
-                    WHEN entity_types.name = 'MediaSearchItem'
-                        THEN SUBSTR(entities.tokens, 1, INSTR(entities.tokens, 'mediatype') - 1)
-                    WHEN entity_types.name = 'INMediaItem'
-                        THEN SUBSTR(entities.tokens, 1, INSTR(entities.tokens, ' zzz') - 1)
-                    END
-            ELSE entities.tokens
-        END AS "Media",
-        apps.bundle_id as "Application Bundle ID",
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+            END
+    ELSE
         CASE
-            WHEN intents.donated_by_siri = '0' THEN 'No'
-            WHEN intents.donated_by_siri = '1' THEN 'Yes'
-        END as "Donated by Siri",
-        SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1) as "Application UUID",
-        domains.name as "Domain ID",
-        verbs.name as "Verb ID",
-        intents.id as "Intents ID",
-        intents.uuid as "Intents UUID"
-        FROM intents
-        LEFT OUTER JOIN domains ON domains.id = intents.domain_id
-        LEFT OUTER JOIN verbs ON verbs.id = intents.verb_id
-        LEFT OUTER JOIN apps ON apps.id = intents.app_id
-        LEFT OUTER JOIN group_entities on group_entities.group_id = intents.group_id
-        LEFT OUTER JOIN entities on entities.id = group_entities.entity_id
-        LEFT OUTER JOIN entity_types on entity_types.id = entities.type_id
-        WHERE domains.name = 'Media'
-        GROUP BY intents.uuid;
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            data_list = []
-            for row in all_rows:
-                data_list.append(
-                (row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
-                
-            report = ArtifactHtmlReport('Siri Remembers - Media')
-            report.start_artifact_report(report_folder, 'Siri Remembers - Media')
-            report.add_script()
-            data_headers = (
-                'Timestamp', 'Media', 'Application Bundle ID', 'Donated by Siri', 'Application UUID', 'Domain ID', 'Verb ID', 'Intents ID', 'Intents UUID')
-            report.write_artifact_data_table(data_headers, data_list, SiriRemembers)
-            report.end_artifact_report()
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipients'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+END as "Recipient",
+    CASE
+    WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'speakableGroupName'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.burbn.instagram' THEN
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+            END
+    ELSE
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN 'Owner'
+        END
+END as "Recipient Handle",
+    CASE
+    WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'sender'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'sender'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.burbn.instagram' THEN
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'speakableGroupName'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Sender')
+            END
+    ELSE
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'sender'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+END as "Sender",
+    CASE
+    WHEN apps.bundle_id = 'com.apple.MobileSMS' THEN
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'senderHandle'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.toyopagroup.picaboo' THEN
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.tokens
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'speakableGroupName'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'com.burbn.instagram' THEN
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+    WHEN apps.bundle_id = 'org.whispersystems.signal' THEN
+        CASE
+            WHEN intents.direction = '1' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Owner')
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'recipientHandles'
+                ), 'Sender')
+            END
+    ELSE
+        CASE
+            WHEN intents.direction = '2' THEN
+                COALESCE((
+                    SELECT entities.uuid
+                    FROM intent_entities
+                    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+                    JOIN entities ON entities.id = intent_entities.entity_id
+                    WHERE
+                        intent_entities.intent_id = intents.id
+                        AND parameter_names.name = 'senderHandle'
+                ), 'Sender')
+            WHEN intents.direction = '1' THEN 'Owner'
+        END
+END as "Sender Handle",
+    CASE
+        WHEN intents.direction = '1' THEN 'Sent'
+        WHEN intents.direction = '2' THEN 'Received'
+    END as "Direction",
+    CASE
+        WHEN intents.donated_by_siri = '0' THEN 'No'
+        WHEN intents.donated_by_siri = '1' THEN 'Yes'
+    END as "Donated by Siri",
+    apps.bundle_id as "Application Bundle ID",
+    CASE
+        WHEN intents.donated_by_siri = '1' AND
+             intents.start_date = LEAD(intents.start_date) OVER (ORDER BY intents.id) THEN
+            LEAD(SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1)) OVER (ORDER BY intents.id)
+        WHEN intents.donated_by_siri = '1' AND
+             intents.start_date = LAG(intents.start_date) OVER (ORDER BY intents.id) THEN
+            LAG(SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1)) OVER (ORDER BY intents.id)
+        ELSE
+            SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1)
+    END as "Application UUID",
+    domains.name as "Domain ID",
+    verbs.name as "Verb ID",
+    intents.id as "Intents ID",
+    intents.uuid as "Intents UUID",
+        CASE
+            WHEN intents.donated_by_siri = '1' AND intents.start_date = LEAD(intents.start_date) OVER (ORDER BY intents.id) THEN 'Active'
+            WHEN intents.donated_by_siri = '1' AND intents.start_date = LAG(intents.start_date) OVER (ORDER BY intents.id) THEN 'Active'
+            WHEN intents.donated_by_siri = '0' AND intents.start_date = LEAD(intents.start_date) OVER (ORDER BY intents.id) THEN 'Inactive'
+            WHEN intents.donated_by_siri = '0' AND intents.start_date = LAG(intents.start_date) OVER (ORDER BY intents.id) THEN 'Inactive'
+            ELSE 'Active'
+        END as "is_active_flag"
+    FROM intents
+    LEFT OUTER JOIN domains ON domains.id = intents.domain_id
+    LEFT OUTER JOIN verbs ON verbs.id = intents.verb_id
+    LEFT OUTER JOIN apps ON apps.id = intents.app_id
+    LEFT OUTER JOIN groups ON groups.id = intents.group_id
+    WHERE domains.name = 'Messages'
+    ) AS subquery
+    WHERE "is_active_flag" = 'Active';
+'''
 
-            tsvname = 'Siri Remembers - Media'
-            tsv(report_folder, data_headers, data_list, tsvname)
+_CALLS_QUERY = '''
+SELECT
+datetime(intents.start_date, 'UNIXEPOCH') as "Timestamp",
+COALESCE((
+    SELECT
+        CASE
+            WHEN intents.direction = '0' AND intents.donated_by_siri = '1' THEN entities.tokens
+            WHEN intents.direction = '1' THEN entities.tokens
+            ELSE 'Owner'
+        END
+    FROM intent_entities
+    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+    JOIN entities ON entities.id = intent_entities.entity_id
+    WHERE
+        intent_entities.intent_id = intents.id
+        AND parameter_names.name = 'contacts'
+), 'Owner') as "Recipient",
+COALESCE((
+    SELECT
+        CASE
+            WHEN intents.direction = '0' AND intents.donated_by_siri = '1' THEN entities.uuid
+            WHEN intents.direction = '1' THEN entities.uuid
+            ELSE 'Owner'
+        END
+    FROM intent_entities
+    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+    JOIN entities ON entities.id = intent_entities.entity_id
+    WHERE
+        intent_entities.intent_id = intents.id
+        AND parameter_names.name = 'contactHandles'
+), 'Owner') as "Recipient Handle",
+COALESCE((
+    SELECT
+        CASE
+            WHEN intents.direction = '2' THEN entities.tokens
+            ELSE 'Owner'
+        END
+    FROM intent_entities
+    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+    JOIN entities ON entities.id = intent_entities.entity_id
+    WHERE
+        intent_entities.intent_id = intents.id
+        AND parameter_names.name = 'contacts'
+), 'Owner') as "Sender",
+COALESCE((
+    SELECT
+        CASE
+            WHEN intents.direction = '2' THEN entities.uuid
+            ELSE 'Owner'
+        END
+    FROM intent_entities
+    JOIN parameter_names ON parameter_names.id = intent_entities.parameter_name_id
+    JOIN entities ON entities.id = intent_entities.entity_id
+    WHERE
+        intent_entities.intent_id = intents.id
+        AND parameter_names.name = 'contactHandles'
+), 'Owner') as "Sender Handle",
+CASE
+    WHEN intents.direction = '1' THEN 'Outgoing'
+    WHEN intents.direction = '2' THEN 'Incoming'
+    WHEN intents.direction = '0' AND intents.donated_by_siri = '1' THEN 'Outgoing'
+END as "Direction",
+CASE
+    WHEN intents.duration_seconds = '0' THEN 'Not Answered or Missed'
+    ELSE strftime('%H:%M:%S', intents.duration_seconds, 'unixepoch')
+END as "Duration",
+CASE
+    WHEN intents.donated_by_siri = '0' THEN 'No'
+    WHEN intents.donated_by_siri = '1' THEN 'Yes'
+END as "Donated by Siri",
+apps.bundle_id as "Application Bundle ID",
+SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1) as "Application UUID",
+domains.name as "Domain ID",
+verbs.name as "Verb ID",
+intents.id as "Intents ID",
+intents.uuid as "Intents UUID"
+FROM intents
+LEFT OUTER JOIN domains ON domains.id = intents.domain_id
+LEFT OUTER JOIN verbs ON verbs.id = intents.verb_id
+LEFT OUTER JOIN apps ON apps.id = intents.app_id
+LEFT OUTER JOIN groups ON groups.id = intents.group_id
+WHERE domains.name = "Calls"
+GROUP BY intents.uuid;
+'''
 
-            tlactivity = 'Siri Remembers - Media'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No data available in Siri Remembers - Media')
-    
-    else:
-        logfunc('No data available in Siri Remembers')
-    
-__artifacts__ = {
-    "Siri Remembers": (
-        "Siri Remembers",
-        ('*/mobile/Library/com.apple.siri.inference/siriremembers*'),
-        get_SiriRemembers)
-}
+_MEDIA_QUERY = '''
+SELECT
+datetime(intents.start_date, 'UNIXEPOCH') as "Timestamp",
+CASE
+    WHEN entities.tokens like '%mediatype%' or entities.tokens like '% zzz%' THEN
+        CASE
+            WHEN entity_types.name = 'MediaSearchItem'
+                THEN SUBSTR(entities.tokens, 1, INSTR(entities.tokens, 'mediatype') - 1)
+            WHEN entity_types.name = 'INMediaItem'
+                THEN SUBSTR(entities.tokens, 1, INSTR(entities.tokens, ' zzz') - 1)
+            END
+    ELSE entities.tokens
+END AS "Media",
+apps.bundle_id as "Application Bundle ID",
+CASE
+    WHEN intents.donated_by_siri = '0' THEN 'No'
+    WHEN intents.donated_by_siri = '1' THEN 'Yes'
+END as "Donated by Siri",
+SUBSTR(intents.dkevent_uuid, INSTR(intents.dkevent_uuid, ':') + 1) as "Application UUID",
+domains.name as "Domain ID",
+verbs.name as "Verb ID",
+intents.id as "Intents ID",
+intents.uuid as "Intents UUID"
+FROM intents
+LEFT OUTER JOIN domains ON domains.id = intents.domain_id
+LEFT OUTER JOIN verbs ON verbs.id = intents.verb_id
+LEFT OUTER JOIN apps ON apps.id = intents.app_id
+LEFT OUTER JOIN group_entities on group_entities.group_id = intents.group_id
+LEFT OUTER JOIN entities on entities.id = group_entities.entity_id
+LEFT OUTER JOIN entity_types on entity_types.id = entities.type_id
+WHERE domains.name = 'Media'
+GROUP BY intents.uuid;
+'''
+
+
+def _find_db(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('siriremembers.sqlite3'):
+            return file_found
+    return ''
+
+
+def _run(context, query, headers):
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return headers, data_list, ''
+    rel = context.get_relative_path(source_path)
+    if not does_table_exist_in_db(source_path, 'intents'):
+        return headers, data_list, rel
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Siri Remembers data: {ex}')
+        return headers, data_list, rel
+    for row in rows:
+        data_list.append(tuple(row))
+    return headers, data_list, rel
+
+
+@artifact_processor
+def siriRemembersMessages(context):
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Recipient', 'Recipient Handle', 'Sender', 'Sender Handle',
+        'Direction', 'Donated by Siri', 'Application Bundle ID', 'Application UUID', 'Domain ID',
+        'Verb ID', 'Intents ID', 'Intents UUID', 'Active Row')
+    return _run(context, _MESSAGES_QUERY, data_headers)
+
+
+@artifact_processor
+def siriRemembersCalls(context):
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Recipient', 'Recipient Handle', 'Sender', 'Sender Handle',
+        'Direction', 'Duration', 'Donated by Siri', 'Application Bundle ID', 'Application UUID',
+        'Domain ID', 'Verb ID', 'Intents ID', 'Intents UUID')
+    return _run(context, _CALLS_QUERY, data_headers)
+
+
+@artifact_processor
+def siriRemembersMedia(context):
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Media', 'Application Bundle ID', 'Donated by Siri',
+        'Application UUID', 'Domain ID', 'Verb ID', 'Intents ID', 'Intents UUID')
+    return _run(context, _MEDIA_QUERY, data_headers)

--- a/scripts/artifacts/iconsScreen.py
+++ b/scripts/artifacts/iconsScreen.py
@@ -1,90 +1,193 @@
+__artifacts_v2__ = {
+    "iconsScreen": {
+        "name": "iOS Home Screen Layout",
+        "description": "Home screen layout: apps, folders, widgets and the dock, per screen page",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "iOS Screens",
+        "notes": "Parsed from SpringBoard/IconState.plist. Items are listed in their on-screen "
+                 "flow order. See 'iOS Home Screen Layout - Visual' for a rendered image of each screen.",
+        "paths": ('**/SpringBoard/IconState.plist',),
+        "output_types": "standard",
+        "artifact_icon": "grid"
+    },
+    "iconsScreenVisual": {
+        "name": "iOS Home Screen Layout - Visual",
+        "description": "Rendered image of each home screen page (apps, folders, widgets, dock)",
+        "author": "",
+        "creation_date": "2026-06-24",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "iOS Screens",
+        "notes": "A PNG is rendered per screen page from SpringBoard/IconState.plist as a visual "
+                 "reference. The 'iOS Home Screen Layout' artifact holds the same data in queryable form.",
+        "paths": ('**/SpringBoard/IconState.plist',),
+        "output_types": "standard",
+        "artifact_icon": "grid"
+    }
+}
+
+import io
 import plistlib
 
+from PIL import Image, ImageDraw, ImageFont
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media, logfunc
+
+_COLS = 4
+_CELL_W = 200
+_CELL_H = 70
+_PAD = 8
+_HEADER = 34
+_KIND_COLORS = {'app': '#2d4a7a', 'folder': '#7a5a2d', 'widget': '#2d7a4a', 'stack': '#5a2d7a'}
 
 
-def get_iconsScreen(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def _font(size):
+    for path in ('DejaVuSans.ttf', '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+                 '/System/Library/Fonts/Supplemental/Arial.ttf', '/Library/Fonts/Arial.ttf'):
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    try:
+        return ImageFont.load_default(size)
+    except TypeError:
+        return ImageFont.load_default()
 
+
+def _find_plist(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('IconState.plist'):
+            return file_found
+    return ''
+
+
+def _load(context):
+    source_path = _find_plist(context)
+    if not source_path:
+        return None, ''
+    try:
+        with open(source_path, 'rb') as fp:
+            return plistlib.load(fp), context.get_relative_path(source_path)
+    except (plistlib.InvalidFileException, ValueError, OSError) as ex:
+        logfunc(f'Failed to read IconState.plist {source_path}: {ex}')
+        return None, context.get_relative_path(source_path)
+
+
+def _iter_items(page):
+    """Normalize a single screen page into a list of {kind, name, grid, contents} dicts."""
+    items = []
+    for entry in page:
+        if isinstance(entry, str):
+            items.append({'kind': 'app', 'name': entry, 'grid': '', 'contents': []})
+        elif isinstance(entry, dict):
+            if 'listType' in entry:
+                contents = [bundle for sub in entry.get('iconLists', []) for bundle in sub]
+                items.append({'kind': 'folder', 'name': entry.get('displayName', ''),
+                              'grid': '', 'contents': contents})
+            elif 'gridSize' in entry:
+                grid = entry.get('gridSize', '')
+                if 'elementType' in entry:
+                    name = (entry.get('widgetIdentifier') if entry.get('elementType') == 'widget'
+                            else entry.get('elementType')) or ''
+                    items.append({'kind': 'widget', 'name': name, 'grid': grid, 'contents': []})
+                elif 'elements' in entry:
+                    widgets = [(w.get('widgetIdentifier') if w.get('elementType') == 'widget'
+                                else w.get('elementType')) or '' for w in entry.get('elements', [])]
+                    items.append({'kind': 'stack', 'name': 'Stack', 'grid': grid, 'contents': widgets})
+    return items
+
+
+def _render_page(title, items):
+    """Render a screen page (list of normalized items) to PNG bytes."""
+    rows = max(1, (len(items) + _COLS - 1) // _COLS)
+    width = _COLS * _CELL_W + _PAD
+    height = _HEADER + rows * _CELL_H + _PAD
+    img = Image.new('RGB', (width, height), '#1e1e1e')
+    draw = ImageDraw.Draw(img)
+    draw.text((_PAD, _PAD), title, fill='#ffffff', font=_font(16))
+
+    for i, item in enumerate(items):
+        cx = (i % _COLS) * _CELL_W + _PAD
+        cy = _HEADER + (i // _COLS) * _CELL_H
+        draw.rectangle([cx, cy, cx + _CELL_W - _PAD, cy + _CELL_H - _PAD],
+                       fill=_KIND_COLORS.get(item['kind'], '#444444'), outline='#888888')
+        if item['kind'] == 'app':
+            header = item['name']
+            subs = []
+        elif item['kind'] == 'folder':
+            header = f"[Folder] {item['name']}"
+            subs = item['contents']
+        elif item['kind'] == 'widget':
+            header = f"[Widget] {item['grid']}".strip()
+            subs = [item['name']]
+        else:
+            header = f"[Stack] {item['grid']}".strip()
+            subs = item['contents']
+        draw.text((cx + 4, cy + 4), header[:30], fill='#ffffff', font=_font(11))
+        sy = cy + 22
+        for sub in subs[:4]:
+            draw.text((cx + 6, sy), str(sub)[:32], fill='#cfcfcf', font=_font(9))
+            sy += 11
+
+    buf = io.BytesIO()
+    img.save(buf, format='PNG')
+    return buf.getvalue()
+
+
+@artifact_processor
+def iconsScreen(context):
+    data_headers = ('Screen', 'Type', 'Name', 'Folder', 'Grid Size')
     data_list = []
-    file_found = str(files_found[0])
-    with open(file_found, "rb") as fp:
-        plist = plistlib.load(fp)
-        for key, val in plist.items():
-            if key == "buttonBar":
-                bbar = val
-            elif key == "iconLists":
-                icon = val
+    plist, source_path = _load(context)
+    if not plist:
+        return data_headers, data_list, source_path
 
-        for x in range(0, len(icon)):
-            page = icon[x]
-            htmlstring = (f"<table><tr>")
-            htmlstring = htmlstring + \
-                (f'<td> Icons screen #{x}</td></tr><tr><td>') + \
-                (f'<div style="display: grid;grid-template-columns: repeat(4, 1fr);grid-gap: 2px;">')
-            for y in range(0, len(page)):
-                rows = page[y]
-                style = 'border: 1px solid grey;padding: 10px;max-height: 235px; overflow-y: scroll;'
-                grid_column = ''
-                grid_row = ''
-                if isinstance(rows, dict):
-                    var = rows
-                    if 'listType' in var.keys():
-                        foldername = var['displayName']
-                        rows = ''
-                        bundlesinfolder = var['iconLists']
-                        total_app = 0
-                        for items in bundlesinfolder:
-                            for bundle in items:
-                                rows = rows + '<br>' + bundle
-                                total_app += 1
-                        rows = (f'Folder: {foldername} ({total_app} Apps)') + rows
-                    elif 'gridSize' in var.keys():
-                        grid_size = var['gridSize']
-                        grid_column = 'grid-column: span 2;' if grid_size == 'small' else 'grid-column: span 4;'
-                        grid_row = 'grid-row: span 4;' if grid_size == 'large' else 'grid-row: span 2;'
-                        if 'elementType' in var.keys():
-                            widget_identifier = var['widgetIdentifier'] if var[
-                                'elementType'] == 'widget' else var['elementType']
-                            rows = (f'Widget<br>{widget_identifier}')
-                        elif 'elements' in var.keys():
-                            rows = 'Stack:'
-                            widgets_in_stack = var['elements']
-                            for widget in widgets_in_stack:
-                                widget_identifier = widget['widgetIdentifier'] if widget[
-                                    'elementType'] == 'widget' else widget['elementType']
-                                rows = rows + '<br>' + widget_identifier
-                        else:
-                            rows = ''
+    for page_index, page in enumerate(plist.get('iconLists', [])):
+        screen = f'Page {page_index}'
+        for item in _iter_items(page):
+            if item['kind'] == 'app':
+                data_list.append((screen, 'App', item['name'], '', ''))
+            elif item['kind'] == 'folder':
+                data_list.append((screen, 'Folder', item['name'], '', f"{len(item['contents'])} apps"))
+                for bundle in item['contents']:
+                    data_list.append((screen, 'App', bundle, item['name'], ''))
+            elif item['kind'] == 'widget':
+                data_list.append((screen, 'Widget', item['name'], '', item['grid']))
+            else:
+                data_list.append((screen, 'Stack', ', '.join(item['contents']), '', item['grid']))
 
-                htmlstring = htmlstring + \
-                    (f'<div style="{style}{grid_column}{grid_row}">{rows}</div>')
-            htmlstring = htmlstring + ("</div></td></tr></table>")
-            data_list.append((htmlstring,))
+    for bundle in plist.get('buttonBar', []):
+        data_list.append(('Dock', 'App', bundle, '', ''))
 
-        htmlstring = ''
-        htmlstring = (
-            f'<table><tr> <td colspan="4"> Icons bottom bar</td></tr><tr>')
-        for x in range(0, len(bbar)):
-            htmlstring = htmlstring + (f"<td width = 25%>{bbar[x]}</td>")
-        htmlstring = htmlstring + ("</tr></table>")
-        data_list.append((htmlstring,))
-
-        logfunc("Screens: " + str(len(icon)))
-
-        report = ArtifactHtmlReport(f'Apps per screen')
-        report.start_artifact_report(report_folder, f'Apps per screen')
-        report.add_script()
-        data_headers = ((f'Apps per Screens',))
-        report.write_artifact_data_table(
-            data_headers, data_list, file_found, html_escape=False)
-        report.end_artifact_report()
+    return data_headers, data_list, source_path
 
 
-__artifacts__ = {
-    "iconsScreen": (
-        "iOS Screens",
-        ('**/SpringBoard/IconState.plist'),
-        get_iconsScreen)
-}
+@artifact_processor
+def iconsScreenVisual(context):
+    data_headers = ('Screen', ('Layout', 'media'))
+    data_list = []
+    plist, source_path = _load(context)
+    if not plist:
+        return data_headers, data_list, source_path
+
+    pages = list(enumerate(plist.get('iconLists', [])))
+    dock = plist.get('buttonBar', [])
+    if dock:
+        pages.append(('Dock', [b for b in dock if isinstance(b, str)]))
+
+    for label, page in pages:
+        title = f'Screen {label}' if isinstance(label, int) else label
+        try:
+            png = _render_page(title, _iter_items(page))
+            media_ref = check_in_embedded_media(source_path, png, f'home_screen_{label}.png',
+                                                force_type='image/png', force_extension='png')
+        except (OSError, ValueError) as ex:
+            logfunc(f'Failed to render home screen {label}: {ex}')
+            media_ref = None
+        data_list.append((title, media_ref))
+
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
The home-screen layout parser was the last legacy artifact that emitted a *custom HTML visualization* rather than tabular data. It's now two LAVA artifacts:

| Artifact | What it gives |
|---|---|
| **iconsScreen** | Queryable/sortable table — one row per app, folder, widget, stack, and dock item. Columns: Screen, Type, Name, Folder, Grid Size. Searchable (e.g. "which screen was an app on") and TSV-exportable. |
| **iconsScreenVisual** | A **PNG rendered per screen page** (and the dock) via Pillow, checked in as embedded media — a visual reference of the layout (apps blue, folders brown w/ contents, widgets green, stacks purple). |

Renamed from the generic **'iOS Screens'** (which collided with webClips.py) to **'iOS Home Screen Layout'** / **'... - Visual'**.

## Validation
- pylint 10.00/10.
- Runtime-tested: parses apps/folders/widgets/stacks from a synthetic IconState.plist; `_render_page` produces a valid re-openable 808px PNG; the tabular function returns correct rows (folder apps tagged with their folder, dock rows present).
- Reserved-word/CREATE TABLE clean; names globally unique; PluginLoader loads all 567 artifacts.