### PR TITLE
Fix case-sensitive path mismatch in Biome artifacts (biome -> Biome)

### DIFF
--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/_DKEvent.Device.BatteryPercentage/local/*'),
+        "paths": ('*/Biome/streams/restricted/_DKEvent.Device.BatteryPercentage/local/*'),
         "output_types": "standard",
         "artifact_icon": "battery",
         "sample_data": {

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/_DKEvent.App.InFocus/local/*'),
+        "paths": ('*/Biome/streams/restricted/_DKEvent.App.InFocus/local/*'),
         "output_types": "standard",
         "artifact_icon": "focus-2",
         "sample_data": {

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/_DKEvent.Device.IsPluggedIn/local/*'),
+        "paths": ('*/Biome/streams/restricted/_DKEvent.Device.IsPluggedIn/local/*'),
         "output_types": "standard",
         "artifact_icon": "battery-charging",
         "sample_data": {

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/App.InFocus/local/*'),
+        "paths": ('*/Biome/streams/restricted/App.InFocus/local/*'),
         "output_types": "standard",
         "artifact_icon": "focus-2"
     }

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/_DKEvent.App.LocationActivity/local/*'),
+        "paths": ('*/Biome/streams/restricted/_DKEvent.App.LocationActivity/local/*'),
         "output_types": "standard",
         "artifact_icon": "map-pin",
         "sample_data": {

--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/_DKEvent.Safari.History/local/*'),
+        "paths": ('*/Biome/streams/restricted/_DKEvent.Safari.History/local/*'),
         "output_types": "standard",
         "artifact_icon": "compass",
         "sample_data": {


### PR DESCRIPTION
Six Biome artifacts glob for */biome/streams/..., but the real iOS path is Biome (uppercase). With case-sensitive fnmatch, these never match and silently log No file found. (17 other Biome artifacts already use Biome.)

Fixed paths in: biomeInfocus, biomeDKInfocus, biomeSafari, biomeBattperc, biomeDevplugin, biomeLocationactivity.

Tested: App.InFocus stream → before No file found, after 5 records parsed.