### PR TITLE
get_relative_path: shorten data_folder everywhere it appears

### DIFF
--- a/scripts/context.py
+++ b/scripts/context.py
@@ -431,9 +431,14 @@ class Context:
         if not full_path or not Context._data_folder:
             return full_path
 
-        if full_path.startswith(Context._data_folder):
-            # Strip the base path and any leading separators
-            return full_path[len(Context._data_folder):].lstrip('/\\')
+        if Context._data_folder in full_path:
+            # Strip the base path everywhere it appears, including inside path
+            # strings concatenated with arbitrary separators (', ', '; ', ...)
+            base = Context._data_folder
+            return (full_path.replace(base + '/', '')
+                             .replace(base + '\\', '')
+                             .replace(base, '')
+                             .lstrip('/\\'))
 
         return full_path
 


### PR DESCRIPTION
Follow-up to the relative-source-paths fix, prompted by @JamesHabben's question about concatenated source paths.

**The gap:** the decorator shortens `source_path` per **newline** segment. Artifacts that join multiple **absolute** paths with other separators (`', '`, `'; '`, `' '`) only had the *first* path shortened — `startswith` matches the head of the concatenated string, strips one prefix, and the rest stayed absolute:

```
in : <data>/a.db, <data>/b.db
out: a.db, /Users/examiner/.../b.db   <- second path leaked
```

**The fix:** `Context.get_relative_path` now globally replaces the data_folder prefix wherever it appears, separator-agnostic — same spirit as the old `file_found.replace(seeker.data_folder, '')` idiom. Artifacts that already relativize before joining (Oops-style, ~24 in iLEAPP) are unaffected: relative segments pass through untouched.

**Verified:** unit tests cover exact path, path == data_folder, literals, already-relative, None, comma/semicolon/space-joined absolute paths, newline decorator path, and no-data_folder passthrough. pylint 10.00/10, byte-compile, PluginLoader smoke test all pass.

Affected artifacts that this transparently fixes: iLEAPP box, home_depot, idstatuscache, sysdiagnose (and skg_archive if its parts are paths); ALEAPP the FCM family, siminfo, wifiConfigstore2, wifiProfiles. All of those modules still exist as of 2026-08-09.

### Correction to the original description (2026-08-09)

The line about RLEAPP and VLEAPP and "the four frameworks" was written on 2026-07-06 and is now wrong on both counts. There are **five** cores, and since this PR was opened **DLEAPP and RLEAPP have received the global-replace fix independently**. So this no longer keeps the cores identical, it *restores* that: iLEAPP, ALEAPP and VLEAPP are the three still carrying the `startswith` version.

### Re-verified on current main, 2026-08-09

Calling `Context.get_relative_path` directly with `_data_folder` set:

| core | cases leaking an absolute path |
|---|---|
| iLEAPP, ALEAPP, VLEAPP | **3 of 5** |
| DLEAPP, RLEAPP | 0 of 5 (already fixed) |

```
in : <data>/a.db, <data>/b.db
out: a.db, /Users/examiner/case/.../data/b.db
```

Comma, semicolon and newline joins all leak; a single path and already-relative input are unaffected. What leaks is the examiner's own filesystem path into a source-path column that reaches the report.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
