### PR TITLE
Fix LAVA CREATE TABLE crashes from duplicate/reserved column names (cashApp, tikTok)

### DIFF
--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -69,8 +69,8 @@ ORDER BY ZPAYMENT.ZDISPLAYDATE ASC
                 date = convert_unix_ts_to_utc(row[6])
                 data_list.append((date, row[1], row[2], row[0], row[3], row[5], row[4], context.get_relative_path(file_found)))
 
-    data_headers = (('Transaction Date', 'datetime'), 'Display Name', 'Cashtag', 'Account Owner Role', 
-                    'Currency Amount', 'Transaction State', 'Transaction State', 'Source File')
+    data_headers = (('Transaction Date', 'datetime'), 'Display Name', 'Cashtag', 'Account Owner Role',
+                    'Currency Amount', 'Transaction State', 'Note', 'Source File')
 
     db.close()
     

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -354,7 +354,7 @@ def tiktok_contacts(context):
         "Unique ID",
         "Custom ID",
         "URL",
-        "Table",
+        "Source Table",
         "Source File",
     )
 


### PR DESCRIPTION
## Problem
Both artifacts crashed in `lava_create_sqlite_table` as soon as they had a record:
```
sqlite3.OperationalError: duplicate column name: transaction_state   # cashApp
sqlite3.OperationalError: near "table": syntax error                # tikTok
```

## Fixes
- **cashApp**: two columns were both labeled `Transaction State`. The second actually holds the payment **NOTE** (`row[4]`) — renamed to **`Note`**. Fixes the duplicate-column crash *and* corrects the mislabeled column.
- **tikTok** (`tiktok_contacts`): a column named `Table` sanitizes to the SQL **reserved word** `table` (the framework doesn't quote identifiers). Renamed to **`Source Table`** (it holds the source table name).

Both are pre-existing bugs surfaced during testing (not from the recent conversions).

## Validation
- pylint 10.00/10 on both.
- A **codebase-wide CREATE TABLE audit** (duplicate + reserved-word sanitized column names across every artifact's `data_headers`) confirms **no other artifacts** are affected.