### PR TITLE
Add Biome stream artifacts: harvested mail/messages, reads, screen time, keyboard

### DIFF
--- a/scripts/artifacts/biomeStreams.py
+++ b/scripts/artifacts/biomeStreams.py
@@ -1,0 +1,215 @@
+__artifacts_v2__ = {
+    "biomeProactiveMail": {
+        "name": "Biome - Proactive Harvesting Mail",
+        "description": "Email metadata harvested by the system into the ProactiveHarvesting.Mail biome stream "
+                       "(harvest time, the message date, subject, sender and recipient).",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The message date comes from an embedded CFAbsoluteTime value; the harvest time is the SEGB "
+                 "record timestamp.",
+        "paths": ('*/Biome/streams/restricted/ProactiveHarvesting.Mail/local/*',
+                  '*/biome/streams/restricted/ProactiveHarvesting.Mail/local/*'),
+        "output_types": "standard",
+        "artifact_icon": "mail",
+    },
+    "biomeProactiveMessages": {
+        "name": "Biome - Proactive Harvesting Messages",
+        "description": "Message content harvested by the system into the ProactiveHarvesting.Messages biome "
+                       "stream (service and handle, message text, sender).",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/Biome/streams/restricted/ProactiveHarvesting.Messages/local/*',
+                  '*/biome/streams/restricted/ProactiveHarvesting.Messages/local/*'),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    },
+    "biomeMessagesRead": {
+        "name": "Biome - Messages Read",
+        "description": "Message read events from the Messages.Read biome stream (message identifier and the "
+                       "time it was read).",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/Biome/streams/restricted/Messages.Read/local/*',
+                  '*/biome/streams/restricted/Messages.Read/local/*'),
+        "output_types": "standard",
+        "artifact_icon": "check",
+    },
+    "biomeScreenTimeAppUsage": {
+        "name": "Biome - ScreenTime App Usage",
+        "description": "Per-app foreground start/end events from the ScreenTime.AppUsage biome stream.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The SEGB record timestamp is used; an embedded timestamp field in this stream is unreliable.",
+        "paths": ('*/Biome/streams/restricted/ScreenTime.AppUsage/local/*',
+                  '*/biome/streams/restricted/ScreenTime.AppUsage/local/*'),
+        "output_types": "standard",
+        "artifact_icon": "clock",
+    },
+    "biomeKeyboardTokens": {
+        "name": "Biome - Keyboard Learned Tokens",
+        "description": "Words and tokens the keyboard learned, from the Keyboard.TokenFrequency biome stream, "
+                       "with their frequency.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-07-11",
+        "last_update_date": "2026-07-11",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Some tokens are stored in a non-text form and appear blank.",
+        "paths": ('*/Biome/streams/restricted/Keyboard.TokenFrequency/local/*',
+                  '*/biome/streams/restricted/Keyboard.TokenFrequency/local/*'),
+        "output_types": "standard",
+        "artifact_icon": "keyboard",
+    },
+}
+
+import os
+import struct
+from datetime import timezone
+
+import blackboxprotobuf
+from google.protobuf.message import DecodeError
+
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, convert_cocoa_core_data_ts_to_utc, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError, IndexError)
+
+
+def _txt(value):
+    """Returns a protobuf field as text ('' when absent or non-text)."""
+    if isinstance(value, bytes):
+        return value.decode('utf-8', errors='replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _header(message, name):
+    """Looks up an email header (name/value pairs in field 10)."""
+    headers = message.get('10', [])
+    if isinstance(headers, dict):
+        headers = [headers]
+    for item in headers:
+        if isinstance(item, dict) and _txt(item.get('1', '')).lower() == name:
+            return _txt(item.get('2', ''))
+    return ''
+
+
+def _cf_double_to_utc(value):
+    """The embedded date is a CFAbsoluteTime (seconds since 2001) stored as the
+    raw bits of a little-endian double."""
+    if not isinstance(value, int):
+        return ''
+    try:
+        seconds = struct.unpack('<d', struct.pack('<q', value))[0]
+    except (struct.error, OverflowError):
+        return ''
+    return convert_cocoa_core_data_ts_to_utc(seconds)
+
+
+def _records(context):
+    """Yields (segb_ts_utc, state_name, decoded_message_or_None, filename, offset)
+    for each non-tombstone SEGB record across the matched stream files."""
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+            continue
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+            if record.state == EntryState.Written and record.data:
+                try:
+                    message, _ = blackboxprotobuf.decode_message(record.data)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Skipping {filename} record at offset {record.data_start_offset} '
+                            f'due to protobuf decode error: {ex}')
+                    message = None
+                yield ts, 'Written', message, filename, record.data_start_offset
+            elif record.state == EntryState.Deleted:
+                yield ts, 'Deleted', None, filename, record.data_start_offset
+
+
+@artifact_processor
+def biomeProactiveMail(context):
+    data_headers = (('Harvest Time', 'datetime'), 'SEGB State', ('Message Date', 'datetime'), 'Subject',
+                    'Sender', 'Recipient', 'Message ID', 'Filename', 'Offset')
+    data_list = []
+    for ts, state, message, filename, offset in _records(context):
+        if message is None:
+            data_list.append((ts, state, '', '', '', '', '', filename, offset))
+            continue
+        data_list.append((ts, state, _cf_double_to_utc(message.get('3')), _txt(message.get('11')),
+                          _header(message, 'from'), _header(message, 'to'), _txt(message.get('2')),
+                          filename, offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def biomeProactiveMessages(context):
+    data_headers = (('Timestamp', 'datetime'), 'SEGB State', 'Service and Handle', 'Content', 'Sender',
+                    'GUID', 'Filename', 'Offset')
+    data_list = []
+    for ts, state, message, filename, offset in _records(context):
+        if message is None:
+            data_list.append((ts, state, '', '', '', '', filename, offset))
+            continue
+        sender = message.get('11', {})
+        sender = _txt(sender.get('1')) if isinstance(sender, dict) else ''
+        data_list.append((ts, state, _txt(message.get('2')), _txt(message.get('10')), sender,
+                          _txt(message.get('1')), filename, offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def biomeMessagesRead(context):
+    data_headers = (('Read Timestamp', 'datetime'), 'SEGB State', 'Message ID', 'Filename', 'Offset')
+    data_list = []
+    for ts, state, message, filename, offset in _records(context):
+        message_id = _txt(message.get('1')) if message else ''
+        data_list.append((ts, state, message_id, filename, offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def biomeScreenTimeAppUsage(context):
+    data_headers = (('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Event', 'Filename', 'Offset')
+    data_list = []
+    for ts, state, message, filename, offset in _records(context):
+        if message is None:
+            data_list.append((ts, state, '', '', filename, offset))
+            continue
+        event = message.get('1')
+        event = 'Start' if event == 1 else 'End' if event == 0 else _txt(event)
+        data_list.append((ts, state, _txt(message.get('3')), event, filename, offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def biomeKeyboardTokens(context):
+    data_headers = (('Timestamp', 'datetime'), 'SEGB State', 'Token', 'Frequency', 'Filename', 'Offset')
+    data_list = []
+    for ts, state, message, filename, offset in _records(context):
+        if message is None:
+            data_list.append((ts, state, '', '', filename, offset))
+            continue
+        token_field = message.get('1', {})
+        token = _txt(token_field.get('1')) if isinstance(token_field, dict) else ''
+        data_list.append((ts, state, token, _txt(message.get('3')), filename, offset))
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## Summary

Five SEGB streams under `Library/Biome/streams/restricted/` that iLEAPP did not previously parse. New module `biomeStreams.py`, verified against the iOS 18.7.8 test image.

| Artifact | Stream | What it recovers | Rows on test image |
|---|---|---|---|
| Biome - Proactive Harvesting Mail | `ProactiveHarvesting.Mail` | Harvest time, the message's own date, subject, sender, recipient | 76 written + 199 deleted markers |
| Biome - Proactive Harvesting Messages | `ProactiveHarvesting.Messages` | Message **content**, service + handle, sender | 118 |
| Biome - Messages Read | `Messages.Read` | Message read events (id + time) | 136 |
| Biome - ScreenTime App Usage | `ScreenTime.AppUsage` | Per-app foreground start/end events (bundle id) | 3,723 |
| Biome - Keyboard Learned Tokens | `Keyboard.TokenFrequency` | Learned keyboard tokens + frequency | 143 |

## Implementation notes

- Records are read with `read_segb_file` and decoded with per-record `blackboxprotobuf` guards; a bad record is logged and skipped, never fatal. Deleted SEGB entries are surfaced as markers (same convention as the existing biome stream artifacts).
- **Timestamps**: the SEGB record timestamp is used throughout (UTC). For Mail, the embedded message date is a CFAbsoluteTime stored as the raw bits of a little-endian double, decoded and confirmed to match the email's own `Date` header. For ScreenTime, an embedded timestamp field is unreliable (skewed by decades), so only the SEGB record time is used.
- Mail sender/recipient come from the RFC-822 header block inside the record. The `Sender`/`Recipient` column names avoid the SQL reserved words `from`/`to` that the LAVA table builder can't quote.
- Paths cover both `Biome/` and `biome/` casings.

## Verification

All five run clean (zero errors) on the test image; spot-checked values decode correctly (harvested Facebook notification emails with sender/recipient, message content, keyboard tokens). `PYTHONPATH=. pylint --disable=C,R`: 10.00/10; PluginLoader loads 603 plugins with no duplicate names.