### PR TITLE
Fix datetime.UTC import breaking Python 3.10

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -14,7 +14,7 @@ import sqlite3
 import sys
 import xml
 
-from datetime import datetime, timezone, timedelta, UTC
+from datetime import datetime, timezone, timedelta
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import quote
@@ -1165,7 +1165,7 @@ def convert_unix_ts_to_utc(ts):
 def convert_unix_ts_to_str(ts):
     if ts:
         ts = convert_unix_ts_in_seconds(ts)
-        return datetime.fromtimestamp(ts, UTC).strftime('%Y-%m-%d %H:%M:%S')
+        return datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
     else:
         return ts
 


### PR DESCRIPTION
Fixes #1676.

`datetime.UTC` is 3.11+, so the explicit import in `ilapfuncs.py` crashed 3.10 at startup (regression from the `import *` → explicit change in 721f9cf). Switched the one use to `timezone.utc` — same value, already used elsewhere in the file.

Tested on 3.10 and 3.14: identical output, all 598 plugins load.