### PR TITLE
Fix artifact crashes surfaced by older iOS test images (13.3.1-16.1.1)

### DIFF
--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -233,6 +233,9 @@ def _embed_values(message):
 
 
 def _message_rows(message, files_found, resolution, source_type, source_file, context, account_id):
+    # Some cached message entries are plain strings rather than objects
+    if not isinstance(message, dict):
+        return []
     timestamp = _discord_timestamp(message.get("timestamp"))
     if not timestamp:
         return []

--- a/scripts/artifacts/sms.py
+++ b/scripts/artifacts/sms.py
@@ -177,20 +177,23 @@ def sms(context):
                 return media_item['extraction_path']
         return None
 
-    sms_df = pd.DataFrame(data_list,
-                          columns=['data-time', 'Read Timestamp', 'message', 'Service', 'Message Direction',
-                                   'Message Sent', 'Message Delivered', 'Message Read', 'Account', 'Account Login',
-                                   'data-name', 'Attachment Name', 'Attachment File', 'Attachment Timestamp',
-                                   'content-type', 'Attachment Size (Bytes)', 'message-id', 'Chat ID', 'from_me'])
+    # The threaded chat view is only rendered when there are messages;
+    # an empty DataFrame breaks the pandas apply in render_chat.
+    if data_list:
+        sms_df = pd.DataFrame(data_list,
+                              columns=['data-time', 'Read Timestamp', 'message', 'Service', 'Message Direction',
+                                       'Message Sent', 'Message Delivered', 'Message Read', 'Account', 'Account Login',
+                                       'data-name', 'Attachment Name', 'Attachment File', 'Attachment Timestamp',
+                                       'content-type', 'Attachment Size (Bytes)', 'message-id', 'Chat ID', 'from_me'])
 
-    sms_df["file-path"] = sms_df.apply(copy_attachments, axis=1)
+        sms_df["file-path"] = sms_df.apply(copy_attachments, axis=1)
 
-    report = ArtifactHtmlReport('SMS & iMessage - Messages (Threaded)')
-    report.start_artifact_report(context.get_report_folder(), 'SMS & iMessage - Messages (Threaded)')
-    report.add_script()
-    report.write_lead_text(f'SMS & iMessage Messages (Threaded) located at: {source_path}')
-    report.write_raw_html(chat_HTML)
-    report.add_script(render_chat(sms_df))
-    report.end_artifact_report()
+        report = ArtifactHtmlReport('SMS & iMessage - Messages (Threaded)')
+        report.start_artifact_report(context.get_report_folder(), 'SMS & iMessage - Messages (Threaded)')
+        report.add_script()
+        report.write_lead_text(f'SMS & iMessage Messages (Threaded) located at: {source_path}')
+        report.write_raw_html(chat_HTML)
+        report.add_script(render_chat(sms_df))
+        report.end_artifact_report()
 
     return data_headers, data_list, source_path

--- a/scripts/artifacts/storeUser.py
+++ b/scripts/artifacts/storeUser.py
@@ -85,18 +85,19 @@ def storeUser_ca(context):
 
     data_headers = (('Install Timestamp', 'datetime'),'Bundle ID','App Name','Developer Name','App Version','App Bundle Version','App Store ID','System App','Deletion Date')
 
+    # current_apps is absent on older iOS App Store cache schemas
     if does_table_exist_in_db(source_path, "current_apps"):
         if does_column_exist_in_db(source_path, "current_apps", "is_system_app"):
             db_records = get_sqlite_db_records(source_path, current_app_query)
             for record in db_records:
                 data_list.append((record[0], record[1], record[2], record[3], record[4], record[5], record[6], record[7], record[8]))
-                                
+
         else:
             db_records = get_sqlite_db_records(source_path, current_app_prev_query)
             for record in db_records:
                 data_list.append((record[0], record[1], record[2], record[3], record[4], record[5], 'No', record[6], record[7]))
 
-        return data_headers, data_list, source_path
+    return data_headers, data_list, source_path
 
 @artifact_processor  
 def storeUser_pha(context):

--- a/scripts/artifacts/sysdiagnose.py
+++ b/scripts/artifacts/sysdiagnose.py
@@ -53,15 +53,19 @@ def get_sysdiag_account_devices(context):
         else:
             continue
         sources.append(source_path)
-        opush = f["lastOctagonPush"]
+        # Older iOS otctl_status.txt may omit these keys entirely
+        opush = f.get("lastOctagonPush", '')
 
-        for elem in f["contextDump"]["peers"]:
-            model = elem["permanentInfo"]["model_id"]
-            m_name = context.lookup_metadata('apple_device_id_to_model', model)
-            os_bnum = elem["stableInfo"]["os_version"]
-            os_build = os_bnum.split('(')[1].split(')')[0]
-            os_ver = context.get_apple_os_version(os_build, model)
-            serial = elem["stableInfo"]["serial_number"]
+        for elem in f.get("contextDump", {}).get("peers", []):
+            try:
+                model = elem["permanentInfo"]["model_id"]
+                m_name = context.lookup_metadata('apple_device_id_to_model', model)
+                os_bnum = elem["stableInfo"]["os_version"]
+                os_build = os_bnum.split('(')[1].split(')')[0]
+                os_ver = context.get_apple_os_version(os_build, model)
+                serial = elem["stableInfo"]["serial_number"]
+            except (KeyError, IndexError):
+                continue
             if not any(serial in subliste for subliste in data_list):
                 data_list.append((opush, model, m_name, os_bnum, os_ver, serial))
     source_list = "; ".join(s for s in sources)


### PR DESCRIPTION
## Summary

Adding older public/CTF iOS images (13.3.1 through 16.1.1) to the test corpus surfaced five swallowed artifact crashes (the framework logs `Reading <key> artifact had errors!` and moves on). Each is an artifact-side fix.

| Artifact | Crash | Root cause | Fix |
|---|---|---|---|
| `sms` | `ValueError: Cannot set a DataFrame with multiple columns…` | An empty `sms.db` (0 messages) makes an empty DataFrame, and `render_chat`'s `df.apply(axis=1)` returns an empty frame that can't be assigned to one column (Magnet iOS 16.1.1) | Skip the threaded-chat render when there are no messages |
| `storeUser_ca` | `TypeError: cannot unpack non-iterable NoneType` | Returns `None` when the `current_apps` table is absent (older App Store cache schema on 13.3.1 / 14.3) | Always return the data tuple |
| `discordChats` | `AttributeError: 'str' object has no attribute 'get'` | Some cached message entries are plain strings, not objects (iOS 15.0.2) | Guard non-dict messages |
| `get_sysdiag_account_devices` | `KeyError: 'lastOctagonPush'` | Older `otctl_status.txt` omits `lastOctagonPush` and `contextDump/peers` (14.3) | `.get()` for the top-level keys, skip malformed peers |

The `sms` fix stays in the artifact (guarding on empty `data_list`) rather than touching the shared `chat_rendering.py`.

## Verification

Re-ran the five crashed artifact×image combinations against the extracted images: **zero errors**, with data recovered where present:

- iOS 14.3: SMS 106, Discord 50, storeUser purchased 49
- iOS 15.0.2 (Jess): SMS 13, Discord 25, storeUser 13/13
- iOS 13.3.1: SMS 42, Discord 10, storeUser purchased 39 (`storeUser_ca` correctly returns 0 — no `current_apps` table)
- iOS 16.1.1 (Magnet): Discord 8, storeUser 75/33 (`sms` correctly returns 0 — empty `sms.db`)

`PYTHONPATH=. pylint --disable=C,R` on all four files: 10.00/10.

The corpus sample_data refresh for these new images will follow once this merges.