### PR TITLE
cacheRoutesGmap: handle non-archive plists + UTC timestamp

### DIFF
--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
 }
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from scripts.ilapfuncs import artifact_processor, get_plist_file_content
 
 @artifact_processor
@@ -22,24 +22,27 @@ def get_cacheRoutesGmap(context):
     data_list = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        noext = os.path.splitext(filename)[0]
-        noext = int(noext)
-        datetime_time = datetime.fromtimestamp(noext/1000)
-        datetime_time = str(datetime_time)
+        noext = os.path.splitext(os.path.basename(file_found))[0]
+        try:
+            epoch_ms = int(noext)
+        except ValueError:
+            continue  # filename is not a numeric (ms epoch) timestamp
+        datetime_time = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
+
         deserialized = get_plist_file_content(file_found)
-        if not deserialized or not isinstance(deserialized, dict):
+        if not isinstance(deserialized, dict):
             continue
-        length = len(deserialized['$objects'])
-        for x in range(length):
-            try: 
-                lat = deserialized['$objects'][x]['_coordinateLat']
-                lon = deserialized['$objects'][x]['_coordinateLong'] #lat longs
+        objects = deserialized.get('$objects')
+        if not isinstance(objects, list):
+            continue  # not an NSKeyedArchiver archive
+        for entry in objects:
+            try:
+                lat = entry['_coordinateLat']
+                lon = entry['_coordinateLong']  # lat/longs
                 data_list.append((datetime_time, lat, lon, context.get_relative_path(file_found)))
             except (KeyError, TypeError):
-                pass    
-            
+                pass
 
-    data_headers = (('Timestamp', 'datetime'),'Latitude','Longitude','Source File')
-    
+    data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Source File')
+
     return data_headers, data_list, 'see Source File for more info'


### PR DESCRIPTION
## Problem
```
KeyError: '$objects'
  cacheRoutesGmap.py:33  length = len(deserialized['$objects'])
```
A cached-route plist that's a dict but **not an NSKeyedArchiver archive** (no `$objects` key) passed the `isinstance(..., dict)` guard and then crashed on `deserialized['$objects']`.

## Fix
- Use `deserialized.get('$objects')` and skip when it isn't a list (non-archive plist).
- 🔴 **UTC**: the filename-epoch timestamp used `datetime.fromtimestamp(...)` with no tz (examiner-local) — now converted as **UTC**.
- Guard `int(filename)` — skip files whose name isn't a numeric ms-epoch (was a latent `ValueError`).

Pre-existing bug surfaced during testing.

## Validation
- pylint 10.00/10.
- Runtime-tested: valid archive → coords with UTC timestamp; non-archive dict → skipped; non-numeric filename → skipped. No crash.