### PR TITLE
BeReal: fix owner identity (drop module globals, return owner id)

### DIFF
--- a/scripts/artifacts/BeReal.py
+++ b/scripts/artifacts/BeReal.py
@@ -206,16 +206,8 @@ from urllib.parse import urlparse, urlunparse
 from scripts.ilapfuncs import get_file_path, get_sqlite_db_records, get_plist_content, get_plist_file_content, convert_unix_ts_to_utc, \
     convert_cocoa_core_data_ts_to_utc, check_in_embedded_media, artifact_processor, logfunc, is_platform_windows
 
-global bereal_user_id, _bereal_processed
-
 # <id, fullname|username>
 map_id_name = {}
-
-# bereal user id
-bereal_user_id = None
-
-# flag
-_bereal_processed = False
 
 
 def format_userid(user_id, name=None):
@@ -440,6 +432,7 @@ def get_tags(obj, html_format=False):
 
 # set up global variables
 def process_bereal_preferences(plist_path):
+    owner_id = None
     
     plist_data = get_plist_file_content(plist_path)
     if not (plist_data):
@@ -458,7 +451,7 @@ def process_bereal_preferences(plist_path):
             if not bool(user_name): user_name = 'Local User'
             map_id_name[user_id] = user_name
             # bereal user id
-            bereal_user_id = user_id
+            owner_id = user_id
             # local profile picture (file:///private/var/mobile/Containers/Shared/AppGroup/<APP_GUID>/notification/file.jpg)
             # bereal_profile_picture = plist_data.get('myAccount', {}).get(user_id, {}).get('profilePictureURL')
 
@@ -467,11 +460,11 @@ def process_bereal_preferences(plist_path):
         for user_id, user_name in current_friends.items():
             map_id_name[user_id] = user_name
             
-        _bereal_processed = True
-        return True
+        return owner_id
 
     except (AttributeError, TypeError, KeyError) as e:
         logfunc(f"Error: {str(e)}")
+        return owner_id
 
 # accounts
 @artifact_processor
@@ -959,9 +952,8 @@ def bereal_posts(context):
     data_list = []
     data_list_html = []
     files_found = context.get_files_found()
-    if not _bereal_processed: 
-        preferences_file = get_file_path(files_found,'group.BeReal.plist')
-        process_bereal_preferences(preferences_file)
+    preferences_file = get_file_path(files_found, 'group.BeReal.plist')
+    bereal_user_id = process_bereal_preferences(preferences_file)
 
     # all files
     for file_found in files_found:
@@ -1332,9 +1324,8 @@ def bereal_realmojis(context):
     data_list_html = []
     
     files_found = context.get_files_found()
-    if not _bereal_processed: 
-        preferences_file = get_file_path(files_found,'group.BeReal.plist')
-        process_bereal_preferences(preferences_file)
+    preferences_file = get_file_path(files_found, 'group.BeReal.plist')
+    bereal_user_id = process_bereal_preferences(preferences_file)
 
     # all files
     for file_found in files_found:
@@ -1579,9 +1570,8 @@ def bereal_comments(context):
     data_list = []
 
     files_found = context.get_files_found()
-    if not _bereal_processed:
-        preferences_file = get_file_path(files_found, 'group.BeReal.plist')
-        process_bereal_preferences(preferences_file)
+    preferences_file = get_file_path(files_found, 'group.BeReal.plist')
+    bereal_user_id = process_bereal_preferences(preferences_file)
 
     # all files
     for file_found in context.get_files_found():
@@ -1813,9 +1803,8 @@ def bereal_messages(context):
     data_list_html = []
     files_found = context.get_files_found()
     
-    if not _bereal_processed:
-        preferences_file = get_file_path(files_found, 'group.BeReal.plist')
-        process_bereal_preferences(preferences_file)
+    preferences_file = get_file_path(files_found, 'group.BeReal.plist')
+    bereal_user_id = process_bereal_preferences(preferences_file)
     
     source_path = get_file_path(files_found, "bereal-chat.sqlite")
 
@@ -1903,9 +1892,8 @@ def bereal_chat_list(context):
     data_list_html = []
     files_found = context.get_files_found()
     
-    if not _bereal_processed:
-        preferences_file = get_file_path(files_found, 'group.BeReal.plist')
-        process_bereal_preferences(preferences_file)
+    preferences_file = get_file_path(files_found, 'group.BeReal.plist')
+    process_bereal_preferences(preferences_file)
     
     source_path = get_file_path(files_found, "bereal-chat.sqlite")
 


### PR DESCRIPTION
## Bug
`process_bereal_preferences` rebinds two **module-level** variables — `bereal_user_id` and `_bereal_processed` — but the function has **no `global` declaration**, so in Python those assignments create throwaway locals and the module globals never change. (There's even a stray `global …` at module level, line 209, where it does nothing.)

Note `map_id_name` was unaffected: `map_id_name[k] = v` is a dict *mutation*, which never needs `global`.

## Impact (corrected, code-review level)
Not data loss — the sections still produce rows. The casualties are:
- **`bereal_user_id` stays `None`** → since `format_userid(None)` returns the literal `"Local User"`, the **device owner is mislabeled** in **Posts (Author)**, **RealMojis (Owner)**, **Comments (Owner)**, and **Messages (Recipient)** — instead of the real `id (username)`.
- **`_bereal_processed` stays `False`** → the prefs plist is re-parsed by every gated section (wasted work).

## Fix — no `global` at all
- `process_bereal_preferences` now **returns `owner_id`** instead of stashing it in a global.
- Removed the module-level `bereal_user_id` / `_bereal_processed` and the dead `_bereal_processed` flag entirely.
- The four sections that use the owner capture it as a **local**: `bereal_user_id = process_bereal_preferences(prefs)`. `bereal_chat_list` doesn't use the owner id, so it calls without capturing (avoids an unused-variable).
- `map_id_name` stays a mutated module dict, so `format_userid` and its **22 call sites are untouched**.

This removes the root-cause pattern (rebinding module state) rather than papering over it with one `global` line, and it deletes a fragile hand-rolled cache flag. Net **−12 lines**.

## Verification
pylint clean (the file's only prior W/E were the three this fixes), `py_compile` OK, module imports, 11 artifacts intact, `bereal_user_id`/`_bereal_processed` confirmed gone from module scope. CRLF line endings preserved.

⚠️ **Please validate against a real BeReal acquisition** before merge — confirm the owner now resolves to `id (username)` (not `Local User`) in Posts/RealMojis/Comments/Messages. I diagnosed and fixed this by reading the code; I haven't run it against BeReal evidence.