### PR TITLE
Fix Notes returning zero rows on iOS 16+ (account FK moved to ZACCOUNT7)

### DIFF
--- a/scripts/artifacts/notes.py
+++ b/scripts/artifacts/notes.py
@@ -37,15 +37,19 @@ __artifacts_v2__ = {
 
 import binascii
 import os
+import re
 import zlib
 from os.path import dirname, join
 
 from scripts.ilapfuncs import (artifact_processor, check_in_embedded_media,
-                               does_column_exist_in_db, get_sqlite_db_records, logfunc)
+                               get_sqlite_db_records, logfunc)
 
 
 def _build_query(creation_col, account_col):
-    """Notes schema varies by iOS version; only the creation-date and account columns differ."""
+    """Notes schema varies by iOS version; only the creation-date and account
+    columns differ (chosen per-db by _query_for_db). Folder and account are
+    LEFT-joined and ZICNOTEDATA is the INNER "is a note" anchor, so a note is
+    never dropped when its folder or account reference can't be resolved."""
     return f'''
     SELECT
         DATETIME(TabA.{creation_col}+978307200,'UNIXEPOCH'),
@@ -66,20 +70,49 @@ def _build_query(creation_col, account_col):
         DATETIME(TabD.ZMODIFICATIONDATE+978307200,'UNIXEPOCH'),
         TabF.ZDATA
     FROM ZICCLOUDSYNCINGOBJECT TabA
-    INNER JOIN ZICCLOUDSYNCINGOBJECT TabB on TabA.ZFOLDER = TabB.Z_PK
-    INNER JOIN ZICCLOUDSYNCINGOBJECT TabC on TabA.{account_col} = TabC.Z_PK
+    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabB on TabA.ZFOLDER = TabB.Z_PK
+    LEFT JOIN ZICCLOUDSYNCINGOBJECT TabC on TabA.{account_col} = TabC.Z_PK
     LEFT JOIN ZICCLOUDSYNCINGOBJECT TabD on TabA.Z_PK = TabD.ZNOTE
     LEFT JOIN ZICCLOUDSYNCINGOBJECT TabE on TabD.Z_PK = TabE.ZATTACHMENT1
-    LEFT JOIN ZICNOTEDATA TabF on TabF.ZNOTE = TabA.Z_PK
+    INNER JOIN ZICNOTEDATA TabF on TabF.ZNOTE = TabA.Z_PK
     '''
 
 
+def _pick_note_column(file_found, prefix, default):
+    """Pick the ZICCLOUDSYNCINGOBJECT ``<prefix>N`` column populated on note rows.
+
+    The note->account foreign key and the note creation date have drifted across
+    iOS versions (account: ZACCOUNT2 on iOS 12-13, ZACCOUNT4 on iOS 14-15,
+    ZACCOUNT7 on iOS 16+). Several same-prefixed columns coexist in one schema
+    and all but one are NULL for notes -- iOS 18 also carries an unrelated
+    ZACCOUNT8 -- so selecting the first column that merely *exists* returned zero
+    notes on iOS 16+. Probe which candidate is non-null on rows that have note
+    data instead, preferring the newest (highest-suffixed) on a tie; this
+    self-adjusts to future schema changes.
+    """
+    candidates = [row[0] for row in get_sqlite_db_records(
+        file_found,
+        "SELECT name FROM pragma_table_info('ZICCLOUDSYNCINGOBJECT') "
+        f"WHERE name LIKE '{prefix}%'")
+        if re.fullmatch(re.escape(prefix) + r'\d*', row[0])]
+    best, best_count, best_suffix = default, 0, -1
+    for col in candidates:
+        records = list(get_sqlite_db_records(
+            file_found,
+            'SELECT COUNT(*) FROM ZICCLOUDSYNCINGOBJECT TabA '
+            'INNER JOIN ZICNOTEDATA TabF ON TabF.ZNOTE = TabA.Z_PK '
+            f'WHERE TabA.{col} IS NOT NULL'))
+        count = records[0][0] if records else 0
+        suffix = int(re.sub(r'\D', '', col) or -1)
+        if count > best_count or (count == best_count > 0 and suffix > best_suffix):
+            best, best_count, best_suffix = col, count, suffix
+    return best
+
+
 def _query_for_db(file_found):
-    if does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT', 'ZACCOUNT4'):
-        if does_column_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT', 'ZCREATIONDATE3'):
-            return _build_query('ZCREATIONDATE3', 'ZACCOUNT4')
-        return _build_query('ZCREATIONDATE1', 'ZACCOUNT3')
-    return _build_query('ZCREATIONDATE1', 'ZACCOUNT2')
+    creation_col = _pick_note_column(file_found, 'ZCREATIONDATE', 'ZCREATIONDATE1')
+    account_col = _pick_note_column(file_found, 'ZACCOUNT', 'ZACCOUNT2')
+    return _build_query(creation_col, account_col)
 
 
 def get_uncompressed_data(compressed):


### PR DESCRIPTION
## Problem

The Notes artifact silently returned **0 rows on every iOS 16 / 17 / 18 image** while working fine on iOS 12–15.

Root cause: `_query_for_db` chose the note→account foreign-key column by which `ZACCOUNT*` column merely *existed* in the schema. On iOS 16+ the previously-correct `ZACCOUNT4` is still present but **entirely NULL** — Apple moved the account FK to `ZACCOUNT7`. The query's `INNER JOIN` on the account therefore matched nothing and dropped every note. (Naively "pick the highest-numbered column" would also be wrong: iOS 18 additionally carries an unrelated `ZACCOUNT8` that is NULL for notes.)

## Fix

- Pick the account and creation-date columns by which candidate is **actually populated on note rows** (rows joined to `ZICNOTEDATA`), preferring the newest column on a tie. This matches the observed drift — `ZACCOUNT2` (iOS 12–13) → `ZACCOUNT4` (iOS 14–15) → `ZACCOUNT7` (iOS 16+) — and self-adjusts to future schema changes without another hard-coded ladder.
- Make the **folder and account joins `LEFT`**, with `ZICNOTEDATA` as the `INNER` "is a note" anchor, so a note is never again silently dropped when its folder/account reference can't be resolved.

## Validation

Ran the real `notes` artifact end-to-end on a 5-image spread (**0 errors** each):

| Image | iOS | Before | After |
|---|---|---|---|
| 2020 CTF | 12.4 | 5 | **5** (unchanged) |
| Jess CTF | 15.0 | 2 | **2** (unchanged) |
| fs-full-002 | 17.1 | 0 | **4** ✅ |
| iPhone12 FFS | 18.7 | 0 | **18** ✅ |
| iPhone14 Plus | 18.0 | 0 | 0 — verified genuinely empty Notes app (`ZICNOTEDATA` has 0 rows) |

Note titles, folders, account name, and decoded bodies all resolve correctly on iOS 18. `pylint --disable=C,R` = 10.00/10.

The `sample_data` coverage notes still show the pre-fix "0 rows" for the iOS 16+ images; those are regenerated by the corpus `sample_data_update.py` pipeline and will be corrected on the next refresh.
