### PR TITLE
Add artifacts for Biome databases and Set.db stores

### DIFF
--- a/scripts/artifacts/biomeApplePaySecurity.py
+++ b/scripts/artifacts/biomeApplePaySecurity.py
@@ -102,6 +102,20 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "map-pin",
     },
+    "biomeDbAudioRoute": {
+        "name": "Biome DB - Audio Route (Daily)",
+        "description": "Per-day audio route change counts (headphones, Bluetooth, speaker) pre-aggregated "
+                       "by Apple in the ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Timestamps are normalized by Apple to the start of the day.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "headphones",
+    },
 }
 
 from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records, does_table_exist_in_db,
@@ -208,4 +222,16 @@ def biomeDbCarPlay(context):
         SELECT date, carPlayActivityCount FROM CarPlayMatView''')
     for row in rows:
         data_list.append((convert_unix_ts_to_utc(row[0]), row[1]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbAudioRoute(context):
+    data_headers = (('Date (UTC)', 'datetime'), 'Route Type', 'External', 'Route Change Reason',
+                    'Audio Route Count')
+    data_list = []
+    rows, source_path = _table_rows(context, 'AudioRouteMatView', '''
+        SELECT date, type, external, routeChangeReason, audioRouteCount FROM AudioRouteMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1], row[2], row[3], row[4]))
     return data_headers, data_list, source_path

--- a/scripts/artifacts/biomeApplePaySecurity.py
+++ b/scripts/artifacts/biomeApplePaySecurity.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - App Openings",
         "description": "Per-launch application records (bundle ID, event time, launch type) pre-aggregated by Apple "
                        "in the ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - App Openings (Hourly)",
         "description": "Hourly per-application launch counts pre-aggregated by Apple in the "
                        "ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -33,7 +33,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - Cable Plug Events",
         "description": "Cable connection/disconnection events pre-aggregated by Apple in the "
                        "ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -47,7 +47,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - Backlight Events",
         "description": "Screen backlight level change events pre-aggregated by Apple in the "
                        "ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -61,7 +61,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - Button Clicks (Daily)",
         "description": "Per-day hardware button click counts pre-aggregated by Apple in the "
                        "ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -76,7 +76,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - Minimum Battery (Daily)",
         "description": "Per-day minimum battery percentage pre-aggregated by Apple in the "
                        "ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -91,7 +91,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - CarPlay Activity (Daily)",
         "description": "Per-day CarPlay activity counts pre-aggregated by Apple in the "
                        "ApplePay.Security.Features Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",

--- a/scripts/artifacts/biomeApplePaySecurity.py
+++ b/scripts/artifacts/biomeApplePaySecurity.py
@@ -1,0 +1,211 @@
+__artifacts_v2__ = {
+    "biomeDbAppOpenings": {
+        "name": "Biome DB - App Openings",
+        "description": "Per-launch application records (bundle ID, event time, launch type) pre-aggregated by Apple "
+                       "in the ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Table availability varies by iOS version; missing tables are skipped with a log message.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "package",
+    },
+    "biomeDbAppOpeningsHourly": {
+        "name": "Biome DB - App Openings (Hourly)",
+        "description": "Hourly per-application launch counts pre-aggregated by Apple in the "
+                       "ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Timestamps are normalized by Apple to the start of the hour.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "clock",
+    },
+    "biomeDbCablePlugEvents": {
+        "name": "Biome DB - Cable Plug Events",
+        "description": "Cable connection/disconnection events pre-aggregated by Apple in the "
+                       "ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    },
+    "biomeDbBacklightEvents": {
+        "name": "Biome DB - Backlight Events",
+        "description": "Screen backlight level change events pre-aggregated by Apple in the "
+                       "ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "device-mobile",
+    },
+    "biomeDbButtonClicks": {
+        "name": "Biome DB - Button Clicks (Daily)",
+        "description": "Per-day hardware button click counts pre-aggregated by Apple in the "
+                       "ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Timestamps are normalized by Apple to the start of the day.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+    "biomeDbMinBattery": {
+        "name": "Biome DB - Minimum Battery (Daily)",
+        "description": "Per-day minimum battery percentage pre-aggregated by Apple in the "
+                       "ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Timestamps are normalized by Apple to the start of the day.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    },
+    "biomeDbCarPlay": {
+        "name": "Biome DB - CarPlay Activity (Daily)",
+        "description": "Per-day CarPlay activity counts pre-aggregated by Apple in the "
+                       "ApplePay.Security.Features Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Timestamps are normalized by Apple to the start of the day.",
+        "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin",
+    },
+}
+
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records, does_table_exist_in_db,
+                               convert_unix_ts_to_utc, logfunc)
+
+DB_BASENAME = 'ApplePay.Security.Features.sqlite3'
+
+
+def _find_db(context):
+    """Returns the main ApplePay.Security.Features.sqlite3 path, skipping the
+    -fullRebuild variant and journal files."""
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith(DB_BASENAME) and not file_found.endswith('-fullRebuild.sqlite3'):
+            return file_found
+    return ''
+
+
+def _table_rows(context, table, query):
+    """Runs the query when the source db and table exist; returns (rows, path)."""
+    source_path = _find_db(context)
+    if not source_path:
+        return [], ''
+    if not does_table_exist_in_db(source_path, table):
+        # Table availability varies by iOS version
+        logfunc(f'No {table} table in {source_path} (not populated on this iOS version)')
+        return [], source_path
+    return get_sqlite_db_records(source_path, query), source_path
+
+
+@artifact_processor
+def biomeDbAppOpenings(context):
+    data_headers = (('Event Timestamp', 'datetime'), 'Bundle ID', 'Starting', 'Launch Type')
+    data_list = []
+    rows, source_path = _table_rows(context, 'AppOpeningsRawMatView', '''
+        SELECT eventTimestamp, bundleID, starting, launchType
+        FROM AppOpeningsRawMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1], row[2], row[3]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbAppOpeningsHourly(context):
+    data_headers = (('Hour (UTC)', 'datetime'), 'Bundle ID', 'Launch Type', 'App Open Count')
+    data_list = []
+    rows, source_path = _table_rows(context, 'AppOpeningsMatView', '''
+        SELECT date_hour, bundleID, launchType, appOpenAcount
+        FROM AppOpeningsMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1], row[2], row[3]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbCablePlugEvents(context):
+    data_headers = (('Event Timestamp', 'datetime'), 'Starting')
+    data_list = []
+    rows, source_path = _table_rows(context, 'PluginRawMatView', '''
+        SELECT eventTimestamp, starting FROM PluginRawMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbBacklightEvents(context):
+    data_headers = (('Event Timestamp', 'datetime'), 'Backlight Level')
+    data_list = []
+    rows, source_path = _table_rows(context, 'BacklightRawMatView', '''
+        SELECT eventTimestamp, backlightLevel FROM BacklightRawMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbButtonClicks(context):
+    data_headers = (('Date (UTC)', 'datetime'), 'Button Click Count', 'Reason')
+    data_list = []
+    rows, source_path = _table_rows(context, 'ButtonClickMatView', '''
+        SELECT date, buttonClickCount, reason FROM ButtonClickMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1], row[2]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbMinBattery(context):
+    data_headers = (('Date (UTC)', 'datetime'), 'Minimum Battery Percentage')
+    data_list = []
+    rows, source_path = _table_rows(context, 'MinBatteryMatView', '''
+        SELECT date, minBatteryPerc FROM MinBatteryMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1]))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeDbCarPlay(context):
+    data_headers = (('Date (UTC)', 'datetime'), 'CarPlay Activity Count')
+    data_list = []
+    rows, source_path = _table_rows(context, 'CarPlayMatView', '''
+        SELECT date, carPlayActivityCount FROM CarPlayMatView''')
+    for row in rows:
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1]))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/biomeIntelligenceEntity.py
+++ b/scripts/artifacts/biomeIntelligenceEntity.py
@@ -1,0 +1,49 @@
+__artifacts_v2__ = {
+    "biomeIntelligenceEntities": {
+        "name": "Biome DB - Intelligence Platform Entities",
+        "description": "Knowledge-graph entity records (contacts, apps, identifiers and their attributes) compiled "
+                       "by Apple in the IntelligencePlatform.Entity Biome database.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "iOS 18 stores subject/predicate/object triples in EntityCentricSubgraph (predicate codes are "
+                 "undocumented; objects carry names, bundle IDs, phone numbers and record identifiers). Newer iOS "
+                 "versions use per-entity tables (Person, Location, FlightReservations) not yet present in test data.",
+        "paths": ('*/Biome/databases/IntelligencePlatform.Entity/IntelligencePlatform.Entity.sqlite3*',),
+        "output_types": "standard",
+        "artifact_icon": "database",
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, does_table_exist_in_db, logfunc
+
+DB_BASENAME = 'IntelligencePlatform.Entity.sqlite3'
+
+
+@artifact_processor
+def biomeIntelligenceEntities(context):
+    data_headers = ('Subject ID', 'Predicate', 'Relationship ID', 'Relationship Predicate', 'Object')
+    data_list = []
+
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith(DB_BASENAME) and not file_found.endswith('-fullRebuild.sqlite3'):
+            source_path = file_found
+            break
+    if not source_path:
+        return data_headers, data_list, ''
+
+    if does_table_exist_in_db(source_path, 'EntityCentricSubgraph'):
+        for row in get_sqlite_db_records(source_path, '''
+                SELECT subject, predicate, relationshipId, relationshipPredicate, object
+                FROM EntityCentricSubgraph'''):
+            data_list.append((str(row[0]), row[1], row[2], row[3], row[4]))
+    else:
+        logfunc(f'No EntityCentricSubgraph table in {source_path} '
+                '(schema differs on this iOS version)')
+
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/biomeIntelligenceEntity.py
+++ b/scripts/artifacts/biomeIntelligenceEntity.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Biome DB - Intelligence Platform Entities",
         "description": "Knowledge-graph entity records (contacts, apps, identifiers and their attributes) compiled "
                        "by Apple in the IntelligencePlatform.Entity Biome database.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",

--- a/scripts/artifacts/biomeSetsStores.py
+++ b/scripts/artifacts/biomeSetsStores.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Biome Sets - Installed Apps",
         "description": "Installed application records (bundle ID and display name) from the App.InstalledApp "
                        "Biome Set.db store.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
     "biomeSetsContacts": {
         "name": "Biome Sets - Contacts",
         "description": "Contact name records from the Contacts.Contact Biome Set.db store.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "name": "Biome Sets - FindMy Devices",
         "description": "FindMy device records (device name and owner name) from the FindMy.Device Biome "
                        "Set.db store.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
         "name": "Biome Sets - Significant Locations",
         "description": "Significant location records (label, street, locality, city, country) from the "
                        "Location.SignificantLocation Biome Set.db store.",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -60,7 +60,7 @@ __artifacts_v2__ = {
         "name": "Biome Sets - App Shortcut Phrases",
         "description": "Per-application Siri/Shortcuts phrases from the App.Shortcut.Phrase Biome Set.db stores "
                        "(one store per source application).",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",
@@ -75,7 +75,7 @@ __artifacts_v2__ = {
         "name": "Biome Sets - App Shortcut Entities",
         "description": "Per-application entity records exposed to Siri/Shortcuts from the App.Shortcut.Entity "
                        "Biome Set.db stores (can include user content names such as note titles and board names).",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
         "last_update_date": "2026-07-11",
         "requirements": "none",

--- a/scripts/artifacts/biomeSetsStores.py
+++ b/scripts/artifacts/biomeSetsStores.py
@@ -1,0 +1,262 @@
+__artifacts_v2__ = {
+    "biomeSetsInstalledApps": {
+        "name": "Biome Sets - Installed Apps",
+        "description": "Installed application records (bundle ID and display name) from the App.InstalledApp "
+                       "Biome Set.db store.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Modified timestamps come from the store's instance table.",
+        "paths": ('*/Biome/sets/Default/App.InstalledApp/Database/Set.db*',),
+        "output_types": "standard",
+        "artifact_icon": "package",
+    },
+    "biomeSetsContacts": {
+        "name": "Biome Sets - Contacts",
+        "description": "Contact name records from the Contacts.Contact Biome Set.db store.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Unmapped protobuf fields are preserved in the Other Fields column.",
+        "paths": ('*/Biome/sets/Default/Contacts.Contact/Database/Set.db*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    },
+    "biomeSetsFindMyDevices": {
+        "name": "Biome Sets - FindMy Devices",
+        "description": "FindMy device records (device name and owner name) from the FindMy.Device Biome "
+                       "Set.db store.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "paths": ('*/Biome/sets/Default/FindMy.Device/Database/Set.db*',),
+        "output_types": "standard",
+        "artifact_icon": "device-mobile",
+    },
+    "biomeSetsSignificantLocations": {
+        "name": "Biome Sets - Significant Locations",
+        "description": "Significant location records (label, street, locality, city, country) from the "
+                       "Location.SignificantLocation Biome Set.db store.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "paths": ('*/Biome/sets/Default/Location.SignificantLocation/Database/Set.db*',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin",
+    },
+    "biomeSetsShortcutPhrases": {
+        "name": "Biome Sets - App Shortcut Phrases",
+        "description": "Per-application Siri/Shortcuts phrases from the App.Shortcut.Phrase Biome Set.db stores "
+                       "(one store per source application).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Documents which intent phrases installed apps registered with the system.",
+        "paths": ('*/Biome/sets/Default/App.Shortcut.Phrase/*/Database/Set.db*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    },
+    "biomeSetsShortcutEntities": {
+        "name": "Biome Sets - App Shortcut Entities",
+        "description": "Per-application entity records exposed to Siri/Shortcuts from the App.Shortcut.Entity "
+                       "Biome Set.db stores (can include user content names such as note titles and board names).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "paths": ('*/Biome/sets/Default/App.Shortcut.Entity/*/Database/Set.db*',),
+        "output_types": "standard",
+        "artifact_icon": "database",
+    },
+}
+
+import re
+import struct
+
+import blackboxprotobuf
+from google.protobuf.message import DecodeError
+
+from scripts.ilapfuncs import (artifact_processor, open_sqlite_db_readonly, does_table_exist_in_db,
+                               convert_unix_ts_to_utc, logfunc)
+
+SOURCE_APP_RE = re.compile(r'sourceIdentifier=([^/\\]+)')
+
+
+def _set_records(file_found):
+    """Yields (modified_utc, protobuf_dict) for every content record of a
+    Set.db store. Records that fail protobuf decoding are logged and skipped."""
+    if not does_table_exist_in_db(file_found, 'content'):
+        logfunc(f'No content table in {file_found} (unsupported Set.db layout?)')
+        return
+    db = open_sqlite_db_readonly(file_found)
+    cursor = db.cursor()
+    try:
+        cursor.execute('''
+            SELECT i.modified, c.content
+            FROM content c
+            JOIN provenance p ON p.content_hash = c.content_hash
+            JOIN instance i ON i.provenance_row_id = p.provenance_row_id
+        ''')
+        rows = cursor.fetchall()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        logfunc(f'Unable to query Set.db {file_found}: {ex}')
+        rows = []
+    db.close()
+
+    for modified, blob in rows:
+        try:
+            message, _ = blackboxprotobuf.decode_message(blob)
+        except (DecodeError, struct.error, KeyError, ValueError, TypeError, IndexError) as ex:
+            logfunc(f'Skipping Set.db record in {file_found} due to protobuf decode error: {ex}')
+            continue
+        # instance.modified is Unix epoch microseconds
+        yield convert_unix_ts_to_utc(modified), message
+
+
+def _text(message, key):
+    """Returns the protobuf field as text ('' when absent)."""
+    value = message.get(key, '')
+    if isinstance(value, bytes):
+        return value.decode('utf-8', errors='replace')
+    if isinstance(value, list):
+        return ', '.join(_text({'x': item}, 'x') for item in value)
+    if isinstance(value, dict):
+        return str(value)
+    return str(value) if value != '' else ''
+
+
+def _nested(message, key):
+    value = message.get(key, {})
+    return value if isinstance(value, dict) else {}
+
+
+def _leftover(message, known_keys):
+    """Returns unmapped fields as readable text so no data is dropped."""
+    rest = {}
+    for key in message:
+        if key in known_keys:
+            continue
+        rest[key] = _text(message, key)
+    return str(rest) if rest else ''
+
+
+def _source_app(file_found):
+    match = SOURCE_APP_RE.search(file_found)
+    return match.group(1) if match else ''
+
+
+@artifact_processor
+def biomeSetsInstalledApps(context):
+    data_headers = (('Modified', 'datetime'), 'Bundle ID', 'App Name', 'Other Fields')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('Set.db'):
+            continue
+        source_path = file_found
+        for modified, message in _set_records(file_found):
+            data_list.append((modified, _text(message, '1'), _text(message, '3'),
+                              _leftover(message, ('1', '3'))))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeSetsContacts(context):
+    data_headers = (('Modified', 'datetime'), 'Given Name', 'Family Name', 'Other Fields')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('Set.db'):
+            continue
+        source_path = file_found
+        for modified, message in _set_records(file_found):
+            data_list.append((modified, _text(message, '1'), _text(message, '3'),
+                              _leftover(message, ('1', '3'))))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeSetsFindMyDevices(context):
+    data_headers = (('Modified', 'datetime'), 'Device Name', 'Owner Given Name', 'Owner Family Name',
+                    'Other Fields')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('Set.db'):
+            continue
+        source_path = file_found
+        for modified, message in _set_records(file_found):
+            owner = _nested(message, '2')
+            data_list.append((modified, _text(message, '1'), _text(owner, '1'), _text(owner, '2'),
+                              _leftover(message, ('1', '2'))))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeSetsSignificantLocations(context):
+    data_headers = (('Modified', 'datetime'), 'Label', 'Street', 'Area', 'City', 'Country', 'Other Fields')
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('Set.db'):
+            continue
+        source_path = file_found
+        for modified, message in _set_records(file_found):
+            address = _nested(message, '3')
+            data_list.append((modified, _text(message, '1'), _text(address, '1'), _text(address, '2'),
+                              _text(address, '3'), _text(address, '4'), _leftover(message, ('1', '2', '3'))))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def biomeSetsShortcutPhrases(context):
+    data_headers = (('Modified', 'datetime'), 'Source App', 'Phrase', 'Phrase Template', 'Intent URL',
+                    'Source File')
+    data_list = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('Set.db'):
+            continue
+        source_app = _source_app(file_found)
+        for modified, message in _set_records(file_found):
+            data_list.append((modified, source_app, _text(message, '1'), _text(message, '2'),
+                              _text(message, '4'), context.get_relative_path(file_found)))
+    return data_headers, data_list, 'see Source File for more info'
+
+
+@artifact_processor
+def biomeSetsShortcutEntities(context):
+    data_headers = (('Modified', 'datetime'), 'Source App', 'Entity Name', 'Entity Identifier', 'Entity Type',
+                    'Query Provider', 'Source File')
+    data_list = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('Set.db'):
+            continue
+        source_app = _source_app(file_found)
+        for modified, message in _set_records(file_found):
+            data_list.append((modified, source_app, _text(message, '1'), _text(message, '2'),
+                              _text(message, '3'), _text(message, '4'),
+                              context.get_relative_path(file_found)))
+    return data_headers, data_list, 'see Source File for more info'


### PR DESCRIPTION
## Summary

Implements parsing for the two pre-analyzed Biome storage locations described in North Loop Consulting's research ([Ready, Sets, Go / "Apple Did Your Homework: Pre-Analyzed Data in Biome Databases"](https://northloopconsulting.com/blog/f/ready-sets-go)): SQLite databases under `Library/Biome/databases/` and syncable Set.db stores under `Library/Biome/sets/Default/<stream>/Database/Set.db`.

**14 new artifacts across 3 modules**, all verified against the iOS 18.7.8 test image:

| Artifact | Source | Rows on test image |
|---|---|---|
| Biome DB - App Openings | ApplePay.Security.Features → AppOpeningsRawMatView | 407 |
| Biome DB - App Openings (Hourly) | AppOpeningsMatView | 86 |
| Biome DB - Cable Plug Events | PluginRawMatView | 409 |
| Biome DB - Backlight Events | BacklightRawMatView | 574 |
| Biome DB - Button Clicks (Daily) | ButtonClickMatView | 17 |
| Biome DB - Minimum Battery (Daily) | MinBatteryMatView | 15 |
| Biome DB - CarPlay Activity (Daily) | CarPlayMatView | 2 |
| Biome DB - Intelligence Platform Entities | IntelligencePlatform.Entity → EntityCentricSubgraph | 1,685 |
| Biome Sets - Installed Apps | App.InstalledApp Set.db | 76 |
| Biome Sets - Contacts | Contacts.Contact Set.db | 2 |
| Biome Sets - FindMy Devices | FindMy.Device Set.db | 1 |
| Biome Sets - Significant Locations | Location.SignificantLocation Set.db | 1 |
| Biome Sets - App Shortcut Phrases | App.Shortcut.Phrase/* Set.db (per app) | 393 |
| Biome Sets - App Shortcut Entities | App.Shortcut.Entity/* Set.db (per app) | 6 |

## Implementation notes

- **Timestamps**: database MatView tables use Unix-epoch REAL seconds (Raw* tables carry full precision; aggregate tables are normalized by Apple to hour/day starts — noted in each artifact's metadata). Set.db `instance.modified` is Unix microseconds. Everything is stored as UTC-aware datetimes.
- **Set.db payloads are protobuf**, decoded with blackboxprotobuf and joined `content → provenance → instance` for per-record modified times. Known fields map to named columns; anything unmapped is preserved in an `Other Fields` column so no data is silently dropped. Per-record decode guards log and skip malformed blobs (same pattern as the SEGB biome artifacts).
- **Version drift is expected and guarded**: every table lookup checks existence first (the article's iOS 26 device shows tables like `AppInstallationMatView` and per-entity `Person`/`Location`/`FlightReservations` that don't exist on iOS 18.7.8, and vice versa). Missing tables log a message instead of erroring.
- The `-fullRebuild.sqlite3` companion databases are excluded to avoid duplicate rows.

## Follow-ups (need newer test data)

The iOS 26 layouts described in the article — `WalletPaymentsCommerce.Internal`, `Games.RecentlyPlayed`, the per-entity IntelligencePlatform tables, and additional set streams (App.Intents.ExtractedEntity, Photos.Extracted.IDCard, Wallet.Pass…) — aren't present in current test data. The artifacts note this and skip gracefully; parsers can be added once an iOS 26 image is in the corpus.

## Verification

- All 14 artifacts run clean on the test image (zero "had errors"), 3,668 total rows; spot-checked values decode correctly (contact names, FindMy owner, significant-location address, shortcut phrases).
- `PYTHONPATH=. pylint --disable=C,R` on all 3 files: 10.00/10; PluginLoader: 612 plugins load, no duplicate artifact names.