### PR TITLE
Update sample_data from the refreshed 13-archive iOS test corpus

### DIFF
--- a/scripts/artifacts/AWESearch.py
+++ b/scripts/artifacts/AWESearch.py
@@ -13,6 +13,8 @@ __artifacts_v2__ = {
         "artifact_icon": "brand-tiktok",
         "sample_data": {
             "otto_ios17": "iOS 17.5.1 | TikTok 35.6.0 | 6 rows",
+            "dexter_ios18": "iOS 18.3.2 | TikTok - Videos, Shop & LIVE 41.8.0 | 3 rows",
+            "iphone12_ios18": "iOS 18.7 | TikTok - Videos, Shop & LIVE 42.7.0 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 151 rows",
             "iphone14plus_ios18": "iOS 18.0 | 92 rows",
             "otto_ios17": "iOS 17.5.1 | 244 rows",
+            "iphone12_ios18": "iOS 18.7 | 123 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "iphone12_ios18": "iOS 18.7 | 936 rows",
             "iphone14plus_ios18": "iOS 18.0 | 132 rows",
             "otto_ios17": "iOS 17.5.1 | 1758 rows",
+            "dexter_ios18": "iOS 18.3.2 | 3838 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeDKKeybag.py
+++ b/scripts/artifacts/biomeDKKeybag.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "iphone12_ios18": "iOS 18.7 | 115 rows",
             "iphone14plus_ios18": "iOS 18.0 | 28 rows",
             "otto_ios17": "iOS 17.5.1 | 62 rows",
+            "dexter_ios18": "iOS 18.3.2 | 382 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
             "hc_ios18_7": "iOS 18.7.8 | 1164 rows",
             "iphone11_ios17": "iOS 17.3 | 1287 rows",
             "iphone14plus_ios18": "iOS 18.0 | 16 rows",
+            "otto_ios17": "iOS 17.5.1 | 87 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeHardware.py
+++ b/scripts/artifacts/biomeHardware.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 1106 rows",
             "iphone12_ios18": "iOS 18.7 | 370 rows",
             "iphone14plus_ios18": "iOS 18.0 | 28 rows",
+            "otto_ios17": "iOS 17.5.1 | 2789 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 93 rows",
             "iphone14plus_ios18": "iOS 18.0 | 0 rows",
             "otto_ios17": "iOS 17.5.1 | 32 rows",
+            "iphone12_ios18": "iOS 18.7 | 92 rows",
         }
     }
 }

--- a/scripts/artifacts/cachev0.py
+++ b/scripts/artifacts/cachev0.py
@@ -17,6 +17,7 @@ __artifacts_v2__ = {
             "hc_ios18_7": "iOS 18.7.8 | Google Docs 1.2026.23106, Google Drive 4.2615.41600 | 1 row",
             "iphone11_ios17": "iOS 17.3 | Google Chat 0.390, Google Voice 23.47, Gmail - Email by Google 6.0.231127 | 79 rows",
             "otto_ios17": "iOS 17.5.1 | Google Drive 4.2430.11801 | 11 rows",
+            "iphone14plus_ios18": "iOS 18.0 | Google Sheets 1.2025.49102 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/findMyItems.py
+++ b/scripts/artifacts/findMyItems.py
@@ -14,6 +14,9 @@ __artifacts_v2__ = {
         "sample_data": {
             "fsfull002_ios17": "iOS 17.1 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 2 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
         },
     },
     "findMyItemsLocations": {
@@ -31,6 +34,9 @@ __artifacts_v2__ = {
         "sample_data": {
             "fsfull002_ios17": "iOS 17.1 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 2 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
         }
     },
     "findMyItemsSafeLocations": {
@@ -48,6 +54,9 @@ __artifacts_v2__ = {
         "sample_data": {
             "fsfull002_ios17": "iOS 17.1 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 2 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
         }
     },
     "findMyItemsCrowdsourcedLocations": {
@@ -65,6 +74,9 @@ __artifacts_v2__ = {
         "sample_data": {
             "fsfull002_ios17": "iOS 17.1 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 2 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
         }
     }
 }

--- a/scripts/artifacts/geodApplications.py
+++ b/scripts/artifacts/geodApplications.py
@@ -14,6 +14,12 @@ __artifacts_v2__ = {
         "sample_data": {
             "fsfull002_ios17": "iOS 17.1 | 0 rows",
             "otto_ios17": "iOS 17.5.1 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 3 rows",
+            "felix_ios17": "iOS 17.6.1 | 1 row",
+            "hc_ios18_7": "iOS 18.7.8 | 18 rows",
+            "iphone11_ios17": "iOS 17.3 | 114 rows",
+            "iphone12_ios18": "iOS 18.7 | 4 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 1 row",
         }
     }
 }

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -22,7 +22,10 @@ __artifacts_v2__ = {
                 "mediaColumn": "Media"
             }
         },
-        "artifact_icon": "message-circle"
+        "artifact_icon": "message-circle",
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | Google Chat 0.390 | 96 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/keychain.py
+++ b/scripts/artifacts/keychain.py
@@ -113,6 +113,7 @@ __artifacts_v2__ = {
             "iphone12_ios18": "iOS 18.7 | 0 rows",
             "iphone14plus_ios18": "iOS 18.0 | 1 row",
             "otto_ios17": "iOS 17.5.1 | 6 rows",
+            "dexter_ios18": "iOS 18.3.2 | 8 rows",
         },
         "function": "keychain_bluetooth_paired"
     },

--- a/scripts/artifacts/netusage.py
+++ b/scripts/artifacts/netusage.py
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 595 rows",
             "iphone12_ios18": "iOS 18.7 | 287 rows",
             "iphone14plus_ios18": "iOS 18.0 | 313 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
         },
     },
     "netusage_connections": {
@@ -43,6 +44,7 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 1232 rows",
             "iphone12_ios18": "iOS 18.7 | 287 rows",
             "iphone14plus_ios18": "iOS 18.0 | 16 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/sms.py
+++ b/scripts/artifacts/sms.py
@@ -21,6 +21,7 @@ __artifacts_v2__ = {
             "iphone12_ios18": "iOS 18.7 | 27 rows",
             "iphone14plus_ios18": "iOS 18.0 | 13 rows",
             "otto_ios17": "iOS 17.5.1 | 223 rows",
+            "felix_ios17": "iOS 17.6.1 | 69 rows",
         },
         "data_views": {
             "conversation": {


### PR DESCRIPTION
## Summary

Metadata-only refresh of `sample_data` after the crash fixes in #1691. The full iOS corpus was re-run with current main — **13/13 archives processed, zero artifact errors** (the pre-fix run had 39) — and the updater recorded coverage for the artifacts that previously crashed and therefore had no entries.

Highlights:

- **Recovered data now documented**: the biome artifacts gain entries on every image including the SEGB2-repaired Otto streams (`get_biomeDevWifi` 87 rows, `get_biomeHardware` 2,789 on Otto; `get_biomeDKInfocus` 3,838 and `get_biomeDKKeybag` 382 on Dexter; `get_biomeAppinstall`/`get_biomeLocationactivity` on the iPhone 12); `sms` 69 rows on Felix (directory attachment skipped cleanly); `google_chat` 96 rows; `get_AWESearch` on both iOS 18 images (new TikTok plist layout); `geodapplications` rows on all eight previously-crashing images; `keychain_bluetooth_paired` and `netusage_*` on their crash images.
- **Honest "0 rows" entries** where the source exists but holds nothing parseable: `findMyItems*` on iOS 17.5+ (encrypted `Items.data`) and `cachev0` on the iPhone 14 Plus.
- Hand-written notes preserved; managed keys only. A second `--apply` reports **zero changes** (idempotent).
- `PYTHONPATH=. pylint --disable=C,R` on all 14 files: 10.00/10; PluginLoader smoke passes (598 plugins).

Android counterpart: abrignoni/ALEAPP#947.

## Corpus housekeeping note

The batch found a **new duplicate archive**: `iOS Extractions/iOS 18.0/00008110-0008196A2299401E_files_full.zip` has the same SHA-256 (`bda204f7…`) as the deliberately-unregistered `00008110-0008196A2299401E_files_full-001.zip` (the second acquisition of the iPhone 14 Plus). It burns a run each refresh and can be deleted or left unregistered; the registered `iPhone14Plus/` copy is unaffected.