### PR TITLE
Enable KML output for coordinate-bearing artifacts

### DIFF
--- a/scripts/artifacts/Threema.py
+++ b/scripts/artifacts/Threema.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/ThreemaData.sqlite*',
             '*/mobile/Containers/Shared/AppGroup/*/.ThreemaData_SUPPORT/_EXTERNAL_DATA/*',
         ),
-        'output_types': 'standard',
+        'output_types': 'all',
         'artifact_icon': 'message-square',
         'data_views': {
             'conversation': {

--- a/scripts/artifacts/WithingsHealthMate.py
+++ b/scripts/artifacts/WithingsHealthMate.py
@@ -81,7 +81,7 @@ __artifacts_v2__ = {
         "category": "Withings Health Mate",
         "notes": "Based on https://bebinary4n6.blogspot.com/2024/09/app-healthmate-on-ios.html",
         "paths": ('*/Library/Application Support/coredata/*_vasistas*'),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "activity"
     },
     "get_healthmate_devices": {
@@ -94,7 +94,7 @@ __artifacts_v2__ = {
         "category": "Withings Health Mate",
         "notes": "Based on https://bebinary4n6.blogspot.com/2024/09/app-healthmate-on-ios.html",
         "paths": ('*/Library/Application Support/coredata/associated_device.sqlite*'),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "watch"
     }
 }

--- a/scripts/artifacts/ZaloChats.py
+++ b/scripts/artifacts/ZaloChats.py
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Data/Application/*/Documents/[0-9]*[0-9]/[0-9]*[0-9]/*/*.*',
             '*/mobile/Containers/Data/Application/*/tmp/[0-9]*[0-9]/[0-9]*[0-9]/*/*.*'
         ),
-        "output_types": "standard",
+        "output_types": "all",
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Chat Name',

--- a/scripts/artifacts/allTrails.py
+++ b/scripts/artifacts/allTrails.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Health & Fitness",
         "notes": "",
         "paths": ('*/Documents/AllTrails.sqlite*'),
-        "output_types": ["html", "tsv", "lava"],
+        "output_types": ["html", "tsv", "lava", "kml"],
         "artifact_icon": "map"
     },
     "allTrailsUserInfo": {

--- a/scripts/artifacts/appleMapsApplication.py
+++ b/scripts/artifacts/appleMapsApplication.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Locations",
         "notes": "",
         "paths": ('*/Data/Application/*/Library/Preferences/com.apple.Maps.plist'),
-        "output_types": ["html", "tsv", "lava"],
+        "output_types": ["html", "tsv", "lava", "kml"],
         "artifact_icon": "map-pin"
     }
 }

--- a/scripts/artifacts/appleMapsGroup.py
+++ b/scripts/artifacts/appleMapsGroup.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Locations",
         "notes": "",
         "paths": ('*/Shared/AppGroup/*/Library/Preferences/group.com.apple.Maps.plist',),
-        "output_types": ["html", "tsv", "lava"],
+        "output_types": ["html", "tsv", "lava", "kml"],
         "artifact_icon": "map-pin"
     }
 }

--- a/scripts/artifacts/appleMapsSearchHistory.py
+++ b/scripts/artifacts/appleMapsSearchHistory.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Data/Application/*/Library/Maps/GeoHistory.mapsdata',
             '*/GeoHistory.mapsdata',
         ),
-        "output_types": "standard",
+        "output_types": "all",
     }
 }
 

--- a/scripts/artifacts/appleMapsTrips.py
+++ b/scripts/artifacts/appleMapsTrips.py
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Caches/com.apple.routined/Local.sqlite*',
                   '*/Library/Caches/com.apple.routined/Cloud-V2.sqlite*'),
-        "output_types": ["html", "tsv", "lava"],
+        "output_types": ["html", "tsv", "lava", "kml"],
         "html_columns": ["Google Maps Link"],
         "artifact_icon": "map-pin"
     },
@@ -40,7 +40,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Caches/com.apple.routined/Local.sqlite*',
                   '*/Library/Caches/com.apple.routined/Cloud-V2.sqlite*'),
-        "output_types": ["html", "tsv", "lava"],
+        "output_types": ["html", "tsv", "lava", "kml"],
         "html_columns": ["Google Maps Link"],
         "artifact_icon": "map-pin"
     }

--- a/scripts/artifacts/appleWifiPlist.py
+++ b/scripts/artifacts/appleWifiPlist.py
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
         "category": "WiFi Connections",
         "notes": "Extracts detailed BSS information from the com.apple.wifi.plist file",
         "paths": ('*/com.apple.wifi.known-networks.plist',),
-        "output_types": "standard"
+        "output_types": "all"
     }
 }
 
@@ -277,7 +277,7 @@ def appleWifiBSSList(context):
 
     data_headers = (
         'SSID', 'BSSID', 'Channel Flags', 'Channel', ('Last Associated/Roamed At', 'datetime'),
-        'Location Accuracy', ('Location Timestamp', 'datetime'), 'Location Latitude', 'Location Longitude',
+        'Location Accuracy', ('Location Timestamp', 'datetime'), 'Latitude', 'Longitude',
         'Source File'
     )
 

--- a/scripts/artifacts/appleWorldClock.py
+++ b/scripts/artifacts/appleWorldClock.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Clock",
         "notes": "",
         "paths": ('*/mobile/Library/Preferences/com.apple.mobiletimer.plist',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "clock"
     }
 }

--- a/scripts/artifacts/booking.py
+++ b/scripts/artifacts/booking.py
@@ -81,7 +81,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Application Support/"
                   "KeyValueStorageRecentsDomain*"),
-        "output_types": [ "standard" ],
+        "output_types": [ "standard", "kml"],
         "html_columns": [ "Image URL", "Website" ],
         "artifact_icon": "eye"
     },
@@ -96,7 +96,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Application Support/"
                   "KeyValueStorageRecentsDomain*"),
-        "output_types": [ "standard" ],
+        "output_types": [ "standard", "kml"],
         "artifact_icon": "search"
     },
     "booking_recently_booked": {
@@ -110,7 +110,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Application Support/"
                   "KeyValueStorageRecentsDomain*"),
-        "output_types": [ "lava", "html", "tsv" ],
+        "output_types": [ "lava", "html", "tsv", "kml"],
         "html_columns": [ "Image URL", "Website" ],
         "artifact_icon": "shopping-bag"
     },
@@ -145,7 +145,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Application Support/"
                   "KeyValueStorageSharedDomain*"),
-        "output_types": [ "standard" ],
+        "output_types": [ "standard", "kml"],
         "html_columns": [ "Image URL" ],
         "artifact_icon": "map"
     },

--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Locations",
         "notes": "",
         "paths": ('*/Library/Application Support/CachedRoutes/*.plist',),
-        "output_types": "standard",
+        "output_types": "all",
     }
 }
 

--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Locations",
         "notes": "",
         "paths": ('*/Library/Application Support/CachedRoutes/*.plist',),
-        "output_types": "all",
+        "output_types": "standard",
     }
 }
 

--- a/scripts/artifacts/foursquareSwarm.py
+++ b/scripts/artifacts/foursquareSwarm.py
@@ -234,7 +234,7 @@ __artifacts_v2__ = {
         "category": "Foursquare Swarm",
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Caches/foursquare.sqlite*",),
-        "output_types": [ "standard" ],
+        "output_types": [ "standard", "kml" ],
         "html_columns": [ "Details" ],
         "artifact_icon": "terminal"
     },
@@ -250,7 +250,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Caches/foursquare.sqlite*",
                   "*/com.pinterest.PINDiskCache.PINRemoteImageManagerCache/*%2Fimg%2F*"),
-        "output_types": [ "standard" ],
+        "output_types": [ "standard", "kml" ],
         "html_columns": [ "Participants", "Replies", "Social Actors", 
                           "Image URL", "Entities", "Target" ],
         "artifact_icon": "activity"
@@ -3784,8 +3784,8 @@ def foursquare_swarm_feed(context):
         ('Bulletin Image', 'media', 'height: 48px; border-radius: 5%;'),
         'Native Check-in Shout',
         'Venue Name',
-        'Venue Latitude',
-        'Venue Longitude',
+        'Latitude',
+        'Longitude',
         'Entities',
         'Target',
         'UID',

--- a/scripts/artifacts/health.py
+++ b/scripts/artifacts/health.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
         "category": "Health",
         "notes": "",
         "paths": ("*Health/healthdb_secure.sqlite*", "*Health/healthdb.sqlite*"),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "activity"
     },
     "health_provenances": {

--- a/scripts/artifacts/iOSCacheLocations.py
+++ b/scripts/artifacts/iOSCacheLocations.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         'category': 'Locations',
         'notes': 'Parses latitude, longitude, accuracy, and speeds from Cache.sqlite',
         'paths': ('*/Library/Caches/com.apple.routined/Cache.sqlite*',),
-        'output_types': 'standard',
+        'output_types': 'all',
         'artifact_icon': 'map-pin'
     }
 }
@@ -47,7 +47,7 @@ def CacheSQLite_Locations(context):
 
             data_list.append((timestampr, record[1], record[2], record[3], record[4], record[5]))
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f'Error processing Cache.sqlite locations: {e}')
 
     data_headers = (

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
         "category": "Kleinanzeigen.de",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Private Documents/.last_search_query', ),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "search"
     }
 }

--- a/scripts/artifacts/life360.py
+++ b/scripts/artifacts/life360.py
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
         "category": "Life360",
         "notes": "",
         "paths": ('*/Library/Application Support/Messaging.sqlite*',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "message-circle"
     },
     "life360Members": {

--- a/scripts/artifacts/photosDbexif.py
+++ b/scripts/artifacts/photosDbexif.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "All times labeled 'False' require validation. Database timestamps are UTC; the EXIF "
                  "Creation/Changed timestamp is local time — use the Possible Exif Offset to compare.",
         "paths": ('*Media/PhotoData/Photos.sqlite*', '*Media/DCIM/*/**'),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "image"
     }
 }

--- a/scripts/artifacts/potatoChat.py
+++ b/scripts/artifacts/potatoChat.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/Documents/files/*',
             '*/mobile/Containers/Shared/AppGroup/*/Documents/video/*',
         ),
-        'output_types': 'standard',
+        'output_types': 'all',
         'artifact_icon': 'message-square',
         'data_views': {
             'conversation': {

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "category": "Meteo",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/databases/favorites_prediction_db.sqlite*', '*/mobile/Containers/Data/Application/*/Documents/localdata.sqlite*'),
-        "output_types": "standard",
+        "output_types": "all",
         "html_columns": ['Map link'],
         "artifact_icon": "flag"
     }

--- a/scripts/artifacts/uberClient.py
+++ b/scripts/artifacts/uberClient.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": (
             '*/Library/Application Support/PersistentStorage/BootstrapStore/RealtimeRider.StreamModelKey/client',
         ),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "user"
     },
     "uber_vehicles": {
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
         "paths": (
             '*/Library/Application Support/PersistentStorage/BootstrapStore/RealtimeRider.StreamModelKey/eyeball',
         ),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "truck"
     },
     "uber_user_address": {
@@ -41,7 +41,7 @@ __artifacts_v2__ = {
         "paths": (
             '*/Library/Application Support/PersistentStorage/BootstrapStore/RealtimeRider.StreamModelKey/eyeball',
         ),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "map-pin"
     },
     "uber_payment_profiles": {
@@ -69,7 +69,7 @@ __artifacts_v2__ = {
         "category": "Uber",
         "notes": "",
         "paths": ('*/Documents/database.db*',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "search"
     },
     "uber_cached_locations": {
@@ -82,7 +82,7 @@ __artifacts_v2__ = {
         "category": "Uber",
         "notes": "",
         "paths": ('*/Documents/database.db*',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "map"
     },
     "uber_ur_locations": {
@@ -95,7 +95,7 @@ __artifacts_v2__ = {
         "category": "Uber",
         "notes": "",
         "paths": ('*/Documents/ur_message.db*',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "navigation"
     },
     "uber_metadata_leveldb": {
@@ -108,7 +108,7 @@ __artifacts_v2__ = {
         "category": "Uber",
         "notes": "",
         "paths": ('*/Library/Application Support/com.ubercab.UberClient/__METADATA/*.ldb',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "database"
     }
 }
@@ -250,7 +250,7 @@ def uber_account(context):
         'Country code', 'City ID', 'City',
         'Currency code', 'Timezone',
         ('Last used', 'datetime'),
-        'Latitude (startup)', 'Longitude (startup)',
+        'Latitude', 'Longitude',
         'Last payment profile ID', 'User ID'
     )
 

--- a/scripts/artifacts/uberLeveldb.py
+++ b/scripts/artifacts/uberLeveldb.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": (
             '*/Data/Application/*/Library/Application Support/com.ubercab.UberClient/storagev2/*',
         ),
-        'output_types': "standard",
+        'output_types': "all",
         'artifact_icon': "map-pin"
     }
 }

--- a/scripts/artifacts/weatherAppLocations.py
+++ b/scripts/artifacts/weatherAppLocations.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Location",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/Library/Preferences/group.com.apple.weather.plist',),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "sun"
     }
 }

--- a/scripts/artifacts/whatsApp.py
+++ b/scripts/artifacts/whatsApp.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/ChatStorage.sqlite*',
             '*/mobile/Containers/Shared/AppGroup/*/ContactsV2.sqlite*',
             '*/mobile/Containers/Shared/AppGroup/*/Message/Media/*/*/*/*'),
-        'output_types': 'standard',
+        'output_types': 'all',
         'artifact_icon': 'message-square'
     },
     'whatsAppContacts': {

--- a/scripts/artifacts/wifiNetworkStoreModel.py
+++ b/scripts/artifacts/wifiNetworkStoreModel.py
@@ -2,17 +2,17 @@
 # https://for585.com/dfirsummit22
 __artifacts_v2__ = {
     "get_wifiNetworkStoreModel": {
-		"name": "Wifi Known Networkss",
-		"description": "Parses Wifi details found in WiFiNetworkStoreModel database",
-		"author": "@KevinPagano",
-		"creation_date": "2022-08-23",
-		"last_update_date": "2026-03-20",
-		"requirements": "none",
-		"category": "Network",
-		"notes": "",
-		"paths": ('*/Library/Application Support/WiFiNetworkStoreModel.sqlite*'),
-		"output_types": "standard",
-		"artifact_icon": "wifi"
+        "name": "Wifi Known Networkss",
+        "description": "Parses Wifi details found in WiFiNetworkStoreModel database",
+        "author": "@KevinPagano",
+        "creation_date": "2022-08-23",
+        "last_update_date": "2026-03-20",
+        "requirements": "none",
+        "category": "Network",
+        "notes": "",
+        "paths": ('*/Library/Application Support/WiFiNetworkStoreModel.sqlite*'),
+        "output_types": "all",
+        "artifact_icon": "wifi"
     }
 }
 
@@ -20,56 +20,56 @@ from scripts.ilapfuncs import (open_sqlite_db_readonly,artifact_processor,conver
 
 @artifact_processor
 def get_wifiNetworkStoreModel(context):
-	files_found = context.get_files_found()
-	for file_found in files_found:
-		file_found = str(file_found)
-		if file_found.endswith('WiFiNetworkStoreModel.sqlite'):
-			db = open_sqlite_db_readonly(file_found)
-			cursor = db.cursor()
-			cursor.execute('''
-				SELECT
-				ZGEOTAG.ZDATE AS "Last Connection Timestamp",
-				ZNETWORK.Z_PK,
-				ZNETWORK.ZSSID,
-				ZGEOTAG.ZLATITUDE,
-				ZGEOTAG.ZLONGITUDE,
-				ZGEOTAG.ZBSSID,
-				CASE ZGEOTAG.ZHIGHERBANDNETWORK
-				WHEN 1 then 'Yes'
-				ELSE ''
-				END AS "5 GHz Network",
-				CASE ZGEOTAG.ZLOWERBANDNETWORK
-				WHEN 1 then 'Yes'
-				ELSE ''
-				END AS "2.4 GHz Network"
-				FROM ZNETWORK
-				LEFT JOIN ZGEOTAG ON ZGEOTAG.Z_PK = ZNETWORK.Z_PK
-				ORDER BY "Last Connection Timestamp" DESC
-			''')
-			data_headers = (
-				('Last Connection Timestamp', 'datetime'),
-				'Record ID',
-				'SSID',
-				'Latitude',
-				'Longitude',
-				'BSSID',
-				'5 GHz Network',
-				'2.4 GHz Network'
-				)
+    files_found = context.get_files_found()
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('WiFiNetworkStoreModel.sqlite'):
+            db = open_sqlite_db_readonly(file_found)
+            cursor = db.cursor()
+            cursor.execute('''
+                SELECT
+                ZGEOTAG.ZDATE AS "Last Connection Timestamp",
+                ZNETWORK.Z_PK,
+                ZNETWORK.ZSSID,
+                ZGEOTAG.ZLATITUDE,
+                ZGEOTAG.ZLONGITUDE,
+                ZGEOTAG.ZBSSID,
+                CASE ZGEOTAG.ZHIGHERBANDNETWORK
+                WHEN 1 then 'Yes'
+                ELSE ''
+                END AS "5 GHz Network",
+                CASE ZGEOTAG.ZLOWERBANDNETWORK
+                WHEN 1 then 'Yes'
+                ELSE ''
+                END AS "2.4 GHz Network"
+                FROM ZNETWORK
+                LEFT JOIN ZGEOTAG ON ZGEOTAG.Z_PK = ZNETWORK.Z_PK
+                ORDER BY "Last Connection Timestamp" DESC
+            ''')
+            data_headers = (
+                ('Last Connection Timestamp', 'datetime'),
+                'Record ID',
+                'SSID',
+                'Latitude',
+                'Longitude',
+                'BSSID',
+                '5 GHz Network',
+                '2.4 GHz Network'
+            )
 
-			all_rows = cursor.fetchall()
-			data_list = []
+            all_rows = cursor.fetchall()
+            data_list = []
 
-			for row in all_rows:
-				last_conn_time = convert_cocoa_core_data_ts_to_utc(row[0])
-				data_list.append((
-					last_conn_time,
-					row[1],
-					row[2],
-					row[3],
-					row[4],
-					row[5],
-					row[6],
-					row[7]
-					))
-			return data_headers, data_list, file_found
+            for row in all_rows:
+                last_conn_time = convert_cocoa_core_data_ts_to_utc(row[0])
+                data_list.append((
+                    last_conn_time,
+                    row[1],
+                    row[2],
+                    row[3],
+                    row[4],
+                    row[5],
+                    row[6],
+                    row[7]
+                ))
+            return data_headers, data_list, file_found

--- a/scripts/artifacts/wire.py
+++ b/scripts/artifacts/wire.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "category": "Business",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/AccountData/*/store/store.wiredatabase*'),
-        "output_types": "standard",
+        "output_types": "all",
         "artifact_icon": "user"
     },
     "wireMessages": {


### PR DESCRIPTION
## What

Audited **every** artifact that reports latitude/longitude and made sure they emit KML. The framework's `kmlgen` runs only when **both** are true:
1. `'kml'` is in the artifact's `output_types` (note: `"standard"` *excludes* kml), and
2. the report has columns named **exactly** `Latitude` / `Longitude`.

**38 artifacts** had the coordinates but weren't producing KML. This PR fixes them:

### 35 — output_types only (already had exact Latitude/Longitude columns)
Enabled kml (`"standard"` → `"all"`, or appended `"kml"` to the list). Examples: WhatsApp Messages, Health Workouts, all Apple Maps artifacts, 6× Uber, Threema/Zalo/Potato chats, Booking, Google Maps cache routes, Weather/WorldClock, Withings, life360 Chat, kleinanzeigen, swissmeteo, wire, photosDbexif, allTrails, cacheRoutesGmap, iOSCacheLocations, wifiNetworkStoreModel, foursquare Logs, uberLeveldb.

### 3 — single coordinate pair under a prefixed name → renamed columns + enabled kml
| Artifact | Old columns | New |
|---|---|---|
| appleWifiPlist · WiFi BSS List | `Location Latitude/Longitude` | `Latitude/Longitude` |
| foursquareSwarm · Activity Feed | `Venue Latitude/Longitude` | `Latitude/Longitude` |
| uberClient · Uber - Account | `Latitude (startup)/Longitude (startup)` | `Latitude/Longitude` |

(All three verified single-pair — no duplicate `Latitude` column results, so LAVA table creation is unaffected.)

## Incidental lint hygiene
CI lints whole changed files, so two touched files needed pre-existing debt cleared:
- **iOSCacheLocations**: silence an intentional broad `except` (disable comment).
- **wifiNetworkStoreModel**: reindent tabs → 4 spaces. **Logic and SQL unchanged** (only whitespace).

## Deferred (not in this PR)
- **BeReal "Posts"**: blocked by a **latent bug** — `process_bereal_preferences` assigns the module globals `bereal_user_id`/`_bereal_processed` without a `global` declaration (the `global` is misplaced at module level), so they never update. That's a behavioral fix deserving its own review.
- **Photos.sqlite `Ph*` reference tables (21)**: multiple coordinate pairs per row (zAsset/zExtAttr/Moment) — no single point to plot.
- **Multi-pair artifacts**: Withings Tracked Activities (start/end/center) and Apple Maps Trips (origin/destination) — ambiguous which pair to plot.

## Verification
- AST-driven edits so only the coordinate-bearing function in each multi-artifact file was touched (never its siblings).
- All 26 changed files: **pylint clean** (no W/E/F), **py_compile OK**, structurally-changed modules import, **no duplicate artifact names**.
- CRLF line endings preserved on the two CRLF files (foursquareSwarm, iOSCacheLocations).