### PR TITLE
Fix Safari Tabs (BrowserState) timestamp on iOS 26+

### DIFF
--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -105,9 +105,17 @@ def safariTabsBrowserState(context):
     if not source_path:
         return data_headers, data_list, ''
 
+    # last_viewed_time is Apple absolute (Cocoa) time on iOS <= 18, but a Unix
+    # timestamp on iOS 26+. Cocoa values for realistic dates stay well below the
+    # 978307200 offset (which equals year 2032 in Cocoa time), while Unix values
+    # are always above it, so the magnitude disambiguates the two encodings.
     query = '''
     SELECT
-        datetime(last_viewed_time + 978307200, 'unixepoch'),
+        CASE
+            WHEN last_viewed_time > 978307200
+                THEN datetime(last_viewed_time, 'unixepoch')
+            ELSE datetime(last_viewed_time + 978307200, 'unixepoch')
+        END,
         title, url, user_visible_url, opened_from_link, private_browsing
     FROM tabs
     '''


### PR DESCRIPTION
Fixes #1699.

## Problem
`Safari Browser - Tabs (BrowserState)` showed timestamps ~31 years in the future (e.g. **2057**) on an iOS 26.5.2 backup.

The query in `safariTabs.py` unconditionally added the Cocoa→Unix offset (`+ 978307200`) to `tabs.last_viewed_time`, assuming the column is always Apple Absolute Time.

## Root cause
- iOS ≤18: `last_viewed_time` is Apple absolute (Cocoa) time, e.g. `742060073` → 2024-07-07. Adding the offset is correct.
- iOS 26+: `last_viewed_time` is already a **Unix** timestamp (~1.7e9). Adding the offset pushes it to ~2057.

## Fix
Disambiguate by magnitude with a `CASE`: values above `978307200` (year 2032 in Cocoa time, but 2001 in Unix) are treated as already-Unix; smaller values keep the Cocoa correction.

## Verification
- Cocoa sample DB (iOS 17): `742060073` → `2024-07-07` ✓ (unchanged)
- Synthetic iOS 26 Unix value `1751900873` → `2025-07-07` ✓
- `pylint --disable=C,R` → 10.00/10

The iCloud Tabs artifact is untouched.