### PR TITLE
Guard date-converter calls in 9 artifacts against string/empty dates

### DIFF
--- a/scripts/artifacts/appItunesmeta.py
+++ b/scripts/artifacts/appItunesmeta.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
 
 import pathlib
 import os
+from datetime import datetime
 from scripts.ilapfuncs import artifact_processor, convert_time_obj_to_utc, convert_plist_date_to_utc, get_plist_file_content
 
 @artifact_processor
@@ -37,8 +38,9 @@ def get_appItunesmeta(context):
                 continue
                 
             purchasedate = plist.get('com.apple.iTunesStore.downloadInfo', {}).get('purchaseDate', '')
-            #print(purchasedate, timezone_offset)
-            purchasedate = convert_plist_date_to_utc(purchasedate)
+            # purchaseDate may be a plist <date> object or an ISO string; only convert objects
+            if isinstance(purchasedate, datetime):
+                purchasedate = convert_plist_date_to_utc(purchasedate)
             
             bundleid = plist.get('softwareVersionBundleId', '')
             itemname = plist.get('itemName', '')
@@ -48,7 +50,8 @@ def get_appItunesmeta(context):
             genre = plist.get('genre', '')
             factoryinstall = plist.get('isFactoryInstall', '')
             appreleasedate = plist.get('releaseDate', '')
-            appreleasedate = convert_plist_date_to_utc(appreleasedate)
+            if isinstance(appreleasedate, datetime):
+                appreleasedate = convert_plist_date_to_utc(appreleasedate)
             sourceapp = plist.get('sourceApp', '')
             sideloaded = plist.get('sideLoadedDeviceBasedVPP', '')
             variantid = plist.get('variantID', '')
@@ -67,7 +70,8 @@ def get_appItunesmeta(context):
                 else:
                     install_date = deserialized_plist.get('installDate', '')
                     #print(install_date, type(install_date))
-                    install_date = convert_time_obj_to_utc(install_date)
+                    if isinstance(install_date, datetime):
+                        install_date = convert_time_obj_to_utc(install_date)
             else:
                 install_date = ''
     

--- a/scripts/artifacts/appleAlarms.py
+++ b/scripts/artifacts/appleAlarms.py
@@ -16,6 +16,13 @@ __artifacts_v2__ = {
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_plist_file_content, convert_plist_date_to_utc, logfunc
 
+from datetime import datetime as _dt
+
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
+
+
 def decode_repeat_schedule(repeat_schedule_value):
     days_list = {
         64: 'Sunday', 
@@ -63,11 +70,11 @@ def alarms(context):
                 alarm_hour = alarms_dict.get('MTAlarmHour', '')
                 alarm_min = alarms_dict.get('MTAlarmMinute', '')
                 fire_date = alarms_dict.get('MTAlarmFireDate', '')
-                fire_date = convert_plist_date_to_utc(fire_date)
+                fire_date = _safe_plist_date(fire_date)
                 dismiss_date = alarms_dict.get('MTAlarmDismissDate', '')
-                dismiss_date = convert_plist_date_to_utc(dismiss_date)
+                dismiss_date = _safe_plist_date(dismiss_date)
                 last_modified_date = alarms_dict.get('MTAlarmLastModifiedDate', '')
-                last_modified_date = convert_plist_date_to_utc(last_modified_date)
+                last_modified_date = _safe_plist_date(last_modified_date)
                 repeat_schedule = decode_repeat_schedule(alarms_dict['MTAlarmRepeatSchedule'])
 
                 alarm_time = str(alarm_hour).zfill(2) + ':' + str(alarm_min).zfill(2)
@@ -93,11 +100,11 @@ def alarms(context):
 
                 alarm_title = sleep_alarm_dict.get('MTAlarmTitle', 'Bedtime')
                 fire_date = sleep_alarm_dict.get('MTAlarmFireDate', '')
-                fire_date = convert_plist_date_to_utc(fire_date)
+                fire_date = _safe_plist_date(fire_date)
                 dismiss_date = sleep_alarm_dict.get('MTAlarmDismissDate', '')
-                dismiss_date = convert_plist_date_to_utc(dismiss_date)
+                dismiss_date = _safe_plist_date(dismiss_date)
                 last_modified_date = sleep_alarm_dict.get('MTAlarmLastModifiedDate', '')
-                last_modified_date = convert_plist_date_to_utc(last_modified_date)
+                last_modified_date = _safe_plist_date(last_modified_date)
                 repeat_schedule = decode_repeat_schedule(sleep_alarm_dict['MTAlarmRepeatSchedule'])
 
                 data_list.append(

--- a/scripts/artifacts/appleWifiPlist.py
+++ b/scripts/artifacts/appleWifiPlist.py
@@ -55,6 +55,13 @@ __artifacts_v2__ = {
 
 from scripts.ilapfuncs import device_info, artifact_processor, get_plist_file_content, convert_plist_date_to_utc
 
+from datetime import datetime as _dt
+
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
+
+
 def _bytes_to_mac_address(encoded_bytes):
     return ':'.join(f"{byte:02x}" for byte in encoded_bytes[:6])
 
@@ -144,31 +151,31 @@ def appleWifiKnownNetworksTimes(context):
             for known_network in deserialized['List of known networks']:
                 ssid = _decode_ssid(known_network.get('SSID_STR', b''))
                 bssid = known_network.get('BSSID', '')
-                last_updated = convert_plist_date_to_utc(known_network.get('lastUpdated', ''))
-                last_auto_joined = convert_plist_date_to_utc(known_network.get('lastAutoJoined', ''))
-                last_joined = convert_plist_date_to_utc(known_network.get('lastJoined', ''))
-                wnpmd = convert_plist_date_to_utc(known_network.get('WiFiNetworkPasswordModificationDate', ''))
-                prev_joined = convert_plist_date_to_utc(known_network.get('prevJoined', ''))
+                last_updated = _safe_plist_date(known_network.get('lastUpdated', ''))
+                last_auto_joined = _safe_plist_date(known_network.get('lastAutoJoined', ''))
+                last_joined = _safe_plist_date(known_network.get('lastJoined', ''))
+                wnpmd = _safe_plist_date(known_network.get('WiFiNetworkPasswordModificationDate', ''))
+                prev_joined = _safe_plist_date(known_network.get('prevJoined', ''))
 
                 data_list.append([ssid, bssid, last_updated, last_auto_joined, last_joined, '', '', wnpmd, '', '', '', '', prev_joined, context.get_relative_path(file_found)])
 
         if 'com.apple.wifi.known-networks.plist' in file_found:
             for _, known_network in deserialized.items():
                 ssid = _decode_ssid(known_network.get('SSID', b''))
-                last_updated = convert_plist_date_to_utc(known_network.get('UpdatedAt', ''))
-                system_joined = convert_plist_date_to_utc(known_network.get('JoinedBySystemAt', ''))
-                user_joined = convert_plist_date_to_utc(known_network.get('JoinedByUserAt', ''))
-                last_discovered = convert_plist_date_to_utc(known_network.get('LastDiscoveredAt', ''))
-                added_at = convert_plist_date_to_utc(known_network.get('AddedAt', ''))
+                last_updated = _safe_plist_date(known_network.get('UpdatedAt', ''))
+                system_joined = _safe_plist_date(known_network.get('JoinedBySystemAt', ''))
+                user_joined = _safe_plist_date(known_network.get('JoinedByUserAt', ''))
+                last_discovered = _safe_plist_date(known_network.get('LastDiscoveredAt', ''))
+                added_at = _safe_plist_date(known_network.get('AddedAt', ''))
 
                 captive_profile = known_network.get('CaptiveProfile', {})
-                whitelisted_probe_date = convert_plist_date_to_utc(captive_profile.get('WhitelistedCaptiveNetworkProbeDate', ''))
-                captive_web_sheet_login_date = convert_plist_date_to_utc(captive_profile.get('CaptiveWebSheetLoginDate', ''))
+                whitelisted_probe_date = _safe_plist_date(captive_profile.get('WhitelistedCaptiveNetworkProbeDate', ''))
+                captive_web_sheet_login_date = _safe_plist_date(captive_profile.get('CaptiveWebSheetLoginDate', ''))
 
                 os_specific = known_network.get('__OSSpecific__', {})
                 bssid = os_specific.get('BSSID', '')
-                wnpmd = convert_plist_date_to_utc(os_specific.get('WiFiNetworkPasswordModificationDate', ''))
-                prev_joined = convert_plist_date_to_utc(os_specific.get('prevJoined', ''))
+                wnpmd = _safe_plist_date(os_specific.get('WiFiNetworkPasswordModificationDate', ''))
+                prev_joined = _safe_plist_date(os_specific.get('prevJoined', ''))
 
                 data_list.append([ssid, bssid, last_updated, '', '', system_joined, user_joined, wnpmd, 
                                     last_discovered, added_at, whitelisted_probe_date, captive_web_sheet_login_date, 
@@ -196,13 +203,13 @@ def appleWifiScannedPrivate(context):
             for scanned_network in deserialized['List of scanned networks with private mac']:
                 ssid = scanned_network.get('SSID_STR', '')
                 bssid = scanned_network.get('BSSID', '')
-                last_updated = convert_plist_date_to_utc(scanned_network.get('lastUpdated', ''))
-                last_joined = convert_plist_date_to_utc(scanned_network.get('lastJoined', ''))
-                added_at = convert_plist_date_to_utc(scanned_network.get('addedAt', ''))
+                last_updated = _safe_plist_date(scanned_network.get('lastUpdated', ''))
+                last_joined = _safe_plist_date(scanned_network.get('lastJoined', ''))
+                added_at = _safe_plist_date(scanned_network.get('addedAt', ''))
                 in_known_networks = scanned_network.get('PresentInKnownNetworks', '')
-                link_down_timestamp = convert_plist_date_to_utc(scanned_network.get('LinkDownTimestamp', ''))
-                mac_generation_timestamp = convert_plist_date_to_utc(scanned_network.get('MacGenerationTimeStamp', ''))
-                first_join_with_new_mac_timestamp = convert_plist_date_to_utc(scanned_network.get('FirstJoinWithNewMacTimestamp', ''))
+                link_down_timestamp = _safe_plist_date(scanned_network.get('LinkDownTimestamp', ''))
+                mac_generation_timestamp = _safe_plist_date(scanned_network.get('MacGenerationTimeStamp', ''))
+                first_join_with_new_mac_timestamp = _safe_plist_date(scanned_network.get('FirstJoinWithNewMacTimestamp', ''))
 
                 private_mac = scanned_network.get('PRIVATE_MAC_ADDRESS', {})
                 private_mac_in_use = _bytes_to_mac_address(private_mac.get('PRIVATE_MAC_ADDRESS_IN_USE', b''))
@@ -239,10 +246,10 @@ def appleWifiBSSList(context):
                 for bss in bss_list:
                     channel_flags = bss.get('ChannelFlags', '')
                     channel = bss.get('Channel', '')
-                    last_associated_at = convert_plist_date_to_utc(bss.get('LastAssociatedAt', ''))
+                    last_associated_at = _safe_plist_date(bss.get('LastAssociatedAt', ''))
                     bssid = bss.get('BSSID', '')
                     location_accuracy = bss.get('LocationAccuracy', '')
-                    location_timestamp = convert_plist_date_to_utc(bss.get('LocationTimestamp', ''))
+                    location_timestamp = _safe_plist_date(bss.get('LocationTimestamp', ''))
                     location_latitude = bss.get('LocationLatitude', '')
                     location_longitude = bss.get('LocationLongitude', '')
 
@@ -258,7 +265,7 @@ def appleWifiBSSList(context):
                 bss_list = known_network.get('networkKnownBSSListKey', [])
                 for bss in bss_list:
                     channel = bss.get('CHANNEL', '')
-                    last_roamed = convert_plist_date_to_utc(bss.get('lastRoamed', ''))
+                    last_roamed = _safe_plist_date(bss.get('lastRoamed', ''))
                     bssid = bss.get('BSSID', '')
                     channel_flags = bss.get('CHANNEL_FLAGS', '')
 

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -20,6 +20,13 @@ from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import convert_time_obj_to_utc, get_plist_content, logfunc, artifact_processor
 
+from datetime import datetime as _dt
+
+def _safe_time_obj(value):
+    """Set UTC tzinfo on datetime objects; pass strings/None through unchanged."""
+    return convert_time_obj_to_utc(value) if isinstance(value, _dt) else value
+
+
 @artifact_processor
 def get_biomeIntents(context):
     data_headers = (('Timestamp', 'datetime'), ('End Date', 'datetime'), 'Duration Interval', 'Donated by Siri',
@@ -75,10 +82,10 @@ def get_biomeIntents(context):
                     continue
 
                 startdate = (deserialized_plist['dateInterval']['NS.startDate'])
-                startdate = convert_time_obj_to_utc(startdate)
+                startdate = _safe_time_obj(startdate)
 
                 enddate = (deserialized_plist['dateInterval']['NS.endDate'])
-                enddate = convert_time_obj_to_utc(enddate)
+                enddate = _safe_time_obj(enddate)
 
                 durationinterval = (deserialized_plist['dateInterval']['NS.duration'])
                 donatedbysiri = 'True' if deserialized_plist['_donatedBySiri'] else 'False'

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -21,6 +21,13 @@ from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, convert_time_obj_to_utc, get_plist_content
 
+from datetime import datetime as _dt
+
+def _safe_time_obj(value):
+    """Set UTC tzinfo on datetime objects; pass strings/None through unchanged."""
+    return convert_time_obj_to_utc(value) if isinstance(value, _dt) else value
+
+
 
 @artifact_processor
 def get_biomeUseractmeta(context):
@@ -57,7 +64,7 @@ def get_biomeUseractmeta(context):
                 
                 title = (deserialized_plist.get('title',''))
                 when = (deserialized_plist['when'])
-                when = convert_time_obj_to_utc(when)
+                when = _safe_time_obj(when)
                 actype = (deserialized_plist['activityType'])
                 #exdate = (deserialized_plist.get('expirationDate',''))
                 

--- a/scripts/artifacts/booking.py
+++ b/scripts/artifacts/booking.py
@@ -193,6 +193,11 @@ from scripts.ilapfuncs import get_sqlite_db_records, \
     get_plist_content, get_plist_file_content, convert_plist_date_to_utc, \
     convert_unix_ts_to_utc, check_in_media, artifact_processor, logfunc
 
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, datetime) else value
+
+
 
 # Constants
 LINE_BREAK = '\n'
@@ -1074,7 +1079,7 @@ def booking_stored_destinations(context):
                 desc, city, region, country, lat, lon = _get_destination_details(loc_dict)
 
                 # Basic fields
-                created = convert_plist_date_to_utc(dest.get('created'))
+                created = _safe_plist_date(dest.get('created'))
                 loc_type = location_type_names(loc_dict.get('locationType_'))
                 img_url = loc_dict.get('image_url')
                 img_url_h = format_url(img_url, html_format=True)
@@ -1161,7 +1166,7 @@ def booking_recently_searched(context):
                 desc, city, region, country, lat, lon = _get_destination_details(dest_dict)
 
                 # Basic search info
-                searched = convert_plist_date_to_utc(ss.get('created'))
+                searched = _safe_plist_date(ss.get('created'))
                 loc_type = location_type_names(dest_dict.get('locationType_'))
 
                 # Precise location within the plist structure for validation
@@ -1330,7 +1335,7 @@ def _get_rooms_details(rooms: list) -> tuple:
         append_tag_value(meta, 'Number of guests', room.get('nr_guests'))
         append_tag_value(meta, 'Cancelled', room.get('is_cancelled'))
 
-        cancel_date = convert_plist_date_to_utc(room.get('cancel_date'))
+        cancel_date = _safe_plist_date(room.get('cancel_date'))
         append_tag_value(meta, 'Cancel date', cancel_date)
         append_tag_value(meta, 'Identifier', room.get('room_id'))
         append_tag_value(meta, 'URL photo', room.get('room_photo'))
@@ -1480,7 +1485,7 @@ def booking_booked(context):
 
                     # Standard row data
                     base_data = (
-                        convert_plist_date_to_utc(val.get('created_epoch')),
+                        _safe_plist_date(val.get('created_epoch')),
                         val.get('hotel_id'),
                         val.get('hotel_name'),
                         full_addr,
@@ -1567,7 +1572,7 @@ def booking_wish_lists(context):
                 hotels = wish.get('hotels', [])
 
                 for j, hotel in enumerate(hotels):
-                    added = convert_plist_date_to_utc(hotel.get('date'))
+                    added = _safe_plist_date(hotel.get('date'))
                     hotel_id = hotel.get('id')
 
                     # Precise location within the plist structure for validation
@@ -1640,7 +1645,7 @@ def booking_viewed(context):
                     continue
 
                 # Basic Info
-                last_viewed = convert_plist_date_to_utc(hotel.get('lastViewed'))
+                last_viewed = _safe_plist_date(hotel.get('lastViewed'))
                 h_type = hotel_type_names(hotel.get('hotel_type'))
 
                 # City and Region logic: checks 'city' dict first, then flattens to root keys

--- a/scripts/artifacts/callHistoryTransactions.py
+++ b/scripts/artifacts/callHistoryTransactions.py
@@ -18,6 +18,13 @@ import nska_deserialize as nd
 from scripts.ilapfuncs import artifact_processor, \
     convert_plist_date_to_utc
 
+from datetime import datetime as _dt
+
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
+
+
 
 @artifact_processor
 def callHistoryTransactions(context):
@@ -35,7 +42,7 @@ def callHistoryTransactions(context):
                 plist_data = file.read(length)
                 ds_plist = nd.deserialize_plist_from_string(plist_data)
                 inner_record = nd.deserialize_plist_from_string(ds_plist['record'])
-                date = convert_plist_date_to_utc(inner_record.get('date', ''))
+                date = _safe_plist_date(inner_record.get('date', ''))
                 data_list.append((date, inner_record['handleType'], inner_record['callStatus'],
                                   inner_record['duration'], inner_record['remoteParticipantHandles'][0]['value'],
                                   inner_record['callerId'], inner_record['timeToEstablish'],

--- a/scripts/artifacts/cloudkit_cache.py
+++ b/scripts/artifacts/cloudkit_cache.py
@@ -38,6 +38,13 @@ from scripts.ilapfuncs import (
     convert_plist_date_to_utc
 )
 
+from datetime import datetime as _dt
+
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
+
+
 def format_size(size):
     """
     Formats a byte size into a human-readable string with appropriate units (B, KiB, MiB, etc.).
@@ -86,13 +93,13 @@ def cloudkit_snapshots(context):
 
             deserialized_plist = nd.deserialize_plist_from_string(snapshot[3])
 
-            mod_date = convert_plist_date_to_utc(deserialized_plist.get('SnapshotModificationDate'))
+            mod_date = _safe_plist_date(deserialized_plist.get('SnapshotModificationDate'))
             device_uuid = deserialized_plist.get('DeviceUUID')
             product_version = deserialized_plist.get('ProductVersion')
             backup_type = deserialized_plist.get('BackupType')
             device_name = deserialized_plist.get('DeviceName')
             backup_reason = deserialized_plist.get('BackupReason')
-            snapshot_created = convert_plist_date_to_utc(deserialized_plist.get('SnapshotCreated'))
+            snapshot_created = _safe_plist_date(deserialized_plist.get('SnapshotCreated'))
             is_allowed_cellular = deserialized_plist.get('IsBackupAllowedOnCellular')
 
             # Calculate file count and total size

--- a/scripts/artifacts/instagramThreads.py
+++ b/scripts/artifacts/instagramThreads.py
@@ -57,6 +57,13 @@ from scripts.ilapfuncs import (
     get_sqlite_db_records,
 )
 
+from datetime import datetime as _dt
+
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
+
+
 
 def _database_files(context):
     return [
@@ -172,7 +179,7 @@ def instagram_threads(context):
 
             thread_id = metadata["NSString*threadId"]
             server_timestamp = metadata["NSDate*serverTimestamp"]
-            server_timestamp = convert_plist_date_to_utc(server_timestamp)
+            server_timestamp = _safe_plist_date(server_timestamp)
             message = content.get("NSString*string")
 
             # VOIP calls
@@ -186,7 +193,7 @@ def instagram_threads(context):
             if reactions:
                 dm_reaction = reactions[0].get("emojiUnicode")
                 reaction_server_timestamp = reactions[0].get("serverTimestamp")
-                reaction_server_timestamp = convert_plist_date_to_utc(reaction_server_timestamp)
+                reaction_server_timestamp = _safe_plist_date(reaction_server_timestamp)
                 reaction_user_id = reactions[0].get("userId")
 
             # Shared media
@@ -215,7 +222,7 @@ def instagram_threads(context):
                     0,
                     "expiration_date",
                 )
-                shared_media_url_expiration_date = convert_plist_date_to_utc(
+                shared_media_url_expiration_date = _safe_plist_date(
                     shared_media_url_expiration_date
                 )
 
@@ -302,7 +309,7 @@ def instagram_calls(context):
             content = plist["IGDirectPublishedMessageContent*content"]
             sender_pk = metadata["NSString*senderPk"]
             server_timestamp = metadata["NSDate*serverTimestamp"]
-            server_timestamp = convert_plist_date_to_utc(server_timestamp)
+            server_timestamp = _safe_plist_date(server_timestamp)
 
             # VOIP calls
             thread_activity = content.get("IGDirectThreadActivityAnnouncement*threadActivity")

--- a/scripts/artifacts/weatherAppLocations.py
+++ b/scripts/artifacts/weatherAppLocations.py
@@ -22,6 +22,13 @@ from scripts.ilapfuncs import (
     convert_plist_date_to_utc
     )
 
+from datetime import datetime as _dt
+
+def _safe_plist_date(value):
+    """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
+    return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
+
+
 
 @artifact_processor
 def weather_app_locations(context):
@@ -43,7 +50,7 @@ def weather_app_locations(context):
                     'Longitude',
                 )
 
-        lastupdated = convert_plist_date_to_utc(plist_content.get('LastUpdated'))
+        lastupdated = _safe_plist_date(plist_content.get('LastUpdated'))
         if plist_content.get('Cities', '0') == '0':
             logfunc('No cities available')
             return (), [], source_path
@@ -79,7 +86,7 @@ def weather_app_locations(context):
             logfunc('No cities available')
             return (), [], source_path
         for city in plist_content['Cities']:
-            update_time = convert_plist_date_to_utc(city.get('UpateTime', ''))
+            update_time = _safe_plist_date(city.get('UpateTime', ''))
             data_list.append((
                 update_time,
                 'Added from User',
@@ -91,7 +98,7 @@ def weather_app_locations(context):
                 city['SecondsFromGMT']
                 ))
         local_weather = plist_content.get('LocalWeather', {})
-        local_update_time = convert_plist_date_to_utc(local_weather.get('UpateTime', ''))
+        local_update_time = _safe_plist_date(local_weather.get('UpateTime', ''))
         last_location_update = convert_unix_ts_to_utc(plist_content.get('LastLocationUpdateTime'))
         data_list.append((
             local_update_time,


### PR DESCRIPTION
## Problem
`convert_plist_date_to_utc` / `convert_time_obj_to_utc` expect a **datetime** object and crash (`AttributeError` / `TypeError`) when handed a **string** or empty value — which happens when a plist stores a date as an ISO string rather than a `<date>` object. This is the same root cause as the appItunesmeta crash from testing ([#1613](https://github.com/abrignoni/iLEAPP/pull/1613)); these 9 artifacts call the same converters and would hit it on similar data.

## Fix
Route each artifact's converter calls through a small local guard (`_safe_plist_date` / `_safe_time_obj`) that converts only `datetime` instances and passes strings/None/empties through unchanged.

Covers: appleAlarms, appleWifiPlist, biomeIntents, biomeUseractmeta, booking, callHistoryTransactions, cloudkit_cache, instagramThreads, weatherAppLocations.

## Note
The proper fix is hardening the two converters in `ilapfuncs.py` directly (one change for all + future artifacts), but CI lints the whole changed file and `ilapfuncs.py` has 35 pre-existing issues (including a real `E0601 used-before-assignment` error) — so that's tracked as a separate dedicated cleanup.

## Validation
- pylint 10.00/10 on all 9.
- Guards verified: datetime → aware UTC; string / '' / None → passed through unchanged (no crash).