### PR TITLE
Support Python 3.13 and 3.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,13 @@ mmh3
 mdplistlib
 nska-deserialize>=1.3.1
 nska_deserialize
-numpy==1.26.4
+numpy==1.26.4; python_version < "3.13"
+numpy>=2.1; python_version >= "3.13"
 packaging==24.1
 pandas
 pathlib2==2.3.5
 PGPy
+standard-imghdr; python_version >= "3.13"  # PGPy imports stdlib imghdr, removed in Python 3.13 (PEP 594)
 pillow
 pillow_heif
 pycryptodome


### PR DESCRIPTION
## What
Adds Python 3.13 / 3.14 support while leaving 3.10–3.12 users **untouched** (no forced numpy/pandas major bump — important for report reproducibility).

## requirements.txt changes
- **numpy — gated by Python version:**
  - `numpy==1.26.4; python_version < "3.13"` — 3.10/3.11/3.12 keep today's pinned stack (numpy 1.26.4 + pandas 2.3.x).
  - `numpy>=2.1; python_version >= "3.13"` — 3.13/3.14 require numpy 2.x (1.26.4 has no cp313/cp314 wheels and won't build against the new C-API). Pulls pandas 3.x on these versions only.
- **`standard-imghdr; python_version >= "3.13"`** — PGPy (`scripts/artifacts/protonMail.py`) imports the stdlib `imghdr` module, **removed in Python 3.13** (PEP 594). Backport restores it on 3.13+; older Pythons keep stdlib `imghdr`.

## Validation (Python 3.14.6, Apple Silicon)
- Full `pip install -r requirements.txt` succeeds
- **All 598 plugins import cleanly** via `PluginLoader` (incl. protonMail)
- `ileapp.py -h` runs; astc / numpy 2.5.1 / pandas 3.0.3 import and function

## Follow-ups before advertising 3.13/3.14 to users (not in this PR)
- **Windows `pyliblzfse`**: bundled `whl_files/` stop at cp312 and there's no PyPI Windows wheel → Windows users on 3.13/3.14 can't install it. Needs cp313/cp314 Windows wheels added.
- On macOS 3.14 `pyliblzfse` compiles from source (needs Xcode CLT); **3.13** has a prebuilt wheel (zero compiles) — the lower-friction target.
- README still states "Python 3.10, 3.11, or 3.12" — update when ready to announce.