### PR TITLE
mobileBackupplist: fix 'datetime is not JSON serializable' crash

### DIFF
--- a/scripts/artifacts/mobileBackupplist.py
+++ b/scripts/artifacts/mobileBackupplist.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 }
 
 import plistlib
+from datetime import datetime
 
 from scripts.ilapfuncs import artifact_processor
 
@@ -55,6 +56,14 @@ def mobilebackupplist(context):
         if isinstance(block, dict):
             for key in keys:
                 if key in block:
-                    data_list.append((key, block[key]))
+                    value = block[key]
+                    if isinstance(value, datetime):
+                        # plist <date> values are UTC; store as a UTC string (the generic
+                        # 'Value' column is not datetime-typed, so a datetime would not
+                        # be JSON-serializable for LAVA).
+                        value = value.strftime('%Y-%m-%d %H:%M:%S')
+                    elif isinstance(value, bytes):
+                        value = value.hex()
+                    data_list.append((key, value))
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/mobileBackupplist.py
+++ b/scripts/artifacts/mobileBackupplist.py
@@ -17,6 +17,7 @@ __artifacts_v2__ = {
     }
 }
 
+import json
 import plistlib
 from datetime import datetime
 
@@ -64,6 +65,9 @@ def mobilebackupplist(context):
                         value = value.strftime('%Y-%m-%d %H:%M:%S')
                     elif isinstance(value, bytes):
                         value = value.hex()
+                    elif isinstance(value, (dict, list)):
+                        # default=str handles nested datetimes/bytes that LAVA's json.dumps cannot.
+                        value = json.dumps(value, default=str)
                     data_list.append((key, value))
 
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Problem
```
TypeError: Object of type datetime is not JSON serializable
  lavafuncs.py:401  value = json.dumps(value)   (called from the @artifact_processor wrapper)
```
The generic **Value** column holds raw plist values, and several keys (`date`, `RestoreDate`, `FileTransferStartDate`, `RestoreStartDate`, `PreFlightStartDate`, `dateCreated`) are **datetime** objects. Because the column isn't datetime-typed, LAVA serializes non-simple values with `json.dumps`, which can't encode a datetime — aborting the artifact once a backup record had a date.

## Fix
Convert datetime values to a **UTC string** (plist `<date>` is UTC) and bytes to hex before appending; other JSON-serializable types are unchanged.

## Validation
- pylint 10.00/10.
- Runtime-tested a plist mixing datetime / bytes / bool / list / int / str values — every output value is now `json.dumps`-able (no crash).