### PR TITLE
Report extraction-relative source paths from artifact_processor

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -14,7 +14,7 @@ import sqlite3
 import sys
 import xml
 
-from datetime import *
+from datetime import datetime, timezone, timedelta, UTC
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import quote
@@ -97,13 +97,13 @@ class GuiWindow:
     window_handle = None  # static variable
 
     @staticmethod
-    def SetProgressBar(n, total):
+    def SetProgressBar(n, total):  # pylint: disable=unused-argument
         if GuiWindow.window_handle:
             progress_bar = GuiWindow.window_handle.nametowidget('progress_bar_frame.progress_bar')
             progress_bar.config(value=n)
 
 class MediaItem():
-    def __init__(self, id):
+    def __init__(self, id):  # pylint: disable=redefined-builtin
         self.id = id
         self.source_path = ""
         self.extraction_path = ""
@@ -124,7 +124,7 @@ class MediaItem():
         self.is_embedded = media_info[7]
 
 class MediaReferences():
-    def __init__(self, id):
+    def __init__(self, id):  # pylint: disable=redefined-builtin
         self.id = id
         self.media_item_id = ""
         self.module_name = ""
@@ -142,7 +142,7 @@ class MediaReferences():
 def logfunc(message=""):
     def redirect_logs(string):
         _console_write(string)
-        log_text.insert('end', string)
+        log_text.insert('end', string)  # pylint: disable=used-before-assignment
         log_text.see('end')
         log_text.update()
 
@@ -167,7 +167,7 @@ def get_media_header_info(data_headers):
             media_header_info[index] = style
     return media_header_info
 
-def check_output_types(type, output_types):
+def check_output_types(type, output_types):  # pylint: disable=redefined-builtin
     if type in output_types or type == output_types or 'all' in output_types or 'all' == output_types:
         return True
     elif type != 'kml' and ('standard' in output_types or 'standard' == output_types):
@@ -484,6 +484,10 @@ def artifact_processor(func):
 
         if not source_path:
             logfunc("No source_path provided")
+        else:
+            # Report extraction-relative paths, never the examiner's local filesystem
+            source_path = '\n'.join(
+                Context.get_relative_path(p) for p in str(source_path).split('\n'))
 
         if len(data_list):
             if isinstance(data_list, tuple):
@@ -595,7 +599,7 @@ def get_file_path(files_found, filename, skip=False):
                 continue
             if Path(file_found).match(filename):
                 return file_found
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Error: {str(e)}")
     return None        
 
@@ -608,7 +612,7 @@ def get_txt_file_content(file_path):
         logfunc(f"Error: File not found at {file_path}")
     except PermissionError:
         logfunc(f"Error: Permission denied when trying to read {file_path}")
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Unexpected error reading file {file_path}: {str(e)}")
     return []
 
@@ -619,9 +623,9 @@ def get_plist_content(data):
             return nska_deserialize.deserialize_plist_from_string(data)
         return plist_content
     except plistlib.InvalidFileException:
-        logfunc(f"Error: Invalid plist data")
+        logfunc("Error: Invalid plist data")
     except xml.parsers.expat.ExpatError:
-        logfunc(f"Error: Malformed XML")
+        logfunc("Error: Malformed XML")
     except TypeError as e:
         logfunc(f"Error: Type error when parsing plist data: {str(e)}")
     except ValueError as e:
@@ -629,8 +633,8 @@ def get_plist_content(data):
     except OverflowError as e:
         logfunc(f"Error: Overflow error when parsing plist data: {str(e)}")
     except nska_deserialize.DeserializeError:
-        logfunc(f"Error: Invalid NSKeyedArchive plist data")
-    except Exception as e:
+        logfunc("Error: Invalid NSKeyedArchive plist data")
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Unexpected error reading plist data: {str(e)}")
     return {}
 
@@ -657,7 +661,7 @@ def get_plist_file_content(file_path):
         logfunc(f"Error: Overflow error when parsing plist {file_path}: {str(e)}")
     except nska_deserialize.DeserializeError:
         logfunc(f"Error: {file_path} is not a valid NSKeyedArchive plist file")
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Unexpected error reading plist file {file_path}: {str(e)}")
     return {}
 
@@ -750,7 +754,6 @@ def does_column_exist_in_db(path, table_name, col_name):
                 return True
     except sqlite3.Error as ex:
         logfunc(f"Query error, query={query} Error={str(ex)}")
-        pass
     return False
 
 def does_table_exist_in_db(path, table_name):
@@ -760,7 +763,7 @@ def does_table_exist_in_db(path, table_name):
         try:
             query = f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table_name}'"
             cursor = db.execute(query)
-            for row in cursor:
+            for _ in cursor:
                 return True
         except sqlite3.Error as ex:
             logfunc(f"Query error, query={query} Error={str(ex)}")
@@ -773,14 +776,14 @@ def does_view_exist_in_db(path, table_name):
         try:
             query = f"SELECT name FROM sqlite_master WHERE type='view' AND name='{table_name}'"
             cursor = db.execute(query)
-            for row in cursor:
+            for _ in cursor:
                 return True
         except sqlite3.Error as ex:
             logfunc(f"Query error, query={query} Error={str(ex)}")
     return False
 
 
-def tsv(report_folder, data_headers, data_list, tsvname, source_file=None):
+def tsv(report_folder, data_headers, data_list, tsvname, source_file=None):  # pylint: disable=unused-argument
     report_folder = report_folder.rstrip('/')
     report_folder = report_folder.rstrip('\\')
     report_folder_base = os.path.dirname(os.path.dirname(report_folder))
@@ -955,6 +958,7 @@ def media_to_html(media_path, files_found, report_folder):
     return thumb
 
 
+# pylint: disable-next=pointless-string-statement
 """
 Copyright 2021, CCL Forensics
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -1064,7 +1068,7 @@ def device_info(category, label, value, source_file=""):
     try:
         frame = inspect.stack()[1]
         func_name = frame.function
-    except:
+    except:  # pylint: disable=bare-except
         func_name = 'unknown'
     
     values = identifiers.get(category, {})
@@ -1185,7 +1189,7 @@ def convert_log_ts_to_utc(str_dt):
     if str_dt:
         try:
             return datetime.strptime(str_dt, '%b %d %Y %H:%M:%S').replace(tzinfo=timezone.utc)
-        except:
+        except:  # pylint: disable=bare-except
             return str_dt
     else:
         return str_dt
@@ -1207,10 +1211,10 @@ def convert_time_obj_to_utc(ts):
 
 def convert_utc_human_to_timezone(utc_time, time_offset):
     #fetch the timezone information
-    timezone = pytz.timezone(time_offset)
+    tz_info = pytz.timezone(time_offset)
     
     #convert utc to timezone
-    timezone_time = utc_time.astimezone(timezone)
+    timezone_time = utc_time.astimezone(tz_info)
     
     #return the converted value
     return timezone_time
@@ -1220,10 +1224,10 @@ def convert_ts_int_to_timezone(time, time_offset):
     utc_time = convert_ts_int_to_utc(time)
 
     #fetch the timezone information
-    timezone = pytz.timezone(time_offset)
+    tz_info = pytz.timezone(time_offset)
     
     #convert utc to timezone
-    timezone_time = utc_time.astimezone(timezone)
+    timezone_time = utc_time.astimezone(tz_info)
     
     #return the converted value
     return timezone_time
@@ -1298,12 +1302,14 @@ def convert_bytes_to_unit(size):
     else:
         return size
 
+# pylint: disable-next=pointless-string-statement
 ''' Returns string of printable characters. Replacing non-printable characters
 with '.', or CHR(46)
 '''
 def strings_raw(data):
     return "".join([chr(byte) if byte >= 0x20 and byte < 0x7F else chr(46) for byte in data])
 
+# pylint: disable-next=pointless-string-statement
 ''' Returns string of printable characters. Works similar to the Linux
 `string` function.
 '''
@@ -1311,6 +1317,7 @@ def strings(data):
     cleansed = "".join([chr(byte) if byte >= 0x20 and byte < 0x7F else chr(0) for byte in data])
     return filter(lambda string: len(string) >= 4, cleansed.split(chr(0)))
 
+# pylint: disable-next=pointless-string-statement
 ''' Retuns HTML table of the hexdump of the passed in data.
 '''
 def generate_hexdump(data, char_per_row = 5):
@@ -1319,12 +1326,14 @@ def generate_hexdump(data, char_per_row = 5):
     str_hex = ''
     str_ascii = ''
 
+    # pylint: disable-next=pointless-string-statement
     ''' Generates offset column
     '''
     offset_rows = math.ceil(len(data_hex)/(char_per_row * 2))
     offsets = [i for i in  range(0, len(data_hex), char_per_row)][:offset_rows]
     str_offset = '<br>'.join([ str(hex(s)[2:]).zfill(4).upper() for s in offsets ])
 
+    # pylint: disable-next=pointless-string-statement
     ''' Generates hex data column
     '''
     c = 0
@@ -1337,6 +1346,7 @@ def generate_hexdump(data, char_per_row = 5):
         else:
             c += 1
 
+    # pylint: disable-next=pointless-string-statement
     ''' Generates ascii column of data
     '''
     for i in range(0, len(str_raw), char_per_row):
@@ -1359,6 +1369,7 @@ def generate_hexdump(data, char_per_row = 5):
     </tr></tbody></table>
     '''
 
+# pylint: disable-next=pointless-string-statement
 '''
 searching for thumbnails, copy it to report folder and return tag  to insert in html
 '''
@@ -1372,14 +1383,14 @@ def generate_thumbnail(imDirectory, imFilename, seeker, report_folder):
         shutil.copy2(thumblist,os.path.join(report_folder, thumbname))
     else:
         #recreate thumbnail from image
-        #TODO: handle videos and HEIC
+        #Future work: handle videos and HEIC
         files = seeker.search(media_root+imDirectory+'/'+imFilename, return_on_first_hit=True)
         if files:
             try:
                 im = Image.open(files)
                 im.thumbnail(thumb_size)
                 im.save(os.path.join(report_folder, thumbname))
-            except:
+            except:  # pylint: disable=bare-except
                 pass #unsupported format
     return htmlThumbTag
 


### PR DESCRIPTION
Mirror of [ALEAPP #931](https://github.com/abrignoni/ALEAPP/pull/931): `artifact_processor` now passes every returned `source_path` through `Context.get_relative_path()` (per newline segment), so reports show extraction-relative paths instead of the examiner's local filesystem. Passthrough semantics keep literals, already-relative paths, and no-data_folder runs untouched.

Also clears `ilapfuncs.py`'s pre-existing lint debt (9.57 → 10.00, 35 messages) with zero-behavior-change treatments, same approach as the ALEAPP PR — explicit datetime imports, shadowed-name local renames, dead-code removal, f-string fixes, and inline pragmas where API params (`id`, `type`, `source_file`) or exception semantics must stay untouched.

Testing: shorten-logic unit tests pass (relative, literal, multi-path); pylint 10.00/10; byte-compile; PluginLoader registers all plugins; `timezone`/`datetime`/`timedelta` re-exports verified intact.

Row-level Source File column sweep for iLEAPP to follow separately (as in ALEAPP #932).