### PR TITLE
Convert dhcphp/dhcpl to context form + relative Source File + UTC

### DIFF
--- a/scripts/artifacts/dhcphp.py
+++ b/scripts/artifacts/dhcphp.py
@@ -3,29 +3,35 @@ __artifacts_v2__ = {
         "name": "DHCP Hotspot Clients",
         "description": "Information about devices that connected to the hotspot",
         "author": "@AlexisBrignoni",
-        "version": "1.0",
-        "date": "2024-10-29",
+        "creation_date": "2024-10-29",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "DHCP",
-        "paths": ('*/db/dhcpd_leases*'),
-        "output_types": "standard"
+        "notes": "",
+        "paths": ('*/db/dhcpd_leases*',),
+        "output_types": "standard",
+        "artifact_icon": "wifi"
     }
 }
 
-
 from scripts.ilapfuncs import artifact_processor
 
-@artifact_processor
-def dhcpHotspotClients(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
 
-    for file_found in files_found:
-        with open(file_found, "r") as filefrom:
+@artifact_processor
+def dhcpHotspotClients(context):
+    data_headers = ('Key Name', 'Value Data', 'Source File')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        rel = context.get_relative_path(file_found)
+        with open(file_found, "r", encoding="utf-8") as filefrom:
             for line in filefrom:
                 cline = line.strip()
                 if "=" in cline:
                     splitline = cline.split("=")
-                    data_list.append((splitline[0], splitline[1], file_found))
-    
-    data_headers = ('Key Name', 'Value Data', 'Source File')   
-    return data_headers, data_list, ''
+                    data_list.append((splitline[0], splitline[1], rel))
+        sources.append(rel)
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))

--- a/scripts/artifacts/dhcpl.py
+++ b/scripts/artifacts/dhcpl.py
@@ -3,41 +3,56 @@ __artifacts_v2__ = {
         "name": "DHCP Received List",
         "description": "DHCP client lease information",
         "author": "",
-        "version": "1.0",
-        "date": "2024-10-29",
+        "creation_date": "2024-10-29",
+        "last_update_date": "2026-06-24",
         "requirements": "none",
         "category": "DHCP",
-        "notes": "",
+        "notes": "LeaseStartDate is stored as UTC.",
         "paths": ('*/db/dhcpclient/leases/en*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "wifi"
     }
 }
 
 import plistlib
-from scripts.ilapfuncs import artifact_processor, convert_plist_date_to_timezone_offset
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_WANTED = ("IPAddress", "LeaseLength", "LeaseStartDate", "RouterHardwareAddress",
+           "RouterIPAddress", "SSID")
+
 
 def format_mac_address(mac_bytes):
     if isinstance(mac_bytes, bytes):
         return ':'.join(f'{b:02x}' for b in mac_bytes)
     return mac_bytes
 
-@artifact_processor
-def dhcpLeases(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    data_list = []
-    
-    for file_found in files_found:
-        with open(file_found, "rb") as fp:
-            pl = plistlib.load(fp)
-            for key, val in pl.items():
-                if key in ["IPAddress", "LeaseLength", "LeaseStartDate", 
-                        "RouterHardwareAddress", "RouterIPAddress", "SSID"]:
-                    if key == "LeaseStartDate":
-                        val = convert_plist_date_to_timezone_offset(val, timezone_offset)
-                        val = val.strftime('%Y-%m-%d %H:%M:%S')
-                    elif key == "RouterHardwareAddress":
-                        val = format_mac_address(val)
-                    data_list.append((key, val, file_found))
 
+@artifact_processor
+def dhcpLeases(context):
     data_headers = ('Property Name', 'Property Value', 'Source File')
-    
-    return data_headers, data_list, ''
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        rel = context.get_relative_path(file_found)
+        try:
+            with open(file_found, "rb") as fp:
+                pl = plistlib.load(fp)
+        except (plistlib.InvalidFileException, ValueError, OSError) as ex:
+            logfunc(f'Failed to read DHCP lease {file_found}: {ex}')
+            continue
+
+        for key, val in pl.items():
+            if key not in _WANTED:
+                continue
+            if key == "LeaseStartDate" and hasattr(val, 'strftime'):
+                # plist <date> values are UTC; format as-is (no examiner-local shift)
+                val = val.strftime('%Y-%m-%d %H:%M:%S')
+            elif key == "RouterHardwareAddress":
+                val = format_mac_address(val)
+            data_list.append((key, val, rel))
+        sources.append(rel)
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary
Finishes the relative-path sweep: the two DHCP artifacts (DHCP Hotspot Clients + DHCP Received List) were on the legacy **5-arg** signature, so they couldn't take the simple `get_relative_path` wrap the other 28 got.

## Changes
- Convert both to the **context form** (drops the unused `report_folder`/`seeker`/`wrap_text`/`timezone_offset` args — the lint debt).
- **Source File** column now uses `context.get_relative_path` (was the full on-disk path).
- 🔴 **dhcpl**: store `LeaseStartDate` as **UTC** (plist `<date>` is UTC) instead of shifting it to the examiner's local tz via `convert_plist_date_to_timezone_offset`; guards the plist read.
- **dhcphp**: add `encoding=` to `open()`; fix the `paths` tuple (was a bare string).
- `version`/`date` → `creation_date`/`last_update_date`; author preserved (@AlexisBrignoni on dhcphp).

## Validation
- pylint 10.00/10 both.
- Runtime-tested: relative source paths, UTC `LeaseStartDate` (unshifted), MAC formatting, non-wanted keys excluded.
- PluginLoader loads all 577.

This closes out the path-in-data-column sweep — every artifact's source column now shows the clean in-extraction path.