### PR TITLE
Class 2 batch 2: derived directions + conversation views for Discord, Teleguard, Reddit

### DIFF
--- a/scripts/artifacts/discord_a.py
+++ b/scripts/artifacts/discord_a.py
@@ -4,75 +4,115 @@ __artifacts_v2__ = {
         "description": "Parses Discord chats from \"a\" database",
         "author": "@stark4n6",
         "creation_date": "2025-03-31",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Discord",
-        "notes": "",
+        "notes": "Direction is derived by comparing the message sender id to the "
+                 "account id in the kv-storage/@account.<id>/ path.",
         "paths": ('*/Library/Caches/kv-storage/@account*/a*'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
         "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Channel ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Message Timestamp",
+                "senderColumn": "Sender Username"
+            }
+        },
     }
 }
 
 import os
+import re
 import json
 
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+_ACCOUNT_ID_RE = re.compile(r'@account\.(\d+)')
+
 
 @artifact_processor
-def DiscordChatsA(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, "a")
+def DiscordChatsA(context):
     data_list = []
-    
+    source_paths = []
+
     query = '''select data from messages0'''
 
-    data_headers = (('Message Timestamp', 'datetime'), ('Edited Timestamp', 'datetime'),'Sender Username','Sender Global Name','Sender ID','Message','Attachment(s)','Message Type','Call Ended','Message ID','Channel ID',)
+    data_headers = (('Message Timestamp', 'datetime'), ('Edited Timestamp', 'datetime'),
+                    'Sender Username', 'Sender Global Name', 'Sender ID', 'Message',
+                    'Attachment(s)', 'Message Type', 'Call Ended', 'Message ID', 'Channel ID',
+                    'Account ID', 'Direction',)
 
-    db_records = get_sqlite_db_records(source_path, query)
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'a':
+            continue
+        source_paths.append(context.get_relative_path(file_found))
 
-    for record in db_records:
-        attach_name = message_type = call_end = sender_id = ''
-        blob_data = record[0]
-        if len(blob_data) > 1:
-            blob_data = blob_data[1:]
-            json_load = json.loads(blob_data)
-            
-            blob_id = json_load.get('id','')
-            channel_id = json_load.get('channelId','')
-            
+        # local account id is part of the kv-storage path
+        account_match = _ACCOUNT_ID_RE.search(file_found)
+        account_id = account_match.group(1) if account_match else ''
+
+        db_records = get_sqlite_db_records(file_found, query)
+
+        for record in db_records:
+            message_ts = edited_ts = auth_username = global_username = ''
+            attach_name = message_type = call_end = sender_id = message = ''
+            blob_id = channel_id = ''
+            blob_data = record[0]
+            if len(blob_data) <= 1:
+                continue
+            try:
+                json_load = json.loads(blob_data[1:])
+            except (json.JSONDecodeError, TypeError, ValueError, UnicodeDecodeError):
+                continue
+
+            blob_id = json_load.get('id', '')
+            channel_id = json_load.get('channelId', '')
+
             if 'message' in json_load:
-                message_ts = str(json_load['message'].get('timestamp','')).replace('T',' ')
-                edited_ts = str(json_load['message'].get('edited_timestamp','')).replace('T',' ')
+                message_ts = str(json_load['message'].get('timestamp', '')).replace('T', ' ')
+                edited_ts = str(json_load['message'].get('edited_timestamp', '')).replace('T', ' ')
                 if edited_ts == 'None':
                     edited_ts = ''
-                if json_load['message'].get('type','') == 0:
+                if json_load['message'].get('type', '') == 0:
                     message_type = 'Message'
-                elif json_load['message'].get('type','') == 3:
+                elif json_load['message'].get('type', '') == 3:
                     message_type = 'Call'
-                    call_end = str(json_load['message']['call'].get('ended_timestamp','')).replace('T',' ')
-                    
-                elif json_load['message'].get('type','') == 7:
+                    call_end = str(json_load['message']['call'].get('ended_timestamp', '')).replace('T', ' ')
+                elif json_load['message'].get('type', '') == 7:
                     message_type = 'User Joined'
-                elif json_load['message'].get('type','') == 19:
-                    message_type = 'Reply'    
+                elif json_load['message'].get('type', '') == 19:
+                    message_type = 'Reply'
                 else:
-                    message_type = json_load['message'].get('type','')
-                message = json_load['message'].get('content','')
-                
+                    message_type = json_load['message'].get('type', '')
+                message = json_load['message'].get('content', '')
+
                 if 'author' in json_load['message']:
-                    auth_username = json_load['message']['author'].get('username','')
-                    global_username = json_load['message']['author'].get('globalName','')
-                    sender_id = json_load['message']['author'].get('id','')
-                    
+                    auth_username = json_load['message']['author'].get('username', '')
+                    global_username = json_load['message']['author'].get('globalName', '')
+                    sender_id = json_load['message']['author'].get('id', '')
+
                 if 'attachments' in json_load['message'] and len(json_load['message']['attachments']) > 0:
                     attachment_list = []
                     for x in json_load['message']['attachments']:
-                        attachment_name = x.get('filename','')
-                        attachment_url = x.get('url','')
+                        attachment_name = x.get('filename', '')
+                        attachment_url = x.get('url', '')
 
                         attachment_list.append(f"{attachment_name} ({attachment_url})")
-                        
+
                     attach_name = "<br>".join(attachment_list)
-            
-        data_list.append((message_ts,edited_ts,auth_username,global_username,sender_id,message,attach_name,message_type,call_end,blob_id,channel_id))
-        
-    return data_headers, data_list, source_path
+
+            if account_id and sender_id:
+                direction = 'Outgoing' if str(sender_id) == account_id else 'Incoming'
+            else:
+                direction = ''
+
+            data_list.append((message_ts, edited_ts, auth_username, global_username, sender_id,
+                              message, attach_name, message_type, call_end, blob_id, channel_id,
+                              account_id, direction))
+
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/reddit.py
+++ b/scripts/artifacts/reddit.py
@@ -14,10 +14,45 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Room ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Server Timestamp",
+                "senderColumn": "Sender Display Name",
+                "mediaColumn": "Attachment"
+            }
+        },
     }
 }
 
+import json
+
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, attach_sqlite_db_readonly, check_in_media
+
+
+def _reddit_owner_id(source_path):
+    """Own Matrix user id from the .m.rule.invite_for_me push rule (its
+    state_key pattern is the account's own id, server-populated)."""
+    rows = get_sqlite_db_records(
+        source_path,
+        "SELECT ZDATA FROM ZACCOUNTSTORAGEACCOUNTDATAITEM WHERE ZEVENTTYPEFIELD = 'm.push_rules'")
+    for (blob,) in rows:
+        try:
+            rules = json.loads(blob.decode('utf-8', 'replace') if isinstance(blob, (bytes, bytearray)) else blob)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+        for section in ((rules.get('content') or {}).get('global') or {}).values():
+            if not isinstance(section, list):
+                continue
+            for rule in section:
+                if rule.get('rule_id') == '.m.rule.invite_for_me':
+                    for cond in rule.get('conditions') or []:
+                        if cond.get('key') == 'state_key' and cond.get('pattern'):
+                            return cond['pattern']
+    return ''
 
 @artifact_processor
 def reddit_chats(context):
@@ -73,15 +108,21 @@ def reddit_chats(context):
     ORDER BY "Timestamp" ASC;
     '''
 
-    data_headers = (('Server Timestamp', 'datetime'),'Event ID', 'Sender Display Name','Sender ID','Recipient(s)','Event Type','Message Type','Message','Attachment Cached Name',('Attachment','media'),'Room ID')
+    data_headers = (('Server Timestamp', 'datetime'),'Event ID', 'Sender Display Name','Sender ID','Recipient(s)','Event Type','Message Type','Message','Attachment Cached Name',('Attachment','media'),'Room ID','Direction')
+
+    owner_id = _reddit_owner_id(source_path)
 
     db_records = get_sqlite_db_records(source_path, query, attach_query)
-    
+
     for record in db_records:
         attachment = ''
         for x in files_found:
             if str(record[8]) in x:
                 attachment = check_in_media(x,str(record[8]))
-        data_list.append((record[0], record[1], record[2], record[3], record[4], record[5], record[6], record[7], record[8], attachment, record[9]))
+        if owner_id and record[3]:
+            direction = 'Outgoing' if record[3] == owner_id else 'Incoming'
+        else:
+            direction = ''
+        data_list.append((record[0], record[1], record[2], record[3], record[4], record[5], record[6], record[7], record[8], attachment, record[9], direction))
 
     return data_headers, data_list, source_path

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -2,11 +2,22 @@ __artifacts_v2__ = {
     "teleguardMessages": {
         "name": "Teleguard Messages",
         "description": "TeleGuard chat messages and shared media",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-03", "requirements": "none",
         "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
         "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',
                   '*/Library/Caches/images/*'),
-        "output_types": "standard", "artifact_icon": "message-circle"
+        "output_types": "standard", "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Chat ID",
+                "textColumn": "Content",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Sender",
+                "mediaColumn": "Media"
+            }
+        },
     },
     "teleguardPosts": {
         "name": "Teleguard Posts",
@@ -51,17 +62,26 @@ def _find_db(context):
 @artifact_processor
 def teleguardMessages(context):
     data_headers = (('Timestamp', 'datetime'), ('User Time', 'datetime'), 'Type', 'Sender',
-                    'Receiver', 'Content', 'Metadata', ('Media', 'media'), 'Status', 'Is Edited?')
+                    'Receiver', 'Content', 'Metadata', ('Media', 'media'), 'Status', 'Is Edited?',
+                    'Direction', 'Chat ID')
     data_list = []
     db_path = _find_db(context)
     if not db_path:
         return data_headers, data_list, ''
 
+    # local account id lives in the service table ('user' row) of the same db
+    owner_id = ''
+    for (svc_data,) in get_sqlite_db_records(db_path, "SELECT data FROM service WHERE id = 'user'"):
+        try:
+            owner_id = (json.loads(svc_data) or {}).get('serverId', '')
+        except (json.JSONDecodeError, TypeError, ValueError):
+            owner_id = ''
+
     query = '''
     SELECT
         datetime(createDate/1000, 'unixepoch'),
         datetime(userTime/1000, 'unixepoch'),
-        type, sender, receiver, content, metadata, status, isEdited
+        type, sender, receiver, content, metadata, status, isEdited, chatId
     FROM messages
     '''
     for row in get_sqlite_db_records(db_path, query):
@@ -75,8 +95,12 @@ def teleguardMessages(context):
                 ref = check_in_media(fname)
                 if ref:
                     media_refs.append(ref)
+        if owner_id and row[3]:
+            direction = 'Outgoing' if row[3] == owner_id else 'Incoming'
+        else:
+            direction = ''
         data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6],
-                          media_refs or '', row[7], row[8]))
+                          media_refs or '', row[7], row[8], direction, row[9]))
 
     return data_headers, data_list, context.get_relative_path(db_path)
 


### PR DESCRIPTION
## Summary
Second class-2 batch: evidence-derived **Direction** columns + LAVA conversation views for the three artifacts whose owner rows needed source-DB digging. All derivations validated read-only against the copied databases from the 11-image validation set.

| Artifact | Owner source | Thread | Validation |
|---|---|---|---|
| Discord (KV) | `kv-storage/@account.<id>/` **path** | Channel ID (existed) | Path id matched the local sender in every image with outgoing traffic (blaisesuttoni, jesse022613, ruthonthego, thisisdfir); realistic splits (e.g. 28/22), all-Incoming on a lurker account |
| Teleguard | `service` table `user` row → `serverId` JSON (same db) | `chatId` → Chat ID (new) | 70 msgs: 36 Out / 29 In / 5 blank (service rows with no sender stay blank, never guessed) |
| Reddit | `.m.rule.invite_for_me` push rule's `state_key` pattern in `m.push_rules` account data (same Account.db) — server-populated, structurally the account's own Matrix id | Room ID (existed) | Owner `@t2_6099i3ch` = This_Is_DFIR (matches known data); 40 msgs split 21/19 |

## Discord also gets real fixes
The rewrite fixes **six latent used-before-assignment crashes** (pylint E0601/E0606 — a record missing JSON keys would raise NameError on the first row), converts the artifact to context form, and iterates **every** `@account` store instead of only the first (multi-account devices previously dropped data silently). File goes 7.22 → 10.00.

## Testing
pylint 10.00/10 (3 files); PluginLoader 3/3 in context form with views; view refs validated against data_headers; derivations executed against real evidence DBs with the splits above. When direction can't be established (no owner row / no sender) the column is blank — never defaulted to a side.