### PR TITLE
Migrate artifact icons to native Tabler names

### DIFF
--- a/scripts/artifacts/AMDSQLiteDB.py
+++ b/scripts/artifacts/AMDSQLiteDB.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Data/PluginKitPlugin/*/Documents/AMDSQLite.db.0*'
             ),
         "output_types": "standard",
-        "artifact_icon": "device-speaker"
+        "artifact_icon": "database"
     }
 }
 

--- a/scripts/artifacts/AMDSQLiteDB.py
+++ b/scripts/artifacts/AMDSQLiteDB.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Data/PluginKitPlugin/*/Documents/AMDSQLite.db.0*'
             ),
         "output_types": "standard",
-        "artifact_icon": "hard-drive"
+        "artifact_icon": "device-speaker"
     }
 }
 
@@ -52,7 +52,7 @@ def get_data_from_itunes(lookup_value, lookup_type):
         with urllib.request.urlopen(url) as response:
             response_data = response.read()
             response_json_data = json.loads(response_data)
-    except Exception as e:
+    except Exception:  # pylint: disable=broad-exception-caught
         return f"\nERROR fetching data for {lookup_value} ({lookup_type})", None
     return None, response_json_data
 

--- a/scripts/artifacts/AWESearch.py
+++ b/scripts/artifacts/AWESearch.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Documents/search_history/history_words/AWESearchHistory*',),
         "output_types": "standard",
+        "artifact_icon": "brand-tiktok",
     }
 }
 

--- a/scripts/artifacts/Airbnb.py
+++ b/scripts/artifacts/Airbnb.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Containers/Data/Application/*/Library/Application Support/user_*_messaging_core.sqlite3*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Thread ID',

--- a/scripts/artifacts/ConnectedDeviceInformation.py
+++ b/scripts/artifacts/ConnectedDeviceInformation.py
@@ -19,7 +19,7 @@ OS History",
 Apple product identification, common name, OS, and timeframe of use",
         "paths": ('*Health/healthdb_secure.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "connected_device_info_consolidated_connected_device_history": {
         "name": "Connected Device Information - Consolidated Connected Device \
@@ -34,7 +34,7 @@ History",
 Apple product grouped for starting and ending timeframe of use",
         "paths": ('*Health/healthdb_secure.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "connected_device_information_current_device_info": {
         "name": "Connected Device Information - Current Device Information",
@@ -48,7 +48,7 @@ Apple product grouped for starting and ending timeframe of use",
 Current Apple Device and OS Information",
         "paths": ('*Health/healthdb.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     }
 }
 

--- a/scripts/artifacts/DataUsage.py
+++ b/scripts/artifacts/DataUsage.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Network Usage",
         "notes": "",
         "paths": ('*/wireless/Library/Databases/DataUsage.sqlite*',),
-        "output_types": ["html", "tsv", "timeline", "lava"]
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "chart-bar"
     }
 }
 

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Documents/msg_database.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "linkedin_conversations": {
         "name": "LinkedIn - Conversations",

--- a/scripts/artifacts/Ph10AssetParsedEmbeddedFiles.py
+++ b/scripts/artifacts/Ph10AssetParsedEmbeddedFiles.py
@@ -15,10 +15,10 @@ import plistlib
 import nska_deserialize as nd
 from packaging import version
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, media_to_html, open_sqlite_db_readonly, iOS
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, open_sqlite_db_readonly, iOS
 
 
-def get_ph10assetparsedembeddedfilesphdapsql(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_ph10assetparsedembeddedfilesphdapsql(files_found, report_folder, _seeker, _wrap_text, _timezone_offset):
     for file_found in files_found:
         file_found = str(file_found)
         
@@ -2222,7 +2222,7 @@ def get_ph10assetparsedembeddedfilesphdapsql(files_found, report_folder, seeker,
         return
 
 
-def get_ph10assetparsedembeddedfilessyndpl(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_ph10assetparsedembeddedfilessyndpl(files_found, report_folder, _seeker, _wrap_text, _timezone_offset):
     for file_found in files_found:
         file_found = str(file_found)
 
@@ -4440,7 +4440,8 @@ __artifacts_v2__ = {
         'category': 'Photos.sqlite-C-Other_Artifacts',
         'notes': '',
         'paths': '*/PhotoData/Photos.sqlite*',
-        'function': 'get_ph10assetparsedembeddedfilesphdapsql'
+        'function': 'get_ph10assetparsedembeddedfilesphdapsql',
+        "artifact_icon": "paperclip"
     },
     'Ph10-2-Assets have embedded files-SyndPL': {
         'name': 'SyndPL Photos.sqlite Ph10.2 assets have embedded files',
@@ -4455,6 +4456,7 @@ __artifacts_v2__ = {
         'category': 'Photos.sqlite-S-Syndication_PL_Artifacts',
         'notes': '',
         'paths': '*/mobile/Library/Photos/Libraries/Syndication.photoslibrary/database/Photos.sqlite*',
-        'function': 'get_ph10assetparsedembeddedfilessyndpl'
+        'function': 'get_ph10assetparsedembeddedfilessyndpl',
+        "artifact_icon": "paperclip"
     }
 }

--- a/scripts/artifacts/Threema.py
+++ b/scripts/artifacts/Threema.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/.ThreemaData_SUPPORT/_EXTERNAL_DATA/*',
         ),
         'output_types': 'all',
-        'artifact_icon': 'message-square',
+        'artifact_icon': 'message',
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Chat-ID',

--- a/scripts/artifacts/WithingsHealthMate.py
+++ b/scripts/artifacts/WithingsHealthMate.py
@@ -69,7 +69,7 @@ __artifacts_v2__ = {
         "notes": "Based on https://bebinary4n6.blogspot.com/2024/09/app-healthmate-on-ios.html",
         "paths": ('*/Library/Application Support/coredata/*_HM3Timeline*'),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "get_healthmate_measurements": {
         "name": "Health Mate - Measurements",
@@ -95,7 +95,7 @@ __artifacts_v2__ = {
         "notes": "Based on https://bebinary4n6.blogspot.com/2024/09/app-healthmate-on-ios.html",
         "paths": ('*/Library/Application Support/coredata/associated_device.sqlite*'),
         "output_types": "all",
-        "artifact_icon": "watch"
+        "artifact_icon": "device-watch"
     }
 }
 

--- a/scripts/artifacts/ZaloChats.py
+++ b/scripts/artifacts/ZaloChats.py
@@ -31,7 +31,7 @@ __artifacts_v2__ = {
                 'mediaColumn': 'Attachment File'
                 }
         },
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "zalo_users": {
         "name": "Zalo - Known Users",

--- a/scripts/artifacts/ZangiChats.py
+++ b/scripts/artifacts/ZangiChats.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/zangidb.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": ""
+        "artifact_icon": "message-circle"
     }
 }
 

--- a/scripts/artifacts/ZangiMessenger.py
+++ b/scripts/artifacts/ZangiMessenger.py
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
                 'mediaColumn': 'Attachment File'
                 }
         },
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "zangi_contacts": {
         "name": "Zangi Messenger - Contacts",

--- a/scripts/artifacts/appItunesmeta.py
+++ b/scripts/artifacts/appItunesmeta.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/iTunesMetadata.plist', '*/BundleMetadata.plist',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "apps"
     }
 }
 

--- a/scripts/artifacts/appleMapsSearchHistory.py
+++ b/scripts/artifacts/appleMapsSearchHistory.py
@@ -13,6 +13,7 @@ __artifacts_v2__ = {
             '*/GeoHistory.mapsdata',
         ),
         "output_types": "all",
+        "artifact_icon": "search",
     }
 }
 

--- a/scripts/artifacts/applePodcasts.py
+++ b/scripts/artifacts/applePodcasts.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Apple Podcasts",
         "notes": "",
         "paths": ('*/MTLibrary.sqlite*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "microphone"
     },
     "get_applePodcastsEpisodes": {
         "name": "Apple Podcasts Episodes",
@@ -21,7 +22,8 @@ __artifacts_v2__ = {
         "category": "Apple Podcasts",
         "notes": "",
         "paths": ('*/MTLibrary.sqlite*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "headphones"
     }
 }
 

--- a/scripts/artifacts/appleWalletCards.py
+++ b/scripts/artifacts/appleWalletCards.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Caches/com.apple.Passbook/Cache.db*'),
         "output_types": "standard",
-        "artifact_icon": "credit_card",
+        "artifact_icon": "credit-card",
     }
 }
 

--- a/scripts/artifacts/appleWalletPasses.py
+++ b/scripts/artifacts/appleWalletPasses.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Apple Wallet",
         "notes": "",
         "paths": ('*/Cards/*.pkpass/pass.json'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "credit-card"
     },
     "get_appleWalletNanoPasses": {
         "name": "Nano Passes",
@@ -21,7 +22,8 @@ __artifacts_v2__ = {
         "category": "Apple Wallet",
         "notes": "",
         "paths": ('*/nanopasses.sqlite3*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "device-watch"
     }
 }
 

--- a/scripts/artifacts/appleWalletTransactions.py
+++ b/scripts/artifacts/appleWalletTransactions.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/mobile/Library/Passes/passes23.sqlite*'),
         'output_types': 'all',
-        'artifact_icon': 'credit_card',
+        'artifact_icon': 'credit-card',
     }
 }
 

--- a/scripts/artifacts/appleWifiPlist.py
+++ b/scripts/artifacts/appleWifiPlist.py
@@ -11,7 +11,8 @@ __artifacts_v2__ = {
         "paths": ('*/com.apple.wifi.plist', 
                   '*/com.apple.wifi-networks.plist.backup', 
                   '*/com.apple.wifi.known-networks.plist'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "wifi"
     },
     "appleWifiKnownNetworksTimes": {
         "name": "WiFi Known Networks Times",
@@ -25,7 +26,8 @@ __artifacts_v2__ = {
         "paths": ('*/com.apple.wifi.plist', 
                   '*/com.apple.wifi-networks.plist.backup', 
                   '*/com.apple.wifi.known-networks.plist'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "clock"
     },
     "appleWifiScannedPrivate": {
         "name": "WiFi Scanned Networks (Private)",
@@ -37,7 +39,8 @@ __artifacts_v2__ = {
         "category": "WiFi Connections",
         "notes": "",
         "paths": ('*/com.apple.wifi-private-mac-networks.plist',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "eye-off"
     },
     "appleWifiBSSList": {
         "name": "WiFi BSS List",
@@ -49,7 +52,8 @@ __artifacts_v2__ = {
         "category": "WiFi Connections",
         "notes": "Extracts detailed BSS information from the com.apple.wifi.plist file",
         "paths": ('*/com.apple.wifi.known-networks.plist',),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "wifi"
     }
 }
 

--- a/scripts/artifacts/apple_atx_images.py
+++ b/scripts/artifacts/apple_atx_images.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
             '**/*.atx',
         ),
         "output_types": "standard",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     }
 }
 

--- a/scripts/artifacts/applicationStateDB.py
+++ b/scripts/artifacts/applicationStateDB.py
@@ -61,7 +61,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/FrontBoard/applicationState.db*'),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "get_snapshot_lastUsedDate": {
         "name": "Application Snapshot lastUsedDate",
@@ -79,7 +79,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/FrontBoard/applicationState.db*'),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     }
 }
 

--- a/scripts/artifacts/ashHistory.py
+++ b/scripts/artifacts/ashHistory.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Linux",
         "notes": "",
         "paths": ('*/.ash_history',),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "terminal"
     }
 }
 

--- a/scripts/artifacts/atxDatastore.py
+++ b/scripts/artifacts/atxDatastore.py
@@ -15,7 +15,8 @@ __artifacts_v2__ = {
             '*DuetExpertCenter/_ATXDataStore.db*', 
             '*routined/Local.sqlite*'
         ),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "map-pin"
     }
 }
 

--- a/scripts/artifacts/audiTripdata.py
+++ b/scripts/artifacts/audiTripdata.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("*/Library/Caches/de.audi.myaudimobileassistant/fsCachedData/**",),
         "output_types": "standard",
+        "artifact_icon": "car",
     }
 }
 

--- a/scripts/artifacts/backupSettings.py
+++ b/scripts/artifacts/backupSettings.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/Preferences/com.apple.mobile.ldbackup.plist',),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "save"
+        "artifact_icon": "device-floppy"
     }
 }
 

--- a/scripts/artifacts/biomeAirpMode.py
+++ b/scripts/artifacts/biomeAirpMode.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/_DKEvent.System.AirplaneMode/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "plane"
     }
 }
 

--- a/scripts/artifacts/biomeAppWebUsage.py
+++ b/scripts/artifacts/biomeAppWebUsage.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/App.WebUsage/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "world"
     }
 }
 
@@ -70,7 +71,7 @@ def get_biomeAppWebUsage(context):
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
-                protostuff, types = blackboxprotobuf.decode_message(record.data, typess)
+                protostuff, _types = blackboxprotobuf.decode_message(record.data, typess)
 
                 guid               = protostuff.get('bundle_id', '')
                 timestamp          = webkit_timestampsconv(protostuff['timestamp'])

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/_DKEvent.App.Install/local/*', '*/Biome/streams/restricted/App.Install/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "package"
     }
 }
 

--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/public/Backlight/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "sun"
     }
 }
 

--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/biome/streams/restricted/_DKEvent.Device.BatteryPercentage/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "battery"
     }
 }
 

--- a/scripts/artifacts/biomeCarplayisconnected.py
+++ b/scripts/artifacts/biomeCarplayisconnected.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/_DKEvent.Carplay.IsConnected/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "car"
     }
 }
 

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/biome/streams/restricted/_DKEvent.App.InFocus/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "focus-2"
     }
 }
 

--- a/scripts/artifacts/biomeDKKeybag.py
+++ b/scripts/artifacts/biomeDKKeybag.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/_DKEvent.Keybag.IsLocked/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "lock"
     }
 }
 

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/Device.Wireless.WiFi/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "wifi"
     }
 }
 

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/biome/streams/restricted/_DKEvent.Device.IsPluggedIn/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "battery-charging"
     }
 }
 

--- a/scripts/artifacts/biomeHardware.py
+++ b/scripts/artifacts/biomeHardware.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/OSAnalytics.Hardware.Reliability/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "cpu"
     }
 }
 

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/biome/streams/restricted/App.InFocus/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "focus-2"
     }
 }
 

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -11,6 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/AppIntent/local/*'),
         "html_columns": ["Data"],
         "output_types": "standard",
+        "artifact_icon": "bolt",
     }
 }
 

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/biome/streams/restricted/_DKEvent.App.LocationActivity/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "map-pin"
     }
 }
 

--- a/scripts/artifacts/biomeNotes.py
+++ b/scripts/artifacts/biomeNotes.py
@@ -11,7 +11,8 @@ __artifacts_v2__ = {
         "paths": ('*/Biome/streams/restricted/NotesContent/local/*'),
         "html_columns" : ['Note'],
         "output_types": "standard",
-        "function": "get_biomeNotes"
+        "function": "get_biomeNotes",
+        "artifact_icon": "notes"
     }
 }
 
@@ -29,7 +30,7 @@ def get_biomeNotes(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Record Num', 'Identifier 1', 
                     'Identifier 2', 'Note', 'Filename', 'Offset')
 
-    # TODO: shouldn't it be used in decode_message?
+    # Note: shouldn't it be used in decode_message?
     # typess = {
     #     '1': {'type': 'str', 'name': ''},
     #     '2': {'type': 'str', 'name': ''},

--- a/scripts/artifacts/biomeNotificationsPub.py
+++ b/scripts/artifacts/biomeNotificationsPub.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/public/Notification/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "bell"
     }
 }
 

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/public/NowPlaying/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "music"
     }
 }
 

--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/biome/streams/restricted/_DKEvent.Safari.History/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "compass"
     }
 }
 

--- a/scripts/artifacts/biomeTextinputses.py
+++ b/scripts/artifacts/biomeTextinputses.py
@@ -11,7 +11,8 @@ __artifacts_v2__ = {
         "paths":
             ('*/Biome/streams/public/TextInputSession/local/*',
              '*/Biome/streams/restricted/Text.InputSession/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "keyboard"
     }
 }
 

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/UserActivityMetadata/local*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "activity"
     }
 }
 

--- a/scripts/artifacts/biomeWifi.py
+++ b/scripts/artifacts/biomeWifi.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "",
         "paths": ('*/Biome/streams/restricted/_DKEvent.Wifi.Connection/local/*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "wifi"
     }
 }
 

--- a/scripts/artifacts/bluetoothOther.py
+++ b/scripts/artifacts/bluetoothOther.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Bluetooth",
         "notes": "",
         "paths": ('*/Library/Database/com.apple.MobileBluetooth.ledevices.other.db*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "bluetooth"
     }
 }
 

--- a/scripts/artifacts/bluetoothPairedLE.py
+++ b/scripts/artifacts/bluetoothPairedLE.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Bluetooth",
         "notes": "",
         "paths": ('*/com.apple.MobileBluetooth.ledevices.paired.db*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "bluetooth-connected"
     }
 }
 

--- a/scripts/artifacts/bluetoothPairedReg.py
+++ b/scripts/artifacts/bluetoothPairedReg.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Bluetooth",
         "notes": "",
         "paths": ('*/com.apple.MobileBluetooth.devices.plist'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "bluetooth-connected"
     }
 }
 

--- a/scripts/artifacts/box.py
+++ b/scripts/artifacts/box.py
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
                   "*/mobile/Containers/Shared/AppGroup/*/File Provider Storage/boxpreview/*/cache/"
                   "files/*/*/*"),
         "output_types": [ "standard" ],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
     "box_recents": {
         "name": "Box - Recents",

--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Application Support/CachedRoutes/*.plist',),
         "output_types": "all",
+        "artifact_icon": "route",
     }
 }
 

--- a/scripts/artifacts/cachev0.py
+++ b/scripts/artifacts/cachev0.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/cacheV0.db*',),
         "output_types": "standard",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/calendarAll.py
+++ b/scripts/artifacts/calendarAll.py
@@ -10,7 +10,8 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Calendar.sqlitedb',),
         "html_columns": ['Calendar Name', 'Location Coordinates', 'Invitees'],
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "calendar"
     },
     "calendarBirthdays": {
         "name": "Calendar Birthdays",
@@ -23,7 +24,8 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Calendar.sqlitedb',),
         "html_columns": ['Calendar Name'],
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "gift"
     },
     "calendarList": {
         "name": "Calendar List",
@@ -36,7 +38,8 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Calendar.sqlitedb',),
         "html_columns": ['Calendar Name', 'Sharing Participants'],
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "list"
     }
 }
 

--- a/scripts/artifacts/callHistoryTransactions.py
+++ b/scripts/artifacts/callHistoryTransactions.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Call History",
         "notes": "",
         "paths": ('*/var/mobile/Library/CallHistoryTransactions/transactions.log*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "phone-call"
     }
 }
 

--- a/scripts/artifacts/carCD.py
+++ b/scripts/artifacts/carCD.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Caches/locationd/cache.plist'),
         "output_types": "none",
+        "artifact_icon": "car",
     }
 }
 

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/CCEntitySync-api.squareup.com.sqlite*',
                   '*/mobile/Containers/Shared/AppGroup/*/CCEntitySync-internal.cashappapi.com.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign",
+        "artifact_icon": "currency-dollar",
     }
 }
 

--- a/scripts/artifacts/cashAppB.py
+++ b/scripts/artifacts/cashAppB.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Environments/Production/Accounts/*/*-internal.cashappapi.com.sqlite*'),
         "output_types": "all",
-        "artifact_icon": "dollar-sign",
+        "artifact_icon": "currency-dollar",
     }
 }
 

--- a/scripts/artifacts/celWireless.py
+++ b/scripts/artifacts/celWireless.py
@@ -10,7 +10,8 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*wireless/Library/Preferences/com.apple.commcenter.plist', 
                   '*wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "antenna"
     }
 }
 

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/Containers/Data/Application/*/Library/Application Support/conversations-*/*.json',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "chatgptConversations": {
         "name": "ChatGPT - Conversations",
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/Containers/Data/Application/*/Library/Application Support/drafts-*/*.json',),
         "output_types": "standard",
-        "artifact_icon": "edit-3"
+        "artifact_icon": "pencil-minus"
     },
     "chatgptPreferences": {
         "name": "ChatGPT - Preferences",
@@ -68,7 +68,7 @@ __artifacts_v2__ = {
                   '**/Containers/Data/Application/*/Library/Application Support/conversations-*/*.json',
                   '**/Containers/Data/Application/*/Library/Preferences/com.openai.chat.StatsigService.plist'),
         "output_types": "standard",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
     "chatgptVoicePrompts": {
         "name": "ChatGPT - Voice Prompts",
@@ -84,7 +84,7 @@ __artifacts_v2__ = {
                   '**/Containers/Data/Application/*/Library/Application Support/conversations-*/*.json',
                   '**/Containers/Data/Application/*/Library/Preferences/com.openai.chat.StatsigService.plist'),
         "output_types": "standard",
-        "artifact_icon": "mic"
+        "artifact_icon": "microphone"
     }
 }
 

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -11,6 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*',
                   '*/Chromium/Default/History*'),
         "output_types": "standard",
+        "artifact_icon": "history",
     },
     "chromeWebVisits": {
         "name": "Web Visits",
@@ -24,6 +25,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*',
                   '*/Chromium/Default/History*'),
         "output_types": "standard",
+        "artifact_icon": "world",
     },
     "chromeWebSearch": {
         "name": "Web Searches",
@@ -37,6 +39,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*',
                   '*/Chromium/Default/History*'),
         "output_types": "standard",
+        "artifact_icon": "search",
     },
     "chromeDownloads": {
         "name": "Downloads",
@@ -50,6 +53,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*',
                   '*/Chromium/Default/History*'),
         "output_types": "standard",
+        "artifact_icon": "download",
     },
     "chromeKeywordSearchTerms": {
         "name": "Keyword Search Terms",
@@ -63,6 +67,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*',
                   '*/Chromium/Default/History*'),
         "output_types": "standard",
+        "artifact_icon": "search",
     },
     "chromeAutofillEntries": {
         "name": "Autofill Entries",
@@ -76,6 +81,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Web Data*', '*/app_sbrowser/Default/Web Data*', '*/app_opera/Web Data*',
                   '*/Chromium/Default/Web Data*'),
         "output_types": "standard",
+        "artifact_icon": "forms",
     },
     "chromeAutofillProfiles": {
         "name": "Autofill Profiles",
@@ -89,6 +95,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Web Data*', '*/app_sbrowser/Default/Web Data*', '*/app_opera/Web Data*',
                   '*/Chromium/Default/Web Data*'),
         "output_types": "standard",
+        "artifact_icon": "user",
     },
     "chromeBookmarks": {
         "name": "Bookmarks",
@@ -102,6 +109,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Bookmarks*', '*/app_sbrowser/Default/Bookmarks*', '*/app_opera/Bookmarks*',
                   '*/Chromium/Default/Bookmarks*'),
         "output_types": "standard",
+        "artifact_icon": "bookmark",
     },
     "chromeCookies": {
         "name": "Cookies",
@@ -114,6 +122,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Chrome/Default/Cookies*', '*/app_sbrowser/Default/Cookies*', '*/app_opera/Cookies*', '*/Chromium/Default/Cookies*'),
         "output_types": "standard",
+        "artifact_icon": "cookie",
     },
     "chromeLoginData": {
         "name": "Login Data",
@@ -126,6 +135,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Chrome/Default/Login Data*', '*/app_sbrowser/Default/Login Data*', '*/app_opera/Login Data*', '*/Chromium/Default/Login Data*'),
         "output_types": "standard",
+        "artifact_icon": "key",
     },
     "chromeTopSites": {
         "name": "Top Sites",
@@ -138,6 +148,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Chrome/Default/Top Sites*', '*/app_sbrowser/Default/Top Sites*', '*/app_opera/Top Sites*', '*/Chromium/Default/Top Sites*'),
         "output_types": ['lava', 'tsv', 'html'],
+        "artifact_icon": "star",
     },
     "chromeOfflinePages": {
         "name": "Offline Pages",
@@ -152,6 +163,7 @@ __artifacts_v2__ = {
                   '*/app_sbrowser/Default/Offline Pages/metadata/OfflinePages.db*',
                   '*/Chromium/Default/Offline Pages/metadata/OfflinePages.db*'),
         "output_types": "standard",
+        "artifact_icon": "wifi-off",
     },
     "chromeMediaHistorySessions": {
         "name": "Media History Sessions",
@@ -165,6 +177,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*',
                   '*/app_opera/Media History*', '*/Chromium/Default/Media History*'),
         "output_types": "standard",
+        "artifact_icon": "movie",
     },
     "chromeMediaHistoryPlaybacks": {
         "name": "Media History Playbacks",
@@ -178,6 +191,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*',
                   '*/app_opera/Media History*', '*/Chromium/Default/Media History*'),
         "output_types": "standard",
+        "artifact_icon": "player-play",
     },
     "chromeMediaHistoryOrigins": {
         "name": "Media History Origins",
@@ -191,6 +205,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*',
                   '*/app_opera/Media History*', '*/Chromium/Default/Media History*'),
         "output_types": "standard",
+        "artifact_icon": "world",
     },
     "chromeNetworkActionPredictor": {
         "name": "Network Action Predictor",
@@ -204,6 +219,7 @@ __artifacts_v2__ = {
         "paths": ('*/Chrome/Default/Network Action Predictor*','*/app_sbrowser/Default/Network Action Predictor*',
                   '*/app_opera/Network Action Predictor*', '*/Chromium/Default/Network Action Predictor*'),
         "output_types": ['lava', 'tsv', 'html'],
+        "artifact_icon": "trending-up",
     },
 }
 

--- a/scripts/artifacts/connectedDevices.py
+++ b/scripts/artifacts/connectedDevices.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Connected Devices",
         "notes": "",
         "paths": ('*/iTunes_Control/iTunes/iTunesPrefs',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "devices"
     }
 }
 

--- a/scripts/artifacts/controlCenter.py
+++ b/scripts/artifacts/controlCenter.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Control Center",
         "notes": "",
         "paths": ('*/mobile/Library/ControlCenter/ModuleConfiguration.plist',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "adjustments"
     }
 }
 

--- a/scripts/artifacts/coreAccessoriesAcc.py
+++ b/scripts/artifacts/coreAccessoriesAcc.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/CoreAccessories/Analytics/acc_analytics_accessoryd_v3.db*',),
         "output_types": "standard",
+        "artifact_icon": "plug-connected",
     }
 }
 

--- a/scripts/artifacts/coreAccessoriesUserEvent.py
+++ b/scripts/artifacts/coreAccessoriesUserEvent.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/CoreAccessories/Analytics/acc_analytics_UserEventAgent_v3.db*',),
         "output_types": "standard",
+        "artifact_icon": "activity",
     }
 }
 

--- a/scripts/artifacts/deviceActivator.py
+++ b/scripts/artifacts/deviceActivator.py
@@ -8,7 +8,8 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Device Information",
         "paths": ('*/mobile/Library/Logs/mobileactivationd/ucrt_oob_request.txt',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "circle-check"
     }
 }
 

--- a/scripts/artifacts/deviceDatam.py
+++ b/scripts/artifacts/deviceDatam.py
@@ -9,17 +9,18 @@ __artifacts_v2__ = {
         "category": "Device Information",
         "notes": "",
         "paths": ('*wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "device-mobile"
     }
 }
 
 import ast
 import plistlib
 from datetime import datetime, timedelta
-from scripts.ilapfuncs import artifact_processor, device_info, convert_plist_date_to_timezone_offset, webkit_timestampsconv
+from scripts.ilapfuncs import artifact_processor, device_info, webkit_timestampsconv
 
 @artifact_processor
-def deviceDatam(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def deviceDatam(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     data_list = []
     file_found = str(files_found[0])
     
@@ -57,7 +58,7 @@ def deviceDatam(files_found, report_folder, seeker, wrap_text, timezone_offset):
                         # Convert from Apple epoch timestamp
                         converted_time = webkit_timestampsconv(float(val))
                         val = f"{converted_time} (original: {val})"
-                except:
+                except Exception:  # pylint: disable=broad-exception-caught
                     val = str(val)
                     
             data_list.append((key, str(val)))

--- a/scripts/artifacts/deviceName.py
+++ b/scripts/artifacts/deviceName.py
@@ -8,7 +8,8 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Identifiers",
         "paths": ('*/root/Library/Lockdown/data_ark.plist',),
-        "output_types": "none"
+        "output_types": "none",
+        "artifact_icon": "device-mobile"
     }
 }
 
@@ -16,7 +17,7 @@ import plistlib
 from scripts.ilapfuncs import device_info, artifact_processor
 
 @artifact_processor
-def deviceName(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def deviceName(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     file_found = str(files_found[0])
     with open(file_found, "rb") as fp:
         pl = plistlib.load(fp)

--- a/scripts/artifacts/discordAcct.py
+++ b/scripts/artifacts/discordAcct.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Discord",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default'),
-        "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
+        "output_types": "standard",
+        "artifact_icon": "brand-discord",  # or ["html", "tsv", "timeline", "lava"]
     }
 }
 

--- a/scripts/artifacts/dmss.py
+++ b/scripts/artifacts/dmss.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Support/configFile1',),
         "output_types": "standard",
+        "artifact_icon": "password",
     },
     "get_dmss_channels": {
         "name": "Dahua Technology (DMSS) - Channels",
@@ -22,6 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Support/Devices.sqlite3*'),
         "output_types": "standard",
+        "artifact_icon": "layout-grid",
     },
     "get_dmss_info": {
         "name": "Dahua Technology (DMSS) - Info",
@@ -34,6 +36,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Support/Devices.sqlite3*'),
         "output_types": "standard",
+        "artifact_icon": "info-circle",
     },
     "get_dmss_registered_sensors": {
         "name": "Dahua Technology (DMSS) - Sensors",
@@ -46,6 +49,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Support/*/DMSSCloud.sqlite*'),
         "output_types": "standard",
+        "artifact_icon": "radar",
     },
     "get_dmss_registered_devices": {
         "name": "Dahua Technology (DMSS) - Devices",
@@ -58,6 +62,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Support/*/DMSSCloud.sqlite*'),
         "output_types": "standard",
+        "artifact_icon": "video",
     },
     "get_dmss_notifications": {
         "name": "Dahua Technology (DMSS) - Notifications",
@@ -70,6 +75,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Support/*/DMSSCloud.sqlite*'),
         "output_types": "standard",
+        "artifact_icon": "bell",
     },
     "get_dmss_created_media": {
         "name": "Dahua Technology (DMSS) - Media",
@@ -82,6 +88,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Documents/Captures/*','*/Documents/Videos/*'),
         "output_types": "standard",
+        "artifact_icon": "movie",
     }
 }
 

--- a/scripts/artifacts/facebookMessenger.py
+++ b/scripts/artifacts/facebookMessenger.py
@@ -86,7 +86,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("*/lightspeed-userDatabases/*.db*",),
         "output_types": "standard",
-        "artifact_icon": "facebook",
+        "artifact_icon": "brand-facebook",
     },
     "facebookMessengerContacts": {
         "name": "Facebook Messenger - Contacts",

--- a/scripts/artifacts/filesApp.py
+++ b/scripts/artifacts/filesApp.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
             '*/mobile/Library/Application Support/CloudDocs/session/db/server.db*',
             ),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "icloud_application_list": {
         "name": "Files App - iCloud Application List",
@@ -108,7 +108,7 @@ __artifacts_v2__ = {
             '*/mobile/Library/Application Support/CloudDocs/session/db/client.db*',
             ),
         "output_types": "standard",
-        "artifact_icon": "refresh-cw"
+        "artifact_icon": "refresh"
     }
 }
 

--- a/scripts/artifacts/findMyItems.py
+++ b/scripts/artifacts/findMyItems.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Caches/com.apple.findmy.fmipcore/Items.data'),
         "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "info-circle",
     },
     "findMyItemsLocations": {
         "name": "FindMy Items Locations",
@@ -21,7 +22,8 @@ __artifacts_v2__ = {
         "category": "Find My",
         "notes": "",
         "paths": ('*/Caches/com.apple.findmy.fmipcore/Items.data'),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "map-pin"
     },
     "findMyItemsSafeLocations": {
         "name": "FindMy Items Safe Locations",
@@ -33,7 +35,8 @@ __artifacts_v2__ = {
         "category": "Find My",
         "notes": "",
         "paths": ('*/Caches/com.apple.findmy.fmipcore/Items.data'),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "shield-check"
     },
     "findMyItemsCrowdsourcedLocations": {
         "name": "FindMy Items Crowdsourced Locations",
@@ -45,7 +48,8 @@ __artifacts_v2__ = {
         "category": "Find My",
         "notes": "",
         "paths": ('*/Caches/com.apple.findmy.fmipcore/Items.data'),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "users"
     }
 }
 
@@ -55,7 +59,7 @@ from scripts.ilapfuncs import artifact_processor
 from scripts.ilapfuncs import convert_unix_ts_to_timezone
 
 @artifact_processor
-def findMyItemsInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def findMyItemsInfo(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     
@@ -64,7 +68,7 @@ def findMyItemsInfo(files_found, report_folder, seeker, wrap_text, timezone_offs
         for x in deserialized:
             name = (x['name'])
             serial = (x['serialNumber'])
-            id = (x['identifier'])
+            item_id = (x['identifier'])
             rname = (x['role'].get('name'))
             remoji = (x['role'].get('emoji'))
             ris = (x['role'].get('identifier'))
@@ -81,7 +85,7 @@ def findMyItemsInfo(files_found, report_folder, seeker, wrap_text, timezone_offs
             sysver = (x['systemVersion'])
 
             data_list.append(
-                (name, serial, id, rname, remoji, ris, ptype, maname, pid, vid, ap, gid, owner, 
+                (name, serial, item_id, rname, remoji, ris, ptype, maname, pid, vid, ap, gid, owner, 
                     batstat, lostmode, cap, sysver,))
 
     data_headers = (
@@ -90,7 +94,7 @@ def findMyItemsInfo(files_found, report_folder, seeker, wrap_text, timezone_offs
     return data_headers, data_list, source_path
 
 @artifact_processor
-def findMyItemsLocations(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def findMyItemsLocations(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     
@@ -101,7 +105,7 @@ def findMyItemsLocations(files_found, report_folder, seeker, wrap_text, timezone
             ltimestamp = convert_unix_ts_to_timezone(ltimestamp, timezone_offset)
             name = (x['name'])
             serial = (x['serialNumber'])
-            id = (x['identifier'])
+            item_id = (x['identifier'])
             rname = (x['role'].get('name'))
             remoji = (x['role'].get('emoji'))
             ris = (x['role'].get('identifier'))
@@ -140,7 +144,7 @@ def findMyItemsLocations(files_found, report_folder, seeker, wrap_text, timezone
             acountry =  (x['address'].get('country'))
 
             data_list.append(
-                (ltimestamp, name, serial, id, rname, remoji, ris, ptype, maname, pid, vid, ap, gid, 
+                (ltimestamp, name, serial, item_id, rname, remoji, ris, ptype, maname, pid, vid, ap, gid, 
                     owner, batstat, lostmode, cap, sysver, asubAdministrativeArea, aslabel, astreetAddress, 
                     acountryCode, astateCode, administrativeArea, astreetName, aformattedAddressLines, 
                     amapItemFullAddress, afullThroroughfare, areaOfInterest, alocality, lpostype, lverticalAccuracy, 
@@ -155,7 +159,7 @@ def findMyItemsLocations(files_found, report_folder, seeker, wrap_text, timezone
     return data_headers, data_list, source_path
 
 @artifact_processor
-def findMyItemsSafeLocations(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def findMyItemsSafeLocations(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     
@@ -164,7 +168,7 @@ def findMyItemsSafeLocations(files_found, report_folder, seeker, wrap_text, time
         for x in deserialized:
             name = (x['name'])
             serial = (x['serialNumber'])
-            id = (x['identifier'])
+            item_id = (x['identifier'])
             rname = (x['role'].get('name'))
             remoji = (x['role'].get('emoji'))
             ris = (x['role'].get('identifier'))
@@ -197,7 +201,7 @@ def findMyItemsSafeLocations(files_found, report_folder, seeker, wrap_text, time
                 scount = (safeloc['address'].get('country'))
 
                 data_list.append(
-                    (stimestamp, name, serial, id, rname, remoji, ris, sname, stype, sid, sva, sha, 
+                    (stimestamp, name, serial, item_id, rname, remoji, ris, sname, stype, sid, sva, sha, 
                         slong, slat, sfloor, sisina, sisold, salt, ssub, slabel, sstreet, scountry, 
                         sstate, sadmin, pstreetn, sformated, smapfull, sthro, saoi, sloc, scount))
 
@@ -209,7 +213,7 @@ def findMyItemsSafeLocations(files_found, report_folder, seeker, wrap_text, time
     return data_headers, data_list, source_path
 
 @artifact_processor
-def findMyItemsCrowdsourcedLocations(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def findMyItemsCrowdsourcedLocations(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     
@@ -220,7 +224,7 @@ def findMyItemsCrowdsourcedLocations(files_found, report_folder, seeker, wrap_te
             crowdtimestamp = convert_unix_ts_to_timezone(crowdtimestamp, timezone_offset)
             name = (x['name'])
             serial = (x['serialNumber'])
-            id = (x['identifier'])
+            item_id = (x['identifier'])
             rname = (x['role'].get('name'))
             remoji = (x['role'].get('emoji'))
             ris = (x['role'].get('identifier'))
@@ -247,7 +251,7 @@ def findMyItemsCrowdsourcedLocations(files_found, report_folder, seeker, wrap_te
             crowdlocfin = (x['crowdSourcedLocation'].get('locationFinished'))
 
             data_list.append(
-                (crowdtimestamp, name, serial, id, rname, remoji, ris, ptype, maname, pid, vid, 
+                (crowdtimestamp, name, serial, item_id, rname, remoji, ris, ptype, maname, pid, vid, 
                 ap, gid, owner, batstat, lostmode, cap, sysver, crowdpostype, crowdvert, crowdlong, 
                 crowdlat, crowdalt, crowdfloor, crowdisacc, crowdisold, crowdhorzcc, crowdlocfin ))
 

--- a/scripts/artifacts/foursquareSwarm.py
+++ b/scripts/artifacts/foursquareSwarm.py
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Caches/foursquare.sqlite*"),
         "output_types": [ "standard" ],
         "html_columns": [ "Profile Picture", "Phone Numbers", "Facebook Profile" ],
-        "artifact_icon": "book-open"
+        "artifact_icon": "book"
     },
     "foursquare_swarm_checkins": {
         "name": "Foursquare Swarm - Check-ins",
@@ -83,7 +83,7 @@ __artifacts_v2__ = {
                   "*/com.pinterest.PINDiskCache.PINRemoteImageManagerCache/*%2Fimg%2Fgeneral%2F*"),
         "output_types": [ "all" ],
         "html_columns": [ "Tip URL", "Short URL", "Photo URL" ],
-        "artifact_icon": "info"
+        "artifact_icon": "info-circle"
     },
     "foursquare_swarm_stickers": {
         "name": "Foursquare Swarm - Stickers",
@@ -148,7 +148,7 @@ __artifacts_v2__ = {
         "paths": ("*/mobile/Containers/Data/Application/*/Library/Caches/foursquare.sqlite*"),
         "output_types": [ "all" ],
         "html_columns": [ "Entities" ],
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "foursquare_swarm_friend_requests": {
         "name": "Foursquare Swarm - Friend Requests",

--- a/scripts/artifacts/geodMapTiles.py
+++ b/scripts/artifacts/geodMapTiles.py
@@ -10,7 +10,8 @@ __artifacts_v2__ = {
         "category": "Location",
         "notes": "",
         "paths": ('**/MapTiles.sqlitedb*'),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "map"
     }
 }
 

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Gmail",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/data/*/searchsqlitedb*',),
-        "output_types": ["html", "tsv", "lava", "timeline"]
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "search"
     },
     "gmailLabelDetails": {
         "name": "Gmail - Label Details",
@@ -21,18 +22,20 @@ __artifacts_v2__ = {
         "category": "Gmail",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/data/*/sqlitedb*',),
-        "output_types": ["html", "tsv", "lava"]
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "tag"
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, logfunc, convert_ts_human_to_timezone_offset
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_timezone_offset
 
 @artifact_processor
-def gmailOfflineSearch(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def gmailOfflineSearch(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
     data_list = []
     data_headers = ()
     source_path = ''
     
+    file_found = ''
     for file_found in files_found:
         source_path = str(file_found)
         if file_found.endswith('searchsqlitedb'):
@@ -90,11 +93,12 @@ def gmailOfflineSearch(files_found, report_folder, seeker, wrap_text, timezone_o
     return data_headers, data_list, source_path
 
 @artifact_processor
-def gmailLabelDetails(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def gmailLabelDetails(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     data_list = []
     data_headers = ()
     source_path = ''
     
+    file_found = ''
     for file_found in files_found:
         source_path = str(file_found)
         if file_found.endswith('sqlitedb'):

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -20,7 +20,8 @@ __artifacts_v2__ = {
                 "senderColumn": "Message Author",
                 "mediaColumn": "Media"
             }
-        }
+        },
+        "artifact_icon": "message-circle"
     }
 }
 
@@ -116,10 +117,10 @@ def aa_flatten_dict_tu(
                             forbidden=forbidden,
                             allowed=allowed,
                         )
-                except Exception:
+                except Exception:  # pylint: disable=broad-exception-caught
                     # if there is an exception, it is probably not an iterable, so we yield it
                     yield v2, listitem
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             # if there is an exception, it is probably not an iterable, so we yield it
             yield v, listitem
             
@@ -163,7 +164,7 @@ def fla_tu(
                     dict_variation=dict_variation,
                 )  # if we have an iterable, we check recursively for other iterables
                 
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 
                 yield xaa, Tuppsub(
                     (walkthrough + Tuppsub((ini,)))
@@ -220,19 +221,19 @@ def fla_tu(
                             allowed=allowed,
                             dict_variation=dict_variation,
                         )
-                except Exception:
+                except Exception:  # pylint: disable=broad-exception-caught
                     
                     yield xaa, Tuppsub(
                         (walkthrough + (ini2,))
                     )  # in case of an exception, we yield  (value, (key1,key2,...))
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             
             yield item, Tuppsub(
                 (walkthrough + Tuppsub(item, ))
             )  # in case of an exception, we yield  (value, (key1,key2,...))
 
 @artifact_processor
-def get_googleChat(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_googleChat(files_found, report_folder, seeker, _wrap_text, timezone_offset):
     for file_found in files_found:
         file_found = str(file_found)
         
@@ -282,11 +283,11 @@ def get_googleChat(files_found, report_folder, seeker, wrap_text, timezone_offse
                         reaction = ''
                         reactionuser = ''
                     else:
-                        protostuff, types = blackboxprotobuf.decode_message(protobufreactions)
+                        protostuff, _types = blackboxprotobuf.decode_message(protobufreactions)
                         reaction = (protostuff['1']['1']['1']['1']).decode()
                         reaction = (utf8_in_extended_ascii(reaction))[1]
 
-                        timestampofreaction = protostuff['1']['1']['4']
+                        _timestampofreaction = protostuff['1']['1']['4']
                         reactionuser = protostuff['1'].get('2')
                         if reactionuser is not None:
                             reactionuser = protostuff['1']['2']['1']
@@ -299,7 +300,6 @@ def get_googleChat(files_found, report_folder, seeker, wrap_text, timezone_offse
                     check = checkforempty.read(3)
 
                     if check == b'\xfe\xff\x00':
-                        media = ''
                         mediafilename = ''
                     else:
                         protostuff, types = blackboxprotobuf.decode_message(protobufmedia)
@@ -334,6 +334,5 @@ def get_googleChat(files_found, report_folder, seeker, wrap_text, timezone_offse
                         'Is Sent', 'Filename', 'Media', 'Reaction', 'Reaction User', 'Account ID')
 
         return data_headers, data_list, file_found
-        
-    else:
-        logfunc('No Google Chat data available')
+
+    logfunc('No Google Chat data available')

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
         "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Google Duo", "notes": "",
         "paths": ('*/Application Support/DataStore*', '*/Application Support/ClipsCache/*.png'),
-        "output_types": "standard", "artifact_icon": "film"
+        "output_types": "standard", "artifact_icon": "movie"
     }
 }
 

--- a/scripts/artifacts/googleTranslate.py
+++ b/scripts/artifacts/googleTranslate.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/translate.db*'),
         "output_types": "standard",
-        "artifact_icon": "type"
+        "artifact_icon": "typography"
     },
     "googleTranslateStarred": {
         "name": "Google Translate Favorite Translations",
@@ -47,7 +47,7 @@ from scripts.filetype import audio_match
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, does_table_exist_in_db, convert_unix_ts_to_utc
 
 @artifact_processor
-def googleTranslateHistory(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def googleTranslateHistory(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "translate.db")
     data_list = []
 
@@ -85,7 +85,7 @@ def googleTranslateHistory(files_found, report_folder, seeker, wrap_text, timezo
 
 
 @artifact_processor
-def googleTranslateStarred(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def googleTranslateStarred(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "translate.db")
     data_list = []
 
@@ -112,7 +112,7 @@ def googleTranslateStarred(files_found, report_folder, seeker, wrap_text, timezo
 
 
 @artifact_processor
-def googleTranslateTts(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def googleTranslateTts(files_found, report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "translate.db")
     data_list = []
     data_list_html = []

--- a/scripts/artifacts/health.py
+++ b/scripts/artifacts/health.py
@@ -40,7 +40,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("*Health/healthdb_secure.sqlite*", "*Health/healthdb.sqlite*"),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "health_headphone_audio_levels": {
         "name": "Health - Headphone Audio Levels",
@@ -182,7 +182,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("*Health/healthdb_secure.sqlite*",),
         "output_types": "standard",
-        "artifact_icon": "watch"
+        "artifact_icon": "device-watch"
     },
     'health_all_watch_sleep_data': {
         'name': 'Health - Sleep - All Watch Sleep Data',
@@ -233,7 +233,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("*Health/healthdb.sqlite*",),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "health_wrist_temperature": {
         "name": "Health - Wrist Temperature",

--- a/scripts/artifacts/hikvision.py
+++ b/scripts/artifacts/hikvision.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Documents/database.hik*',),
         "output_types": "standard",
-        "artifact_icon": "info"
+        "artifact_icon": "info-circle"
     },
     "hikvisionActivity": {
         "name": "Hikvision - CCTV Activity",
@@ -63,7 +63,7 @@ __artifacts_v2__ = {
         "notes": "Media are stored under Documents/YYYY/MM/DD within the app container.",
         "paths": ('*/Documents/*/*/*/*.jpg', '*/Documents/*/*/*/*.mov', '*/Documents/*/*/*/*.mp4'),
         "output_types": "standard",
-        "artifact_icon": "film"
+        "artifact_icon": "movie"
     }
 }
 

--- a/scripts/artifacts/home_depot.py
+++ b/scripts/artifacts/home_depot.py
@@ -117,7 +117,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Containers/Data/Application/*/Library/Preferences/com.thehomedepot.homedepot.plist',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "home_depot_search_url_cache": {
         "name": "Home Depot - Search URL Cache",
@@ -143,7 +143,7 @@ __artifacts_v2__ = {
         "notes": "Excludes product image cache, search URL cache, and SDK analytics keys.",
         "paths": ('*/Containers/Data/Application/*/Library/Preferences/com.thehomedepot.homedepot.plist',),
         "output_types": "standard",
-        "artifact_icon": "sliders",
+        "artifact_icon": "adjustments-alt",
     },
 }
 

--- a/scripts/artifacts/iTunesBackupInfo.py
+++ b/scripts/artifacts/iTunesBackupInfo.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("info.plist",),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "refresh-cw"
+        "artifact_icon": "refresh"
     },
     "itunes_backup_installed_applications": {
         "name": "iTunes Backup - Installed Applications",

--- a/scripts/artifacts/icloudPhotoMeta.py
+++ b/scripts/artifacts/icloudPhotoMeta.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
                  "report folder's 'bplists' subfolder.",
         "paths": ('*/cloudphotolibrary/Metadata.txt',),
         "output_types": ["html", "tsv", "timeline", "lava", "kml"],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     }
 }
 

--- a/scripts/artifacts/icloudSharedalbums.py
+++ b/scripts/artifacts/icloudSharedalbums.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
         "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "iCloud Shared Albums", "notes": "",
         "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
-        "output_types": "standard", "artifact_icon": "image"
+        "output_types": "standard", "artifact_icon": "photo"
     },
     "icloudSharedPersonInfo": {
         "name": "iCloud Shared Albums - Person Info",

--- a/scripts/artifacts/imeiImsi.py
+++ b/scripts/artifacts/imeiImsi.py
@@ -10,7 +10,8 @@ __artifacts_v2__ = {
         "category": "Identifiers",
         "notes": "",
         "paths": ('*/wireless/Library/Preferences/com.apple.commcenter.plist'),
-        "output_types": ["html", "tsv", "lava"]
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "hash"
     }
 }
 
@@ -18,7 +19,7 @@ import plistlib
 from scripts.ilapfuncs import artifact_processor, device_info
 
 @artifact_processor
-def imeiImsi(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def imeiImsi(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     
@@ -45,7 +46,6 @@ def imeiImsi(files_found, report_folder, seeker, wrap_text, timezone_offset):
                 device_info("Cellular", "Last Known ICCI", lastknownicci, source_path)
                 
             elif key == 'PhoneNumber':
-                phonenumber = val
                 data_list.append(('Phone Number', val))
                 device_info("Cellular", "Phone Number", val, source_path)
                 

--- a/scripts/artifacts/instagramThreads.py
+++ b/scripts/artifacts/instagramThreads.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
             "*/mobile/Containers/Data/Application/*/Library/Application Support/DirectSQLiteDatabase/*.db*",
         ),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
         "sample_data": {
             "josh_ios_15": "75 rows; includes messages, VOIP call activity, and conversation view fields",
             "mvs_2026": "0 rows; verifies multi-DB handling with no matching thread records",

--- a/scripts/artifacts/keyboard.py
+++ b/scripts/artifacts/keyboard.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "User Activity",
         "notes": "",
         "paths": ('*/mobile/Library/Keyboard/*-dynamic.lm/dynamic-lexicon.dat',),
-        "output_types": ["html", "tsv", "lava", "timeline"]
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "vocabulary"
     },
     "keyboardAppUsage": {
         "name": "Keyboard Application Usage",
@@ -21,7 +22,8 @@ __artifacts_v2__ = {
         "category": "User Activity",
         "notes": "",
         "paths": ('*/mobile/Library/Keyboard/app_usage_database.plist',),
-        "output_types": ["html", "tsv", "lava", "timeline"]
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "keyboard"
     },
     "keyboardUsageStats": {
         "name": "Keyboard Usage Stats",
@@ -33,7 +35,8 @@ __artifacts_v2__ = {
         "category": "User Activity",
         "notes": "",
         "paths": ('*/mobile/Library/Keyboard/user_model_database.sqlite*',),
-        "output_types": ["html", "tsv", "lava", "timeline"]
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "chart-bar"
     }
 }
 

--- a/scripts/artifacts/keychain.py
+++ b/scripts/artifacts/keychain.py
@@ -50,7 +50,8 @@ __artifacts_v2__ = {
             '*/Keychains/keychain-2.db*',
         ),
         "output_types": "none",
-        "function": "keychain_bluetooth_info"
+        "function": "keychain_bluetooth_info",
+        "artifact_icon": "bluetooth"
     },
     "keychain_bluetooth_paired": {
         "name": "Paired Bluetooth Devices",
@@ -87,7 +88,7 @@ __artifacts_v2__ = {
             '*/Keychains/keychain-2.db*',
         ),
         "output_types": "standard",
-        "artifact_icon": "at-sign",
+        "artifact_icon": "at",
         "function": "keychain_mail_accounts"
     },
 }
@@ -283,7 +284,7 @@ def _decrypt_itb_key(data, decryption_keys) -> bytes | None:
         return None
 
     try:
-        key_uwkey = AES.new(key_dkey['Unwrapped'], AES.MODE_KW).unseal(key_wkey)  # type: ignore[attr-defined]
+        key_uwkey = AES.new(key_dkey['Unwrapped'], AES.MODE_KW).unseal(key_wkey)  # type: ignore[attr-defined]  # pylint: disable=no-member
         decrypted_data = gcm_decrypt(key_uwkey, b"", key_data, b"")
         return decrypted_data
     except ValueError as e:

--- a/scripts/artifacts/knowledgeC.py
+++ b/scripts/artifacts/knowledgeC.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "KnowledgeC",
         "notes": "",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "battery"
     },
     "knowledgeC_DevicePluginStatus": {
         "name": "knowledgeC - Device Plugin Status",
@@ -21,7 +22,8 @@ __artifacts_v2__ = {
         "category": "KnowledgeC",
         "notes": "",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "battery-charging"
     },
     "knowledgeC_MediaPlaying": {
         "name": "knowledgeC - Media Playing",
@@ -35,7 +37,8 @@ __artifacts_v2__ = {
             - Sarah Edwards as part of her APOLLO project https://github.com/mac4n6/APOLLO \
             - Ian Wiffin blog post https://www.doubleblak.com/blogPosts.php?id=29",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "music"
     },
     "knowledgeC_DoNotDisturb": {
         "name": "knowledgeC - Do Not Disturb",
@@ -47,7 +50,8 @@ __artifacts_v2__ = {
         "category": "KnowledgeC",
         "notes": "Based on research by Geraldine Blay and Dan Ogden",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "moon"
     },
     "knowledgeC_AppUsage": {
         "name": "knowledgeC - App Usage",
@@ -86,7 +90,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
     "knowledgeC_isBacklit": {
         "name": "knowledgeC - Device Screen Status",
@@ -99,7 +103,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     }
 }
 

--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/Medialibrary.sqlitedb*',),
         "output_types": "standard",
-        "artifact_icon": "info"
+        "artifact_icon": "info-circle"
     }
 }
 

--- a/scripts/artifacts/mobileBackupplist.py
+++ b/scripts/artifacts/mobileBackupplist.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
         "paths": ('*/Library/Preferences/com.apple.MobileBackup.plist',
                   '*/Preferences/com.apple.MobileBackup.plist'),
         "output_types": "standard",
-        "artifact_icon": "save"
+        "artifact_icon": "device-floppy"
     }
 }
 

--- a/scripts/artifacts/mobileContainerManager.py
+++ b/scripts/artifacts/mobileContainerManager.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/containermanagerd.log.*',),
         "output_types": "standard",
-        "artifact_icon": "trash-2"
+        "artifact_icon": "trash"
     }
 }
 

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
         "notes": _NOTE,
         "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "trash-2"
+        "artifact_icon": "trash"
     },
     "mobileInstall_historical": {
         "name": "Apps - Historical Combined",
@@ -51,7 +51,7 @@ __artifacts_v2__ = {
         "notes": _NOTE,
         "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "refresh-cw"
+        "artifact_icon": "refresh"
     }
 }
 

--- a/scripts/artifacts/mobileInstallb.py
+++ b/scripts/artifacts/mobileInstallb.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "All timestamps are in LOCAL device time (the log records local time), not UTC.",
         "paths": ('*/mobile_installation.log.*',),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "refresh-cw"
+        "artifact_icon": "refresh"
     }
 }
 

--- a/scripts/artifacts/netusage.py
+++ b/scripts/artifacts/netusage.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/netusage.sqlite*'),
         "output_types": "standard",
+        "artifact_icon": "chart-pie",
     },
     "netusage_connections": {
         "name": "Connections",
@@ -22,6 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/netusage.sqlite*'),
         "output_types": "standard",
+        "artifact_icon": "network",
     }
 }
 

--- a/scripts/artifacts/obliterated.py
+++ b/scripts/artifacts/obliterated.py
@@ -10,6 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/root/.obliterated'),
         "output_types": "standard",
+        "artifact_icon": "trash",
     }
 }
 
@@ -19,7 +20,7 @@ import os
 from scripts.ilapfuncs import logdevinfo, artifact_processor
 
 @artifact_processor
-def get_obliterated(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def get_obliterated(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     file_found = str(files_found[0])
     
     modified_time = os.path.getmtime(file_found)

--- a/scripts/artifacts/parsecdCache.py
+++ b/scripts/artifacts/parsecdCache.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("**/EngagedCompletions/Cache.db*"),
         "output_types": "standard",
+        "artifact_icon": "search",
     }
 }
 

--- a/scripts/artifacts/photosDbexif.py
+++ b/scripts/artifacts/photosDbexif.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
                  "Creation/Changed timestamp is local time — use the Possible Exif Offset to compare.",
         "paths": ('*Media/PhotoData/Photos.sqlite*', '*Media/DCIM/*/**'),
         "output_types": "all",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     }
 }
 

--- a/scripts/artifacts/photosMetadata.py
+++ b/scripts/artifacts/photosMetadata.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
                  "Reverse-location bplists are written to the report folder.",
         "paths": ('*/mobile/Media/PhotoData/Photos.sqlite*',),
         "output_types": ["html", "tsv", "timeline", "lava", "kml"],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     }
 }
 

--- a/scripts/artifacts/pingertextfree.py
+++ b/scripts/artifacts/pingertextfree.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Messaging_*.sqlite*',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     }
 }
 

--- a/scripts/artifacts/potatoChat.py
+++ b/scripts/artifacts/potatoChat.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/Documents/video/*',
         ),
         'output_types': 'all',
-        'artifact_icon': 'message-square',
+        'artifact_icon': 'message',
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Chat-ID',
@@ -44,7 +44,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/Documents/video/*',
         ),
         'output_types': 'standard',
-        'artifact_icon': 'message-square',
+        'artifact_icon': 'message',
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Group-ID',

--- a/scripts/artifacts/preferencesPlist.py
+++ b/scripts/artifacts/preferencesPlist.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Identifiers",
         "notes": "",
         "paths": ('*preferences/SystemConfiguration/preferences.plist', ),
-        "output_types": ["html", "tsv", "lava"]
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "settings"
     }
 }
 
@@ -18,7 +19,7 @@ import plistlib
 from scripts.ilapfuncs import artifact_processor, device_info
 
 @artifact_processor
-def preferencesPlist(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def preferencesPlist(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     data_list = []
     source_path = str(files_found[0])
     with open(source_path, "rb") as fp:

--- a/scripts/artifacts/queryPredictions.py
+++ b/scripts/artifacts/queryPredictions.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/query_predictions.db',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     }
 }
 

--- a/scripts/artifacts/rctAsyncStorageManifest.py
+++ b/scripts/artifacts/rctAsyncStorageManifest.py
@@ -13,6 +13,7 @@ __artifacts_v2__ = {
             "*/mobile/Containers/Data/Application/*/Library/Application Support/RCTAsyncLocalStorage_V1/manifest.json",
         ),
         "output_types": "standard",
+        "artifact_icon": "database",
     }
 }
 

--- a/scripts/artifacts/restoreLog.py
+++ b/scripts/artifacts/restoreLog.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/mobile/MobileSoftwareUpdate/restore.log',),
         'output_types': 'standard',
-        'artifact_icon': 'refresh-cw'
+        'artifact_icon': 'refresh'
     }
 }
 

--- a/scripts/artifacts/safariFavicons.py
+++ b/scripts/artifacts/safariFavicons.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Containers/Data/Application/*/Library/Image Cache/Favicons/Favicons.db*',),
         "output_types": "standard",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     }
 }
 

--- a/scripts/artifacts/serialNumber.py
+++ b/scripts/artifacts/serialNumber.py
@@ -9,7 +9,8 @@ __artifacts_v2__ = {
         "category": "Identifiers",
         "notes": "",
         "paths": ('*/Library/Caches/locationd/consolidated.db*'),
-        "output_types": "none"
+        "output_types": "none",
+        "artifact_icon": "hash"
     }
 }
 
@@ -17,7 +18,7 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info
 
 @artifact_processor
-def serialNumber(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def serialNumber(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     db_file = ''
 
     for file_found in files_found:

--- a/scripts/artifacts/skg_archive.py
+++ b/scripts/artifacts/skg_archive.py
@@ -14,19 +14,19 @@ __artifacts_v2__ = {
             #'*/CoreSpotlight/SpotlightKnowledge/index.V2/archives/NSFileProtectionComplete/skg_archive-*',
             '*/CoreSpotlight/SpotlightKnowledge/index.V2/archives/NSFileProtectionCompleteUntilFirstUserAuthentication/skg_archive-*'
         ),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "search"
     }
 }
 
 from scripts.ilapfuncs import artifact_processor, logfunc
 import mdplist
 import nska_deserialize as nd
-import os
 from collections import defaultdict
 from pathlib import Path
 
 @artifact_processor
-def skg_archive(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def skg_archive(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
 
     data_list = []
     dedupe = 0

--- a/scripts/artifacts/sms.py
+++ b/scripts/artifacts/sms.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/Library/SMS/sms.db*',
                   '*/Library/SMS/Attachments/*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Chat ID",

--- a/scripts/artifacts/splitwise.py
+++ b/scripts/artifacts/splitwise.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Application Support/database.sqlite*',),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign"
+        "artifact_icon": "currency-dollar"
     },
     "splitwiseExpenseBalances": {
         "name": "Splitwise - Expense Balances",
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Application Support/database.sqlite*',),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign"
+        "artifact_icon": "currency-dollar"
     },
     "splitwiseTotalBalances": {
         "name": "Splitwise - Total Balances",
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/Application Support/database.sqlite*',),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign"
+        "artifact_icon": "currency-dollar"
     },
     "splitwiseGroups": {
         "name": "Splitwise - Groups",
@@ -84,7 +84,7 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, convert_unix_ts_to_utc
 
 @artifact_processor
-def splitwiseUsers(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def splitwiseUsers(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "database.sqlite")
     data_list = []
 
@@ -131,7 +131,7 @@ def splitwiseUsers(files_found, report_folder, seeker, wrap_text, timezone_offse
 
 
 @artifact_processor
-def splitwiseExpenses(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def splitwiseExpenses(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "database.sqlite")
     data_list = []
 
@@ -178,7 +178,7 @@ def splitwiseExpenses(files_found, report_folder, seeker, wrap_text, timezone_of
 
 
 @artifact_processor
-def splitwiseExpenseBalances(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def splitwiseExpenseBalances(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "database.sqlite")
     data_list = []
 
@@ -213,7 +213,7 @@ def splitwiseExpenseBalances(files_found, report_folder, seeker, wrap_text, time
 
 
 @artifact_processor
-def splitwiseTotalBalances(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def splitwiseTotalBalances(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "database.sqlite")
     data_list = []
 
@@ -250,7 +250,7 @@ def splitwiseTotalBalances(files_found, report_folder, seeker, wrap_text, timezo
 
 
 @artifact_processor
-def splitwiseGroups(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def splitwiseGroups(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "database.sqlite")
     data_list = []
     data_list_html = []
@@ -312,7 +312,7 @@ def splitwiseGroups(files_found, report_folder, seeker, wrap_text, timezone_offs
 
 
 @artifact_processor
-def splitwiseNotifications(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def splitwiseNotifications(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
     source_path = get_file_path(files_found, "database.sqlite")
     data_list = []
     data_list_html = []
@@ -337,8 +337,7 @@ def splitwiseNotifications(files_found, report_folder, seeker, wrap_text, timezo
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
         data_list_html.append((created_ts, record[1], record[2], record[3]))
-        if '<strong>' and '</strong>' in record[1]:
-            remove_html = record[1].replace('<strong>', '').replace('</strong>', '')
+        remove_html = record[1].replace('<strong>', '').replace('</strong>', '')
         data_list.append((created_ts, remove_html, record[2], record[3]))
 
     return data_headers, (data_list, data_list_html), source_path

--- a/scripts/artifacts/springboard.py
+++ b/scripts/artifacts/springboard.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
                  "flow order. See 'iOS Home Screen Layout - Visual' for a rendered image of each screen.",
         "paths": ('**/SpringBoard/IconState.plist',),
         "output_types": "standard",
-        "artifact_icon": "grid"
+        "artifact_icon": "layout-grid"
     },
     "icons_screen_visual": {
         "name": "iOS Home Screen Layout - Visual",
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
                  "reference. The 'iOS Home Screen Layout' artifact holds the same data in queryable form.",
         "paths": ('**/SpringBoard/IconState.plist',),
         "output_types": "standard",
-        "artifact_icon": "grid"
+        "artifact_icon": "layout-grid"
     },
     "springboard_wallpaper": {
         "name": "SpringBoard Wallpaper",
@@ -47,7 +47,7 @@ __artifacts_v2__ = {
             '**/SpringBoard/*Background*.heic',
         ),
         "output_types": "standard",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
     "posterboard_wallpaper": {
         "name": "PosterBoard Wallpaper",
@@ -66,7 +66,7 @@ __artifacts_v2__ = {
             '**/output.layerStack/*.png',
         ),
         "output_types": "standard",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     }
 }
 

--- a/scripts/artifacts/sysShutdown.py
+++ b/scripts/artifacts/sysShutdown.py
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/shutdown*.log',),
         "output_types": "standard",
-        "artifact_icon": "refresh-cw"
+        "artifact_icon": "refresh"
     }
 }
 

--- a/scripts/artifacts/sysdiagnose.py
+++ b/scripts/artifacts/sysdiagnose.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
             '*/otctl_status.txt',
             '*/mobile/Library/Logs/CrashReporter/DiagnosticLogs/sysdiagnose/sysdiagnose_*.tar.gz'),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     }
 }
 

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -23,7 +23,8 @@ __artifacts_v2__ = {
                 "mediaColumn": "Media",
                 #"sentMessageStaticLabel": "This Device" 
             }
-        }
+        },
+        "artifact_icon": "message-circle"
     },
     "teamsContacts": {
         "name": "Teams Contacts",
@@ -34,7 +35,8 @@ __artifacts_v2__ = {
         "category": "Microsoft Teams",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/SkypeSpacesDogfood/*/Skype*.sqlite*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "address-book"
     },
     "teamsUser": {
         "name": "Teams User Information",
@@ -45,7 +47,8 @@ __artifacts_v2__ = {
         "category": "Microsoft Teams",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/SkypeSpacesDogfood/*/Skype*.sqlite*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "user"
     },
     "teamsCalls": {
         "name": "Teams Call Logs",
@@ -56,7 +59,8 @@ __artifacts_v2__ = {
         "category": "Microsoft Teams",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/SkypeSpacesDogfood/*/Skype*.sqlite*',),
-        "output_types": "standard"
+        "output_types": "standard",
+        "artifact_icon": "phone-call"
     },
     "teamsLocations": {
         "name": "Teams Shared Locations",
@@ -67,7 +71,8 @@ __artifacts_v2__ = {
         "category": "Microsoft Teams",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/SkypeSpacesDogfood/*/Skype*.sqlite*',),
-        "output_types": "all"
+        "output_types": "all",
+        "artifact_icon": "map-pin"
     }
 }
 

--- a/scripts/artifacts/telegramMesssages.py
+++ b/scripts/artifacts/telegramMesssages.py
@@ -34,7 +34,8 @@ __artifacts_v2__ = {
                 "sentMessageLabelColumn": "Author",
                 "mediaColumn": "Thumbnail"
             }
-        }
+        },
+        "artifact_icon": "brand-telegram"
     }
 }
 

--- a/scripts/artifacts/textinputTyping.py
+++ b/scripts/artifacts/textinputTyping.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/DES/Records/com.apple.TextInput.TypingDESPlugin/*.desdata',),
         "output_types": "standard",
-        "artifact_icon": "type"
+        "artifact_icon": "typography"
     }
 }
 

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/*.torrent',),
         'output_types': 'standard',
-        'artifact_icon': 'download-cloud',
+        'artifact_icon': 'cloud-download',
         'html_columns': ['Data']
     }
 }

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/*.resume',),
         'output_types': 'standard',
-        'artifact_icon': 'download-cloud',
+        'artifact_icon': 'cloud-download',
         'html_columns': ['Data']
     }
 }

--- a/scripts/artifacts/trustedPeers.py
+++ b/scripts/artifacts/trustedPeers.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/*TrustedPeersHelper.db*',),
         "output_types": "standard",
-        "artifact_icon": "check-circle",
+        "artifact_icon": "circle-check",
         "sample_data": {
             "josh_ios_15": "23 rows",
             "mvs_2026": "6 rows but ZPEERINFO is empty"

--- a/scripts/artifacts/twint.py
+++ b/scripts/artifacts/twint.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/var/mobile/Containers/Data/Application/*/Library/Application Support/Twint.sqlite*',),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign"
+        "artifact_icon": "currency-dollar"
     }
 }
 from scripts.ilapfuncs import (

--- a/scripts/artifacts/userDefaults.py
+++ b/scripts/artifacts/userDefaults.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
             "*/Containers/Data/Application/*/Library/Preferences/*.plist",
         ),
         "output_types": "standard",
-        "artifact_icon": "sliders",
+        "artifact_icon": "adjustments-alt",
     }
 }
 

--- a/scripts/artifacts/venmo.py
+++ b/scripts/artifacts/venmo.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*PrivateFeed','*PublicFeed','*FriendsFeed'),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign"
+        "artifact_icon": "currency-dollar"
     },
     "venmo_users": {
         "name": "Venmo - Users",

--- a/scripts/artifacts/viber.py
+++ b/scripts/artifacts/viber.py
@@ -62,7 +62,7 @@ __artifacts_v2__ = {
             '**/Containers/Data/Application/*/Documents/Attachments/*.*',
             '**/com.viber/ViberIcons/*.*'),
         'output_types': "all",
-        'artifact_icon': 'message-square'
+        'artifact_icon': 'message'
     }
 
 }

--- a/scripts/artifacts/vipps.py
+++ b/scripts/artifacts/vipps.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/Vipps.sqlite*',),
         'output_types': 'standard',
-        'artifact_icon': 'message-square'
+        'artifact_icon': 'message'
     }
 }
 

--- a/scripts/artifacts/voiceRecordings.py
+++ b/scripts/artifacts/voiceRecordings.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
             '*/Recordings/*.m4a'
             ),
         "output_types": "standard",
-        "artifact_icon": "mic"
+        "artifact_icon": "microphone"
     }   
 }
 

--- a/scripts/artifacts/voiceTriggers.py
+++ b/scripts/artifacts/voiceTriggers.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Library/VoiceTrigger/SAT/*/td/audio/*.json', '*/Library/VoiceTrigger/SAT/*/td/audio/*.wav'),
         "output_types": "standard",
-        "artifact_icon": "mic"
+        "artifact_icon": "microphone"
     }
 }
 

--- a/scripts/artifacts/voicemail.py
+++ b/scripts/artifacts/voicemail.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
             '*/mobile/Library/Voicemail/*.amr',
             '*/mobile/Library/Voicemail/*.transcript'),
         'output_types': 'standard',
-        'artifact_icon': 'mic'
+        'artifact_icon': 'microphone'
     }
 }
 

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Preferences/com.waze.iphone.plist"),
         "output_types": [ "all" ],
-        "artifact_icon": "navigation-2"
+        "artifact_icon": "navigation"
     },
     "waze_track_gps_quality": {
         "name": "Waze - Track GPS Quality",
@@ -45,7 +45,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Documents/spdlog.*logdata"),
         "output_types": [ "all" ],
-        "artifact_icon": "navigation-2"
+        "artifact_icon": "navigation"
     },
     "waze_search_history": {
         "name": "Waze - Search History",

--- a/scripts/artifacts/webkit.py
+++ b/scripts/artifacts/webkit.py
@@ -13,7 +13,8 @@ __artifacts_v2__ = {
             '*/Library/Caches/WebKit/NetworkCache/Version*/Records/*/Resource/*',
         ),
         "output_types": "standard",
-        "research_mode": False # Set to True to include all fields
+        "research_mode": False,
+        "artifact_icon": "archive" # Set to True to include all fields
     }
 }
 

--- a/scripts/artifacts/whatsApp.py
+++ b/scripts/artifacts/whatsApp.py
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/ContactsV2.sqlite*',
             '*/mobile/Containers/Shared/AppGroup/*/Message/Media/*/*/*/*'),
         'output_types': 'all',
-        'artifact_icon': 'message-square'
+        'artifact_icon': 'message'
     },
     'whatsAppContacts': {
         'name': 'WhatsApp - Contacts',


### PR DESCRIPTION
Follow-up to #1639 (Tabler icons implementation). Moves artifact metadata onto **native Tabler icon names** and gives every icon-less artifact a purpose-matched icon.

## What changed (130 files, +325/−216)
| Change | Count | Notes |
|---|--:|---|
| Feather → Tabler value rewrites | **85** | Each rewritten to the exact name the `feather_to_tabler_icon_names.json` shim already resolves it to — **rendering is pixel-identical**, the metadata just no longer depends on the translation layer |
| Broken icons fixed | **2** | `credit_card` (underscore typo) matched nothing and rendered **alert-triangle** → `credit-card` (Apple Wallet Transactions + Cards) |
| New icons for icon-less artifacts | **113** | These all rendered the **alert-triangle** fallback. Purpose-based picks: Safari→`compass`, Calendar Birthdays→`gift`, Do Not Disturb→`moon`, Telegram→`brand-telegram`, TikTok→`brand-tiktok`, Bash History→`terminal`, Cookies→`cookie`, Web History→`history`, Obliterated Time→`trash`, etc. |
| Duplicate key cleanup | 1 | ZangiChats had a stale `"artifact_icon": ""` alongside the new value |

**Every assigned name verified to exist in `assets/tabler_icons/`** (and none collide with `tabler_icon_correction.json` keys, so no render-time remapping surprises).

## Lint fixes (CI lints every changed file)
Touched files carried pre-existing pylint findings that would fail CI, fixed with zero-behavior edits: underscore-prefixed unused arguments, removed unused imports/variables, inline `# pylint: disable` comments (repo precedent), `file_found` init before loops (gmail), for-`else` de-indent (googleChat), `id` → `item_id` builtin-shadow rename (findMyItems). Line endings preserved on CRLF files.

## ⚠️ One real data bug fixed — `splitwise.py`
The notifications parser built each row with:
```python
if '<strong>' and '</strong>' in record[1]:          # always-truthy constant
    remove_html = record[1].replace('<strong>', '').replace('</strong>', '')
data_list.append((created_ts, remove_html, ...))     # stale value reused
```
A record without `</strong>` **inherited the previous record's notification text** (or crashed on the first record). The strip is now applied per-record unconditionally — output rows always carry their own record's text. Flagging explicitly since this changes (corrects) report output.

## Held back for a follow-up
18 `Ph*` Photos.sqlite files + `BeReal.py` carry heavy pre-existing lint debt (1,400+ `bad-indentation` in Ph70 alone, `undefined-loop-variable` patterns needing real flow analysis). They keep feather names — **still rendered correctly via the shim** — and Ph70's 7 artifacts keep no icon for now. A follow-up can clean those files and finish the migration (32 shim-rendered + 7 icon-less remaining).

## Validation
- `py_compile`: all 130 files clean
- `PYTHONPATH=. pylint --disable=C,R` on all 130 changed files: **10.00/10**
- PluginLoader: 598 artifacts load; final state **559 native Tabler / 32 feather-via-shim (held-back files) / 7 no-icon (Ph70)**; no duplicate names