### PR TITLE
Convert 25 artifacts to the context function form (mechanical batch)

### DIFF
--- a/scripts/artifacts/Threema.py
+++ b/scripts/artifacts/Threema.py
@@ -59,8 +59,8 @@ from scripts.ilapfuncs import artifact_processor, \
     check_in_media, check_in_embedded_media
 
 @artifact_processor
-def threema_chats(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'ThreemaData.sqlite')
+def threema_chats(context):
+    source_path = get_file_path(context.get_files_found(), 'ThreemaData.sqlite')
     data_list = []
 
     chat_query = '''
@@ -233,8 +233,8 @@ def threema_chats(files_found, _report_folder, _seeker, _wrap_text, _timezone_of
     return data_headers, data_list, source_path
 
 @artifact_processor
-def threema_users(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'ThreemaData.sqlite')
+def threema_users(context):
+    source_path = get_file_path(context.get_files_found(), 'ThreemaData.sqlite')
     data_list = []
 
     user_query = '''

--- a/scripts/artifacts/ZangiMessenger.py
+++ b/scripts/artifacts/ZangiMessenger.py
@@ -83,8 +83,8 @@ from scripts.ilapfuncs import artifact_processor, \
     convert_cocoa_core_data_ts_to_utc, check_in_media
 
 @artifact_processor
-def zangi_messages(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+def zangi_messages(context):
+    files_found = [x for x in context.get_files_found() if not x.endswith('wal') and not x.endswith('shm')]
     data_list = []
 
     query = '''
@@ -274,9 +274,9 @@ def zangi_messages(files_found, _report_folder, _seeker, _wrap_text, _timezone_o
 
 
 @artifact_processor
-def zangi_contacts(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def zangi_contacts(context):
 
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in context.get_files_found() if not x.endswith('wal') and not x.endswith('shm')]
 
     main_db = ''
     data_list = []
@@ -351,9 +351,9 @@ def zangi_contacts(files_found, _report_folder, _seeker, _wrap_text, _timezone_o
 
 
 @artifact_processor
-def zangi_accounts(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def zangi_accounts(context):
 
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in context.get_files_found() if not x.endswith('wal') and not x.endswith('shm')]
 
     main_db = ''
     data_list = []

--- a/scripts/artifacts/deviceDatam.py
+++ b/scripts/artifacts/deviceDatam.py
@@ -37,9 +37,9 @@ from datetime import datetime, timedelta
 from scripts.ilapfuncs import artifact_processor, device_info, webkit_timestampsconv
 
 @artifact_processor
-def deviceDatam(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def deviceDatam(context):
     data_list = []
-    file_found = str(files_found[0])
+    file_found = str(context.get_files_found()[0])
     
     timestamp_keys = [
         'AccountCreationTimestamp',

--- a/scripts/artifacts/deviceName.py
+++ b/scripts/artifacts/deviceName.py
@@ -17,8 +17,8 @@ import plistlib
 from scripts.ilapfuncs import device_info, artifact_processor
 
 @artifact_processor
-def deviceName(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    file_found = str(files_found[0])
+def deviceName(context):
+    file_found = str(context.get_files_found()[0])
     with open(file_found, "rb") as fp:
         pl = plistlib.load(fp)
         for key, val in pl.items():

--- a/scripts/artifacts/imeiImsi.py
+++ b/scripts/artifacts/imeiImsi.py
@@ -36,9 +36,9 @@ import plistlib
 from scripts.ilapfuncs import artifact_processor, device_info
 
 @artifact_processor
-def imeiImsi(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def imeiImsi(context):
     data_list = []
-    source_path = str(files_found[0])
+    source_path = str(context.get_files_found()[0])
     
     with open(source_path, "rb") as fp:
         pl = plistlib.load(fp)

--- a/scripts/artifacts/kikBplistmeta.py
+++ b/scripts/artifacts/kikBplistmeta.py
@@ -31,14 +31,14 @@ from scripts.ilapfuncs import artifact_processor, check_in_embedded_media
 
 
 @artifact_processor
-def kikBplistmeta(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikBplistmeta(context):
     data_headers = ('Content ID', 'Filename', 'File Size', 'Allow Forward', 'Layout', 'App Name',
                     'App ID', 'SHA1 Original', 'SHA1 Scaled', 'Blockhash Scaled',
                     ('Internal Thumbnail', 'media'))
     data_list = []
     source_path = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if os.path.isdir(file_found):
             continue

--- a/scripts/artifacts/kikGroupadmins.py
+++ b/scripts/artifacts/kikGroupadmins.py
@@ -73,7 +73,7 @@ def _decode_entity_blob(blob):
 
 
 @artifact_processor
-def kikGroupadmins(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikGroupadmins(context):
     data_headers = ('User ID', 'Display Name', 'Username', 'Profile Pic URL', 'Member Group ID',
                     'Group Tag', 'Group Name', 'Group ID', 'Group Pic URL', 'Blob User',
                     'Blob Description', 'Blob Interests', 'Additional Info User A',
@@ -81,7 +81,7 @@ def kikGroupadmins(files_found, _report_folder, _seeker, _wrap_text, _timezone_o
     data_list = []
 
     source_path = ''
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('kik.sqlite'):
             source_path = file_found

--- a/scripts/artifacts/kikLocaladmin.py
+++ b/scripts/artifacts/kikLocaladmin.py
@@ -27,14 +27,14 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def kikLocaladmin(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikLocaladmin(context):
     data_headers = ('User ID', 'Display Name', 'Username', 'Profile Pic URL', 'Member Group ID',
                     'Administrator Group ID', 'Group Tag', 'Group Name', 'Group ID', 'Group Pic URL',
                     'Blob', 'Additional Information')
     data_list = []
 
     source_path = ''
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('kik.sqlite'):
             source_path = file_found

--- a/scripts/artifacts/kikMessages.py
+++ b/scripts/artifacts/kikMessages.py
@@ -82,11 +82,11 @@ def _find_db(files_found):
 
 
 @artifact_processor
-def kikMessages(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikMessages(context):
     data_headers = (('Received Time', 'datetime'), ('Timestamp', 'datetime'), 'Message', 'Type',
                     'User', 'Display Name', 'User Name', 'Attachment Name', ('Attachment', 'media'))
     data_list = []
-    source_path = _find_db(files_found)
+    source_path = _find_db(context.get_files_found())
     if not source_path:
         return data_headers, data_list, ''
 
@@ -121,11 +121,11 @@ def kikMessages(files_found, _report_folder, _seeker, _wrap_text, _timezone_offs
 
 
 @artifact_processor
-def kikUsers(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikUsers(context):
     data_headers = ('PK', 'Display Name', 'User Name', 'Email', 'JID', 'First Name', 'Last Name',
                     ('Profile Pic Timestamp', 'datetime'), 'Profile Pic URL')
     data_list = []
-    source_path = _find_db(files_found)
+    source_path = _find_db(context.get_files_found())
     if not source_path:
         return data_headers, data_list, ''
 

--- a/scripts/artifacts/kikPendingUploads.py
+++ b/scripts/artifacts/kikPendingUploads.py
@@ -33,13 +33,13 @@ from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
 @artifact_processor
-def kikPendingUploads(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikPendingUploads(context):
     data_headers = ('Upload Start Time', 'App ID', 'Content ID', 'Progress', 'Retries Remaining',
                     'State', ('Pending File', 'media'))
     data_list = []
     source_path = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith('pending_uploads'):
             continue
@@ -68,7 +68,7 @@ def kikPendingUploads(files_found, _report_folder, _seeker, _wrap_text, _timezon
         content_id = a_dict.get('contentID', '')
         media = ''
         if content_id:
-            for match in files_found:
+            for match in context.get_files_found():
                 match = str(match)
                 if content_id in match and os.path.isfile(match):
                     media = check_in_media(match) or ''

--- a/scripts/artifacts/kikUsersgroups.py
+++ b/scripts/artifacts/kikUsersgroups.py
@@ -27,14 +27,14 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def kikUsersgroups(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def kikUsersgroups(context):
     data_headers = ('User ID', 'Display Name', 'Username', 'Profile Pic URL', 'Member Group ID',
                     'Group Tag', 'Group Name', 'Group ID', 'Group Pic URL', 'Blob',
                     'Additional Information')
     data_list = []
 
     source_path = ''
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('kik.sqlite'):
             source_path = file_found

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -71,8 +71,8 @@ import datetime
 from scripts.ilapfuncs import artifact_processor, get_file_path
 
 @artifact_processor
-def get_kleinanzeigenmessagecache(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'conversation_cache')
+def get_kleinanzeigenmessagecache(context):
+    source_path = get_file_path(context.get_files_found(), 'conversation_cache')
     data_list = []
 
     with open(source_path, 'r', encoding='utf-8') as ka_in:
@@ -149,8 +149,8 @@ def get_kleinanzeigenmessagecache(files_found, _report_folder, _seeker, _wrap_te
     return data_headers, data_list, source_path
 
 @artifact_processor
-def get_kleinanzeigenlastquery(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, '.last_search_query')
+def get_kleinanzeigenlastquery(context):
+    source_path = get_file_path(context.get_files_found(), '.last_search_query')
     data_list = []
 
     with open(source_path, 'r', encoding='utf-8') as ka_in:
@@ -171,8 +171,8 @@ def get_kleinanzeigenlastquery(files_found, _report_folder, _seeker, _wrap_text,
     return data_headers, data_list, source_path
 
 @artifact_processor
-def get_kleinanzeigenuser(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'com.ebaykleinanzeigen.ebc.plist')
+def get_kleinanzeigenuser(context):
+    source_path = get_file_path(context.get_files_found(), 'com.ebaykleinanzeigen.ebc.plist')
     data_list = []
 
     with open(source_path, 'rb') as ka_in:
@@ -197,8 +197,8 @@ def get_kleinanzeigenuser(files_found, _report_folder, _seeker, _wrap_text, _tim
     return data_headers, data_list, source_path
 
 @artifact_processor
-def get_kleinanzeigensearchhistory(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'com.ebaykleinanzeigen.ebc.plist')
+def get_kleinanzeigensearchhistory(context):
+    source_path = get_file_path(context.get_files_found(), 'com.ebaykleinanzeigen.ebc.plist')
     data_list = []
 
     with open(source_path, 'rb') as ka_in:

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -205,8 +205,8 @@ def truncate_after_last_bracket(file_path):
         print("No closing bracket `]` found.")
 
 @artifact_processor
-def logarchive(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, 'logarchive*.json')
+def logarchive(context):
+    source_path = get_file_path(context.get_files_found(), 'logarchive*.json')
     data_list = []
 
     incval = 0
@@ -233,8 +233,8 @@ def logarchive(files_found, report_folder, seeker, wrap_text, timezone_offset):
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_artifacts(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_artifacts(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
 
     query = '''
@@ -383,8 +383,8 @@ def logarchive_artifacts(files_found, report_folder, seeker, wrap_text, timezone
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_time_change(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_time_change(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -400,8 +400,8 @@ def logarchive_time_change(files_found, report_folder, seeker, wrap_text, timezo
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_flashlight(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_flashlight(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -418,8 +418,8 @@ def logarchive_flashlight(files_found, report_folder, seeker, wrap_text, timezon
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_executed_apps(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_executed_apps(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -437,8 +437,8 @@ def logarchive_executed_apps(files_found, report_folder, seeker, wrap_text, time
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_motionstate(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_motionstate(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -454,8 +454,8 @@ def logarchive_motionstate(files_found, report_folder, seeker, wrap_text, timezo
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_tethering(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_tethering(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -473,8 +473,8 @@ def logarchive_tethering(files_found, report_folder, seeker, wrap_text, timezone
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_airplane_mode(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_airplane_mode(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -502,8 +502,8 @@ def logarchive_airplane_mode(files_found, report_folder, seeker, wrap_text, time
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_lock_status(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_lock_status(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -527,8 +527,8 @@ def logarchive_lock_status(files_found, report_folder, seeker, wrap_text, timezo
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_wifi_status(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_wifi_status(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -567,8 +567,8 @@ def logarchive_wifi_status(files_found, report_folder, seeker, wrap_text, timezo
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_bluetooth_status(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_bluetooth_status(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -612,8 +612,8 @@ def logarchive_bluetooth_status(files_found, report_folder, seeker, wrap_text, t
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_audio_status(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_audio_status(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''
@@ -637,8 +637,8 @@ def logarchive_audio_status(files_found, report_folder, seeker, wrap_text, timez
     return data_headers, data_list, source_path
 
 @artifact_processor
-def logarchive_navigation(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, '_lava_artifacts.db')
+def logarchive_navigation(context):
+    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
     data_list = []
     
     query = '''

--- a/scripts/artifacts/medicalID.py
+++ b/scripts/artifacts/medicalID.py
@@ -34,12 +34,12 @@ def get_name(name_with_prefix):
 
 
 @artifact_processor
-def medicalID(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def medicalID(context):
     data_headers = ('Key', 'Value')
     data_list = []
 
     source_path = ''
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('MedicalIDData.archive'):
             source_path = file_found

--- a/scripts/artifacts/mobileContainerManager.py
+++ b/scripts/artifacts/mobileContainerManager.py
@@ -34,12 +34,12 @@ _MARKER = ('[MCMGroupManager _removeGroupContainersIfNeededforUser:groupContaine
 
 
 @artifact_processor
-def mobileContainerManager(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def mobileContainerManager(context):
     data_headers = (('Datetime', 'datetime'), 'Removed', 'Line')
     data_list = []
     source_path = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         source_path = source_path or file_found
         try:

--- a/scripts/artifacts/obliterated.py
+++ b/scripts/artifacts/obliterated.py
@@ -34,8 +34,8 @@ import os
 from scripts.ilapfuncs import logdevinfo, artifact_processor
 
 @artifact_processor
-def get_obliterated(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    file_found = str(files_found[0])
+def get_obliterated(context):
+    file_found = str(context.get_files_found()[0])
     
     modified_time = os.path.getmtime(file_found)
     utc_modified_date = datetime.datetime.fromtimestamp(modified_time, tz=timezone.utc)

--- a/scripts/artifacts/potatoChat.py
+++ b/scripts/artifacts/potatoChat.py
@@ -122,8 +122,8 @@ def decode_varint(source_data, offset): # Taken from https://github.com/Whee30/A
     return value, offset
 
 @artifact_processor
-def potatochat_chats(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'tgdata.db')
+def potatochat_chats(context):
+    source_path = get_file_path(context.get_files_found(), 'tgdata.db')
     data_list = []
     #The table names aren't fix and change the trailing number from time to time
     messages_query = "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'messages_v__';"
@@ -411,8 +411,8 @@ def potatochat_chats(files_found, _report_folder, _seeker, _wrap_text, _timezone
     return data_headers, data_list, source_path
 
 @artifact_processor
-def potatochat_users(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'tgdata.db')
+def potatochat_users(context):
+    source_path = get_file_path(context.get_files_found(), 'tgdata.db')
     data_list = []
     users_query = "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'users_v__';"
     users_nr = get_sqlite_db_records(source_path, users_query)[0]['name']
@@ -455,9 +455,9 @@ def potatochat_users(files_found, _report_folder, _seeker, _wrap_text, _timezone
     return data_headers, data_list, source_path
 
 @artifact_processor
-def potatochat_group_chats(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, 'tgdata.db')
-    share_dialog = get_file_path(files_found, 'shareDialogList.db')
+def potatochat_group_chats(context):
+    source_path = get_file_path(context.get_files_found(), 'tgdata.db')
+    share_dialog = get_file_path(context.get_files_found(), 'shareDialogList.db')
     data_list = []
     media_cache_query = "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'media_cache_v__';"
     media_cache_nr = get_sqlite_db_records(source_path, media_cache_query)[0]['name']

--- a/scripts/artifacts/preferencesPlist.py
+++ b/scripts/artifacts/preferencesPlist.py
@@ -36,9 +36,9 @@ import plistlib
 from scripts.ilapfuncs import artifact_processor, device_info
 
 @artifact_processor
-def preferencesPlist(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def preferencesPlist(context):
     data_list = []
-    source_path = str(files_found[0])
+    source_path = str(context.get_files_found()[0])
     with open(source_path, "rb") as fp:
         pl = plistlib.load(fp)
         for key, val in pl.items():

--- a/scripts/artifacts/serialNumber.py
+++ b/scripts/artifacts/serialNumber.py
@@ -35,10 +35,10 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info
 
 @artifact_processor
-def serialNumber(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def serialNumber(context):
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         if file_found.endswith('consolidated.db'):
             db_file = file_found
             break

--- a/scripts/artifacts/skg_archive.py
+++ b/scripts/artifacts/skg_archive.py
@@ -29,13 +29,13 @@ from collections import defaultdict
 from pathlib import Path
 
 @artifact_processor
-def skg_archive(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def skg_archive(context):
 
     data_list = []
     dedupe = 0
     grouped_files = defaultdict(list)
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         path = Path(file_found)
         grouped_files[path.parent].append(path.name)
 

--- a/scripts/artifacts/splitwise.py
+++ b/scripts/artifacts/splitwise.py
@@ -102,8 +102,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, convert_unix_ts_to_utc
 
 @artifact_processor
-def splitwiseUsers(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, "database.sqlite")
+def splitwiseUsers(context):
+    source_path = get_file_path(context.get_files_found(), "database.sqlite")
     data_list = []
 
     query = '''
@@ -149,8 +149,8 @@ def splitwiseUsers(files_found, _report_folder, _seeker, _wrap_text, _timezone_o
 
 
 @artifact_processor
-def splitwiseExpenses(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, "database.sqlite")
+def splitwiseExpenses(context):
+    source_path = get_file_path(context.get_files_found(), "database.sqlite")
     data_list = []
 
     query = '''
@@ -196,8 +196,8 @@ def splitwiseExpenses(files_found, _report_folder, _seeker, _wrap_text, _timezon
 
 
 @artifact_processor
-def splitwiseExpenseBalances(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, "database.sqlite")
+def splitwiseExpenseBalances(context):
+    source_path = get_file_path(context.get_files_found(), "database.sqlite")
     data_list = []
 
     query = '''
@@ -231,8 +231,8 @@ def splitwiseExpenseBalances(files_found, _report_folder, _seeker, _wrap_text, _
 
 
 @artifact_processor
-def splitwiseTotalBalances(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, "database.sqlite")
+def splitwiseTotalBalances(context):
+    source_path = get_file_path(context.get_files_found(), "database.sqlite")
     data_list = []
 
     query = '''
@@ -268,8 +268,8 @@ def splitwiseTotalBalances(files_found, _report_folder, _seeker, _wrap_text, _ti
 
 
 @artifact_processor
-def splitwiseGroups(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, "database.sqlite")
+def splitwiseGroups(context):
+    source_path = get_file_path(context.get_files_found(), "database.sqlite")
     data_list = []
     data_list_html = []
 
@@ -330,8 +330,8 @@ def splitwiseGroups(files_found, _report_folder, _seeker, _wrap_text, _timezone_
 
 
 @artifact_processor
-def splitwiseNotifications(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
-    source_path = get_file_path(files_found, "database.sqlite")
+def splitwiseNotifications(context):
+    source_path = get_file_path(context.get_files_found(), "database.sqlite")
     data_list = []
     data_list_html = []
 

--- a/scripts/artifacts/subscriberInfo.py
+++ b/scripts/artifacts/subscriberInfo.py
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, convert_cocoa_core_data_ts_to_utc, device_info
 
 @artifact_processor
-def subscriberInfo(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def subscriberInfo(context):
     data_list = []
     db_file = ''
     db_records = []
@@ -50,7 +50,7 @@ def subscriberInfo(files_found, report_folder, seeker, wrap_text, timezone_offse
     FROM subscriber_info
     '''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         if file_found.endswith('CellularUsage.db'):
             db_file = file_found
             db_records = get_sqlite_db_records(db_file, query)

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -33,14 +33,14 @@ from scripts.ilapfuncs import artifact_processor, get_file_path, \
     get_sqlite_db_records, logfunc, open_sqlite_db_readonly
 
 @artifact_processor
-def plz_interaction(files_found, _report_folder, _seeker, _wrap_text):
-    source_path = get_file_path(files_found, "favorites_prediction_db.sqlite")
+def plz_interaction(context):
+    source_path = get_file_path(context.get_files_found(), "favorites_prediction_db.sqlite")
     data_list = []
     cursor = None
     prediction_db = ""
     localdata_db = ""
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith("favorites_prediction_db.sqlite"):
             prediction_db = file_found
@@ -84,12 +84,12 @@ def plz_interaction(files_found, _report_folder, _seeker, _wrap_text):
         logfunc('No Swissmeteo')
 
 @artifact_processor
-def swissmeteo_plz(files_found, _report_folder, _seeker, _wrap_text):
-    source_path = get_file_path(files_found, "favorites_prediction_db.sqlite")
+def swissmeteo_plz(context):
+    source_path = get_file_path(context.get_files_found(), "favorites_prediction_db.sqlite")
     data_list = []
     prediction_db = ""
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('favorites_prediction_db.sqlite'):
             prediction_db = file_found

--- a/scripts/artifacts/tcc.py
+++ b/scripts/artifacts/tcc.py
@@ -39,8 +39,8 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def tcc(files_found, report_folder, seeker, wrap_text, timezone_offset):
-    source_path = get_file_path(files_found, 'TCC.db')
+def tcc(context):
+    source_path = get_file_path(context.get_files_found(), 'TCC.db')
     data_list = []
 
     last_modified_timestamp_exists = does_column_exist_in_db(

--- a/scripts/artifacts/tileAppDisc.py
+++ b/scripts/artifacts/tileAppDisc.py
@@ -22,9 +22,9 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def tileAppDisc(files_found, report_folder, seeker, wrap_text, timezone_offset):
+def tileAppDisc(context):
     source_path = get_file_path(
-        files_found, 'com.thetileapp.tile-DiscoveredTileDB.sqlite')
+        context.get_files_found(), 'com.thetileapp.tile-DiscoveredTileDB.sqlite')
     data_list = []
 
     query = '''


### PR DESCRIPTION
First batch of the context-form migration. Moves **52 artifact functions across 25 files** from the legacy signature

```python
def name(files_found, report_folder, seeker, wrap_text, timezone_offset):
```

to the modern single-parameter **context form**

```python
def name(context):
    ... context.get_files_found() ...
```

## Why these 25

An audit of all `@artifact_processor` functions found 453 already on the context form and 157 still on the legacy signature — of which 87 (non-`Ph*`) are convertible. These 25 files are the **purely mechanical** subset: every function references *only* `files_found` (the other four parameters were unused), so the change is a pure signature migration — **no change to parsing logic, output columns, or returned source paths** (the decorator still relativizes them).

`ZangiMessenger` (which filters `files_found` into a local) was handled by hand so only the parameter read is rewritten; the local filtering is preserved.

## Verification

- **AST:** every decorated function is now 1-parameter with **zero** leftover references to the removed parameters
- **Compile:** all 25 files compile
- **PluginLoader:** loads **619** plugins (unchanged from `main`)
- **Lint:** `pylint --disable=C,R` on all 25 files → **10.00/10**
- **Behavioural equivalence:** an old-vs-new harness called each artifact with its correct arity (legacy 5/4-arg vs new 1-arg context) over identical inputs — **byte-identical data output** (headers + rows) for every sampled artifact; the one apparent diff (`swissmeteo` no-match) was confirmed to be both versions returning `None` identically.

Diff is symmetric (108 insertions / 108 deletions — every line is a 1:1 replacement).

Photos.sqlite (`Ph*`) artifacts are intentionally left on the legacy form. Follow-up batches will cover the `seeker`/`report_folder`-using files and the 3 `timezone_offset` files (which need UTC-always changes and will get their own reviewed PR).