### PR TITLE
Fix BeReal artifact_icons to valid Tabler names

### DIFF
--- a/scripts/artifacts/BeReal.py
+++ b/scripts/artifacts/BeReal.py
@@ -129,7 +129,7 @@ __artifacts_v2__ = {
             "senderColumn": "Author",
             "textColumn": "Emoji"
         },
-        "artifact_icon": "thumbs-up"
+        "artifact_icon": "thumb-up"
     },
     "bereal_comments": {
         "name": "BeReal Comments",
@@ -155,7 +155,7 @@ __artifacts_v2__ = {
             "senderColumn": "Author",
             "textColumn": "Text"
         },
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "bereal_messages": {
         "name": "BeReal Messages",
@@ -179,7 +179,7 @@ __artifacts_v2__ = {
             "senderColumn": "Sender",
             "textColumn": "Message"
         },
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "bereal_chat_list": {
         "name": "BeReal Chat List",


### PR DESCRIPTION
Follow-up to the BeReal rework (#1638). Three `artifact_icon` values were still using Feather names that have no bundled Tabler asset, so those icons wouldn't render. This maps them to their Tabler equivalents in `assets/tabler_icons`:

- `thumbs-up` → `thumb-up` (realmojis)
- `message-square` → `message` (comments)
- `message-square` → `message` (messages)

Verified each target exists (`thumb-up.svg`, `message.svg`) and the file still compiles. Icon-only change; no logic touched.