### PR TITLE
Convert Oops, sysShutdown, mediaLibrary to LAVA (function-key -> @artifact_processor)

### DIFF
--- a/scripts/artifacts/Oops.py
+++ b/scripts/artifacts/Oops.py
@@ -3,78 +3,60 @@ __artifacts_v2__ = {
         "name": "Oops: Make New Friends",
         "description": "Parses Oops Message Database",
         "author": "Heather Charpentier",
-        "version": "0.0.1",
-        "date": "2024-06-26",
+        "creation_date": "2024-06-26",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "Oops",
         "notes": "",
-        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/RongCloud/*/storage*'),
-        "function": "get_OopsMessages"
+        "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/RongCloud/*/storage*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle"
     }
 }
 
 import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
 
-def get_OopsMessages(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
+_QUERY = '''
+SELECT
+    datetime(send_time/1000, 'unixepoch'),
+    datetime(receive_time/1000, 'unixepoch'),
+    clazz_name,
+    json_extract(RCT_MESSAGE.content, '$.user.name'),
+    sender_id,
+    CASE message_direction
+        WHEN 1 THEN 'Incoming'
+        WHEN 0 THEN 'Outgoing'
+        ELSE 'Unknown'
+    END,
+    json_extract(RCT_Message.content, '$.content'),
+    json_extract(json_extract(RCT_Message.content, '$.extra'), '$.nickName'),
+    json_extract(json_extract(RCT_Message.content, '$.extra'), '$.userId')
+FROM RCT_MESSAGE
+WHERE json_valid(json_extract(RCT_Message.content, '$.extra'))
+'''
+
+
+@artifact_processor
+def Oops(context):
+    data_headers = (
+        ('Date Sent', 'datetime'), ('Date Received', 'datetime'), 'Message Type', 'Sender Name',
+        'Sender ID', 'Direction', 'Message', 'Nickname', 'User ID')
     data_list = []
-    
-    for file_found in files_found:
+    sources = []
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        if file_found.endswith('storage'):
-            db = open_sqlite_db_readonly(file_found)
-            #SQL QUERY TIME!
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-            datetime(send_time/1000, 'unixepoch') as 'Date Sent',
-            datetime(receive_time/1000, 'unixepoch') as 'Date Received',
-            clazz_name as 'Message Type',
-            json_extract(RCT_MESSAGE.content, '$.user.name') as 'Sender Name',
-            sender_id as 'Sender ID',
-            CASE message_direction
-                WHEN 1 THEN 'Incoming'
-                WHEN 0 THEN 'Outgoing'
-                ELSE 'Unknown'
-            END as Direction,
-            json_extract(RCT_Message.content, '$.content') as 'Message',
-            json_extract(json_extract(RCT_Message.content, '$.extra'), '$.nickName') AS 'Nickname',
-            json_extract(json_extract(RCT_Message.content, '$.extra'), '$.userId') AS 'User ID'
-            FROM RCT_MESSAGE
-            WHERE
-            json_valid(json_extract(RCT_Message.content, '$.extra'))
-            ''')
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-               for row in all_rows:
-               
-                   data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
-            db.close()
-                    
-        else:
+        if not file_found.endswith('storage'):
             continue
-        
-    if data_list:
-        description = 'Oops: Make New Friends'
-        report = ArtifactHtmlReport('Oops Messages')
-        report.start_artifact_report(report_folder, 'Oops Messages', description)
-        report.add_script()
-        data_headers = ('Date Sent','Date Received','Message Type','Sender Name','Sender ID','Direction','Message','Nickname','User ID')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'Oops Messages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Oops Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    
-    else:
-        logfunc('No Oops data available')
+        try:
+            rows = get_sqlite_db_records(file_found, _QUERY)
+        except sqlite3.Error as ex:
+            logfunc(f'Error reading Oops messages from {file_found}: {ex}')
+            continue
+        for row in rows:
+            data_list.append(tuple(row))
+        sources.append(context.get_relative_path(file_found))
 
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -1,132 +1,115 @@
 __artifacts_v2__ = {
     "mediaLibrary": {
         "name": "Media Library",
-        "description": "",
+        "description": "Media items (music, video, podcasts, e-books) from Medialibrary.sqlitedb",
         "author": "",
-        "version": "0.2",
-        "date": "2023-11-21",
+        "creation_date": "2023-11-21",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "Media Library",
         "notes": "",
-        "paths": ('**/Medialibrary.sqlitedb*'),
-        "function": "get_mediaLibrary"
+        "paths": ('**/Medialibrary.sqlitedb*',),
+        "output_types": "standard",
+        "artifact_icon": "music"
+    },
+    "mediaLibraryInfo": {
+        "name": "Media Library - Database Properties",
+        "description": "iCloud/account properties from the Medialibrary.sqlitedb _MLDATABASEPROPERTIES table",
+        "author": "",
+        "creation_date": "2023-11-21",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Media Library",
+        "notes": "",
+        "paths": ('**/Medialibrary.sqlitedb*',),
+        "output_types": "standard",
+        "artifact_icon": "info"
     }
 }
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone 
+import sqlite3
 
-def get_mediaLibrary(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    
-    data_list = []
-    data_list_info = []
-    
-    for file_found in files_found:
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+
+_MEDIA_KIND = {0: 'E-book', 1: 'Audio', 2: 'Film', 4: 'Podcast', 33: 'Video M4V'}
+
+_MEDIA_QUERY = '''
+SELECT
+    ext.title, ext.media_kind, itep.format,
+    ext.location, ext.total_time_ms, ext.file_size, ext.year,
+    alb.album, alba.album_artist, com.composer, gen.genre,
+    ite.track_number, art.artwork_token,
+    itev.extended_content_rating, itev.movie_info,
+    ext.description_long, sto.account_id,
+    datetime(sto.date_purchased + 978307200, 'unixepoch'),
+    sto.store_item_id, sto.purchase_history_id, ext.copyright
+FROM item_extra ext
+JOIN item_store sto USING (item_pid)
+JOIN item ite USING (item_pid)
+JOIN item_stats ites USING (item_pid)
+JOIN item_playback itep USING (item_pid)
+JOIN item_video itev USING (item_pid)
+LEFT JOIN album alb ON sto.item_pid = alb.representative_item_pid
+LEFT JOIN album_artist alba ON sto.item_pid = alba.representative_item_pid
+LEFT JOIN composer com ON sto.item_pid = com.representative_item_pid
+LEFT JOIN genre gen ON sto.item_pid = gen.representative_item_pid
+LEFT JOIN item_artist itea ON sto.item_pid = itea.representative_item_pid
+LEFT JOIN artwork_token art ON sto.item_pid = art.entity_pid
+'''
+
+
+def _find_db(context):
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
         if file_found.endswith('Medialibrary.sqlitedb'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            
-            # Execute query for retrieving media information
-            try:
-                cursor.execute(
-                """
-                SELECT ext.title, ext.media_kind, itep.format,
-                        ext.location, ext.total_time_ms, ext.file_size, ext.year,
-                        alb.album, alba.album_artist, com.composer, gen.genre,
-                        ite.track_number, art.artwork_token,
-                        itev.extended_content_rating, itev.movie_info,
-                        ext.description_long, sto.account_id,
-                        strftime(\'%d/%m/%Y %H:%M:%S\', 
-                        datetime(sto.date_purchased + 978397200, \'unixepoch\'))
-                        date_purchased, sto.store_item_id, sto.purchase_history_id, ext.copyright
-                        from item_extra
-                        ext join item_store sto using (item_pid)
-                        join item ite using (item_pid)
-                        join item_stats ites using (item_pid)
-                        join item_playback itep using (item_pid)
-                        join item_video itev using (item_pid)
-                        left join album alb on sto.item_pid=alb.representative_item_pid
-                        left join album_artist alba
-                        on sto.item_pid=alba.representative_item_pid
-                        left join composer com on
-                        sto.item_pid=com.representative_item_pid
-                        left join genre gen on sto.item_pid=gen.representative_item_pid
-                        left join item_artist itea on
-                        sto.item_pid=itea.representative_item_pid
-                        left join artwork_token art on sto.item_pid=art.entity_pid
-                """
-                )
-            except:
-                logfunc('Error executing SQLite query')
+            return file_found
+    return ''
 
-            all_rows = cursor.fetchall()
-            media_type = ''
 
-            for row in all_rows:
-                col_count = 0 
-                tmp_row = []
+@artifact_processor
+def mediaLibrary(context):
+    data_headers = (
+        'Title', 'Media Type', 'File Format', 'File', 'Total Time (ms)', 'File Size', 'Year',
+        'Album Name', 'Album Artist', 'Composer', 'Genre', 'Track Number', 'Artwork',
+        'Content Rating', 'Movie Information', 'Description', 'Account ID',
+        ('Date Purchased', 'datetime'), 'Item ID', 'Purchase History ID', 'Copyright')
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return data_headers, data_list, ''
 
-                for media_type in row:
-                    if col_count == 1:
-                        if media_type == 0:
-                            media_type = "E-book"
-                        if media_type == 1:
-                            media_type = "Audio"
-                        if media_type == 2:
-                            media_type = "Film"
-                        if media_type == 33:
-                            media_type = "Video M4V"
-                if media_type == 4:
-                    media_type = "Podcast"
-                    if col_count == 4:
-                        media_type = int(media_type)
+    try:
+        rows = get_sqlite_db_records(source_path, _MEDIA_QUERY)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Media Library: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
 
-                    col_count = col_count + 1
-                    tmp_row.append(str(media_type).replace('\n', ''))
+    for row in rows:
+        values = list(row)
+        values[1] = _MEDIA_KIND.get(values[1], values[1])
+        data_list.append(tuple(values))
 
-                data_list.append(tmp_row)
-            
-            # Recover account information
-            cursor.execute(
-            """
-            select * from _MLDATABASEPROPERTIES;
-            """
-            )
-            iOS_info = cursor.fetchall()
+    return data_headers, data_list, context.get_relative_path(source_path)
 
-            iCloud_items = [
-                'MLJaliscoAccountID', 'MPDateLastSynced',
-                'MPDateToSyncWithUbiquitousStore', 'OrderingLanguage']
 
-            for row in iOS_info:
-                for elm in iCloud_items:
-                    if row[0] == elm:
-                        data_list_info.append((row[0],row[1]))
+@artifact_processor
+def mediaLibraryInfo(context):
+    data_headers = ('Key', 'Value')
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return data_headers, data_list, ''
 
-            db.close()
-    
-    if data_list:
-        report = ArtifactHtmlReport('Media Library')
-        report.start_artifact_report(report_folder, 'Media Library')
-        report.add_script()
-        data_headers_info = ('key', 'value')
-        data_headers = ('Title','Media Type','File Format','File','Total Time (ms)',
-                        'File Size','Year','Album Name','Album Artist','Composer',
-                        'Genre','Track Number', 'Artwork','Content Rating',
-                        'Movie Information','Description','Account ID',
-                        'Date Purchased','Item ID','Purchase History ID','Copyright')
-                        
-        report.write_artifact_data_table(data_headers_info, data_list_info, file_found, cols_repeated_at_bottom=False)
-        report.write_artifact_data_table(data_headers, data_list, file_found, True, False)
-        
-        report.end_artifact_report()
+    wanted = ('MLJaliscoAccountID', 'MPDateLastSynced', 'MPDateToSyncWithUbiquitousStore',
+              'OrderingLanguage')
+    try:
+        rows = get_sqlite_db_records(source_path, 'SELECT * FROM _MLDATABASEPROPERTIES')
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Media Library properties: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
 
-        tsvname = 'Media Library'
-        tsv(report_folder, data_headers_info, data_list_info, tsvname)
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Media Library data available')
-    
+    for row in rows:
+        if row[0] in wanted:
+            data_list.append((row[0], row[1]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/sysShutdown.py
+++ b/scripts/artifacts/sysShutdown.py
@@ -1,106 +1,87 @@
 __artifacts_v2__ = {
-    "get_sysShutdown": {
-        "name": "Sysdiagnose - Shutdown Log",
-        "description": "Parses the shutdown.log file from Sysdiagnose logs, based off work by Kaspersky Lab https://github.com/KasperskyLab/iShutdown",
+    "sysShutdownProcesses": {
+        "name": "Sysdiagnose - Shutdown Log Processes",
+        "description": "Parses the processes still running at shutdown from the shutdown.log file "
+                       "in Sysdiagnose logs, based off work by Kaspersky Lab "
+                       "https://github.com/KasperskyLab/iShutdown",
         "author": "@KevinPagano3",
-        "version": "0.1",
-        "date": "2024-02-13",
+        "creation_date": "2024-02-13",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "Sysdiagnose",
         "notes": "",
-        "paths": ('*/shutdown*.log'),
-        "output_types": "none", #["html","tsv","timeline","lava"]
-        "function": "get_sysShutdown"
+        "paths": ('*/shutdown*.log',),
+        "output_types": "standard",
+        "artifact_icon": "power"
+    },
+    "sysShutdownReboots": {
+        "name": "Sysdiagnose - Shutdown Log Reboots",
+        "description": "Parses reboot events from the shutdown.log file in Sysdiagnose logs, based off "
+                       "work by Kaspersky Lab https://github.com/KasperskyLab/iShutdown",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-02-13",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Sysdiagnose",
+        "notes": "",
+        "paths": ('*/shutdown*.log',),
+        "output_types": "standard",
+        "artifact_icon": "refresh-cw"
     }
 }
 
-from datetime import datetime
-import os
 import re
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, convert_ts_int_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, convert_ts_int_to_utc, logfunc
 
-def get_sysShutdown(files_found, report_folder, seeker, wrap_text, time_offset):
-    
-    data_list_shutdown_log = []
-    data_list_shutdown_reboot = []
-    category = "Sysdiagnose"
-    module_name = "get_sysShutdown"
-    
-    for file_found in files_found:
+
+def _parse_shutdown_logs(context):
+    """Parse shutdown.log(s): return (processes, reboots, joined sources). Times are UTC."""
+    processes = []
+    reboots = []
+    sources = []
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
+        rel = context.get_relative_path(file_found)
+        try:
+            with open(file_found, encoding='utf-8', mode='r') as fh:
+                lines = fh.readlines()
+        except OSError as ex:
+            logfunc(f'Failed to read shutdown log {file_found}: {ex}')
+            continue
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            lines = f.readlines()
-            
-            entry_num = 1
-            entries = []
-            reboots = 1
-            
-            for line in lines:
-                pid_match = re.search(r'remaining client pid: (\d+) \((.*?)\)', line)
-                if pid_match:
-                    pid, path = pid_match.groups()
-                    entries.append((pid, path))
+        entry_num = 1
+        reboot_num = 1
+        entries = []
+        for line in lines:
+            pid_match = re.search(r'remaining client pid: (\d+) \((.*?)\)', line)
+            if pid_match:
+                entries.append(pid_match.groups())
 
-                sigterm_match = re.search(r'SIGTERM: \[(\d+)\]', line)
-                if sigterm_match:
-                    timestamp = int(sigterm_match.group(1))
-                    reboot_time = convert_utc_human_to_timezone(convert_ts_int_to_utc(timestamp),time_offset)
-                    data_list_shutdown_reboot.append((reboot_time,reboots,file_found))
-                    reboots += 1
-                    
-                    for pid, path in entries:
-                        data_list_shutdown_log.append((reboot_time,entry_num,pid,path,file_found))
-                        
-                        entry_num += 1
-                    entries = []
-           
-    # Shutdown Log Processes Report    
-    if len(data_list_shutdown_log) > 0:
-        report1 = ArtifactHtmlReport('Sysdiagnose - Shutdown Log Processes')
-        report1.start_artifact_report(report_folder, 'Sysdiagnose - Shutdown Log Processes')
-        report1.add_script()
-        data_headers1 = ('Timestamp','Entry Number','PID','Path','Source File')
-        data_headers1_lava = (('Timestamp','datetime'),'Entry Number','PID','Path','Source File')
+            sigterm_match = re.search(r'SIGTERM: \[(\d+)\]', line)
+            if sigterm_match:
+                reboot_time = convert_ts_int_to_utc(int(sigterm_match.group(1)))
+                reboots.append((reboot_time, reboot_num, rel))
+                reboot_num += 1
+                for pid, path in entries:
+                    processes.append((reboot_time, entry_num, pid, path, rel))
+                    entry_num += 1
+                entries = []
+        sources.append(rel)
 
-        report1.write_artifact_data_table(data_headers1, data_list_shutdown_log, file_found)
-        report1.end_artifact_report()
-        
-        tsv(report_folder, data_headers1, data_list_shutdown_log, 'Sysdiagnose - Shutdown Log Processes')
-        
-        timeline(report_folder, 'Sysdiagnose - Shutdown Log Processes', data_list_shutdown_log, data_headers1)
-        
-        #data_headers1[0] = (data_headers1[0], 'datetime')
-        
-        table_name1, object_columns1, column_map1 = lava_process_artifact(category, module_name, 'Sysdiagnose - Shutdown Log Processes', data_headers1_lava, len(data_list_shutdown_log))
-        lava_insert_sqlite_data(table_name1, data_list_shutdown_log, object_columns1, data_headers1_lava, column_map1)
-        
-    else:
-        logfunc('No Sysdiagnose - Shutdown Log Processes data available')
-        
-    # Shutdown Log Report    
-    if len(data_list_shutdown_reboot) > 0:
-        report = ArtifactHtmlReport('Sysdiagnose - Shutdown Log Reboots')
-        report.start_artifact_report(report_folder, 'Sysdiagnose - Shutdown Log Reboots')
-        report.add_script()
-        data_headers2 = ('Timestamp','Reboot Number','Source File')
-        data_headers2_lava = (('Timestamp','datetime'),'Reboot Number','Source File')
+    return processes, reboots, ', '.join(dict.fromkeys(sources))
 
-        report.write_artifact_data_table(data_headers2, data_list_shutdown_reboot, file_found)
-        report.end_artifact_report()
-        
-        tsv(report_folder, data_headers2, data_list_shutdown_reboot, 'Sysdiagnose - Shutdown Log Reboots')
-        
-        timeline(report_folder, 'Sysdiagnose - Shutdown Log Reboots', data_list_shutdown_reboot, data_headers2)
-        
-        #data_headers2[0] = (data_headers2[0], 'datetime')
-        
-        table_name2, object_columns2, column_map2 = lava_process_artifact(category, module_name, 'Sysdiagnose - Shutdown Log Reboots', data_headers2_lava, len(data_list_shutdown_reboot))
-        lava_insert_sqlite_data(table_name2, data_list_shutdown_reboot, object_columns2, data_headers2_lava, column_map2)
-        
-    else:
-        logfunc('No Sysdiagnose - Shutdown Log Reboots data available')
-        
+
+@artifact_processor
+def sysShutdownProcesses(context):
+    data_headers = (('Timestamp', 'datetime'), 'Entry Number', 'PID', 'Path', 'Source File')
+    processes, _reboots, source_path = _parse_shutdown_logs(context)
+    return data_headers, processes, source_path
+
+
+@artifact_processor
+def sysShutdownReboots(context):
+    data_headers = (('Timestamp', 'datetime'), 'Reboot Number', 'Source File')
+    _processes, reboots, source_path = _parse_shutdown_logs(context)
+    return data_headers, reboots, source_path


### PR DESCRIPTION
## Summary
Converts three legacy `"function"`-key artifacts (no `@artifact_processor`) to the context form, fixing several pre-existing bugs.

| Artifact | Result | Notable |
|---|---|---|
| **Oops** | 1 artifact | function-key → `@ap`; SQL already UTC. Author preserved (Heather Charpentier) |
| **sysShutdown** | 2 artifacts (Processes/Reboots) | 🔴 stores **UTC** (was examiner-local); drops manual `lava_insert` for the `@ap` pipeline. Author preserved (@KevinPagano3) |
| **mediaLibrary** | 2 artifacts (items + DB properties) | 🔴 **Fixes a broken media-kind decode loop** that emitted mostly empty rows (now 0/1/2/4/33 → E-book/Audio/Film/Podcast/Video M4V); **fixes a date_purchased epoch typo** (978397200 → 978307200, ~25h off) and returns a real datetime instead of a DD/MM/YYYY string |

## Validation
- pylint 10.00/10 each.
- Runtime-verified: sysShutdown log parsing (UTC timestamps, processes+reboots); mediaLibrary media-kind decode → 'Audio' and correct UTC purchase date with 21/21 column alignment.
- Reserved-word + CREATE TABLE clean; names unique; PluginLoader loads all 574.