### PR TITLE
Update report.py - Fix HTML report generation issue with Python3.10-3.11

### DIFF
--- a/scripts/report.py
+++ b/scripts/report.py
@@ -23,11 +23,20 @@ from leapp_functions.data_sources.json_files import get_json_file_content
 
 def get_tabler_icon_names():
     """Returns a set of available tabler icon names by scanning the tabler_icons directory."""
-    for _, dirs, files in Path.cwd().joinpath("assets/tabler_icons").walk():
-        if '__pycache__' in dirs:
-            dirs.remove('__pycache__')
-        return set(file.replace('.svg', '') for file in files if file.endswith('.svg'))
+    tabler_icon_dir = Path.cwd().joinpath("assets/tabler_icons")
+    return set(file.stem for file in tabler_icon_dir.rglob("*.svg"))
 
+
+def get_svg_icons():
+    root_dir = Path.cwd() / "assets/tabler_icons"
+    
+    # On utilise rglob pour trouver tous les fichiers
+    # On filtre les chemins qui contiennent '__pycache__'
+    return {
+        file.stem 
+        for file in root_dir.rglob("*.svg") 
+        if "__pycache__" not in file.parts
+    }
 
 def get_tabler_icon(icon_name):
     """Return the SVG contents for a Tabler icon by name."""


### PR DESCRIPTION
Replace Pathlib walk attribute with rglob, compatible with Python versions earlier than 3.12.