### PR TITLE
appleMapsTrips: handle -wal/sidecar + wrong-schema DBs without crashing; relative Source File

### DIFF
--- a/scripts/artifacts/appleMapsTrips.py
+++ b/scripts/artifacts/appleMapsTrips.py
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
 def get_google_map_link(latitude_value, longitude_value):
     if latitude_value is None or longitude_value is None:
@@ -86,15 +86,13 @@ def appleMapsTrips(context):
     for file_found in files_found:
         file_found = str(file_found)
         
-        LocalDB = str(file_found)
-        LocalDB_found.append(LocalDB)
+        if file_found.endswith('.sqlite'):   # skip -wal/-shm/-journal sidecar files
+            LocalDB_found.append(str(file_found))
         
     for i in range(len(LocalDB_found)):
         LocalDB = LocalDB_found[i]
         
-        db = open_sqlite_db_readonly(LocalDB)
-        cursor = db.cursor()
-        cursor.execute('''
+        all_rows = get_sqlite_db_records(LocalDB, '''
         SELECT 
         CASE 
             WHEN trip.ZSTARTDATE < 0 THEN NULL 
@@ -110,12 +108,10 @@ def appleMapsTrips(context):
         ZRTLEARNEDLOCATIONOFINTERESTVISITMO as dest
         on trip.ZVISITIDENTIFIERDESTINATION = dest.ZIDENTIFIER
         ''')
-
-        all_rows = cursor.fetchall()
         for row in all_rows:
             row = list(row)
 
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6], get_google_dir_link(row[2], row[3], row[4], row[5], row[6]), LocalDB))
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6], get_google_dir_link(row[2], row[3], row[4], row[5], row[6]), context.get_relative_path(LocalDB)))
 
     data_headers = (('Start DateTime', 'datetime'), ('End DateTime', 'datetime'), 'Origin Latitude','Origin Longitude', 'Destination Latitude', 'Destination Longitude','ZZPREDOMINANTMOTIONACTIVITYTYPE', 'Google Maps Link','Source File')
     return data_headers, data_list, 'See source file(s) below:'
@@ -132,15 +128,13 @@ def appleMapsSignificantLocationsVisits(context):
     for file_found in files_found:
         file_found = str(file_found)
         
-        LocalDB = str(file_found)
-        LocalDB_found.append(LocalDB)
+        if file_found.endswith('.sqlite'):   # skip -wal/-shm/-journal sidecar files
+            LocalDB_found.append(str(file_found))
         
     for i in range(len(LocalDB_found)):
         LocalDB = LocalDB_found[i]
         
-        db = open_sqlite_db_readonly(LocalDB)
-        cursor = db.cursor()
-        cursor.execute('''
+        all_rows = get_sqlite_db_records(LocalDB, '''
         SELECT m.ZNAME, m.ZCATEGORY, a.ZSUBTHOROUGHFARE || ' ' || a.ZTHOROUGHFARE as Address, a.ZLOCALITY, a.ZADMINISTRATIVEAREA, a.ZADMINISTRATIVEAREACODE, 
             a.ZCOUNTRY, a.ZPOSTALCODE, a.ZSUBLOCALITY, a.ZAREASOFINTEREST, m.ZLATITUDE, m.ZLONGITUDE, 
             datetime(p.ZCREATIONDATE + 978307200, 'unixepoch') as CreationDateTime
@@ -148,24 +142,20 @@ def appleMapsSignificantLocationsVisits(context):
         ZRTADDRESSMO as a on p.ZMAPITEM = a.ZMAPITEM AND p.ZDEVICE = a.ZDEVICE INNER JOIN 
         ZRTMAPITEMMO as m on p.ZDEVICE = m.ZDEVICE AND p.ZMAPITEM = m.ZPLACE
         ''')
-
-        all_rows = cursor.fetchall()
         for row in all_rows:
             row = list(row)
 
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11], get_google_map_link(row[10], row[11]),row[12],LocalDB))
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11], get_google_map_link(row[10], row[11]),row[12],context.get_relative_path(LocalDB)))
 
-        cursor.execute('''
+        all_rows = get_sqlite_db_records(LocalDB, '''
         SELECT NULL,NULL,NULL,NULL, NULL, NULL, NULL, NULL, NULL, NULL, p.ZLOCATIONLATITUDE, p.ZLOCATIONLONGITUDE, 
             datetime(p.ZPLACECREATIONDATE + 978307200, 'unixepoch') as CreationDateTime
         FROM ZRTLEARNEDLOCATIONOFINTERESTMO as p
         ''')
-
-        all_rows = cursor.fetchall()
         for row in all_rows:
             row = list(row)
 
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11], get_google_map_link(row[10], row[11]),row[12],LocalDB))
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11], get_google_map_link(row[10], row[11]),row[12],context.get_relative_path(LocalDB)))
 
     data_headers = ('Significant Location Name', 'Category', 'Address','City', 'State', 'State-Abbrev',  'Country', 'Zip Code', 'ZSUBLOCALITY', 'ZAREASOFINTEREST', 'Latitude', 'Longitude', 'Google Maps Link', ('Created DateTime','datetime'), 'Source File')
     return data_headers, data_list, 'See source file(s) below:'
@@ -182,27 +172,23 @@ def appleMapsSignificantLocations(context):
     for file_found in files_found:
         file_found = str(file_found)
         
-        LocalDB = str(file_found)
-        LocalDB_found.append(LocalDB)
+        if file_found.endswith('.sqlite'):   # skip -wal/-shm/-journal sidecar files
+            LocalDB_found.append(str(file_found))
         
     for i in range(len(LocalDB_found)):
         LocalDB = LocalDB_found[i]
         
-        db = open_sqlite_db_readonly(LocalDB)
-        cursor = db.cursor()
-        cursor.execute('''
+        all_rows = get_sqlite_db_records(LocalDB, '''
         SELECT  datetime(ZENTRYDATE + 978307200, 'unixepoch') as VicinityEntryDate,  
                 datetime(ZEXITDATE + 978307200, 'unixepoch') as VicinityExitDate, 
                 datetime(ZCREATIONDATE + 978307200, 'unixepoch') as CreatedDateTime, 
                 ZLOCATIONLATITUDE, ZLOCATIONLONGITUDE, ZLOCATIONHORIZONTALUNCERTAINTY  
         FROM ZRTLEARNEDLOCATIONOFINTERESTVISITMO
         ''')
-
-        all_rows = cursor.fetchall()
         for row in all_rows:
             row = list(row)
 
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5], get_google_map_link(row[3], row[4]), LocalDB))
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5], get_google_map_link(row[3], row[4]), context.get_relative_path(LocalDB)))
 
     data_headers = (('Vicinity Entry Datetime','datetime'), ('Vicinity Exit Datetime','datetime'), ('Created Datetime','datetime'), 'Latitude', 'Longitude', 'Uncertainty', 'Google Maps Link', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'


### PR DESCRIPTION
## Problem
```
sqlite3.DatabaseError: file is not a database
  appleMapsTrips.py:97  cursor.execute('''...
```
The path glob (`Local.sqlite*` / `Cloud-V2.sqlite*`) also matches the **`-wal`/`-shm`** sidecar files, and the code opened **each** matched file as a database — so a sidecar (not a valid DB) threw and aborted the artifact.

## Fix
- Only process files ending in `.sqlite` (SQLite auto-uses the `-wal`/`-shm` sidecars).
- Route all queries through `get_sqlite_db_records`, which catches `sqlite3.DatabaseError` — covering both *file is not a database* **and** *no such table* (schema varies across iOS versions) — and returns `[]` instead of crashing.
- Fix a full on-disk path leak: the **Source File** column used the raw `LocalDB` path; now uses `context.get_relative_path` (my earlier relative-path sweep missed it because the variable wasn't named `file_found`/`source_path`).

Applies to all three processors (Trips / Significant Locations / Visits).

## Validation
- pylint 10.00/10.
- Runtime-tested against a bogus `-wal` sidecar (skipped) and an empty/wrong-schema `.sqlite` (returns 0 rows, logs + continues) — **no crash**.