### PR TITLE
Fix packaged builds: bundle leapp_functions & assets, resolve report assets when frozen

### DIFF
--- a/scripts/pyinstaller/ileapp.spec
+++ b/scripts/pyinstaller/ileapp.spec
@@ -3,10 +3,11 @@
 block_cipher = None
 
 a = Analysis(['..\\..\\ileapp.py'],
-             pathex=['..\\scripts\\artifacts'],
+             pathex=['..\\scripts\\artifacts', '..\\..'],
              binaries=[],
-             datas=[('..\\', '.\\scripts')],
+             datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets'), ('..\\..\\leapp_functions', '.\\leapp_functions')],
              hiddenimports=[
+        'leapp_functions.parsers.apple_atx',
                 'astc_decomp_faster',
                 'bencoding',
                 'blackboxprotobuf',
@@ -25,7 +26,7 @@ a = Analysis(['..\\..\\ileapp.py'],
                 ],
              hookspath=['./'],
              runtime_hooks=[],
-             excludes=[],
+             excludes=['scipy', 'matplotlib', 'pyarrow'],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
              cipher=block_cipher,

--- a/scripts/pyinstaller/ileappGUI.spec
+++ b/scripts/pyinstaller/ileappGUI.spec
@@ -3,10 +3,11 @@
 block_cipher = None
 
 a = Analysis(['..\\..\\ileappGUI.py'],
-             pathex=['..\\scripts\\artifacts'],
+             pathex=['..\\scripts\\artifacts', '..\\..'],
              binaries=[],
-             datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets')],
+             datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets'), ('..\\..\\leapp_functions', '.\\leapp_functions')],
              hiddenimports=[
+        'leapp_functions.parsers.apple_atx',
                 'astc_decomp_faster',
                 'bencoding',
                 'blackboxprotobuf',
@@ -24,7 +25,7 @@ a = Analysis(['..\\..\\ileappGUI.py'],
                 'xml.etree.ElementTree',
                 ],
              runtime_hooks=[],
-             excludes=[],
+             excludes=['scipy', 'matplotlib', 'pyarrow'],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
              cipher=block_cipher,

--- a/scripts/pyinstaller/ileappGUI_Linux.spec
+++ b/scripts/pyinstaller/ileappGUI_Linux.spec
@@ -3,10 +3,11 @@
 
 a = Analysis(
     ['../../ileappGUI.py'],
-    pathex=['../scripts/artifacts'],
+    pathex=['../scripts/artifacts', '../..'],
     binaries=[],
-    datas=[('../', 'scripts'), ('../../assets', 'assets')],
+    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')],
     hiddenimports=[
+        'leapp_functions.parsers.apple_atx',
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
@@ -27,7 +28,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=['scipy', 'matplotlib', 'pyarrow'],
     noarchive=False,
 )
 pyz = PYZ(a.pure)

--- a/scripts/pyinstaller/ileappGUI_macOS.spec
+++ b/scripts/pyinstaller/ileappGUI_macOS.spec
@@ -3,10 +3,11 @@
 
 a = Analysis(
     ['../../ileappGUI.py'],
-    pathex=['../scripts/artifacts'],
+    pathex=['../scripts/artifacts', '../..'],
     binaries=[],
-    datas=[('../', 'scripts'), ('../../assets', 'assets')],
+    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')],
     hiddenimports=[
+        'leapp_functions.parsers.apple_atx',
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
@@ -26,7 +27,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=['scipy', 'matplotlib', 'pyarrow'],
     noarchive=False,
 )
 pyz = PYZ(a.pure)

--- a/scripts/pyinstaller/ileapp_Linux.spec
+++ b/scripts/pyinstaller/ileapp_Linux.spec
@@ -3,10 +3,11 @@
 
 a = Analysis(
     ['../../ileapp.py'],
-    pathex=['../scripts/artifacts'],
+    pathex=['../scripts/artifacts', '../..'],
     binaries=[],
-    datas=[('../', 'scripts')],
+    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')],
     hiddenimports=[
+        'leapp_functions.parsers.apple_atx',
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
@@ -26,7 +27,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=['scipy', 'matplotlib', 'pyarrow'],
     noarchive=False,
 )
 pyz = PYZ(a.pure)

--- a/scripts/pyinstaller/ileapp_macOS.spec
+++ b/scripts/pyinstaller/ileapp_macOS.spec
@@ -3,10 +3,11 @@
 
 a = Analysis(
     ['../../ileapp.py'],
-    pathex=['../scripts/artifacts'],
+    pathex=['../scripts/artifacts', '../..'],
     binaries=[],
-    datas=[('../', 'scripts')],
+    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')],
     hiddenimports=[
+        'leapp_functions.parsers.apple_atx',
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
@@ -26,7 +27,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=['scipy', 'matplotlib', 'pyarrow'],
     noarchive=False,
 )
 pyz = PYZ(a.pure)

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -5,8 +5,17 @@ sidebar navigation, and the index summary page with case information and credits
 
 import html
 import os
+import sys
 from pathlib import Path
 import shutil
+
+
+def _base_dir():
+    """Directory holding bundled data (assets/, scripts/data/). In a PyInstaller
+    build this is sys._MEIPASS; running from source it is the cwd (repo root).
+    Resolving from here (not Path.cwd()) lets a packaged binary find its assets
+    no matter which directory it is launched from."""
+    return Path(getattr(sys, "_MEIPASS", Path.cwd()))
 
 from collections import OrderedDict
 from scripts.html_parts import nav_bar_script, nav_bar_script_footer, \
@@ -23,7 +32,7 @@ from leapp_functions.data_sources.json_files import get_json_file_content
 
 def get_tabler_icon_names():
     """Returns a set of available tabler icon names by scanning the tabler_icons directory."""
-    for _, dirs, files in Path.cwd().joinpath("assets/tabler_icons").walk():
+    for _, dirs, files in _base_dir().joinpath("assets/tabler_icons").walk():
         if '__pycache__' in dirs:
             dirs.remove('__pycache__')
         return set(file.replace('.svg', '') for file in files if file.endswith('.svg'))
@@ -31,7 +40,7 @@ def get_tabler_icon_names():
 
 def get_tabler_icon(icon_name):
     """Return the SVG contents for a Tabler icon by name."""
-    return get_txt_file_content(Path.cwd().joinpath("assets/tabler_icons", f"{icon_name}.svg"))
+    return get_txt_file_content(_base_dir().joinpath("assets/tabler_icons", f"{icon_name}.svg"))
 
 
 def generate_report(reportfolderbase, time_in_secs, time_hms, extraction_type, image_input_path,
@@ -42,8 +51,8 @@ def generate_report(reportfolderbase, time_in_secs, time_hms, extraction_type, i
     """
 
     tabler_icon_names = get_tabler_icon_names()
-    tabler_icon_correction = get_json_file_content('scripts/data/tabler_icon_correction.json')
-    feather_to_tabler_icon_names = get_json_file_content('scripts/data/feather_to_tabler_icon_names.json')
+    tabler_icon_correction = get_json_file_content(str(_base_dir() / 'scripts/data/tabler_icon_correction.json'))
+    feather_to_tabler_icon_names = get_json_file_content(str(_base_dir() / 'scripts/data/feather_to_tabler_icon_names.json'))
 
     control = None
     side_heading = \


### PR DESCRIPTION
## Problem

Building the CLI from `scripts/pyinstaller/ileapp_macOS.spec` on current `main` produces a **broken binary**. Two independent bugs, plus a size issue:

### 1. `leapp_functions` is not bundled → plugin loader crashes on startup
`scripts/artifacts/apple_atx_images.py` does:
```python
from leapp_functions.parsers.apple_atx import decode_atx_file
```
Artifacts are loaded **dynamically** (`plugin_loader.py`), so PyInstaller's static analysis never sees `leapp_functions` and doesn't bundle it. Running the packaged binary:
```
ModuleNotFoundError: No module named 'leapp_functions.parsers'
[ileapp] Failed to execute script 'ileapp' due to unhandled exception!
```
This aborts the whole run (the loader imports every artifact at startup).

### 2. Report assets are resolved from `Path.cwd()` → no icons in a packaged binary
`scripts/report.py` loads its Tabler icons and correction JSON with paths relative to the current working directory:
```python
Path.cwd().joinpath("assets/tabler_icons")
get_json_file_content('scripts/data/tabler_icon_correction.json')
```
That only works when iLEAPP is launched from the repo root. A packaged binary run from anywhere else logs:
```
Error: JSON file 'scripts/data/tabler_icon_correction.json' not found.
Error: File '.../assets/tabler_icons/home.svg' not found.
```
and generates a report with missing icons. The three CLI specs also never bundled `assets/` at all (the GUI specs already do).

### 3. Size — unused heavy libs bundled
`scipy`, `matplotlib`, and `pyarrow` are imported by **zero** iLEAPP files (they come in transitively via `pandas`). They add a lot to the binary for nothing.

## Fix

- **`scripts/report.py`** — resolve `assets/` and `scripts/data/` from `sys._MEIPASS` when frozen, falling back to `cwd` from source (no behavior change when run from source). New `_base_dir()` helper.
- **All six specs** (`ileapp[_macOS/_Linux].spec`, `ileappGUI[_macOS/_Linux].spec`) — add `leapp_functions` to `datas` + a hidden import for `leapp_functions.parsers.apple_atx`, and put the repo root on `pathex` so analysis can find it.
- **CLI specs** — also bundle `assets/` (the GUI specs already did).
- **All six specs** — add `scipy`, `matplotlib`, `pyarrow` to `excludes`.

## Testing

Built the macOS CLI (`ileapp_macOS.spec`) and verified end-to-end:
- Loads all 295 artifacts, including `apple_atx_images`, with **no import error**.
- Full parse of a test extraction **from an unrelated working directory**: report generates with Tabler icons rendered and **no missing-asset errors**.

The other five specs received the analogous change but were not built in this environment (no Windows/Linux here). They share the identical gaps, so the same fix applies.