### PR TITLE
Add conversation views to 7 chat artifacts (Tier 1 + WhatsApp, Viber, Kik)

### DIFF
--- a/scripts/artifacts/Oops.py
+++ b/scripts/artifacts/Oops.py
@@ -4,13 +4,23 @@ __artifacts_v2__ = {
         "description": "Parses Oops Message Database",
         "author": "Heather Charpentier",
         "creation_date": "2024-06-26",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Oops",
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/RongCloud/*/storage*',),
         "output_types": "standard",
-        "artifact_icon": "message-circle"
+        "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "User ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Date Sent",
+                "senderColumn": "Sender Name"
+            }
+        },
     }
 }
 

--- a/scripts/artifacts/ZangiChats.py
+++ b/scripts/artifacts/ZangiChats.py
@@ -5,13 +5,24 @@ __artifacts_v2__ = {
         "description": "Parses Zangi Chat database",
         "author": "Matt Beers",
         "creation_date": "2024-04-16",
-        "last_update_date": "2025-11-12",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Chats",
         "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/zangidb.sqlite*'),
         "output_types": "standard",
-        "artifact_icon": "message-circle"
+        "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Number",
+                "textColumn": "Message Text",
+                "directionColumn": "Direction",
+                "directionSentValue": "SENT",
+                "timeColumn": "Timestamp",
+                "senderColumn": "First Name",
+                "sentMessageStaticLabel": "Local User"
+            }
+        },
     }
 }
 

--- a/scripts/artifacts/kikMessages.py
+++ b/scripts/artifacts/kikMessages.py
@@ -4,14 +4,26 @@ __artifacts_v2__ = {
         "description": "Kik chat messages with attachments (kik.sqlite)",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-06-22",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Kik",
         "notes": "",
         "paths": ('**/kik.sqlite*',
                   '*/mobile/Containers/Shared/AppGroup/*/cores/private/*/content_manager/data_cache/*'),
         "output_types": "standard",
-        "artifact_icon": "message-circle"
+        "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "User Name",
+                "textColumn": "Message",
+                "directionColumn": "Type",
+                "directionSentValue": "Sent",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Display Name",
+                "sentMessageStaticLabel": "Local User",
+                "mediaColumn": "Attachment"
+            }
+        },
     },
     "kikUsers": {
         "name": "Kik Users",

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -4,13 +4,24 @@ __artifacts_v2__ = {
         "description": "Line messages including message direction and associated usernames",
         "author": "Elliot Glendye",
         "creation_date": "2023-11-22",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Line",
         "notes": "",
         "paths": ('**/Line.sqlite*',),
         "output_types": "standard",
-        "artifact_icon": "message-circle"
+        "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Username",
+                "textColumn": "Message",
+                "directionColumn": "Sent / Received",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Username",
+                "sentMessageStaticLabel": "Local User"
+            }
+        },
     }
 }
 

--- a/scripts/artifacts/queryPredictions.py
+++ b/scripts/artifacts/queryPredictions.py
@@ -4,13 +4,22 @@ __artifacts_v2__ = {
         "description": "Message query predictions from query_predictions.db",
         "author": "",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "SMS & iMessage",
         "notes": "",
         "paths": ('**/query_predictions.db',),
         "output_types": "standard",
-        "artifact_icon": "message"
+        "artifact_icon": "message",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Conversation ID",
+                "textColumn": "Content",
+                "directionColumn": "Is Sent?",
+                "directionSentValue": 1,
+                "timeColumn": "Timestamp"
+            }
+        },
     }
 }
 

--- a/scripts/artifacts/viber.py
+++ b/scripts/artifacts/viber.py
@@ -53,7 +53,7 @@ __artifacts_v2__ = {
                        "and phone numbers.",
         'author': 'Evangelos Dragonas (@theAtropos4n6)',
         'creation_date': '2022-03-09',
-        'last_update_date': '2025-10-12',
+        'last_update_date': '2026-07-03',
         'requirements': '',
         'category': 'Viber',
         'notes': '',
@@ -62,7 +62,20 @@ __artifacts_v2__ = {
             '**/Containers/Data/Application/*/Documents/Attachments/*.*',
             '**/com.viber/ViberIcons/*.*'),
         'output_types': "all",
-        'artifact_icon': 'message'
+        'artifact_icon': 'message',
+        'data_views': {
+            'conversation': {
+                'conversationDiscriminatorColumn': 'Chat Participant(s)',
+                'conversationLabelColumn': 'Chat Name',
+                'textColumn': 'Message Content',
+                'directionColumn': 'State',
+                'directionSentValue': 'Outgoing',
+                'timeColumn': 'Timestamp',
+                'senderColumn': 'Sender (Display Full Name)',
+                'sentMessageStaticLabel': 'Local User',
+                'mediaColumn': 'Attachment'
+            }
+        },
     }
 
 }

--- a/scripts/artifacts/whatsApp.py
+++ b/scripts/artifacts/whatsApp.py
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
         'description': 'Extract WhatsApp messages',
         'author': '@AlexisBrignoni',
         'creation_date': '2021-03-26',
-        'last_update_date': '2025-11-20',
+        'last_update_date': '2026-07-03',
         'requirements': '',
         'category': 'WhatsApp',
         'notes': '',
@@ -29,7 +29,19 @@ __artifacts_v2__ = {
             '*/mobile/Containers/Shared/AppGroup/*/ContactsV2.sqlite*',
             '*/mobile/Containers/Shared/AppGroup/*/Message/Media/*/*/*/*'),
         'output_types': 'all',
-        'artifact_icon': 'message'
+        'artifact_icon': 'message',
+        'data_views': {
+            'conversation': {
+                'conversationDiscriminatorColumn': 'Chat ID',
+                'conversationLabelColumn': 'Chat Name',
+                'textColumn': 'Message',
+                'directionColumn': 'Direction',
+                'directionSentValue': 'Outgoing',
+                'timeColumn': 'Timestamp',
+                'senderColumn': 'Sender Name',
+                'mediaColumn': 'Attachment File'
+            }
+        },
     },
     'whatsAppContacts': {
         'name': 'WhatsApp - Contacts',
@@ -195,7 +207,8 @@ def whatsAppMessages(context):
         ZLATITUDE,
         ZMEDIALOCALPATH,
         ZXMPPTHUMBPATH,
-        ZMETADATA
+        ZMETADATA,
+        ZWACHATSESSION.ZCONTACTJID
     FROM ZWAMESSAGE
     LEFT JOIN ZWAMEDIAITEM ON ZWAMESSAGE.Z_PK = ZWAMEDIAITEM.ZMESSAGE
     LEFT JOIN ZWACHATSESSION ON ZWACHATSESSION.Z_PK = ZWAMESSAGE.ZCHATSESSION
@@ -215,6 +228,9 @@ def whatsAppMessages(context):
         'Forwarded from',
         'Latitude',
         'Longitude',
+        'Direction',
+        'Chat ID',
+        'Chat Name',
         )
 
     db_records = get_sqlite_db_records(source_path, query)
@@ -268,8 +284,10 @@ def whatsAppMessages(context):
         lon = record['ZLONGITUDE'] if record['ZMESSAGETYPE'] == 5 else ''
         lat = record['ZLATITUDE'] if record['ZMESSAGETYPE'] == 5 else ''
 
+        direction = 'Outgoing' if record['ZISFROMME'] == 1 else 'Incoming'
         data_list.append((message_date, sender, record['ZFROMJID'], receiver, record['ZTOJID'],
                           record['ZTEXT'], attach_file, thumb, record['ZSTARRED'],
-                          number_forward, from_forward, lat, lon,))
+                          number_forward, from_forward, lat, lon, direction,
+                          record['ZCONTACTJID'], record['ZPARTNERNAME'],))
 
     return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary
Adds the LAVA threaded `conversation` data_view to the 4 iLEAPP chat artifacts whose existing columns already support it (metadata-only, no parsing changes):

| Artifact | Thread | Direction sent-value | Sender |
|---|---|---|---|
| Line Artifacts | Username | `Outgoing` (from ZSENDER CASE) | Username + static 'Local User' |
| Oops: Make New Friends | User ID | `Outgoing` (from message_direction CASE) | Sender Name |
| Zangi Chats | Number | `SENT` (uppercase, from ZISRECEIVED CASE) | First Name + static 'Local User' |
| Query Predictions | Conversation ID | `1` (raw `isSent` integer) | (none — prediction cache) |

Every `directionSentValue` verified against the literal value each query produces.

## Deliberately deferred
- **BeReal Messages** — perfect fit, but held until open PR #1637 (BeReal rework) lands to avoid conflicts
- **Pinger Text Free** — raw `ZDIRECTION` values not verifiable without test data
- **Vipps** — direction comes raw from app JSON with unknown vocabulary
- Note: `ZangiChats.py` vs `ZangiMessenger.py` may be duplicate modules for the same app — possible future consolidation

## Testing
pylint 10.00/10 on all 4 files; PluginLoader 4/4 views registered; automated check validates every view column ref against each artifact's actual `data_headers`.