### PR TITLE
Migrate last legacy 'chat' data_views to 'conversation'

### DIFF
--- a/scripts/artifacts/facebookMessenger.py
+++ b/scripts/artifacts/facebookMessenger.py
@@ -25,8 +25,8 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "message-circle",
         "data_views": {
-            "chat": {
-                "threadDiscriminatorColumn": "Thread ID",
+            "conversation": {
+                "conversationDiscriminatorColumn": "Thread ID",
                 "textColumn": "Message",
                 "directionColumn": "Message Direction",
                 "directionSentValue": "Sent",
@@ -51,8 +51,8 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "message-circle",
         "data_views": {
-            "chat": {
-                "threadDiscriminatorColumn": "Thread ID",
+            "conversation": {
+                "conversationDiscriminatorColumn": "Thread ID",
                 "textColumn": "Message",
                 "directionColumn": "Message Direction",
                 "directionSentValue": "Sent",

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -11,9 +11,9 @@ __artifacts_v2__ = {
         "paths": ('*/Documents/user_accounts/*/dynamite.db*',),
         "output_types": "all",  # or ["html", "tsv", "timeline", "lava"]
         "data_views": {
-            "chat": {
+            "conversation": {
                 "directionSentValue": 1,
-                "threadDiscriminatorColumn": "Conversation Name",
+                "conversationDiscriminatorColumn": "Conversation Name",
                 "textColumn": "Message",
                 "directionColumn": "Is Sent",
                 "timeColumn": "Timestamp",
@@ -302,7 +302,7 @@ def get_googleChat(files_found, report_folder, seeker, _wrap_text, timezone_offs
                     if check == b'\xfe\xff\x00':
                         mediafilename = ''
                     else:
-                        protostuff, types = blackboxprotobuf.decode_message(protobufmedia)
+                        protostuff, _ = blackboxprotobuf.decode_message(protobufmedia)
                         aggregator = []
                         if isinstance(protostuff['1'], list):
                             nested_whatever=list(fla_tu(protostuff['1']))
@@ -324,7 +324,6 @@ def get_googleChat(files_found, report_folder, seeker, _wrap_text, timezone_offs
                                     thumb = media_to_html(attachment, (attachment,), report_folder)
                             else:
                                 mediafilename = ''
-                                media = ''
                     timestamp = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
 
                     data_list.append((timestamp, row[1], row[2], row[3], row[4], row[7], mediafilename, thumb, reaction, reactionuser, account_id))


### PR DESCRIPTION
Converts the final two modules still declaring the legacy `chat` data_view (`googleChat.py`, and both artifacts in `facebookMessenger.py`) to the current `conversation` form (`threadDiscriminatorColumn` → `conversationDiscriminatorColumn`). Column mappings unchanged.

With this, **every data_view in iLEAPP is on `conversation`** (verified via PluginLoader dump — 18 artifacts, zero `chat` remaining), so the backward-compat shim in `lavafuncs.py` ("Remove 'chat' once modules are updated") no longer has in-repo users and can be retired in a future framework pass.

Also clears googleChat's two pre-existing unused-variable warnings (whole-file CI lint): `types` from the blackboxprotobuf decode → `_`, and a dead `media = ''` assignment.

Testing: pylint `--disable=C,R` → 10.00/10 on both files; byte-compile clean; PluginLoader registers all artifacts with the converted views.