### PR TITLE
locServicesconfig: make raw plist values LAVA-serializable (proactive)

### DIFF
--- a/scripts/artifacts/locServicesconfig.py
+++ b/scripts/artifacts/locServicesconfig.py
@@ -40,9 +40,22 @@ __artifacts_v2__ = {
     }
 }
 
+import json
 import plistlib
+from datetime import datetime
 
 from scripts.ilapfuncs import artifact_processor, convert_cocoa_core_data_ts_to_utc, logfunc
+
+
+def _lava_safe(value):
+    """Make a raw plist value safe for LAVA's generic-column json serialization."""
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')   # plist <date> is UTC
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, default=str)
+    return value
 
 
 def _load_plist(context, filename):
@@ -96,7 +109,7 @@ def locServicesConfigLocationd(context):
         return data_headers, data_list, source_path
 
     for key, value in plist.items():
-        data_list.append((value, key))
+        data_list.append((_lava_safe(value), key))
 
     return data_headers, data_list, source_path
 
@@ -111,6 +124,6 @@ def locServicesConfigRoutined(context):
 
     for key, value in plist.items():
         if key != 'CloudKitAccountInfoCache':
-            data_list.append((value, key))
+            data_list.append((_lava_safe(value), key))
 
     return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
Proactive fix for the same crash class as [#1617](https://github.com/abrignoni/iLEAPP/pull/1617) (`Object of type datetime is not JSON serializable`). The `locationd` and `routined` processors dump **raw plist key/values** into a generic `Value` column, so a datetime value — or a `dict`/`list` containing one, or `bytes` — would crash LAVA's `json.dumps` in `lava_insert_sqlite_data`.

## Fix
Add a `_lava_safe` helper (datetime → UTC string, bytes → hex, dict/list → `json.dumps(..., default=str)`) and route the two raw appends through it. The `clients` processor already converts its timestamps, so it was unaffected.

## Validation
- pylint 10.00/10.
- Runtime-tested a locationd plist with datetime / nested-dict-with-datetime / bytes values — all output values are `json.dumps`-able (no crash).

## Note
The root-cause fix is one line in `lavafuncs.py` (`json.dumps(value, default=str)`), which would cover every artifact — but that file has pre-existing lint debt (9.25/10) and is tracked with the framework-cleanup task.