### PR TITLE
Convert life360 to LAVA @artifact_processor (4 artifacts: Locations/Battery/Chat/Members)

### DIFF
--- a/scripts/artifacts/life360.py
+++ b/scripts/artifacts/life360.py
@@ -1,225 +1,207 @@
 __artifacts_v2__ = {
-    "Life360": {
-        "name": "Life360",
-        "description": "Parses Life360 app logs, chat messages, and more",
+    "life360Locations": {
+        "name": "Life360 - Locations",
+        "description": "Parses Life360 location records from app logs",
         "author": "@KevinPagano3",
-        "version": "0.2",
-        "date": "2024-01-15",
+        "creation_date": "2024-01-15",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "Life360",
         "notes": "",
-        "paths": ('*/com.life360.safetymap *.log','*/Library/Application Support/Messaging.sqlite*'),
-        "function": "get_life360"
+        "paths": ('*/com.life360.safetymap *.log',),
+        "output_types": ["html", "tsv", "timeline", "lava", "kml"],
+        "artifact_icon": "map-pin"
+    },
+    "life360DeviceBattery": {
+        "name": "Life360 - Device Battery",
+        "description": "Parses Life360 device battery records from app logs",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-01-15",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "",
+        "paths": ('*/com.life360.safetymap *.log',),
+        "output_types": "standard",
+        "artifact_icon": "battery"
+    },
+    "life360ChatMessages": {
+        "name": "Life360 - Chat Messages",
+        "description": "Parses Life360 chat messages",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-01-15",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "",
+        "paths": ('*/Library/Application Support/Messaging.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle"
+    },
+    "life360Members": {
+        "name": "Life360 - Members",
+        "description": "Parses Life360 circle members",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-01-15",
+        "last_update_date": "2026-06-24",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "",
+        "paths": ('*/Library/Application Support/Messaging.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "users"
     }
 }
 
-from datetime import *
 import json
-import os
 import sqlite3
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone, kmlgen
+from scripts.ilapfuncs import artifact_processor, convert_ts_human_to_utc, get_sqlite_db_records, logfunc
 
-def get_life360(files_found, report_folder, seeker, wrap_text, time_offset):
 
-    data_list_geo = []
-    data_list_dev = []
-    data_list_messaging = []
-    data_list_members = []
-    
-    for file_found in files_found:
+def _iter_usercontext(context):
+    """Yield (location-timestamp UTC, parsed JSON) for each X-UserContext log line."""
+    items = []
+    sources = []
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        if file_found.endswith('.log'):
-            with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-                lines = f.readlines()
-                
-                for line in lines:
-                    if 'X-UserContext header set: ' in line:
-                        log_split = line.split(' Life360[')
-                        
-                        timestamp = log_split[0]
-                        
-                        json_split = line.split('X-UserContext header set: ')
-                        
-                        json_str = json_split[1].strip()
-                        json_load = json.loads(json_str)
-                        
-                        json_lat = json_load['geolocation'].get('lat','')
-                        json_long = json_load['geolocation'].get('lon','')
-                        json_speed = json_load['geolocation'].get('speed','')
-                        json_heading = json_load['geolocation'].get('heading','')
-                        json_alt = json_load['geolocation'].get('alt','')
-                        json_accuracy = json_load['geolocation'].get('accuracy','')
-                        json_vert_accuracy = json_load['geolocation'].get('vertical_accuracy','')
-                        json_age = json_load['geolocation'].get('age','')
-                        
-                        json_timestamp = str(datetime.fromtimestamp(json_load['geolocation'].get('timestamp',''),tz=timezone.utc))[:-6]
-                        time_create = convert_utc_human_to_timezone(convert_ts_human_to_utc(json_timestamp),time_offset)
-                        
-                        json_preciseLocation = json_load['flags'].get('preciseLocation','')
-                        json_lmode = json_load['geolocation_meta'].get('lmode','').title()
-                        json_userActivity = json_load['device'].get('userActivity','').replace('os_','').title()
-                        
-                        json_battery = json_load['device'].get('battery','')
-                        json_charge = json_load['device'].get('charge','')
-                        if json_charge == '0':
-                            json_charge = ''
-                        elif json_charge == '1':
-                            json_charge = 'Yes'
+        if not file_found.endswith('.log'):
+            continue
+        try:
+            with open(file_found, encoding='utf-8', mode='r') as fh:
+                lines = fh.readlines()
+        except OSError as ex:
+            logfunc(f'Failed to read Life360 log {file_found}: {ex}')
+            continue
+        for line in lines:
+            if 'X-UserContext header set: ' not in line:
+                continue
+            try:
+                json_load = json.loads(line.split('X-UserContext header set: ')[1].strip())
+            except (json.JSONDecodeError, IndexError):
+                continue
+            ts = json_load.get('geolocation', {}).get('timestamp')
+            try:
+                time_create = datetime.fromtimestamp(float(ts), tz=timezone.utc) if ts else ''
+            except (ValueError, TypeError, OSError, OverflowError):
+                time_create = ''
+            items.append((time_create, json_load))
+        sources.append(context.get_relative_path(file_found))
+    return items, ', '.join(dict.fromkeys(sources))
 
-                        data_list_geo.append((time_create,json_lat,json_long,json_alt,json_speed,json_heading,json_userActivity,json_lmode,json_preciseLocation,json_accuracy,json_vert_accuracy,json_age))
-                        data_list_dev.append((time_create,json_battery,json_charge))
-                        
+
+def _find_db(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
         if file_found.endswith('Messaging.sqlite'):
-            messaging_db = file_found            
-            db = open_sqlite_db_readonly(messaging_db)
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            datetime(ZCHATMESSAGE.ZDATE + 978307200,'unixepoch'),
-            ZCHATMESSAGE.ZMESSAGEID,
-            ZCHATMEMBER.ZFIRSTNAME,
-            ZCHATMEMBER.ZLASTNAME,
-            ZCHATMESSAGE.ZMESSAGETEXT,
-            case ZCHATMESSAGE.ZSENTSTATUSASINTEGER
-                when 2 then 'Sent'
-                when 3 then 'Failed'
-            end,
-            case ZCHATMESSAGE.ZISREAD
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Read',
-            case ZCHATMESSAGE.ZISLOCALLYDELETED
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Deleted',
-            case ZCHATMESSAGE.ZISLIKED
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Liked',
-            ZCHATMESSAGE.ZACTION,
-            ZCHATMESSAGELOCATION.ZNAME,
-            ZCHATMESSAGELOCATION.ZLATITUDE,
-            ZCHATMESSAGELOCATION.ZLONGITUDE            
-            from ZCHATMESSAGE
-            left join ZCHATMEMBER ON ZCHATMEMBER.Z_PK = ZCHATMESSAGE.ZSENDER
-            left join ZCHATMESSAGELOCATION ON ZCHATMESSAGELOCATION.ZMESSAGE = ZCHATMESSAGE.Z_PK
-            ''')
+            return file_found
+    return ''
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),time_offset)
-                    data_list_messaging.append((timestamp,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12]))
-            
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            ZCHATMEMBER.ZFIRSTNAME,
-            ZCHATMEMBER.ZLASTNAME,
-            ZCHATMEMBER.ZEMAIL,
-            ZCHATMEMBER.ZPHONE,
-            ZCHATMEMBER.ZMEMBERID,
-            ZCHATMEMBER.ZAVATARURL,
-            case ZCHATMEMBER.ZISLOGGEDINUSER
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Local User',
-            case ZCHATMEMBER.ZISADMIN
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Admin',
-            ZCHATCIRCLE.ZNAME as 'Circle Name'
-            from ZCHATMEMBER
-            left join ZCHATCIRCLE on ZCHATCIRCLE.Z_PK = ZCHATMEMBER.ZCIRCLE
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    avatar = f'<img src="{row[5]}" alt="image"width="150">'
-                
-                    data_list_members.append((row[0],row[1],row[2],row[3],row[4],avatar,row[6],row[7],row[8]))
-            db.close()
-            
-        else:
-            continue # skip -journal and other files
-            
-    if len(data_list_geo) > 0:
-        report = ArtifactHtmlReport('Life360 - Locations')
-        report.start_artifact_report(report_folder, 'Life360 - Locations')
-        report.add_script()
-        data_headers = ('Timestamp', 'Latitude', 'Longitude', 'Altitude', 'Speed (mps)', 'Heading', 'Activity Type', 'Location Mode', 'Location Precision','Accuracy (+/- m)','Vertical Accuracy (+/- m)','Age')
+@artifact_processor
+def life360Locations(context):
+    data_headers = ('Timestamp', 'Latitude', 'Longitude', 'Altitude', 'Speed (mps)', 'Heading',
+                    'Activity Type', 'Location Mode', 'Location Precision', 'Accuracy (+/- m)',
+                    'Vertical Accuracy (+/- m)', 'Age')
+    data_headers = (('Timestamp', 'datetime'),) + data_headers[1:]
+    data_list = []
+    items, source_path = _iter_usercontext(context)
+    for time_create, jl in items:
+        geo = jl.get('geolocation', {})
+        activity = jl.get('device', {}).get('userActivity', '').replace('os_', '').title()
+        lmode = jl.get('geolocation_meta', {}).get('lmode', '').title()
+        precise = jl.get('flags', {}).get('preciseLocation', '')
+        data_list.append((time_create, geo.get('lat', ''), geo.get('lon', ''), geo.get('alt', ''),
+                          geo.get('speed', ''), geo.get('heading', ''), activity, lmode, precise,
+                          geo.get('accuracy', ''), geo.get('vertical_accuracy', ''), geo.get('age', '')))
+    return data_headers, data_list, source_path
 
-        report.write_artifact_data_table(data_headers, data_list_geo, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Locations'
-        tsv(report_folder, data_headers, data_list_geo, tsvname)
-        
-        tlactivity = 'Life360 - Locations'
-        timeline(report_folder, tlactivity, data_list_geo, data_headers)
-        
-        kmlactivity = 'Life360 - Locations'
-        kmlgen(report_folder, kmlactivity, data_list_geo, data_headers)
-        
-    else:
-        logfunc('No Life360 - Locations data available')
-        
-    if len(data_list_dev) > 0:
-        report = ArtifactHtmlReport('Life360 - Device Battery')
-        report.start_artifact_report(report_folder, 'Life360 - Device Battery')
-        report.add_script()
-        data_headers = ('Timestamp', 'Device Battery (%)', 'Charging')
 
-        report.write_artifact_data_table(data_headers, data_list_dev, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Device Battery'
-        tsv(report_folder, data_headers, data_list_dev, tsvname)
-        
-        tlactivity = 'Life360 - Device Battery'
-        timeline(report_folder, tlactivity, data_list_dev, data_headers)
-        
-    else:
-        logfunc('No Life360 - Device Battery data available')
-        
-    if len(data_list_messaging) > 0:
-        report = ArtifactHtmlReport('Life360 - Chat Messages')
-        report.start_artifact_report(report_folder, 'Life360 - Chat Messages')
-        report.add_script()
-        data_headers = ('Timestamp', 'Message ID', 'Sender First Name', 'Sender Last Name', 'Message', 'Sent Status', 'Message Seen', 'Message Deleted', 'Message Liked', 'Action','Location Name','Latitude','Longitude')
+@artifact_processor
+def life360DeviceBattery(context):
+    data_headers = (('Timestamp', 'datetime'), 'Device Battery (%)', 'Charging')
+    data_list = []
+    items, source_path = _iter_usercontext(context)
+    for time_create, jl in items:
+        device = jl.get('device', {})
+        charge = device.get('charge', '')
+        charge = 'Yes' if charge == '1' else ('' if charge == '0' else charge)
+        data_list.append((time_create, device.get('battery', ''), charge))
+    return data_headers, data_list, source_path
 
-        report.write_artifact_data_table(data_headers, data_list_messaging, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Chat Messages'
-        tsv(report_folder, data_headers, data_list_messaging, tsvname)
-        
-        tlactivity = 'Life360 - Chat Messages'
-        timeline(report_folder, tlactivity, data_list_messaging, data_headers)
-        
-    else:
-        logfunc('No Life360 - Chat Messages data available')
-        
-    if len(data_list_members) > 0:
-        report = ArtifactHtmlReport('Life360 - Members')
-        report.start_artifact_report(report_folder, 'Life360 - Members')
-        report.add_script()
-        data_headers = ('First Name','Last Name','Email','Phone','Member ID','Avatar URL','Local User','Admin','Cirle Name')
 
-        report.write_artifact_data_table(data_headers, data_list_members, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Members'
-        tsv(report_folder, data_headers, data_list_members, tsvname)
-        
-        tlactivity = 'Life360 - Members'
-        timeline(report_folder, tlactivity, data_list_members, data_headers)
-        
-    else:
-        logfunc('No Life360 - Members data available')
+@artifact_processor
+def life360ChatMessages(context):
+    data_headers = (('Timestamp', 'datetime'), 'Message ID', 'Sender First Name', 'Sender Last Name',
+                    'Message', 'Sent Status', 'Message Seen', 'Message Deleted', 'Message Liked',
+                    'Action', 'Location Name', 'Latitude', 'Longitude')
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        datetime(ZCHATMESSAGE.ZDATE + 978307200, 'unixepoch'),
+        ZCHATMESSAGE.ZMESSAGEID,
+        ZCHATMEMBER.ZFIRSTNAME,
+        ZCHATMEMBER.ZLASTNAME,
+        ZCHATMESSAGE.ZMESSAGETEXT,
+        CASE ZCHATMESSAGE.ZSENTSTATUSASINTEGER WHEN 2 THEN 'Sent' WHEN 3 THEN 'Failed' END,
+        CASE ZCHATMESSAGE.ZISREAD WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE ZCHATMESSAGE.ZISLOCALLYDELETED WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE ZCHATMESSAGE.ZISLIKED WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        ZCHATMESSAGE.ZACTION,
+        ZCHATMESSAGELOCATION.ZNAME,
+        ZCHATMESSAGELOCATION.ZLATITUDE,
+        ZCHATMESSAGELOCATION.ZLONGITUDE
+    FROM ZCHATMESSAGE
+    LEFT JOIN ZCHATMEMBER ON ZCHATMEMBER.Z_PK = ZCHATMESSAGE.ZSENDER
+    LEFT JOIN ZCHATMESSAGELOCATION ON ZCHATMESSAGELOCATION.ZMESSAGE = ZCHATMESSAGE.Z_PK
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Life360 chat messages: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append((convert_ts_human_to_utc(row[0]),) + tuple(row[1:]))
+
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def life360Members(context):
+    data_headers = ('First Name', 'Last Name', 'Email', ('Phone', 'phonenumber'), 'Member ID',
+                    'Avatar URL', 'Local User', 'Admin', 'Circle Name')
+    data_list = []
+    source_path = _find_db(context)
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT
+        ZCHATMEMBER.ZFIRSTNAME,
+        ZCHATMEMBER.ZLASTNAME,
+        ZCHATMEMBER.ZEMAIL,
+        ZCHATMEMBER.ZPHONE,
+        ZCHATMEMBER.ZMEMBERID,
+        ZCHATMEMBER.ZAVATARURL,
+        CASE ZCHATMEMBER.ZISLOGGEDINUSER WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE ZCHATMEMBER.ZISADMIN WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        ZCHATCIRCLE.ZNAME
+    FROM ZCHATMEMBER
+    LEFT JOIN ZCHATCIRCLE ON ZCHATCIRCLE.Z_PK = ZCHATMEMBER.ZCIRCLE
+    '''
+    try:
+        rows = get_sqlite_db_records(source_path, query)
+    except sqlite3.Error as ex:
+        logfunc(f'Error reading Life360 members: {ex}')
+        return data_headers, data_list, context.get_relative_path(source_path)
+
+    for row in rows:
+        data_list.append(tuple(row))
+
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary
Converts the legacy `"function"`-key `life360` parser into four `@artifact_processor` artifacts.

| Artifact | Notes |
|---|---|
| **Life360 - Locations** | Emits **KML** |
| **Life360 - Device Battery** | |
| **Life360 - Chat Messages** | |
| **Life360 - Members** | Phone tagged with `phonenumber` type; avatar kept as URL text; fixed 'Cirle Name' typo |

## Changes
- 🔴 **UTC**: dropped `convert_utc_human_to_timezone` (examiner-local); locations use the geolocation timestamp as aware UTC, chat times via SQL unixepoch + `convert_ts_human_to_utc`.
- Replaced the `from datetime import *` wildcard with explicit imports.
- `creation_date`/`last_update_date`; keys match function names. Author preserved (**@KevinPagano3**).

## Validation
- pylint 10.00/10; log parsing produces UTC location/battery rows on sample data.
- Reserved-word + CREATE TABLE clean; names unique; PluginLoader loads all 577.