### PR TITLE
biomeAppWebUsage: use Context form

### DIFF
--- a/scripts/artifacts/biomeAppWebUsage.py
+++ b/scripts/artifacts/biomeAppWebUsage.py
@@ -23,7 +23,7 @@ from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
 
 
 @artifact_processor
-def get_biomeAppWebUsage(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def get_biomeAppWebUsage(context):
 
     # Tested with:
     # MagnetCTF2026/00008110-0008196A2299401E_files_full.zip
@@ -51,7 +51,7 @@ def get_biomeAppWebUsage(files_found, _report_folder, _seeker, _wrap_text, _time
     data_list = []
     report_file = 'Unknown'
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
 


### PR DESCRIPTION
Small cleanup: `biomeAppWebUsage.py` was the **only** biome artifact still on the legacy 5-parameter signature — the other 22 all use the Context form. This brings it in line.

## Change (2 lines)
- `def get_biomeAppWebUsage(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):` → `def get_biomeAppWebUsage(context):`
- `for file_found in files_found:` → `for file_found in context.get_files_found():`

## No behavior change
The artifact already stored UTC (`webkit_timestampsconv`, no timezone conversion) and already used properly typed `('...', 'datetime')` headers, so nothing else needed to change. Field mappings, `typess`, the Written/Deleted handling, and author attribution are untouched.

## Validation
- `py_compile` clean
- PluginLoader registers it as **Biome - App Web Usage**; `.__wrapped__` signature is now `(context)`