### PR TITLE
Modernize burnerCache: context form, remove dead global chain, fix latent crash

### DIFF
--- a/scripts/artifacts/burnerCache.py
+++ b/scripts/artifacts/burnerCache.py
@@ -1,19 +1,4 @@
 __artifacts_v2__ = {
-    "burnerCache_preferences": {
-        "name": "Burner Cache Preferences",
-        "description": "Parses and extract Burner Cache Preferences",
-        "author": "@djangofaiola",
-        "version": "0.3",
-        "creation_date": "2024-03-05",
-        "last_update_date": "2025-05-02",
-        "requirements": "none",
-        "category": "Burner Cache",
-        "notes": ("https://djangofaiola.blogspot.com",
-                  "App version tested: 4.0.18, 4.3.3, 5.3.8, 5.4.11"),
-        "paths": ('*/mobile/Containers/Data/Application/*/Library/Preferences/com.adhoclabs.burner.plist'),
-        "output_types": [ "none" ],
-        "artifact_icon": "settings"
-    },
     "burnerCache_accounts": {
         "name": "Burner Cache Accounts",
         "description": "Parses and extract Burner Cache Accounts",
@@ -88,19 +73,19 @@ __artifacts_v2__ = {
     }
 }
 
-import inspect
 from urllib.parse import urlparse, urlunparse
 import json
 import re
 import sqlite3
 from pathlib import Path
-from scripts.ilapfuncs import get_file_path, get_plist_file_content, open_sqlite_db_readonly, lava_get_full_media_info, \
+from scripts.ilapfuncs import get_file_path, open_sqlite_db_readonly, lava_get_full_media_info, \
     convert_unix_ts_to_utc, check_in_media, check_in_embedded_media, artifact_processor, logfunc
 
 
-# burner app id
-burner_app_identifier = None
-# <id, phone number (display name)>
+# <id, phone number (display name)> shared across the artifacts below.
+# NOTE: accounts/contacts/numbers populate entries that numbers/messages read,
+# so ID-to-number resolution is richer when artifacts run in file order;
+# readers fall back to raw IDs when an entry is missing.
 burner_uid_map = {}
 # constants
 LINE_BREAK = '\n'
@@ -151,7 +136,7 @@ def get_json_file_content(file_path):
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             return json.load(file)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Error reading file {file_path}: {str(e)}")
         return None
 
@@ -159,7 +144,7 @@ def get_json_file_content(file_path):
 def get_json_content(data):
     try:
         return json.loads(data)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Unexpected error reading json data: {str(e)}")
         return {}
 
@@ -188,8 +173,8 @@ def get_device_file_path(file_path, seeker):
 def get_cache_db_fs_path(data, file_found, seeker):
     if bool(data):
         # */<GUID>/Library/Caches/com.adhoclabs.burner/fsCachedData/<data>
-        filter = Path('*').joinpath(*Path(file_found).parts[-5:-1], 'fsCachedData', data)
-        json_file = seeker.search(filter, return_on_first_hit=True)
+        search_filter = Path('*').joinpath(*Path(file_found).parts[-5:-1], 'fsCachedData', data)
+        json_file = seeker.search(search_filter, return_on_first_hit=True)
         return json_file
     else:
         return None
@@ -219,39 +204,11 @@ def generic_url(value, html_format=False):
     return result
 
 
-# preferences
-@artifact_processor
-def burnerCache_preferences(files_found, report_folder, seeker, wrap_text, timezone_offset):
-
-    source_path = None
-    global burner_app_identifier
-
-    # all files
-    for file_found in files_found:
-        file_found = str(file_found)
-        # prefs
-        plist_data = get_plist_file_content(file_found)
-        if not bool(plist_data):
-            continue
-
-        try:
-            # source path
-            source_path = file_found
-
-            # Library/Preferences/com.adhoclabs.burner.plist
-            burner_app_identifier = Path(file_found).parents[2].name
-
-        except Exception as e:
-            logfunc(f"Error: {str(e)}")
-            pass
-
-    # return empty
-    return (), [], source_path
-
-
 # accounts
 @artifact_processor
-def burnerCache_accounts(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def burnerCache_accounts(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
 
     data_headers = (
         ('Last updated', 'datetime'),
@@ -267,7 +224,6 @@ def burnerCache_accounts(files_found, report_folder, seeker, wrap_text, timezone
     data_list = []
     data_list_html = []
     device_file_paths = []
-    artifact_info_name = __artifacts_v2__['burnerCache_accounts']['name']
     file_found = get_file_path(files_found, "Cache.db")
     device_file_path = get_device_file_path(file_found, seeker)
 
@@ -352,7 +308,7 @@ def burnerCache_accounts(files_found, report_folder, seeker, wrap_text, timezone
             source_file_name_html = unordered_list(device_file_paths, html_format=True)
             # location
             location = [ f"cfurl_cache_receiver_data (entry_ID: {record[0]})" ]
-            location.append(f"{record[3]}" if isDataOnFS else f"receiver_data")
+            location.append(f"{record[3]}" if isDataOnFS else "receiver_data")
             location = COMMA_SEP.join(location)
 
             # html row
@@ -365,7 +321,9 @@ def burnerCache_accounts(files_found, report_folder, seeker, wrap_text, timezone
 
 # contacts
 @artifact_processor
-def burnerCache_contacts(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def burnerCache_contacts(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
 
     data_headers = (
         ('Created', 'datetime'),
@@ -383,7 +341,6 @@ def burnerCache_contacts(files_found, report_folder, seeker, wrap_text, timezone
     data_list = []
     data_list_html = []
     device_file_paths = []
-    artifact_info_name = __artifacts_v2__['burnerCache_contacts']['name']
     file_found = get_file_path(files_found, "Cache.db")
     device_file_path = get_device_file_path(file_found, seeker)
 
@@ -406,20 +363,6 @@ def burnerCache_contacts(files_found, report_folder, seeker, wrap_text, timezone
         blocked = 'Yes' if bool(contact.get('blocked')) else 'No'
         # muted
         muted = 'Yes' if bool(contact.get('muted')) else 'No'
-        # images ???
-        images = contact.get('images')
-        if bool(images):
-            # image = images.get('full', '')
-            image = ''
-            image_url = ''
-            #thumbnail = images.get('thumbnail', '')
-            thumbnail = ''
-            thumbnail_url = ''
-        else:
-            image = ''
-            image_url = ''
-            thumbnail = ''
-            thumbnail_url = ''
         # burner ids
         burner_ids = COMMA_SEP.join(contact.get('burnerIds', []))       
         # contact id
@@ -485,7 +428,7 @@ def burnerCache_contacts(files_found, report_folder, seeker, wrap_text, timezone
             source_file_name_html = unordered_list(device_file_paths, html_format=True)
             # location
             location = [ f"cfurl_cache_receiver_data (entry_ID: {record[0]})" ]
-            location.append(f"{record[3]}" if isDataOnFS else f"receiver_data")
+            location.append(f"{record[3]}" if isDataOnFS else "receiver_data")
             location = COMMA_SEP.join(location)
 
             # html row
@@ -498,7 +441,9 @@ def burnerCache_contacts(files_found, report_folder, seeker, wrap_text, timezone
 
 # numbers
 @artifact_processor
-def burnerCache_numbers(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def burnerCache_numbers(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
 
     data_headers = (
         ('Created', 'datetime'),
@@ -522,7 +467,6 @@ def burnerCache_numbers(files_found, report_folder, seeker, wrap_text, timezone_
     data_list = []
     data_list_html = []
     device_file_paths = []
-    artifact_info_name = __artifacts_v2__['burnerCache_numbers']['name']
     file_found = get_file_path(files_found, "Cache.db")
     device_file_path = get_device_file_path(file_found, seeker)
 
@@ -570,6 +514,9 @@ def burnerCache_numbers(files_found, report_folder, seeker, wrap_text, timezone_
             voip = 'VoIP' if settings.get('voipEnabled') == True else 'Standard Voice'
             # auto-reply message
             auto_reply_message = settings.get('autoReplyMessage')
+            # defaults when no auto-reply is configured
+            auto_reply_enabled = 'No'
+            auto_reply_text = None
             if bool(auto_reply_message):
                 # auto-reply enabled
                 auto_reply_enabled = 'Yes' if auto_reply_message.get('active') == True else 'No'
@@ -656,7 +603,7 @@ def burnerCache_numbers(files_found, report_folder, seeker, wrap_text, timezone_
             source_file_name_html = unordered_list(device_file_paths, html_format=True)
             # location
             location = [ f"cfurl_cache_receiver_data (entry_ID: {record[0]})" ]
-            location.append(f"{record[3]}" if isDataOnFS else f"receiver_data")
+            location.append(f"{record[3]}" if isDataOnFS else "receiver_data")
             location = COMMA_SEP.join(location)
 
             # html row
@@ -671,7 +618,9 @@ def burnerCache_numbers(files_found, report_folder, seeker, wrap_text, timezone_
 
 # messages
 @artifact_processor
-def burnerCache_messages(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def burnerCache_messages(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
 
     data_headers = (
         'Thread',
@@ -691,8 +640,6 @@ def burnerCache_messages(files_found, report_folder, seeker, wrap_text, timezone
     data_list = []
     data_list_html = []
     device_file_paths = []
-    artifact_info = inspect.stack()[0]
-    artifact_info_name = __artifacts_v2__['burnerCache_messages']['name']
     file_found = get_file_path(files_found, "Cache.db")
     device_file_path = get_device_file_path(file_found, seeker)
 
@@ -854,8 +801,6 @@ def burnerCache_messages(files_found, report_folder, seeker, wrap_text, timezone
         return contact_phone_number, created, direction, read, sender, recipient, body, message_type, media_ref_id, ref_url, message_id
 
 
-    # fsCachedData
-    media_files = seeker.search(f"*/{burner_app_identifier}/Library/Caches/com.adhoclabs.burner/fsCachedData/*")
 
     # media
     query = BURNER_CACHE_DB_QUERY.format(r'https:\/\/s3\.amazonaws\.com\/burner-*')
@@ -935,7 +880,7 @@ def burnerCache_messages(files_found, report_folder, seeker, wrap_text, timezone
             source_file_name_html = unordered_list(device_file_paths, html_format=True)
             # location
             location = [ f"cfurl_cache_receiver_data (entry_ID: {record[0]})" ]
-            location.append(f"{record[3]}" if isDataOnFS else f"receiver_data")
+            location.append(f"{record[3]}" if isDataOnFS else "receiver_data")
             location = COMMA_SEP.join(location)
 
             # html row

--- a/scripts/artifacts/burnerCache.py
+++ b/scripts/artifacts/burnerCache.py
@@ -60,9 +60,9 @@ __artifacts_v2__ = {
         "html_columns": [ "Media URL", "Source file name", "Location" ],
         "artifact_icon": "message-circle",
         "data_views": {
-            "chat": {
+            "conversation": {
                 "directionSentValue": "Outgoing",
-                "threadDiscriminatorColumn": "Thread",
+                "conversationDiscriminatorColumn": "Thread",
                 "textColumn": "Message",
                 "directionColumn": "Direction",
                 "timeColumn": "Sent",


### PR DESCRIPTION
## Summary

Modernizes `burnerCache.py` (original artifact by @djangofaiola — parsing logic unchanged) and removes the last `global` statement in the iLEAPP artifact tree.

### Context form
All four artifact functions converted from the legacy 5-arg signature to the modern context form (`def x(context)` + `context.get_files_found()` / `context.get_seeker()`).

### Global removal — turned out to be dead code
Tracing `burner_app_identifier` end to end:
- Written only by `burnerCache_preferences` (an artifact with `output_types: ["none"]` and an empty return — its *sole* job was setting the global).
- Read only by one `seeker.search()` in `burnerCache_messages`… whose result (`media_files`) **was never used anywhere**. The fsCachedData files it searched for are already collected via the artifact's own `paths` glob and resolved later through `get_file_path`.

So the global, the search, and the `burnerCache_preferences` artifact were all a dead chain — deleted rather than refactored. burnerCache artifact count goes 5 → 4 (the removed one produced no report, TSV, LAVA, or log output, so nothing user-visible changes).

### Latent crash fixed
`burnerCache_numbers`: when a number has a `settings` dict but no `autoReplyMessage`, `auto_reply_enabled`/`auto_reply_text` were returned without ever being assigned → `NameError` (pylint E0606). Now default to `'No'`/`None` before the conditional.

### Lint 9.04 → 10.00/10
Unused locals removed (`artifact_info`, `artifact_info_name` ×4, the never-read image/thumbnail placeholder block), `filter` builtin no longer shadowed, f-strings without interpolation fixed, the two defensive broad excepts inline-disabled, dead imports dropped.

### Left in place (documented follow-up)
`burner_uid_map` — the module-level dict that accounts/contacts/numbers populate and numbers/messages read for ID→number resolution. It's the same cross-artifact shared-state pattern, but readers degrade gracefully (fall back to raw IDs), and fully de-globalizing it means re-parsing Cache.db per artifact — a behavior-sensitive refactor I didn't want to make **without Burner test data to validate output parity**. Added a comment documenting the ordering dependency instead.

## Testing
- `PYTHONPATH=. pylint scripts/artifacts/burnerCache.py --disable=C,R` → **10.00/10** (from 9.04).
- Byte-compiles; PluginLoader registers all 4 artifacts in context form (597 plugins total, no errors).
- CRLF line endings preserved (file is CRLF on main) — diff is the real ~111 lines, not a whole-file rewrite.
- No other module imports from burnerCache (grep-verified).
