### PR TITLE
Shorten per-row Source File paths (follow-up to #1656) + dmss data_list fix

### DIFF
--- a/scripts/artifacts/appItunesmeta.py
+++ b/scripts/artifacts/appItunesmeta.py
@@ -76,7 +76,7 @@ def get_appItunesmeta(context):
             else:
                 install_date = ''
     
-            data_list.append((install_date, purchasedate, bundleid, itemname, artistname, versionnum, downloadedby, genre, factoryinstall, appreleasedate, sourceapp, sideloaded, variantid, parent))   
+            data_list.append((install_date, purchasedate, bundleid, itemname, artistname, versionnum, downloadedby, genre, factoryinstall, appreleasedate, sourceapp, sideloaded, variantid, context.get_relative_path(parent)))   
 
     data_headers = (
         ('Installed Date','datetime'), 

--- a/scripts/artifacts/dmss.py
+++ b/scripts/artifacts/dmss.py
@@ -409,6 +409,6 @@ def get_dmss_created_media(context):
     for mfile in media_data_list:          
         if mfile[1] is not None:
             media = check_in_media(mfile[2], mfile[0])
-            data_list.append((mfile[0],media, mfile[2]))
+            data_list.append((mfile[0],media, context.get_relative_path(mfile[2])))
  
-    return data_headers, data_headers, 'see Source File for more info'
+    return data_headers, data_list, 'see Source File for more info'

--- a/scripts/artifacts/voiceTriggers.py
+++ b/scripts/artifacts/voiceTriggers.py
@@ -58,7 +58,7 @@ def voiceTriggers(context):
                     fl.get('productType', ''),
                     fl.get('utteranceWav', ''),
                     audio_id,
-                    info_file
+                    context.get_relative_path(info_file)
                 ))
 
         except (OSError, TypeError, ValueError, KeyError) as e:


### PR DESCRIPTION
Counterpart of [ALEAPP #932](https://github.com/abrignoni/ALEAPP/pull/932): the central fix in #1656 can't reach absolute paths embedded in per-record *Source File* columns. Full audit of all artifact functions found only **3 true positives** (everything else already shortens via helpers — BeReal's `relative_to`, discordChats/walStrings/mobileInstallb/sysShutdown via `context.get_relative_path`, burnerCache/discord_cache via seeker file_infos — or emits device paths/basenames):

- **appItunesmeta** — parent dir of iTunesMetadata.plist
- **voiceTriggers** — info json path
- **dmss** — media path, **plus a real bug found during the audit**: `return data_headers, data_headers, ...` returned the headers tuple as the data list, discarding every built row. Now returns `data_list`.

Testing: pylint 10.00/10 on all 3, byte-compile clean.