### PR TITLE
Add missing descriptions to 17 artifacts

### DIFF
--- a/scripts/artifacts/AWESearch.py
+++ b/scripts/artifacts/AWESearch.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_AWESearch": {
         "name": "TikTok",
-        "description": "",
+        "description": "Parses TikTok in-app search terms and timestamps from the AWESearchHistory file.",
         "author": "@gforce4n6",
         "creation_date": "2023-02-25",
         "last_update_date": "2022-09-26",

--- a/scripts/artifacts/appleMapsApplication.py
+++ b/scripts/artifacts/appleMapsApplication.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "appleMapsApplication": {
         "name": "Apple Maps Last Activity Camera",
-        "description": "",
+        "description": "Parses the last Apple Maps camera/map location (latitude and longitude) from com.apple.Maps.plist.",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-08-03",
         "last_update_date": "2025-10-08",

--- a/scripts/artifacts/appleMapsGroup.py
+++ b/scripts/artifacts/appleMapsGroup.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "appleMapsGroup": {
         "name": "Apple Maps Group",
-        "description": "",
+        "description": "Parses cached location coordinates from the Apple Maps app group preferences (group.com.apple.Maps.plist).",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-08-03",
         "last_update_date": "2025-12-16",

--- a/scripts/artifacts/appleMapsSearchHistory.py
+++ b/scripts/artifacts/appleMapsSearchHistory.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_appleMapsSearchHistory": {
         "name": "Get Apple Maps seach history",
-        "description": "",
+        "description": "Parses Apple Maps search history entries and timestamps from GeoHistory.mapsdata.",
         "author": "@any333",
         "creation_date": "2021-01-29",
         "last_update_date": "2023-10-22",

--- a/scripts/artifacts/audiTripdata.py
+++ b/scripts/artifacts/audiTripdata.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_audiTripdata": {
         "name": "Audi Trip Data",
-        "description": "",
+        "description": "Parses trip data cached by the Audi myAudi mobile assistant app.",
         "author": "@abrignoni",
         "creation_date": "2024-06-01",
         "last_update_date": "2025-10-28",

--- a/scripts/artifacts/bluetoothOther.py
+++ b/scripts/artifacts/bluetoothOther.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_bluetoothOtherLE": {
         "name": "Bluetooth Other LE",
-        "description": "",
+        "description": "Parses non-paired (other) Bluetooth Low Energy devices seen by the device from com.apple.MobileBluetooth.ledevices.other.db.",
         "author": "@JohnHyla",
         "creation_date": "2024-10-21",
         "last_update_date": "2025-11-03",

--- a/scripts/artifacts/bluetoothPairedLE.py
+++ b/scripts/artifacts/bluetoothPairedLE.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_bluetoothPairedLE": {
         "name": "Bluetooth Paired LE",
-        "description": "",
+        "description": "Parses paired Bluetooth Low Energy devices, including name, address and last connection time, from com.apple.MobileBluetooth.ledevices.paired.db.",
         "author": "@JohnHyla",
         "creation_date": "2024-10-21",
         "last_update_date": "2025-11-03",

--- a/scripts/artifacts/bluetoothPairedReg.py
+++ b/scripts/artifacts/bluetoothPairedReg.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_bluetoothPairedReg": {
         "name": "Bluetooth Paired",
-        "description": "",
+        "description": "Parses paired Bluetooth Classic devices and their last-seen times from com.apple.MobileBluetooth.devices.plist.",
         "author": "@JohnHyla",
         "creation_date": "2024-10-21",
         "last_update_date": "2025-11-03",

--- a/scripts/artifacts/cacheRoutesGmap.py
+++ b/scripts/artifacts/cacheRoutesGmap.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_cacheRoutesGmap": {
         "name": "Google Maps Cache Routes",
-        "description": "",
+        "description": "Parses cached Google Maps route data and timestamps from the app CachedRoutes plists.",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-08-03",
         "last_update_date": "2025-11-12",

--- a/scripts/artifacts/carCD.py
+++ b/scripts/artifacts/carCD.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "carCD": {
         "name": "Last Car Connection and UDID",
-        "description": "",
+        "description": "Parses the last connected CarPlay vehicle and the device UDID from the locationd cache.plist.",
         "author": "@AlexisBrignoni",
         "creation_date": "2023-09-30",
         "last_update_date": "2025-11-12",

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_cashApp": {
         "name": "Cash App",
-        "description": "",
+        "description": "Parses Cash App transactions and account data from the CCEntitySync SQLite stores.",
         "author": "@gforce4n6",
         "creation_date": "2021-10-06",
         "last_update_date": "2025-11-12",

--- a/scripts/artifacts/cashAppB.py
+++ b/scripts/artifacts/cashAppB.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_cashAppB": {
         "name": "Cash App (B)",
-        "description": "",
+        "description": "Parses Cash App activity from the production account cashappapi SQLite database (alternate location).",
         "author": "Alexis Brignoni",
         "creation_date": "2025-08-24",
         "last_update_date": "2026-05-14",

--- a/scripts/artifacts/draftmessage.py
+++ b/scripts/artifacts/draftmessage.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_draftmessage": {  # This should match the function name exactly
         "name": "Draft Native Messages",
-        "description": "",
+        "description": "Parses unsent draft iMessage and SMS messages and their modified times from SMS/Drafts composition.plist files.",
         "author": "",
         "creation_date": "",
         "last_updated": "2025-11-25",

--- a/scripts/artifacts/fmfdDevices.py
+++ b/scripts/artifacts/fmfdDevices.py
@@ -1,6 +1,7 @@
 __artifacts_v2__ = {
     "fmfd_notbackedup_devices": {
         "name": "Find My - Devices",
+        "description": "Parses Find My registered devices (name, identifier and capabilities) from the fmfd notbackedup preferences plist.",
         "author": "@ghmihkel",
         "version": "1.0",
         "date": "2026-03-31",
@@ -102,7 +103,7 @@ def fmfd_notbackedup_devices(context):
             devices = _parse_fmfd_plist(raw)
             data_list.extend(devices)
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             logfunc(f'fmfd: Error parsing {source_file}: {e}')
 
     return data_headers, data_list, source_file

--- a/scripts/artifacts/tileAppNetDb.py
+++ b/scripts/artifacts/tileAppNetDb.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     'tileAppNetDb': {
         'name': 'Tile App Account Information',
-        'description': '',
+        'description': 'Parses the registered Tile account (registration timestamp, email, full name and phone number) from TileNetworkDB.',
         'author': '@AlexisBrignoni',
         'creation_date': '2020-09-03',
         'last_update_date': '2025-04-05',

--- a/scripts/artifacts/weatherAppLocations.py
+++ b/scripts/artifacts/weatherAppLocations.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "weather_app_locations": {
         "name": "Weather App - Locations",
-        "description": "",
+        "description": "Parses saved locations and update times from the iOS Weather app (group.com.apple.weather.plist).",
         "author": "@Anna-Mariya Mateyna",
         "creation_date": "2021-01-29",
         "last_update_date": "2025-11-20",

--- a/scripts/artifacts/webClips.py
+++ b/scripts/artifacts/webClips.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "web_clips": {
         "name": "iOS Screens",
-        "description": "",
+        "description": "Parses home screen web clips (bookmarked web apps), including titles, URLs and icons, from the WebClips directory.",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-04-20",
         "last_update_date": "2025-11-20",


### PR DESCRIPTION
## What

Fills in empty or absent \`description\` fields in the \`__artifacts_v2__\` metadata block for **17 iOS artifacts**. The \`description\` renders in the artifact's HTML report header and is carried into LAVA, so these previously showed no explanation of what the artifact does.

Each description was written from the artifact's **actual paths, SQL query and output columns** (not guessed), following the existing house style ("Parses X from Y").

| Artifact | Description |
|---|---|
| AWESearch | TikTok in-app search terms/timestamps from AWESearchHistory |
| appleMapsApplication | Last Apple Maps camera/map lat-lon from com.apple.Maps.plist |
| appleMapsGroup | Cached coordinates from group.com.apple.Maps.plist |
| appleMapsSearchHistory | Apple Maps search history from GeoHistory.mapsdata |
| audiTripdata | Trip data cached by the Audi myAudi assistant app |
| bluetoothOther | Non-paired BLE devices seen (…ledevices.other.db) |
| bluetoothPairedLE | Paired BLE devices + last connection (…ledevices.paired.db) |
| bluetoothPairedReg | Paired Bluetooth Classic devices (…devices.plist) |
| cacheRoutesGmap | Cached Google Maps route data + timestamps |
| carCD | Last connected CarPlay vehicle + device UDID (locationd cache) |
| cashApp | Cash App transactions/account from CCEntitySync stores |
| cashAppB | Cash App activity from the cashappapi DB (alt location) |
| draftmessage | Unsent iMessage/SMS drafts from composition.plist files |
| fmfdDevices | Find My registered devices from the fmfd preferences plist |
| tileAppNetDb | Registered Tile account from TileNetworkDB |
| weatherAppLocations | Saved locations/update times from the Weather app |
| webClips | Home-screen web clips (title, URL, icon) from WebClips |

## Notes

- No parser logic changed — metadata only.
- One extra line: a \`# pylint: disable=broad-exception-caught\` pragma on \`fmfdDevices\`' existing per-file resilience \`except\` (log-and-continue), so the now-touched file lints at **10.00/10**. No behavior change.
- Verified: all 17 \`__artifacts_v2__\` blocks parse with a non-empty description; PluginLoader loads 598 plugins; \`pylint --disable=C,R\` on all changed files exits 0 at 10.00/10; CRLF files kept CRLF.