### PR TITLE
bluetoothOther: clean Source File path via context.get_relative_path

### DIFF
--- a/scripts/artifacts/bluetoothOther.py
+++ b/scripts/artifacts/bluetoothOther.py
@@ -40,7 +40,7 @@ def get_bluetoothOtherLE(context):
             all_rows = cursor.fetchall()
 
             for row in all_rows:
-                data_list.append((row[0], row[1], row[3], file_found))
+                data_list.append((row[0], row[1], row[3], context.get_relative_path(file_found)))
 
             db.close()
 


### PR DESCRIPTION
## Summary
The **Bluetooth Other LE** artifact's `Source File` column held the full on-disk path. Use `context.get_relative_path(file_found)` so it shows the clean in-extraction path, consistent with the rest of the converted artifacts.

## Validation
- pylint 10.00/10.

## Observation (not changed here)
The query `SELECT`s `LastSeenTime` but `data_list` uses only `row[0], row[1], row[3]` — so the **LastSeenTime** column (row[2]) is fetched and discarded. That's a useful per-device timestamp; happy to add it as a datetime column if desired (would need to confirm its stored format).