### PR TITLE
Finalize 4 hybrid artifacts to LAVA @artifact_processor (line, pingertextfree, payByPhone, facebookMessenger)

### DIFF
--- a/scripts/artifacts/facebookMessenger.py
+++ b/scripts/artifacts/facebookMessenger.py
@@ -82,21 +82,18 @@ __artifacts_v2__ = {
 }
 
 
-from os.path import basename
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 from scripts.ilapfuncs import artifact_processor, \
     does_table_exist_in_db, does_view_exist_in_db, get_sqlite_multiple_db_records, \
     convert_unix_ts_to_utc
 
 
 @artifact_processor
-def facebookMessengerCalls(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def facebookMessengerCalls(context):
     db_path_list = []
     data_list = []
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         if file_found.endswith('.db'):
             if does_view_exist_in_db(file_found, 'thread_messages'):
                 db_path_list.append(file_found)
@@ -124,24 +121,20 @@ def facebookMessengerCalls(files_found, report_folder, seeker, wrap_text, timezo
         db_path_list, query, data_headers)
 
     for record in db_records:
-        record_data = []
-        for key in record.keys():
-            if key == 'timestamp_ms':
-                timestamp_ms = convert_unix_ts_to_utc(record['timestamp_ms'])
-                record_data.append(timestamp_ms)
-            else:
-                record_data.append(record[key])
-        data_list.append(tuple(record_data))
+        row = list(record)
+        row[0] = convert_unix_ts_to_utc(row[0])
+        data_list.append(tuple(row))
 
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def facebookMessengerChats(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def facebookMessengerChats(context):
     db_path_list = []
     data_list = []
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         if file_found.endswith('.db'):
             if does_view_exist_in_db(file_found, 'thread_messages'):
                 db_path_list.append(file_found)
@@ -153,7 +146,7 @@ def facebookMessengerChats(files_found, report_folder, seeker, wrap_text, timezo
         WHEN (SELECT CASE
 		WHEN _user_info.facebook_user_id IS NOT NULL THEN 'Sent'
 		ELSE 'Received'
-	END) = 'Sent' THEN concat(contacts.name, ' (Local User)')
+	END) = 'Sent' THEN COALESCE(contacts.name, '') || ' (Local User)'
         ELSE contacts.name
     END,
 	contacts.id,
@@ -192,25 +185,20 @@ def facebookMessengerChats(files_found, report_folder, seeker, wrap_text, timezo
         db_path_list, query, data_headers)
 
     for record in db_records:
-        record_data = []
-        for key in record.keys():
-            if key == 'timestamp_ms':
-                timestamp_ms = convert_unix_ts_to_utc(record['timestamp_ms'])
-                record_data.append(timestamp_ms)
-            else:
-                record_data.append(record[key])
-           
-        data_list.append(tuple(record_data))
+        row = list(record)
+        row[0] = convert_unix_ts_to_utc(row[0])
+        data_list.append(tuple(row))
 
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def facebookMessengerSecretConversations(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def facebookMessengerSecretConversations(context):
     db_path_list = []
     data_list = []
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         if file_found.endswith('.db'):
             if does_table_exist_in_db(file_found, 'contacts'):
                 db_path_list.append(file_found)
@@ -235,24 +223,20 @@ def facebookMessengerSecretConversations(files_found, report_folder, seeker, wra
         db_path_list, query, data_headers)
 
     for record in db_records:
-        record_data = []
-        for key in record.keys():
-            if key == 'timestamp_ms':
-                timestamp_ms = convert_unix_ts_to_utc(record['timestamp_ms'])
-                record_data.append(timestamp_ms)
-            else:
-                record_data.append(record[key])
-        data_list.append(tuple(record_data))
+        row = list(record)
+        row[0] = convert_unix_ts_to_utc(row[0])
+        data_list.append(tuple(row))
 
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def facebookMessengerConversationGroups(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def facebookMessengerConversationGroups(context):
     db_path_list = []
     data_list = []
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         if file_found.endswith('.db'):
             if does_table_exist_in_db(file_found, 'thread_participant_detail'):
                 db_path_list.append(file_found)
@@ -264,7 +248,7 @@ def facebookMessengerConversationGroups(files_found, report_folder, seeker, wrap
         group_concat(thread_participant_detail.name, ';') 
     FROM thread_participant_detail
     JOIN threads
-        OM threads.thread_key = thread_participant_detail.thread_key
+        ON threads.thread_key = thread_participant_detail.thread_key
     GROUP BY thread_participant_detail.thread_key
     '''
 
@@ -275,24 +259,20 @@ def facebookMessengerConversationGroups(files_found, report_folder, seeker, wrap
         db_path_list, query, data_headers)
 
     for record in db_records:
-        record_data = []
-        for key in record.keys():
-            if key == 'timestamp_ms':
-                timestamp_ms = convert_unix_ts_to_utc(record['timestamp_ms'])
-                record_data.append(timestamp_ms)
-            else:
-                record_data.append(record[key])
-        data_list.append(tuple(record_data))
+        row = list(record)
+        row[0] = convert_unix_ts_to_utc(row[0])
+        data_list.append(tuple(row))
 
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def facebookMessengerContacts(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def facebookMessengerContacts(context):
     db_path_list = []
     data_list = []
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         if file_found.endswith('.db'):
             if does_table_exist_in_db(file_found, 'contacts'):
                 db_path_list.append(file_found)

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -1,68 +1,54 @@
 __artifacts_v2__ = {
     "line": {
         "name": "Line Artifacts",
-        "description": "Get Line",
+        "description": "Line messages including message direction and associated usernames",
         "author": "Elliot Glendye",
-        "version": "0.0.1",
-        "date": "2023-11-22",
-        "requirements": "",
+        "creation_date": "2023-11-22",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
         "category": "Line",
-        "notes": "No notes at present.",
-        "paths": ('**/Line.sqlite*'),
-        "function": "get_line"
+        "notes": "",
+        "paths": ('**/Line.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle"
     }
 }
 
 import sqlite3
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, open_sqlite_db_readonly, iOS
 
-def get_line(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        iOSversion = iOS.get_version()
-        if version.parse(iOSversion) < version.parse('15'):
-            logfunc('Line parsing has not been tested on iOS version ' + iOSversion)
-            
-        if file_found.endswith('Line.sqlite'):
-            break
-        
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    Select datetime(ZMESSAGE.ZTIMESTAMP / 1000, 'unixepoch') AS Timestamp,
-    CASE 
-    WHEN ZMESSAGE.ZSENDER IS NULL THEN "Outgoing"
-     ELSE "Incoming" END AS "Sent / Received",
-    ZUSER.ZNAME AS "Username",
-    ZMESSAGE.ZTEXT AS "Message Content"
-    From ZMESSAGE
-    LEFT Join ZUSER On ZMESSAGE.ZSENDER = ZUSER.Z_PK
-    ORDER BY ZMESSAGE.ZTIMESTAMP Desc;
-    ''')
-        
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+
+
+@artifact_processor
+def line(context):
+    data_headers = (('Timestamp', 'datetime'), 'Sent / Received', 'Username', 'Message')
     data_list = []
-        
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3]))
-            
-        description = 'A report of Line Messages, including message direction and associated usernames.'
-        report = ArtifactHtmlReport('Line Messages')
-        report.start_artifact_report(report_folder, 'Line Messages', description)
-        report.add_script()
-        data_headers = ('Timestamp', 'Sent / Received', 'Username', 'Message',)
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = 'Line Messages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    
-    else:
-        logfunc('No Line messages present')
-    db.close()
-    return
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith('Line.sqlite'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZMESSAGE.ZTIMESTAMP / 1000, 'unixepoch'),
+        CASE WHEN ZMESSAGE.ZSENDER IS NULL THEN 'Outgoing' ELSE 'Incoming' END,
+        ZUSER.ZNAME,
+        ZMESSAGE.ZTEXT
+    FROM ZMESSAGE
+    LEFT JOIN ZUSER ON ZMESSAGE.ZSENDER = ZUSER.Z_PK
+    ORDER BY ZMESSAGE.ZTIMESTAMP DESC
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Line messages: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/payByPhone.py
+++ b/scripts/artifacts/payByPhone.py
@@ -1,25 +1,25 @@
 __artifacts_v2__ = {
-    "userPayByPhone": {  
+    "userPayByPhone": {
         "name": "PayByPhone - Users and Vehicules Info",
         "description": "Extract users and vehicules infos",
         "author": "@flashesc, @thibgav, @borelmo",
-        "version": "1.2",
-        "date": "2024-11-20",
+        "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
-        "category": "Parking",  
-        "notes": "",
+        "category": "Parking",
+        "notes": "Vehicule Picture is the on-device picture filename for the vehicle.",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/PayByPhone.sqlite*',),
-        "output_types": ["tsv", "timeline", "kml", "lava"],
+        "output_types": "standard",
         "artifact_icon": "users"
     },
-    "sessionPayByPhone": { 
-        "name": "PayByPhone - Parking Sessions",  
+    "sessionPayByPhone": {
+        "name": "PayByPhone - Parking Sessions",
         "description": "List of parking sessions",
         "author": "@flashesc, @thibgav, @borelmo",
-        "version": "1.2",
-        "date": "2024-11-20",
+        "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
-        "category": "Parking",  
+        "category": "Parking",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/PayByPhone.sqlite*',),
         "output_types": "all",
@@ -27,56 +27,48 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, media_to_html, webkit_timestampsconv
 import re
 
-def price_format(value): # limit to two digits after the decimal point
+from scripts.ilapfuncs import (artifact_processor, get_file_path, get_sqlite_db_records,
+                               webkit_timestampsconv)
+
+
+def price_format(value):
+    """Limit a price to two digits after the decimal point."""
     if value:
         try:
             return f"{float(value):.2f}"
         except (ValueError, TypeError):
             return value
-    else:
-        return value
-    
+    return value
 
-def clean_text(html): # remove html tags
+
+def clean_text(html):
+    """Strip HTML tags and unescape a handful of entities from a lot message."""
     if not html:
-        return "" 
-
-    try:
-        text_without_tags = re.sub(r'<[^>]+>', '', html)
-        
-        text_without_tags = text_without_tags.replace('&quot;', '"')
-        text_without_tags = text_without_tags.replace('&nbsp;', ' ')
-        text_without_tags = text_without_tags.replace('&amp;', '&')
-        
-        lignes = [ligne.strip() for ligne in text_without_tags.split('\n') if ligne.strip()]
-        cleaned_text = "\n".join(lignes)
-        
-        return cleaned_text
-    except Exception as e:
-        print(f"Error while processing HTML contents : {e}")
         return ""
+    text_without_tags = re.sub(r'<[^>]+>', '', html)
+    text_without_tags = text_without_tags.replace('&quot;', '"')
+    text_without_tags = text_without_tags.replace('&nbsp;', ' ')
+    text_without_tags = text_without_tags.replace('&amp;', '&')
+    lignes = [ligne.strip() for ligne in text_without_tags.split('\n') if ligne.strip()]
+    return "\n".join(lignes)
+
 
 @artifact_processor
-def userPayByPhone(files_found, report_folder, seeker, wrap_text, time_offset):
-    source_path = get_file_path(files_found, "PayByPhone.sqlite")
+def userPayByPhone(context):
+    source_path = get_file_path(context.get_files_found(), "PayByPhone.sqlite")
     data_list = []
-    html_data_list = []
-    pictures_path = source_path[source_path.find("/mobile"):]
-    pictures_found = seeker.search(f"*{pictures_path}")
 
     query = '''
-    SELECT 
-        ZUSERACCOUNT.ZEMAIL AS "EMAIL",
-        ZUSERACCOUNT.ZMEMBERID AS "ID Membre",
-        ZUSERACCOUNT.ZUSERNAME AS "Telephone",
-        ZVEHICLE.ZCOUNTRY AS "Pays",
-        ZVEHICLE.ZLICENSEPLATE AS "Numero plaque",
-        ZVEHICLE.ZVEHICLEDESCRIPTION AS "Description véhicule",
-        ZVEHICLE.ZVEHICLETYPESTRING AS "Catégorie",
+    SELECT
+        ZUSERACCOUNT.ZEMAIL,
+        ZUSERACCOUNT.ZMEMBERID,
+        ZUSERACCOUNT.ZUSERNAME,
+        ZVEHICLE.ZCOUNTRY,
+        ZVEHICLE.ZLICENSEPLATE,
+        ZVEHICLE.ZVEHICLEDESCRIPTION,
+        ZVEHICLE.ZVEHICLETYPESTRING,
         ZVEHICLE.ZVEHICLEID
     FROM ZUSERACCOUNT
     LEFT JOIN ZVEHICLE ON ZUSERACCOUNT.Z_PK = ZVEHICLE.ZUSERACCOUNT
@@ -89,50 +81,36 @@ def userPayByPhone(files_found, report_folder, seeker, wrap_text, time_offset):
                     'License Plate',
                     'Vehicule Description',
                     'Vehicule Type',
-                    'Vehicule Picture'
-                    )
+                    'Vehicule Picture')
 
-    db_records = get_sqlite_db_records(source_path, query)
-
-    for record in db_records:
-        media_path = f'{record[-1]}.png'
-        media_tag = media_to_html(media_path, pictures_found, report_folder)
+    for record in get_sqlite_db_records(source_path, query):
         data_list.append(
-            (record[0], record[1], record[2], record[3], record[4], record[5], record[6], media_path)
-            )
-        html_data_list.append(
-            (record[0], record[1], record[2], record[3], record[4], record[5], record[6], media_tag)
-            )
-
-    report = ArtifactHtmlReport('PayByPhone - Users and Vehicules Info')
-    report.start_artifact_report(report_folder, 'PayByPhone - Users and Vehicules Info', artifact_description= "Extract users and vehicules infos")
-    report.add_script()
-    report.write_artifact_data_table(data_headers, html_data_list, source_path, html_no_escape=['Vehicule Picture'])
-    report.end_artifact_report()
+            (record[0], record[1], record[2], record[3], record[4], record[5], record[6],
+             f'{record[-1]}.png'))
 
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def sessionPayByPhone(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, "PayByPhone.sqlite")
+def sessionPayByPhone(context):
+    source_path = get_file_path(context.get_files_found(), "PayByPhone.sqlite")
     data_list = []
 
     query = '''
-    SELECT 
-        ps.ZSTARTTIME AS "Heure_arrivee",
-        ps.ZEXPIRETIME AS "Heure_depart",
+    SELECT
+        ps.ZSTARTTIME,
+        ps.ZEXPIRETIME,
         u.ZEMAIL,
-        v.ZVEHICLEDESCRIPTION as Voiture,
-        ps.ZAMOUNT as Prix,
-        l.ZCURRENCY as Devise,
-        ps.ZCOORDINATELATITUDE as Latitude,
-        ps.ZCOORDINATELONGITUDE as Longitude,
-        ps.ZLOCATIONNUMBER AS "tarif/zone",             
-        l.ZNAME as Nom_parking,
-        l.ZVENDORNAME as Ville,
-        l.ZCOUNTRY as Pays,
-        l.ZLOTMESSAGE as Info
+        v.ZVEHICLEDESCRIPTION,
+        ps.ZAMOUNT,
+        l.ZCURRENCY,
+        ps.ZCOORDINATELATITUDE,
+        ps.ZCOORDINATELONGITUDE,
+        ps.ZLOCATIONNUMBER,
+        l.ZNAME,
+        l.ZVENDORNAME,
+        l.ZCOUNTRY,
+        l.ZLOTMESSAGE
     FROM ZVEHICLE AS v
     JOIN ZPARKINGSESSION AS ps ON v.Z_PK = ps.ZVEHICLE
     JOIN ZLOCATION AS l ON ps.ZLOCATIONNUMBER = l.ZLOCATIONNUMBER
@@ -140,31 +118,24 @@ def sessionPayByPhone(files_found, report_folder, seeker, wrap_text, timezone_of
     '''
 
     data_headers = (
-            ('Start Time', 'datetime'),
-            ('Expire Time', 'datetime'),
-            'Email',
-            'Vehicule',
-            'Price',
-            'Currency',
-            'Latitude',
-            'Longitude',
-            'Location Number',
-            'Parking Name',
-            'City',
-            'Country',
-            'Info')
-    
-    db_records = get_sqlite_db_records(source_path, query)
-    
-    for record in db_records:
-        start_timestamp = webkit_timestampsconv(record[0])
-        expire_timestamp = webkit_timestampsconv(record[1])
-        price = price_format(record[4])
-        info_lisible = clean_text(record[12])
-        data_list.append(
-            (start_timestamp, expire_timestamp, record[2],record[3], price, record[5], record[6], record[7], 
-                record[8], record[9], record[10], record[11], info_lisible,)
-            )
+        ('Start Time', 'datetime'),
+        ('Expire Time', 'datetime'),
+        'Email',
+        'Vehicule',
+        'Price',
+        'Currency',
+        'Latitude',
+        'Longitude',
+        'Location Number',
+        'Parking Name',
+        'City',
+        'Country',
+        'Info')
 
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append(
+            (webkit_timestampsconv(record[0]), webkit_timestampsconv(record[1]), record[2],
+             record[3], price_format(record[4]), record[5], record[6], record[7], record[8],
+             record[9], record[10], record[11], clean_text(record[12])))
 
     return data_headers, data_list, source_path

--- a/scripts/artifacts/pingertextfree.py
+++ b/scripts/artifacts/pingertextfree.py
@@ -1,103 +1,64 @@
 __artifacts_v2__ = {
     "pingertextfree": {
         "name": "Text Free - Pinger",
-        "description": "Text free messages",
+        "description": "Text Free (Pinger) messages",
         "author": "@AlexisBrignoni",
-        "version": "0.0.1",
-        "date": "2020-11-18",
+        "creation_date": "2020-11-18",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "Pinger",
         "notes": "",
-        "paths": ('*/Messaging_*.sqlite*'),
-        "function": "get_pingertextfree",
-        "output_types": "standard"
+        "paths": ('*/Messaging_*.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square"
     }
 }
 
-
-import os
-import shutil
 import sqlite3
-#import scripts.artifacts.artGlobals
 
-#from packaging import version
-#from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import artifact_processor, logfunc, logdevinfo, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, media_to_html
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+
 
 @artifact_processor
-def get_pingertextfree(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    for file_found in files_found:
+def pingertextfree(context):
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Conversation ID',
+        'Directionality to from Other Party',
+        'Other Party',
+        'Status',
+        'Text',
+        'Type')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
         if file_found.endswith('.sqlite'):
-            
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-            ZCONVERSATIONCD.Z_PK
-            from ZCONVERSATIONCD 
-            order by ZCONVERSATIONCD.Z_PK
-            ''')
-        
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            data_list = []  
-            
-            if usageentries > 0:
-                for row in all_rows:
-                    cursor.execute(f'''
-                    SELECT
-                    ZCONVERSATIONCD.Z_PK,
-                    datetime(ZCOMMUNICATIONCD.ZTIMECREATED, 'unixepoch'),
-                    ZCOMMUNICATIONCD.ZCONVERSATION,
-                    ZCOMMUNICATIONCD.ZDIRECTION,
-                    ZCONVERSATIONCD.ZDISPLAYNAME,
-                    ZCOMMUNICATIONCD.ZMYSTATUS,
-                    ZCOMMUNICATIONCD.ZTEXT,
-                    ZCOMMUNICATIONCD.ZTYPE,
-                    ZCOMMUNICATIONCD.ZTIMECREATED
-                    FROM ZCONVERSATIONCD, ZCOMMUNICATIONCD
-                    WHERE ZCONVERSATIONCD.Z_PK = {row[0]}  AND ZCOMMUNICATIONCD.ZCONVERSATION = {row[0]}
-                    order by ZCOMMUNICATIONCD.ZTIMECREATED
-                    ''')
-                    
-                    all_rowsb = cursor.fetchall()
-                    usageentriesb = len(all_rowsb)
-                
-                    
-                    if usageentriesb > 0:
-                        for rowb in all_rowsb:
-                            data_list.append((rowb[1], rowb[2], rowb[3], rowb[4], rowb[5], rowb[6], rowb[7]))
-        
-            
-            data_headers = (
-                'Timestamp', 
-                'Conversation ID',
-                'Directionality to from Other Party', 
-                'Other Party',
-                'Status',
-                'Text', 
-                'Type'
-                )
-            return data_headers, data_list, file_found
-        
-            '''
-            description = 'Text Free Messages'
-            report = ArtifactHtmlReport('Text Free Messages')
-            report.start_artifact_report(report_folder, 'Text Free Messages', description)
-            report.add_script()
-            data_headers = ('Timestamp', 'Conversation ID', 'Directionality to/from Other Party', 'Other Party', 'Status', 'Text', 'Type')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Attachment'])
-            report.end_artifact_report()
-            
-            tsvname = 'Text Free Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = 'Text Free Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        '''
-        else:
-            logfunc('No Text Free Messages  data available')
-        
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZCOMMUNICATIONCD.ZTIMECREATED, 'unixepoch'),
+        ZCOMMUNICATIONCD.ZCONVERSATION,
+        ZCOMMUNICATIONCD.ZDIRECTION,
+        ZCONVERSATIONCD.ZDISPLAYNAME,
+        ZCOMMUNICATIONCD.ZMYSTATUS,
+        ZCOMMUNICATIONCD.ZTEXT,
+        ZCOMMUNICATIONCD.ZTYPE
+    FROM ZCOMMUNICATIONCD
+    JOIN ZCONVERSATIONCD ON ZCONVERSATIONCD.Z_PK = ZCOMMUNICATIONCD.ZCONVERSATION
+    ORDER BY ZCOMMUNICATIONCD.ZCONVERSATION, ZCOMMUNICATIONCD.ZTIMECREATED
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Text Free messages: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary
Finalizes four 'hybrid' artifacts (mixed legacy + LAVA state) to the clean `@artifact_processor`/context form. Fixes several latent bugs found along the way.

| Artifact | What changed |
|---|---|
| **line** | Legacy `"function"`-key form → `@artifact_processor`/context; `creation_date`/`last_update_date`; author preserved (Elliot Glendye) |
| **pingertextfree** | Finished a half-done conversion: had `@ap` but a 5-arg body, a redundant `"function"` key, key≠function name, deprecated `version`/`date`, and a `return` inside the file loop. Now context form + a single JOIN query; author preserved (@AlexisBrignoni) |
| **payByPhone** | Dropped the redundant manual `ArtifactHtmlReport` (its inline-image lookup resolved the **DB path**, not the image dirs, so it never rendered); both functions → context form; `version`/`date` → `creation_date`/`last_update_date` |
| **facebookMessenger** | Removed dead imports; all 5 functions → context form; **fixed a `JOIN … OM` typo that crashed Conversation Groups**; fixed the timestamp conversion (old key-name check silently skipped Conversation Groups); **replaced SQLite `concat()` (3.44+ only — errored and returned zero chat rows on older builds) with portable `COALESCE(…) || …`** |

## Validation
- pylint 10.00/10 on all four.
- Runtime-tested against temp schemas: all facebookMessenger queries execute; Chats now returns rows with correct UTC timestamps.
- Reserved-word/CREATE TABLE clean; keys match function names; PluginLoader loads all 567.

## Note
`sms` was reviewed and intentionally **not** changed — its `ArtifactHtmlReport` is a value-add threaded-chat renderer (not redundant), and it's already on the modern form.