### PR TITLE
Fix typo'd last_update_date in biomeSync (2029 -> 2025)

### DIFF
--- a/scripts/artifacts/biomeSync.py
+++ b/scripts/artifacts/biomeSync.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "description": "Parses Biome Device Sync records",
         "author": "@JohnHyla",
         'creation_date': '2023-03-22',
-        'last_update_date': '2029-09-29',
+        'last_update_date': '2025-09-29',
         "requirements": "none",
         "category": "Biome",
         "notes": "",


### PR DESCRIPTION
`biomeSync.py` ("Biome - Device Syncs") has `last_update_date: '2029-09-29'` — a future date. Git history shows the value was set in commit b67c38a5 ("Update last_update_date in appConduit.py and biomeSync.py") authored **2025-09-29**, and `creation_date` is `2023-03-22`, so the intended year is **2025**. One-character metadata fix, no logic change.

Spotted while surfacing `last_update_date` on the leapps.org artifact browser.