### PR TITLE
feat: allow custom output folder name

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -18,6 +18,7 @@ from shutil import copy2
 from getpass import getpass
 from scripts.search_files import *
 from scripts.ilapfuncs import *
+from leapp_functions.output import validate_output_folder_available
 from scripts.version_info import leapp_name, leapp_version
 from time import process_time, gmtime, strftime, perf_counter
 from scripts.lavafuncs import *
@@ -44,6 +45,12 @@ def validate_args(args):
         raise argparse.ArgumentError(None, 'OUTPUT path \'{args.output_path}\' does not exist! Run the program again.')
     if not os.path.isdir(os.path.abspath(args.output_path)):
         raise argparse.ArgumentError(None, f'OUTPUT path \'{args.output_path}\' must be a directory! Run the program again.')
+
+    # Validate new folder name for output path
+    output_folder_valid, output_folder_error = validate_output_folder_available(
+        os.path.abspath(args.output_path), args.custom_output_folder)
+    if not output_folder_valid:
+        raise argparse.ArgumentError(None, output_folder_error)
 
     # Validate input_path based on type
     abs_input_path = os.path.abspath(args.input_path)

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -24,8 +24,14 @@ from leapp_functions.lava_launcher import (
     open_lava_project,
     open_output_folder,
 )
+from leapp_functions.platform import sanitize_file_name
+from leapp_functions.output import default_output_folder_name, validate_output_folder_available
 from scripts.context import Context
 from scripts.lavafuncs import lava_json_name
+
+
+def allow_output_folder_name_chars(proposed):
+    return sanitize_file_name(proposed) == proposed
 
 
 def show_history_menu(button, path_type):
@@ -223,8 +229,17 @@ def ValidateInput():
         ext_type = Path(i_path).suffix[1:].lower()
 
     # check output now
-    if len(o_path) == 0:  # output folder
-        tk_msgbox.showerror(title='Error', message='No OUTPUT folder selected!', parent=main_window)
+    if len(o_path) == 0:  # output path
+        tk_msgbox.showerror(title='Error', message='No output path provided!', parent=main_window)
+        return False, ext_type, None
+
+    folder_name = output_folder_name_entry.get().strip()
+    if not folder_name:
+        tk_msgbox.showerror(title='Error', message='Output folder name cannot be empty!', parent=main_window)
+        return False, ext_type, None
+    folder_name_valid, folder_name_error = validate_output_folder_available(o_path, folder_name)
+    if not folder_name_valid:
+        tk_msgbox.showerror(title='Error', message=folder_name_error, parent=main_window)
         return False, ext_type, None
 
     # check if at least one module is selected
@@ -476,7 +491,7 @@ def process(casedata):
         selected_modules = [loader[module] for module in selected_modules]
         progress_bar.config(maximum=len(selected_modules))
         casedata = {key: value.get() for key, value in casedata.items()}
-        out_params = OutputParameters(output_folder)
+        out_params = OutputParameters(output_folder, output_folder_name_entry.get().strip())
         Context.set_output_params(out_params)
         wrap_text = True
         time_offset = timezone_set.get()
@@ -862,15 +877,26 @@ input_file_button.pack(side='left', padx=5, pady=4)
 input_folder_button = ttk.Button(input_frame, text='Browse Folder', command=lambda: select_input('folder'))
 input_folder_button.pack(side='left', padx=5, pady=4)
 
-output_frame = ttk.LabelFrame(main_window, text=' Select Output Folder: ')
+output_frame = ttk.LabelFrame(main_window, text=' Select Output Path ')
 output_frame.pack(padx=14, pady=5, fill='x')
-output_entry = ttk.Entry(output_frame)
+output_path_row = ttk.Frame(output_frame)
+output_path_row.pack(fill='x')
+output_entry = ttk.Entry(output_path_row)
 output_entry.pack(side='left', padx=5, pady=4, fill='x', expand=True)
-output_history_button = ttk.Button(output_frame, text='▼', width=3,
+output_history_button = ttk.Button(output_path_row, text='▼', width=3,
                                  command=lambda: show_history_menu(output_history_button, 'output'))
 output_history_button.pack(side='left', padx=2, pady=4)
-output_folder_button = ttk.Button(output_frame, text='Browse Folder', command=select_output)
+output_folder_button = ttk.Button(output_path_row, text='Browse Folder', command=select_output)
 output_folder_button.pack(side='left', padx=5, pady=4)
+output_folder_name_row = ttk.Frame(output_frame)
+output_folder_name_row.pack(fill='x', padx=5, pady=(0, 4))
+ttk.Label(output_folder_name_row, text='Folder name:').pack(side='left', padx=(0, 5))
+output_folder_name_entry = ttk.Entry(output_folder_name_row)
+output_folder_name_entry.insert(0, default_output_folder_name())
+output_folder_name_entry.configure(
+    validate='key',
+    validatecommand=(main_window.register(allow_output_folder_name_chars), '%P'))
+output_folder_name_entry.pack(side='left', fill='x', expand=True)
 
 mlist_frame = ttk.LabelFrame(main_window, text=' Available Modules: ', name='f_list')
 mlist_frame.pack(padx=14, pady=5, expand=True, fill='both')

--- a/leapp_functions/output.py
+++ b/leapp_functions/output.py
@@ -1,0 +1,41 @@
+"""Output folder path resolution and availability checks."""
+
+import os
+from datetime import datetime
+
+from leapp_functions.platform import validate_filename
+from scripts.version_info import leapp_name
+
+
+def default_output_folder_name():
+    '''Return the default report subfolder name for a new run.'''
+    currenttime = datetime.now().strftime('%Y-%m-%d_%A_%H%M%S')
+    return f'{leapp_name}_Output_{currenttime}'
+
+
+def resolve_output_folder_name(custom_folder_name=None):
+    '''Return the report subfolder name that will be created under the output path.'''
+    if custom_folder_name:
+        return custom_folder_name
+    return default_output_folder_name()
+
+
+def get_output_folder_base(output_folder, custom_folder_name=None):
+    '''Return the full path to the report output folder.'''
+    return os.path.join(output_folder, resolve_output_folder_name(custom_folder_name))
+
+
+def validate_output_folder_available(output_folder, custom_folder_name=None):
+    '''Return (is_valid, error_message) for filename rules and folder availability.'''
+    folder_name = resolve_output_folder_name(custom_folder_name)
+    if custom_folder_name:
+        is_valid, error_message = validate_filename(folder_name)
+        if not is_valid:
+            return False, error_message
+    output_folder_base = os.path.join(output_folder, folder_name)
+    if os.path.exists(output_folder_base):
+        return False, (
+            f'Output folder already exists:\n{output_folder_base}\n\n'
+            'Choose a different folder name or output path to avoid overwriting existing data.'
+        )
+    return True, None

--- a/leapp_functions/platform.py
+++ b/leapp_functions/platform.py
@@ -1,0 +1,67 @@
+"""Cross-platform filename and path string safety utilities."""
+
+import re
+
+ILLEGAL_FILENAME_CHARS = {
+    '\\': '\\ backslash',
+    '/': '/ forward slash',
+    '*': '* asterisk',
+    '?': '? question mark',
+    ':': ': colon',
+    '"': '" double quote',
+    '<': '< less than',
+    '>': '> greater than',
+    '|': '| pipe',
+    "'": "' apostrophe",
+    '\r': '\\r carriage return',
+    '\n': '\\n newline',
+}
+
+
+def _illegal_filename_char_pattern():
+    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + ']'
+
+
+def _illegal_filepath_char_pattern():
+    chars = ''.join(c for c in ILLEGAL_FILENAME_CHARS if c not in '\\/')
+    return '[' + re.escape(chars) + ']'
+
+
+def format_illegal_filename_chars(chars):
+    '''Format illegal characters for user-facing messages.'''
+    order = {char: index for index, char in enumerate(ILLEGAL_FILENAME_CHARS)}
+    unique_chars = sorted(set(chars), key=lambda c: order.get(c, len(order)))
+    return ', '.join(ILLEGAL_FILENAME_CHARS.get(c, repr(c)) for c in unique_chars)
+
+
+def illegal_chars_in_filename(filename):
+    '''Return sorted illegal characters present in filename.'''
+    return sorted({c for c in filename if c in ILLEGAL_FILENAME_CHARS},
+                  key=lambda c: list(ILLEGAL_FILENAME_CHARS).index(c))
+
+
+def sanitize_file_path(filename, replacement_char='_'):
+    r'''
+    Removes illegal characters (for windows) from the string passed. Does not replace \ or /
+    '''
+    return re.sub(_illegal_filepath_char_pattern(), replacement_char, filename)
+
+
+def sanitize_file_name(filename, replacement_char='_'):
+    '''
+    Removes illegal characters (for windows) from the string passed.
+    '''
+    return re.sub(_illegal_filename_char_pattern(), replacement_char, filename)
+
+
+def validate_filename(filename):
+    '''Return (is_valid, error_message) using centralized filename rules.'''
+    sanitized_filename = sanitize_file_name(filename)
+    if sanitized_filename == filename:
+        return True, None
+    char_list = format_illegal_filename_chars(illegal_chars_in_filename(filename))
+    allowed_list = ', '.join(ILLEGAL_FILENAME_CHARS.values())
+    return False, (
+        f'Output folder name contains invalid character(s): {char_list}\n\n'
+        f'Folder names cannot include: {allowed_list}'
+    )

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -20,7 +20,23 @@ from pathlib import Path
 from urllib.parse import quote
 import scripts.artifact_report as artifact_report
 from scripts.context import Context
+from scripts.version_info import leapp_name
 
+# new location for modules imported for backward compatibility
+# existing functions that are moved should leave a commented out def line
+from leapp_functions.platform import (
+    ILLEGAL_FILENAME_CHARS,
+    format_illegal_filename_chars,
+    illegal_chars_in_filename,
+    sanitize_file_name,
+    sanitize_file_path,
+    validate_filename,
+)
+from leapp_functions.output import (
+    get_output_folder_base,
+    resolve_output_folder_name,
+    validate_output_folder_available,
+)
 
 _console_write = sys.stdout.write
 
@@ -70,13 +86,7 @@ class OutputParameters:
     screen_output_file_path = ''
 
     def __init__(self, output_folder, custom_folder_name=None):
-        now = datetime.now()
-        currenttime = str(now.strftime('%Y-%m-%d_%A_%H%M%S'))
-        if custom_folder_name:
-            folder_name = custom_folder_name
-        else:
-            folder_name = 'iLEAPP_Reports_' + currenttime
-        self.output_folder_base = os.path.join(output_folder, folder_name)
+        self.output_folder_base = get_output_folder_base(output_folder, custom_folder_name)
         self.data_folder = os.path.join(self.output_folder_base, 'data')
         self.media_folder = os.path.join(self.output_folder_base, 'media')
         self.html_media_folder = os.path.join(self.output_folder_base, '_HTML', 'media')
@@ -554,17 +564,11 @@ def is_platform_windows():
     '''Returns True if running on Windows'''
     return sys.platform == 'win32'
 
-def sanitize_file_path(filename, replacement_char='_'):
-    r'''
-    Removes illegal characters (for windows) from the string passed. Does not replace \ or /
-    '''
-    return re.sub(r'[*?:"<>|\'\r\n]', replacement_char, filename)
+# def sanitize_file_path(filename, replacement_char='_'):
+# Moved to leapp_functions.platform
 
-def sanitize_file_name(filename, replacement_char='_'):
-    '''
-    Removes illegal characters (for windows) from the string passed.
-    '''
-    return re.sub(r'[\\/*?:"<>|\'\r\n]', replacement_char, filename)
+# def sanitize_file_name(filename, replacement_char='_'):
+# Moved to leapp_functions.platform
 
 def get_next_unused_name(path):
     '''Checks if path exists, if it does, finds an unused name by appending -xx


### PR DESCRIPTION
- note: CLI and framework functionality was already in place
- GUI now has textbox to allow customization of output folder name
- guards illegal folder name characters in both CLI and GUI
- guards to prevent overwriting existing folder in CLI and GUI
- illegal character file/folder functions moved from `ilapfuncs` to new modularized `/leapp_functions/` path
- `ilapfuncs` imports old functions from new path to keep backwards compatibility
- left commented out def lines in `ilapfuncs` to note they have been moved