### PR TITLE
cacheRoutesGmap: read raw plist to avoid nska_deserialize 'unhashable' warnings

### DIFF
--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -9,13 +9,14 @@ __artifacts_v2__ = {
         "category": "Locations",
         "notes": "",
         "paths": ('*/Library/Application Support/CachedRoutes/*.plist',),
-        "output_types": "standard",
+        "output_types": "all",
     }
 }
 
 import os
+import plistlib
 from datetime import datetime, timezone
-from scripts.ilapfuncs import artifact_processor, get_plist_file_content
+from scripts.ilapfuncs import artifact_processor
 
 @artifact_processor
 def get_cacheRoutesGmap(context):
@@ -29,7 +30,16 @@ def get_cacheRoutesGmap(context):
             continue  # filename is not a numeric (ms epoch) timestamp
         datetime_time = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
 
-        deserialized = get_plist_file_content(file_found)
+        # Read the raw archive and walk $objects ourselves. Do NOT route this
+        # through get_plist_file_content / nska_deserialize: these CachedRoutes
+        # archives contain unhashable NSDictionary keys, which makes the
+        # deserializer emit noisy "unhashable" warnings, and it strips the
+        # $objects array this artifact actually needs.
+        try:
+            with open(file_found, 'rb') as f:
+                deserialized = plistlib.load(f)
+        except (plistlib.InvalidFileException, ValueError, OSError):
+            continue
         if not isinstance(deserialized, dict):
             continue
         objects = deserialized.get('$objects')


### PR DESCRIPTION
## Problem
Running **Google Maps Cache Routes** floods the log with `unhashable` NSKeyedArchiver warnings — one per CachedRoutes file.

## Root cause
The artifact walks the **raw** `$objects` array itself (`entry['_coordinateLat']`), but it read each file via `get_plist_file_content`, which — for NSKeyedArchiver plists — routes through `nska_deserialize` ([ilapfuncs.py:641](scripts/ilapfuncs.py)):

```python
if plist_content.get('$archiver','') == 'NSKeyedArchiver':
    return nska_deserialize.deserialize_plist(file_path)
```

These CachedRoutes archives contain **unhashable NSDictionary keys**, so the deserializer emits the `unhashable` warnings. Worse, that call is *counterproductive*: deserialization strips the `$objects` array, which is exactly what this artifact reads — so the deserialize step is pure cost.

## Fix
Read the raw plist directly with `plistlib.load` and skip the deserializer entirely. No `nska_deserialize` call ⇒ **no warnings**, and `$objects` is present as the code already expects (so it's also more correct, not just quieter).

## Also
Re-enables KML output (`output_types: "all"`). cacheRoutesGmap was pulled out of the KML batch (#1624) solely because of these warnings; with the warnings fixed, it rejoins. It has exact `Latitude`/`Longitude` columns, so `kmlgen` now produces a KML.

## Verify
pylint 10.00/10, py_compile OK, audit confirms it's KML-producing. Note: `get_plist_file_content`/`nska` now appear only in an explanatory code comment, not in any code path.