### PR TITLE
whatsApp: fix AttributeError crash on messages without forward metadata

### DIFF
--- a/scripts/artifacts/whatsApp.py
+++ b/scripts/artifacts/whatsApp.py
@@ -244,8 +244,9 @@ def whatsAppMessages(context):
         if metadata:
             try:
                 decoded_data, _ = blackboxprotobuf.decode_message(metadata)
-                number_forward = f'{decoded_data.get("17")}'
-                from_forward = f'{decoded_data.get("21").decode("utf-8")}'
+                number_forward = f'{decoded_data.get("17", "")}'
+                forward_id = decoded_data.get("21")
+                from_forward = forward_id.decode("utf-8") if isinstance(forward_id, bytes) else ''
                 if contacts_db and from_forward:
                     attach_query = attach_sqlite_db_readonly(contacts_db, 'ContactsV2')
                     query_contact = f"""


### PR DESCRIPTION
## Problem
`whatsAppMessages` crashed with:
```
AttributeError: 'NoneType' object has no attribute 'decode'
  whatsApp.py:248  from_forward = f'{decoded_data.get("21").decode("utf-8")}'
```
Protobuf field `21` (the forwarded-message sender ID) is **absent on any message that isn't a forward** — i.e. most messages — so `.get("21")` returns `None` and `.decode()` raises, aborting the entire artifact.

## Fix
- Decode field 21 only when it's `bytes`, else `''`:
  ```python
  forward_id = decoded_data.get("21")
  from_forward = forward_id.decode("utf-8") if isinstance(forward_id, bytes) else ''
  ```
- Default field 17 to `''` so `number_forward` shows `''` instead of the literal `'None'` when absent.

Pre-existing bug (not from the recent conversions). pylint 10.00/10; verified present-bytes / absent / None all handled without crashing.