### PR TITLE
Convert findMyItems, gmail, knowledgeC to context form (UTC timestamps)

### DIFF
--- a/scripts/artifacts/findMyItems.py
+++ b/scripts/artifacts/findMyItems.py
@@ -96,7 +96,7 @@ __artifacts_v2__ = {
 
 import json
 from scripts.ilapfuncs import artifact_processor, logfunc
-from scripts.ilapfuncs import convert_unix_ts_to_timezone
+from scripts.ilapfuncs import convert_unix_ts_to_utc
 
 
 def _read_items_json(source_path):
@@ -116,9 +116,9 @@ def _read_items_json(source_path):
 
 
 @artifact_processor
-def findMyItemsInfo(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def findMyItemsInfo(context):
     data_list = []
-    source_path = str(files_found[0])
+    source_path = str(context.get_files_found()[0])
 
     deserialized = _read_items_json(source_path)
     if deserialized:
@@ -151,15 +151,15 @@ def findMyItemsInfo(files_found, _report_folder, _seeker, _wrap_text, _timezone_
     return data_headers, data_list, source_path
 
 @artifact_processor
-def findMyItemsLocations(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def findMyItemsLocations(context):
     data_list = []
-    source_path = str(files_found[0])
+    source_path = str(context.get_files_found()[0])
     
     deserialized = _read_items_json(source_path)
     if deserialized:
         for x in deserialized:
             ltimestamp = (x['location'].get('timeStamp'))
-            ltimestamp = convert_unix_ts_to_timezone(ltimestamp, timezone_offset)
+            ltimestamp = convert_unix_ts_to_utc(ltimestamp)
             name = (x['name'])
             serial = (x['serialNumber'])
             item_id = (x['identifier'])
@@ -216,9 +216,9 @@ def findMyItemsLocations(files_found, _report_folder, _seeker, _wrap_text, timez
     return data_headers, data_list, source_path
 
 @artifact_processor
-def findMyItemsSafeLocations(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def findMyItemsSafeLocations(context):
     data_list = []
-    source_path = str(files_found[0])
+    source_path = str(context.get_files_found()[0])
     
     deserialized = _read_items_json(source_path)
     if deserialized:
@@ -231,7 +231,7 @@ def findMyItemsSafeLocations(files_found, _report_folder, _seeker, _wrap_text, t
             ris = (x['role'].get('identifier'))
             for safeloc in x.get('safeLocations'):
                 stimestamp = (safeloc['location'].get('timeStamp'))
-                stimestamp = convert_unix_ts_to_timezone(stimestamp, timezone_offset)
+                stimestamp = convert_unix_ts_to_utc(stimestamp)
                 sname = (safeloc.get('name'))
                 stype = (safeloc.get('type'))
                 sid = (safeloc.get('identifier'))
@@ -270,15 +270,15 @@ def findMyItemsSafeLocations(files_found, _report_folder, _seeker, _wrap_text, t
     return data_headers, data_list, source_path
 
 @artifact_processor
-def findMyItemsCrowdsourcedLocations(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def findMyItemsCrowdsourcedLocations(context):
     data_list = []
-    source_path = str(files_found[0])
+    source_path = str(context.get_files_found()[0])
     
     deserialized = _read_items_json(source_path)
     if deserialized:
         for x in deserialized:
             crowdtimestamp= (x['crowdSourcedLocation'].get('timeStamp'))
-            crowdtimestamp = convert_unix_ts_to_timezone(crowdtimestamp, timezone_offset)
+            crowdtimestamp = convert_unix_ts_to_utc(crowdtimestamp)
             name = (x['name'])
             serial = (x['serialNumber'])
             item_id = (x['identifier'])

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -46,16 +46,16 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_timezone_offset
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_utc
 
 @artifact_processor
-def gmailOfflineSearch(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def gmailOfflineSearch(context):
     data_list = []
     data_headers = ()
     source_path = ''
     
     file_found = ''
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         source_path = str(file_found)
         if file_found.endswith('searchsqlitedb'):
             break
@@ -80,7 +80,7 @@ def gmailOfflineSearch(files_found, _report_folder, _seeker, _wrap_text, timezon
     all_rows = cursor.fetchall()
         
     for row in all_rows:
-        timestamp = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
+        timestamp = convert_ts_human_to_utc(row[0])
 
         sender = row[1]
         sender_split = [sender_split.strip() for sender_split in sender.split(',')]
@@ -112,13 +112,13 @@ def gmailOfflineSearch(files_found, _report_folder, _seeker, _wrap_text, timezon
     return data_headers, data_list, source_path
 
 @artifact_processor
-def gmailLabelDetails(files_found, _report_folder, _seeker, _wrap_text, _timezone_offset):
+def gmailLabelDetails(context):
     data_list = []
     data_headers = ()
     source_path = ''
     
     file_found = ''
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         source_path = str(file_found)
         if file_found.endswith('sqlitedb'):
             break

--- a/scripts/artifacts/knowledgeC.py
+++ b/scripts/artifacts/knowledgeC.py
@@ -237,14 +237,14 @@ __artifacts_v2__ = {
 
 import plistlib
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, does_column_exist_in_db, \
-    convert_ts_human_to_timezone_offset
+    convert_ts_human_to_utc
 
 @artifact_processor
-def knowledgeC_BatteryPercentage(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_BatteryPercentage(context):
     data_list = []
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
             break
@@ -270,9 +270,9 @@ def knowledgeC_BatteryPercentage(files_found, _report_folder, _seeker, _wrap_tex
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[-1],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[-1])
             data_list.append((start_time, end_time, row[2], row[3], added_time))
 
     data_headers = (
@@ -281,12 +281,12 @@ def knowledgeC_BatteryPercentage(files_found, _report_folder, _seeker, _wrap_tex
     return data_headers, data_list, db_file
 
 @artifact_processor
-def knowledgeC_DevicePluginStatus(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_DevicePluginStatus(context):
     data_list = []
     data_headers = ()
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
             break
@@ -332,9 +332,9 @@ def knowledgeC_DevicePluginStatus(files_found, _report_folder, _seeker, _wrap_te
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[-1],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[-1])
             if does_adapteriswireless_exist:
                 data_list.append((start_time, end_time, row[2], row[3], added_time))
             else:
@@ -343,12 +343,12 @@ def knowledgeC_DevicePluginStatus(files_found, _report_folder, _seeker, _wrap_te
     return data_headers, data_list, db_file
 
 @artifact_processor
-def knowledgeC_MediaPlaying(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_MediaPlaying(context):
     data_list = []
     data_headers = ()
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
             break
@@ -407,9 +407,9 @@ def knowledgeC_MediaPlaying(files_found, _report_folder, _seeker, _wrap_text, ti
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[-1],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[-1])
 
             if does_airplayvideo_exist:
                 output_device = ''
@@ -429,11 +429,11 @@ def knowledgeC_MediaPlaying(files_found, _report_folder, _seeker, _wrap_text, ti
     return data_headers, data_list, db_file
 
 @artifact_processor
-def knowledgeC_DoNotDisturb(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_DoNotDisturb(context):
     data_list = []
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
             break
@@ -460,9 +460,9 @@ def knowledgeC_DoNotDisturb(files_found, _report_folder, _seeker, _wrap_text, ti
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[3],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[3])
             data_list.append((start_time, end_time, row[2], added_time))
 
     data_headers = (
@@ -471,12 +471,12 @@ def knowledgeC_DoNotDisturb(files_found, _report_folder, _seeker, _wrap_text, ti
 
 
 @artifact_processor
-def knowledgeC_AppUsage(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_AppUsage(context):
     ''' parse /app/usage entries from knowledgeC.db '''
 
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
@@ -499,9 +499,9 @@ def knowledgeC_AppUsage(files_found, _report_folder, _seeker, _wrap_text, timezo
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[2],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[2])
             data_list.append((start_time, end_time, added_time, row[3]))
 
     data_headers = (
@@ -511,7 +511,7 @@ def knowledgeC_AppUsage(files_found, _report_folder, _seeker, _wrap_text, timezo
 
 
 @artifact_processor
-def knowledgeC_AppUsage_EndTime(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_AppUsage_EndTime(context):
     ''' Parse /app/usage entries from knowledgeC.db with End Time as first column'''
 
     # NOTE: there is no need to add this to html and lava output, the only
@@ -520,7 +520,7 @@ def knowledgeC_AppUsage_EndTime(files_found, _report_folder, _seeker, _wrap_text
 
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
@@ -543,9 +543,9 @@ def knowledgeC_AppUsage_EndTime(files_found, _report_folder, _seeker, _wrap_text
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            end_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            start_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[2],timezone_offset)
+            end_time = convert_ts_human_to_utc(row[0])
+            start_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[2])
             data_list.append((end_time, start_time, added_time, row[3]))
 
     data_headers = (
@@ -554,12 +554,12 @@ def knowledgeC_AppUsage_EndTime(files_found, _report_folder, _seeker, _wrap_text
 
 
 @artifact_processor
-def knowledgeC_isLocked(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_isLocked(context):
     ''' parse /device/isLocked entries from knowledgeC.db '''
 
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
@@ -585,9 +585,9 @@ def knowledgeC_isLocked(files_found, _report_folder, _seeker, _wrap_text, timezo
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[2],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[2])
             data_list.append((start_time, end_time, added_time, row[3]))
 
     data_headers = (
@@ -596,12 +596,12 @@ def knowledgeC_isLocked(files_found, _report_folder, _seeker, _wrap_text, timezo
 
 
 @artifact_processor
-def knowledgeC_isBacklit(files_found, _report_folder, _seeker, _wrap_text, timezone_offset):
+def knowledgeC_isBacklit(context):
     ''' parse /display/isBacklit entries from knowledgeC.db '''
 
     db_file = ''
 
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('knowledgeC.db'):
             db_file = file_found
@@ -628,9 +628,9 @@ def knowledgeC_isBacklit(files_found, _report_folder, _seeker, _wrap_text, timez
         all_rows = cursor.fetchall()
 
         for row in all_rows:
-            start_time = convert_ts_human_to_timezone_offset(row[0], timezone_offset)
-            end_time = convert_ts_human_to_timezone_offset(row[1], timezone_offset)
-            added_time = convert_ts_human_to_timezone_offset(row[2],timezone_offset)
+            start_time = convert_ts_human_to_utc(row[0])
+            end_time = convert_ts_human_to_utc(row[1])
+            added_time = convert_ts_human_to_utc(row[2])
             data_list.append((start_time, end_time, added_time, row[3]))
 
     data_headers = (


### PR DESCRIPTION
Final batch of the context-form migration — the 3 files (14 functions) that were the **only** non-`Ph*` artifacts still using the legacy `timezone_offset` parameter.

## The change

The context form doesn't receive `timezone_offset` — context-form artifacts store **UTC** and let the LAVA viewer apply the offset. So these move to the UTC conversion helpers:

| legacy | → | modern |
|---|---|---|
| `convert_unix_ts_to_timezone(ts, timezone_offset)` | → | `convert_unix_ts_to_utc(ts)` |
| `convert_ts_human_to_timezone_offset(ts, timezone_offset)` | → | `convert_ts_human_to_utc(ts)` |

plus `def name(context)` and `context.get_files_found()`.

## ⚠️ Behaviour note (please read)

The affected timestamp columns (all typed `'datetime'`) now store **UTC** instead of a pre-applied local offset. This is:

1. **The same instant in every case** — verified that `convert_*_to_timezone(v, tz)` and `convert_*_to_utc(v)` are instant-identical across seconds/ms/µs inputs and multiple offsets.
2. **Consistent** with every other context-form artifact (UTC-always).
3. **A latent-bug fix**: a `'datetime'` column that already held a *local* time was being offset **again** by the LAVA viewer (double-offset). Storing UTC makes the viewer's single offset correct.

The HTML/TSV output now shows UTC (e.g. `+00:00`) rather than the examiner's local time — the intended, consistent representation. **No queries, columns, or non-timestamp data changed.**

## Verification

- **AST:** all 14 functions are 1-parameter with zero leftover parameter references
- **Surgical diff:** every changed line is one of — the 2 import swaps, the 14 signatures, `files_found` → `context.get_files_found()`, or a `timezone`→`utc` conversion call (59 insertions / 59 deletions, all 1:1)
- **Instant-equivalence:** proven directly for both conversion families across magnitudes/offsets
- **Real-SQLite run:** a synthetic gmail `searchsqlitedb` gave old = `2023-11-14T17:13:20-05:00` (local) and new = `2023-11-14T22:13:20+00:00` (UTC) — same instant, all other columns identical
- **Gates:** compile ✓, PluginLoader **619** plugins, `pylint --disable=C,R` **10.00/10**

---

This completes the context-form migration of the convertible non-`Ph*` artifacts. Only `chrome` remains on the legacy form intentionally — it does manual per-browser HTML reporting and uses `wrap_text` (no context equivalent), so it needs a deliberate refactor rather than a mechanical swap. Photos.sqlite (`Ph*`) artifacts are out of scope by design.