### PR TITLE
Class 2: derived directions + conversation views for Slack, Life360, TikTok

### DIFF
--- a/scripts/artifacts/life360.py
+++ b/scripts/artifacts/life360.py
@@ -30,13 +30,23 @@ __artifacts_v2__ = {
         "description": "Parses Life360 chat messages",
         "author": "@KevinPagano3",
         "creation_date": "2024-01-15",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Life360",
         "notes": "",
         "paths": ('*/Library/Application Support/Messaging.sqlite*',),
         "output_types": "all",
-        "artifact_icon": "message-circle"
+        "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Thread ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Sender First Name"
+            }
+        },
     },
     "life360Members": {
         "name": "Life360 - Members",
@@ -135,7 +145,7 @@ def life360DeviceBattery(context):
 def life360ChatMessages(context):
     data_headers = (('Timestamp', 'datetime'), 'Message ID', 'Sender First Name', 'Sender Last Name',
                     'Message', 'Sent Status', 'Message Seen', 'Message Deleted', 'Message Liked',
-                    'Action', 'Location Name', 'Latitude', 'Longitude')
+                    'Action', 'Location Name', 'Latitude', 'Longitude', 'Direction', 'Thread ID')
     data_list = []
     source_path = _find_db(context)
     if not source_path:
@@ -155,7 +165,9 @@ def life360ChatMessages(context):
         ZCHATMESSAGE.ZACTION,
         ZCHATMESSAGELOCATION.ZNAME,
         ZCHATMESSAGELOCATION.ZLATITUDE,
-        ZCHATMESSAGELOCATION.ZLONGITUDE
+        ZCHATMESSAGELOCATION.ZLONGITUDE,
+        CASE ZCHATMEMBER.ZISLOGGEDINUSER WHEN 1 THEN 'Outgoing' ELSE 'Incoming' END,
+        ZCHATMESSAGE.ZTHREAD
     FROM ZCHATMESSAGE
     LEFT JOIN ZCHATMEMBER ON ZCHATMEMBER.Z_PK = ZCHATMESSAGE.ZSENDER
     LEFT JOIN ZCHATMESSAGELOCATION ON ZCHATMESSAGELOCATION.ZMESSAGE = ZCHATMESSAGE.Z_PK

--- a/scripts/artifacts/slack.py
+++ b/scripts/artifacts/slack.py
@@ -2,10 +2,21 @@ __artifacts_v2__ = {
     "slackModelMessages": {
         "name": "Slack - Messages (ModelDatabase)",
         "description": "Slack chat messages from the newer ModelDatabase (ZCOREDATA*) schema",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-03", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
-        "output_types": "standard", "artifact_icon": "message-circle"
+        "output_types": "standard", "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Conversation ID",
+                "conversationLabelColumn": "Channel Name",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Sent",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Sender Name"
+            }
+        },
     },
     "slackModelUsers": {
         "name": "Slack - User Data (ModelDatabase)",
@@ -99,7 +110,7 @@ def _slack_prefix(db_path):
 @artifact_processor
 def slackModelMessages(context):
     data_headers = (('Timestamp', 'datetime'), 'Sender ID', 'Sender Name', 'Channel Name',
-                    'Message', 'Conversation ID', 'Group ID')
+                    'Message', 'Conversation ID', 'Group ID', 'Direction')
     data_list = []
     db_path = _find_model_db(context)
     if not db_path:
@@ -113,7 +124,8 @@ def slackModelMessages(context):
         ZCOREDATACONVERSATION.ZNAME,
         ZCOREDATAMESSAGE.ZTEXT,
         ZCOREDATAMESSAGE.ZCONVERSATIONID,
-        ZCOREDATACONVERSATION.ZCONTEXTTEAMID
+        ZCOREDATACONVERSATION.ZCONTEXTTEAMID,
+        CASE ZCOREDATAUSER.ZISME WHEN 1 THEN 'Sent' ELSE 'Received' END
     FROM ZCOREDATAMESSAGE
     LEFT OUTER JOIN ZCOREDATAUSER ON ZCOREDATAMESSAGE.ZUSERID = ZCOREDATAUSER.ZTSID
     LEFT OUTER JOIN ZCOREDATACONVERSATION ON ZCOREDATAMESSAGE.ZCONVERSATIONID = ZCOREDATACONVERSATION.ZTSID

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Extracts TikTok message data from the ChatFiles databases",
         "author": "James Habben, John Hyla",
         "creation_date": "2024-11-08",
-        "last_update_date": "2026-06-18",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "TikTok",
         "notes": (
@@ -18,6 +18,16 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Conversation ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Nickname"
+            }
+        },
         "sample_data": {
             "josh_ios_15": (
                 "32 message rows; AwemeContactsV5, TIMMessageORM, TIMMessageKVORM, "
@@ -255,7 +265,8 @@ def tiktok_messages(context):
                 END AS links_gifs_urls,
                 servercreatedat,
                 url1,
-                source_table
+                source_table,
+                belongingConversationIdentifier
             FROM TIMMessageORM
             LEFT JOIN DeduplicatedContacts ON DeduplicatedContacts.uid = sender
             ORDER BY localcreatedat
@@ -278,6 +289,8 @@ def tiktok_messages(context):
                 record[10],
                 account_id,
                 source_file,
+                record[11],
+                'Outgoing' if str(record[1]) == str(account_id) else 'Incoming',
             ))
 
     data_headers = (
@@ -294,6 +307,8 @@ def tiktok_messages(context):
         "Contact Table",
         "Account ID",
         "Source File",
+        "Conversation ID",
+        "Direction",
     )
 
     return data_headers, data_list, "see Source File column"


### PR DESCRIPTION
## Summary
Adds evidence-derived **Direction** columns and LAVA conversation views to three artifacts whose databases record the account owner. Every derivation was **validated against real test extractions** (11-image validation set) before implementation.

| Artifact | Direction source | Thread added | Validation result |
|---|---|---|---|
| Slack (ModelDatabase) | `ZCOREDATAUSER.ZISME` — join already present | (Conversation ID existed) | 61 msgs: 28 Sent, all from the ZISME user; 33 Received |
| Life360 Chat | `ZCHATMEMBER.ZISLOGGEDINUSER` — join already present | `ZTHREAD` → Thread ID | **Cross-device proof:** same CTF conversation on two phones — owner's device shows Outgoing, counterpart's device shows those messages Incoming |
| TikTok Messages | `sender == account id` (account already derived from the `ChatFiles/<account>/` path) | `belongingConversationIdentifier` → Conversation ID | 44 msgs: 25/19 split across 17 conversations |

## Notes
- **Life360's existing `Sent Status` column is delivery state, not direction** — it reads 'Sent' on *incoming* messages (verified in CTF data). It's retained as-is; the new Direction column is the direction truth.
- All new columns appended at the end; existing column order unchanged.
- No external/analyst input used — every derivation comes from data inside the evidence.

## Testing
pylint 10.00/10 (3 files); byte-compile; PluginLoader 3/3 views registered; view column refs validated against data_headers; the exact new SQL executed read-only against the real copied databases from the validation runs with the splits shown above.