### PR TITLE
Use context.get_relative_path for Source File/Path columns (28 artifacts)

### DIFF
--- a/scripts/artifacts/AWESearch.py
+++ b/scripts/artifacts/AWESearch.py
@@ -26,7 +26,7 @@ def get_AWESearch(context):
             kword = (x['keyword'])
             cocoatime = (x['time'])
             timestamp = convert_cocoa_core_data_ts_to_utc(cocoatime)
-            data_list.append((timestamp, kword, file_found))
+            data_list.append((timestamp, kword, context.get_relative_path(file_found)))
             
     data_headers = (('Time', 'datetime'), 'Keyword', 'Source File')
     return data_headers, data_list, 'see Source File for more info'

--- a/scripts/artifacts/ZaloChats.py
+++ b/scripts/artifacts/ZaloChats.py
@@ -405,7 +405,7 @@ def zalo_messages(context):
                     if message in [None, "", " "]:
                         message = f"geo:{latitude},{longitude}"
 
-            data_list.append([message_date, chat_name, sender_id, sender_name, msg_type, print_type, message, attach_file, latitude, longitude, outgoing, isgroup, source_file])
+            data_list.append([message_date, chat_name, sender_id, sender_name, msg_type, print_type, message, attach_file, latitude, longitude, outgoing, isgroup, context.get_relative_path(source_file)])
 
     data_headers = (('Timestamp', 'datetime'), "Chat Name", "Sender-ID", "Sender", "Type ID", "Message Type", "Message", ('Attachment File', 'media'), "Latitude", "Longitude", "Outgoing", "Group Chat", "Source File")
 

--- a/scripts/artifacts/ZangiChats.py
+++ b/scripts/artifacts/ZangiChats.py
@@ -66,7 +66,7 @@ def get_zangichats(context):  # your def variable should match what you have aft
                         row[3],
                         row[4],
                         row[5],
-                        file_found
+                        context.get_relative_path(file_found)
                         ))
             db.close()
         else:

--- a/scripts/artifacts/appSnapshots.py
+++ b/scripts/artifacts/appSnapshots.py
@@ -80,7 +80,7 @@ def applicationSnapshots(context): #files_found, report_folder, seeker, wrap_tex
             continue
             
         last_modified_date = convert_unix_ts_to_utc(lava_get_full_media_info(media_item)['updated_at'])
-        data_list.append([last_modified_date, app_name, file_found, media_item])
+        data_list.append([last_modified_date, app_name, context.get_relative_path(file_found), media_item])
     
     data_headers = (('Date Modified', 'datetime'), 'App Name', 'Source Path', ('Snapshot', 'media'))
 

--- a/scripts/artifacts/applePodcasts.py
+++ b/scripts/artifacts/applePodcasts.py
@@ -72,7 +72,7 @@ def get_applePodcastsShows(context):
             timestampdupdate = convert_cocoa_core_data_ts_to_utc(row[2])
             timestampdowndate = convert_cocoa_core_data_ts_to_utc(row[3])
             
-            data_list.append((timestampadded,timestampdateplayed,timestampdupdate,timestampdowndate,row[4],row[5],row[6],row[7],row[8], file_found))
+            data_list.append((timestampadded,timestampdateplayed,timestampdupdate,timestampdowndate,row[4],row[5],row[6],row[7],row[8], context.get_relative_path(file_found)))
     
     return data_headers, data_list, 'see Source File for more info'
         
@@ -137,6 +137,6 @@ def get_applePodcastsEpisodes(context):
             timestamplastmod = convert_cocoa_core_data_ts_to_utc(row[3])
             timestampdowndate = convert_cocoa_core_data_ts_to_utc(row[4])
 
-            data_list.append((timestampimport,timestampmeta,timestamplastplay,timestamplastmod,timestampdowndate,row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13], file_found))
+            data_list.append((timestampimport,timestampmeta,timestamplastplay,timestamplastmod,timestampdowndate,row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13], context.get_relative_path(file_found)))
     
     return data_headers, data_list, 'see Source File for more info'

--- a/scripts/artifacts/appleWalletPasses.py
+++ b/scripts/artifacts/appleWalletPasses.py
@@ -39,7 +39,7 @@ def get_appleWalletPKPasses(context):
             with open(file_found, 'r', encoding='utf-8') as f:
                 data = json.load(f)
                 for x, y in data.items():
-                    data_list.append((x,str(y), file_found))
+                    data_list.append((x,str(y), context.get_relative_path(file_found)))
     
     data_headers = ['Identifier','Items', 'Source File']
     return data_headers, data_list, 'see Source File for more info'
@@ -113,7 +113,7 @@ def get_appleWalletNanoPasses(context):
                 
                 timestamp = convert_cocoa_core_data_ts_to_utc(row[4])
                 
-                data_list.append((timestamp, row[0], row[1], row[2], row[3], row[5], front_field, back_field, encoded_pass, file_found))
+                data_list.append((timestamp, row[0], row[1], row[2], row[3], row[5], front_field, back_field, encoded_pass, context.get_relative_path(file_found)))
     
     data_headers = [('Pass Added', 'datetime'),'Unique ID', 'Organization Name', 'Type', 'Localized Description',
         'Pending Delete', 'Front Fields Content', 'Back Fields Content', 'Encoded Pass', 'Source File']

--- a/scripts/artifacts/appleWifiPlist.py
+++ b/scripts/artifacts/appleWifiPlist.py
@@ -103,7 +103,7 @@ def appleWifiKnownNetworks(context):
 
                 data_list.append([ssid, bssid, net_usage, country_code, device_name, manufacturer, 
                                     serial_number, model_name, enabled, carplay, hidden, captive_network, 
-                                    user_portal_url, '', '', file_found])
+                                    user_portal_url, '', '', context.get_relative_path(file_found)])
 
         if 'com.apple.wifi.known-networks.plist' in file_found:
             for _, known_network in deserialized.items():
@@ -122,7 +122,7 @@ def appleWifiKnownNetworks(context):
                 user_portal_url = captive_profile.get('UserPortalURL', '')
 
                 data_list.append([ssid, bssid, net_usage, '', '', '', '', '', '', carplay, hidden, 
-                                    captive_network, user_portal_url, add_reason, bundle, file_found])
+                                    captive_network, user_portal_url, add_reason, bundle, context.get_relative_path(file_found)])
 
     data_headers = ('SSID', 'BSSID', 'Network Usage', 'Country Code', 'Device Name', 'Manufacturer', 
                     'Serial Number', 'Model Name', 'Enabled', 'Carplay Network', 'Hidden', 
@@ -150,7 +150,7 @@ def appleWifiKnownNetworksTimes(context):
                 wnpmd = convert_plist_date_to_utc(known_network.get('WiFiNetworkPasswordModificationDate', ''))
                 prev_joined = convert_plist_date_to_utc(known_network.get('prevJoined', ''))
 
-                data_list.append([ssid, bssid, last_updated, last_auto_joined, last_joined, '', '', wnpmd, '', '', '', '', prev_joined, file_found])
+                data_list.append([ssid, bssid, last_updated, last_auto_joined, last_joined, '', '', wnpmd, '', '', '', '', prev_joined, context.get_relative_path(file_found)])
 
         if 'com.apple.wifi.known-networks.plist' in file_found:
             for _, known_network in deserialized.items():
@@ -172,7 +172,7 @@ def appleWifiKnownNetworksTimes(context):
 
                 data_list.append([ssid, bssid, last_updated, '', '', system_joined, user_joined, wnpmd, 
                                     last_discovered, added_at, whitelisted_probe_date, captive_web_sheet_login_date, 
-                                    prev_joined, file_found])
+                                    prev_joined, context.get_relative_path(file_found)])
 
     data_headers = ('SSID', 'BSSID', ('Last Updated', 'datetime'), ('Last Auto Joined', 'datetime'), 
                     ('Last Joined', 'datetime'), ('System Joined', 'datetime'), ('User Joined', 'datetime'),
@@ -212,7 +212,7 @@ def appleWifiScannedPrivate(context):
                 data_list.append([last_updated, added_at, last_joined, link_down_timestamp,
                                     mac_generation_timestamp, first_join_with_new_mac_timestamp,
                                     ssid, bssid, private_mac_in_use, private_mac_value, private_mac_valid, 
-                                    in_known_networks, file_found])
+                                    in_known_networks, context.get_relative_path(file_found)])
 
     data_headers = (('Last Updated', 'datetime'), ('Added At', 'datetime'), 
                     ('Last Joined', 'datetime'), ('Link Down Timestamp', 'datetime'),
@@ -249,7 +249,7 @@ def appleWifiBSSList(context):
                     data_list.append([
                         ssid, bssid, channel_flags, channel, last_associated_at,
                         location_accuracy, location_timestamp, location_latitude, location_longitude,
-                        file_found
+                        context.get_relative_path(file_found)
                     ])
 
         if 'List of known networks' in deserialized:
@@ -265,7 +265,7 @@ def appleWifiBSSList(context):
                     data_list.append([
                         ssid, bssid, channel_flags, channel, last_roamed,
                         '', '', '', '',
-                        file_found
+                        context.get_relative_path(file_found)
                     ])
 
     data_headers = (

--- a/scripts/artifacts/audiTripdata.py
+++ b/scripts/artifacts/audiTripdata.py
@@ -59,7 +59,7 @@ def get_audiTripdata(context):
 
                             data_list.append((timestamp, avgspeed, traveltime, startmileage, mileage,
                                     overallmileage, tripid, avgelecconsumpt, avgfuelconsumpt,
-                                    zeroemdistance, triptyme, reportreason, file_found,
+                                    zeroemdistance, triptyme, reportreason, context.get_relative_path(file_found),
                             ))
 
     data_headers = (

--- a/scripts/artifacts/batteryBDC.py
+++ b/scripts/artifacts/batteryBDC.py
@@ -68,7 +68,7 @@ def battery_bdc(context):
 
                 data_list.append((
                     timestamp, soc, current_cap, charging_status, temp, temp2,
-                    amperage, voltage, watts, file_found,
+                    amperage, voltage, watts, context.get_relative_path(file_found),
                 ))
 
     data_headers = (

--- a/scripts/artifacts/bluetoothOther.py
+++ b/scripts/artifacts/bluetoothOther.py
@@ -40,7 +40,7 @@ def get_bluetoothOtherLE(context):
             all_rows = cursor.fetchall()
 
             for row in all_rows:
-                data_list.append((row[0], row[1], row[3], file_found))
+                data_list.append((row[0], row[1], row[3], context.get_relative_path(file_found)))
 
             db.close()
 

--- a/scripts/artifacts/bluetoothPairedLE.py
+++ b/scripts/artifacts/bluetoothPairedLE.py
@@ -40,7 +40,7 @@ def get_bluetoothPairedLE(context):
 
             all_rows = cursor.fetchall()
             for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4],row[6], file_found))
+                data_list.append((row[0], row[1], row[2], row[3], row[4],row[6], context.get_relative_path(file_found)))
 
             db.close()
 

--- a/scripts/artifacts/bluetoothPairedReg.py
+++ b/scripts/artifacts/bluetoothPairedReg.py
@@ -47,7 +47,7 @@ def get_bluetoothPairedReg(context):
                 else:
                     defname = ''
 
-                data_list.append((lastseen, macaddress, usernkey, nameu, deviceid, defname, file_found))
+                data_list.append((lastseen, macaddress, usernkey, nameu, deviceid, defname, context.get_relative_path(file_found)))
 
     data_headers = (('Last Seen Time', 'datetime'), 'MAC Address', 'Name Key', 'Name', 'Device Product ID', 'Default Name', 'Source File')     
 

--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -35,7 +35,7 @@ def get_cacheRoutesGmap(context):
             try: 
                 lat = deserialized['$objects'][x]['_coordinateLat']
                 lon = deserialized['$objects'][x]['_coordinateLong'] #lat longs
-                data_list.append((datetime_time, lat, lon, file_found))
+                data_list.append((datetime_time, lat, lon, context.get_relative_path(file_found)))
             except (KeyError, TypeError):
                 pass    
             

--- a/scripts/artifacts/cachev0.py
+++ b/scripts/artifacts/cachev0.py
@@ -43,7 +43,7 @@ def cachev0(context):
                 media_ref = check_in_embedded_media(
                     file_found, row[1], str(row[0]))
                 if media_ref:
-                    data_list.append((row[0], media_ref, file_found))
+                    data_list.append((row[0], media_ref, context.get_relative_path(file_found)))
             
     if not data_list:
         return

--- a/scripts/artifacts/calendarAll.py
+++ b/scripts/artifacts/calendarAll.py
@@ -256,11 +256,11 @@ def calendarEvents(context):
 
                     data_list_html.append((start_time, end_time, timezone, calendar_name_tag, row[6], row[7], row[8], 
                                       row[9], location_coordinates_tag, invitation_from, attendees_tag, row[15], 
-                                      row[16], row[17], creation_time, modification_time, file_found))
+                                      row[16], row[17], creation_time, modification_time, context.get_relative_path(file_found)))
             
                     data_list.append((start_time, end_time, timezone, calendar_name, row[6], row[7], row[8], 
                                       row[9], location_coordinates, invitation_from, attendees, row[15], row[16],
-                                      row[17], creation_time, modification_time, file_found))
+                                      row[17], creation_time, modification_time, context.get_relative_path(file_found)))
                     
 
     return data_headers, (data_list, data_list_html), 'see Source File for more info'
@@ -303,8 +303,8 @@ def calendarBirthdays(context):
                 calendar_name = row[2]
                 calendar_name_tag = get_calendar_name(row[2], row[3])
 
-                data_list_html.append((birthdate, row[0], calendar_name_tag, row[4], file_found))
-                data_list.append((birthdate, row[0], calendar_name, row[4], file_found))
+                data_list_html.append((birthdate, row[0], calendar_name_tag, row[4], context.get_relative_path(file_found)))
+                data_list.append((birthdate, row[0], calendar_name, row[4], context.get_relative_path(file_found)))
 
     return data_headers, (data_list, data_list_html), 'see Source File for more info'
 
@@ -362,11 +362,11 @@ def calendarList(context):
                         sharing_participants_html = sharees.get(row[0], '')
                         sharing_participants = sharees.get(row[0], '').replace('<br>', ' ')
                         data_list_html.append((calendar_name_tag, row[3], row[4], row[5], owner_email, row[7],
-                                          sharing_participants_html, row[8], file_found))
+                                          sharing_participants_html, row[8], context.get_relative_path(file_found)))
                         data_list.append((calendar_name, row[3], row[4], row[5], owner_email, row[7],
-                                              sharing_participants, row[8], file_found))
+                                              sharing_participants, row[8], context.get_relative_path(file_found)))
                     else:
-                        data_list_html.append((calendar_name_tag, row[3], row[4], row[5], owner_email, row[7], None, row[8], file_found))
-                        data_list.append((calendar_name, row[3], row[4], row[5], owner_email, row[7], None, row[8], file_found))
+                        data_list_html.append((calendar_name_tag, row[3], row[4], row[5], owner_email, row[7], None, row[8], context.get_relative_path(file_found)))
+                        data_list.append((calendar_name, row[3], row[4], row[5], owner_email, row[7], None, row[8], context.get_relative_path(file_found)))
                 
     return data_headers, (data_list, data_list_html), 'see Source File for more info'

--- a/scripts/artifacts/callHistoryTransactions.py
+++ b/scripts/artifacts/callHistoryTransactions.py
@@ -39,7 +39,7 @@ def callHistoryTransactions(context):
                 data_list.append((date, inner_record['handleType'], inner_record['callStatus'],
                                   inner_record['duration'], inner_record['remoteParticipantHandles'][0]['value'],
                                   inner_record['callerId'], inner_record['timeToEstablish'],
-                                  inner_record['disconnectedCause'], inner_record['uniqueId'], file_found))
+                                  inner_record['disconnectedCause'], inner_record['uniqueId'], context.get_relative_path(file_found)))
 
     data_headers = (('Date', 'datetime'), 'handleType', 'callStatus', 'duration', 'remoteParticipantHandle', 'callerId',
                     'timeToEstablish', 'disconnectedCause', 'uniqueId', 'Source File')

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -67,7 +67,7 @@ ORDER BY ZPAYMENT.ZDISPLAYDATE ASC
             
             for row in all_rows:
                 date = convert_unix_ts_to_utc(row[6])
-                data_list.append((date, row[1], row[2], row[0], row[3], row[5], row[4], file_found))
+                data_list.append((date, row[1], row[2], row[0], row[3], row[5], row[4], context.get_relative_path(file_found)))
 
     data_headers = (('Transaction Date', 'datetime'), 'Display Name', 'Cashtag', 'Account Owner Role', 
                     'Currency Amount', 'Transaction State', 'Transaction State', 'Source File')

--- a/scripts/artifacts/cashAppB.py
+++ b/scripts/artifacts/cashAppB.py
@@ -149,7 +149,7 @@ def get_cashAppB(context):
                                   role, howmuch, currency, note, region, dunits, url, cardbrand,
                                   suffix, displayname, displayinstrument, instrumenttype, transactionid,
                                   token, receipt, state, createdat, capturedat, reachedcustomerat, 
-                                  paidoutat, depositedat, displaydate, file_found))
+                                  paidoutat, depositedat, displaydate, context.get_relative_path(file_found)))
         
     data_headers = (('Timestamp', 'datetime'), 'Customer Token', 'Name', 'Username', 'ID', 'Full Name',
                     'Role', 'Amount', 'Currency', 'Note', 'Region', 'Units', 'URL', 'Card Brand',

--- a/scripts/artifacts/celWireless.py
+++ b/scripts/artifacts/celWireless.py
@@ -25,7 +25,7 @@ def celWireless(context):
         if basename in ["com.apple.commcenter.device_specific_nobackup.plist", "com.apple.commcenter.plist"]:
             plist = get_plist_file_content(filepath)
             for key, val in plist.items():
-                data_list.append((key, str(val), filepath))
+                data_list.append((key, str(val), context.get_relative_path(filepath)))
                 if key == "ReportedPhoneNumber":
                     device_info("Cellular", "Reported Phone Number", val, filepath)
                 elif key == "CDMANetworkPhoneNumberICCID":

--- a/scripts/artifacts/cloudkitSharing.py
+++ b/scripts/artifacts/cloudkitSharing.py
@@ -144,7 +144,7 @@ def cloudkit_sharing(context):
 
         for z_pk, s in shares.items():
             data_list.append((
-                file_found, z_pk, s['z_id'], s['record_id'], s['root_id'], s['record_type'],
+                context.get_relative_path(file_found), z_pk, s['z_id'], s['record_id'], s['root_id'], s['record_type'],
                 s['ctime'], s['creator'], s['mtime'], s['modifier'], s['device'],
                 s['container'], s['hostname'], s['permission'], s['visibility'],
                 s['anon'], s['known']
@@ -195,7 +195,7 @@ def cloudkit_participants(context):
                     name_priv = deep_get(ui, ['NameComponents', 'NS.nameComponentsPrivate'], {})
 
                     data_list.append((
-                        file_found, z_pk, z_id, share_record_id, root_record_id,
+                        context.get_relative_path(file_found), z_pk, z_id, share_record_id, root_record_id,
                         p.get('ParticipantID', ''),
                         deep_get(ui, ['UserRecordID', 'RecordName']),
                         deep_get(ui, ['LookupInfo', 'EmailAddress']),

--- a/scripts/artifacts/controlCenter.py
+++ b/scripts/artifacts/controlCenter.py
@@ -30,7 +30,7 @@ def controlCenter(context):
             if key in pl and pl[key]:
                 for position, module in enumerate(pl[key], 1):
                     formatted_position = f"{prefix}-{position}"
-                    data_list.append((formatted_position, module, control_type, file_found))
+                    data_list.append((formatted_position, module, control_type, context.get_relative_path(file_found)))
 
     data_headers = ('Position', 'App Bundle', 'Control Type', 'Source File')
     

--- a/scripts/artifacts/discordAcct.py
+++ b/scripts/artifacts/discordAcct.py
@@ -47,7 +47,7 @@ def get_discordAcct(context):
             if 'user_id_cache' in x:
                 wf = searchlist[counter].split('"')
                 try:
-                    data_list.append(('USER_ID_CACHE', wf[1], file_found))
+                    data_list.append(('USER_ID_CACHE', wf[1], context.get_relative_path(file_found)))
                 except (IndexError, TypeError) as e:
                     logfunc(f"Error parsing user_id_cache: {str(e)}")
                 
@@ -55,7 +55,7 @@ def get_discordAcct(context):
                 #print(x)
                 wfa = searchlist[counter].split('"')
                 try:
-                    data_list.append(('EMAIL_CACHE', wfa[1], file_found))
+                    data_list.append(('EMAIL_CACHE', wfa[1], context.get_relative_path(file_found)))
                 except (IndexError, TypeError) as e:
                     logfunc(f"Error parsing email_cache: {str(e)}")
 

--- a/scripts/artifacts/dmss.py
+++ b/scripts/artifacts/dmss.py
@@ -135,7 +135,7 @@ def get_dmss_pin(context):
                     if "5" == str(v[3]) and "True" == str(v[4]):
                         pin_code = v[5] #v[5] value is where the PIN gets stored
                         
-            data_list.append((pin_code, file_found))
+            data_list.append((pin_code, context.get_relative_path(file_found)))
         
     data_headers = ('PIN', 'Source File')
     return data_headers, data_list, 'see Source File for more info'
@@ -160,7 +160,7 @@ def get_dmss_channels(context):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2], file_found))
+            data_list.append((row[0],row[1],row[2], context.get_relative_path(file_found)))
         db.close()
         
     return data_headers, data_list, 'see Source File for more info'
@@ -201,7 +201,7 @@ def get_dmss_info(context):
 
         for row in all_rows:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10],
-                                row[11], row[12], file_found))
+                                row[11], row[12], context.get_relative_path(file_found)))
         db.close()
         
     return data_headers, data_list, 'see Source File for more info'
@@ -255,7 +255,7 @@ def get_dmss_registered_sensors(context):
             db_owner = "(without DMSS account)" if str(dmss_db_file_list[-2]) == "0" else f'(Account- {str(dmss_db_file_list[-2])})'
 
             for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], db_owner, file_found))
+                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], db_owner, context.get_relative_path(file_found)))
         
             db.close()
         except sqlite3.OperationalError as e:
@@ -307,7 +307,7 @@ def get_dmss_registered_devices(context):
             db_owner = "(without DMSS account)" if str(dmss_db_file_list[-2]) == "0" else f'(Account- {str(dmss_db_file_list[-2])})'
             
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14], db_owner, file_found))
+                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14], db_owner, context.get_relative_path(file_found)))
         
             db.close()
         except sqlite3.OperationalError as e:
@@ -371,7 +371,7 @@ def get_dmss_notifications(context):
             db_owner = "(without DMSS account)" if str(dmss_db_file_list[-2]) == "0" else f'(Account- {str(dmss_db_file_list[-2])})'
 
             for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], db_owner, file_found))
+                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], db_owner, context.get_relative_path(file_found)))
             
             db.close()
         

--- a/scripts/artifacts/draftmessage.py
+++ b/scripts/artifacts/draftmessage.py
@@ -43,6 +43,6 @@ def get_draftmessage(context):
         
         pl = get_plist_file_content(file_found)
         deserialized_plist = nd.deserialize_plist_from_string(pl['text'])
-        data_list.append((modifiedtime, directoryname, deserialized_plist.get('NSString', ''), file_found))
+        data_list.append((modifiedtime, directoryname, deserialized_plist.get('NSString', ''), context.get_relative_path(file_found)))
     
     return data_headers, data_list, 'see Source File for more info'

--- a/scripts/artifacts/keyboard.py
+++ b/scripts/artifacts/keyboard.py
@@ -113,7 +113,7 @@ def keyboardUsageStats(context):
             for row in cursor.fetchall():
                 create_ts = convert_ts_human_to_utc(row[0])
                 update_ts = convert_ts_human_to_utc(row[1])
-                data_list.append((create_ts, update_ts, row[2], row[3], file_found))
+                data_list.append((create_ts, update_ts, row[2], row[3], context.get_relative_path(file_found)))
     
     data_headers = (('Creation Date', 'datetime'), ('Last Update Date', 'datetime'), 'Key', 'Data Value', 'Source File')
     return data_headers, data_list, 'See source paths in data'

--- a/scripts/artifacts/tikTokReplied.py
+++ b/scripts/artifacts/tikTokReplied.py
@@ -310,7 +310,7 @@ def tiktok_replied(context):
                 record[16],
                 record[17],
                 account_id,
-                source_file,
+                context.get_relative_path(source_file),
             ))
 
     data_headers = (

--- a/scripts/artifacts/vippsContacts.py
+++ b/scripts/artifacts/vippsContacts.py
@@ -67,7 +67,7 @@ def vippsContacts(context):
                     name=f"{contact_id}_profile"
                 )
 
-            data_list.append((thumb_id, name, phonenumbers, source_path))
+            data_list.append((thumb_id, name, phonenumbers, context.get_relative_path(source_path)))
 
     data_headers = (
         ('Profile Image', 'media'),

--- a/scripts/artifacts/webkit.py
+++ b/scripts/artifacts/webkit.py
@@ -103,7 +103,7 @@ def webkit_cache_records(context):
             'Application GUID': app_guid,
             'Records GUID': records_guid,
             'File': os.path.basename(file_found),
-            'Full File Path': file_found
+            'Full File Path': context.get_relative_path(file_found)
         }
         try:
             with open(file_found, 'rb') as f:

--- a/scripts/artifacts/widgets.py
+++ b/scripts/artifacts/widgets.py
@@ -69,7 +69,7 @@ def widgets(context):
         last_modified_date = convert_unix_ts_to_utc(
             lava_get_full_media_info(media_item)[-2])
         data_list.append(
-            [last_modified_date, app_name, file_found, media_item])
+            [last_modified_date, app_name, context.get_relative_path(file_found), media_item])
 
     data_headers = (('Date Modified', 'datetime'), 'App Name',
                     'Source Path', ('Snapshot', 'media'))


### PR DESCRIPTION
## Summary
Overall sweep of the **"full on-disk path stored in a data column"** pattern (the issue spotted in bluetoothOther, webkit, calendarAll, celWireless). Wraps the appended path variable in `context.get_relative_path()` so **Source File / Source Path / Source DB / Location / Full File Path** columns show the clean in-extraction path instead of the examiner's full local path.

- **49 append sites across 27 artifacts** + webkit's dict-built `Full File Path` column.
- Targeted via **AST node offsets** so only the column value is wrapped — `open()`, `.endswith()`, DB opens, and media check-ins keep the full path. No header/schema changes.

## How the set was found
AST audit for path variables (`file_found`/`source_file`/`source_path`/`filepath`) appended into a path/source-named column, then filtered to genuine raw-path leaks.

## Excluded (correctly)
- Source column **already** relative via `get_relative_path`: tikTok, uberClient, uberLeveldb, userDefaults, venmo, walStrings.
- **dhcphp / dhcpl** use the legacy **5-arg** signature (no `context` object) — they need conversion to the context form first; flagged for a follow-up.

## Validation
- pylint **10.00/10** on all 28 files (unchanged).
- Spot-checked that file operations keep the full path while only the source column is relativized.
- PluginLoader loads all 577.