### PR TITLE
Update apple_build_id_to_os_version.json

### DIFF
--- a/scripts/data/apple_build_id_to_os_version.json
+++ b/scripts/data/apple_build_id_to_os_version.json
@@ -939,6 +939,7 @@
     "23G5043d": "iOS 26.6 beta 2",
     "23G5052d": "iOS 26.6 beta 3",
     "23G5057c": "iOS 26.6 beta 4",
+    "23G5065a": "iOS 26.6 beta 5",
     "24A5355q": "iOS 27.0 beta 1",
     "24A5370h": "iOS 27.0 beta 2",
     "24A5380h": "iOS 27.0 beta 3"
@@ -2287,6 +2288,7 @@
     "23J607": "macOS 14.8.8 RC 2",
     "23J610": "macOS 14.8.8 RC 3",
     "23J612": "macOS 14.8.8 RC 4",
+    "23J615": "macOS 14.8.8 RC 5",
     "24A5264n": "macOS 15.0 beta 1",
     "24A5279h": "macOS 15.0 beta 2",
     "24A5289g": "macOS 15.0 beta 3",
@@ -2374,6 +2376,7 @@
     "24G809": "macOS 15.7.8 RC 2",
     "24G812": "macOS 15.7.8 RC 3",
     "24G814": "macOS 15.7.8 RC 4",
+    "24G817": "macOS 15.7.8 RC 5",
     "25A5279m": "macOS 26.0 beta 1",
     "25A5295e": "macOS 26.0 beta 2",
     "25A5306g": "macOS 26.0 beta 3",
@@ -2431,6 +2434,7 @@
     "25G5043d": "macOS 26.6 beta 2",
     "25G5052e": "macOS 26.6 beta 3",
     "25G5057c": "macOS 26.6 beta 4",
+    "25G5065a": "macOS 26.6 beta 5",
     "26A5353q": "macOS 27.0 beta 1",
     "26A5368g": "macOS 27.0 beta 2",
     "26A5378j": "macOS 27.0 beta 3"
@@ -2559,6 +2563,7 @@
     "23O5743c": "visionOS 26.6 beta 2",
     "23O5752d": "visionOS 26.6 beta 3",
     "23O5757c": "visionOS 26.6 beta 4",
+    "23O5765a": "visionOS 26.6 beta 5",
     "24M5291p": "visionOS 27.0 beta 1",
     "24M5306i": "visionOS 27.0 beta 2",
     "24M5316k": "visionOS 27.0 beta 3"
@@ -3050,6 +3055,7 @@
     "23U5040d": "watchOS 26.6 beta 2",
     "23U5049c": "watchOS 26.6 beta 3",
     "23U5054b": "watchOS 26.6 beta 4",
+    "23U5062b": "watchOS 26.6 beta 5",
     "24R5289n": "watchOS 27.0 beta 1",
     "24R5305k": "watchOS 27.0 beta 2",
     "24R5305g": "watchOS 27.0 beta 2",
@@ -3565,6 +3571,7 @@
     "23L5744d": "tvOS 26.6 beta 2",
     "23L5753c": "tvOS 26.6 beta 3",
     "23L5758b": "tvOS 26.6 beta 4",
+    "23L5766a": "tvOS 26.6 beta 5",
     "24J5289o": "tvOS 27.0 beta 1",
     "24J5305f": "tvOS 27.0 beta 2",
     "24J5315i": "tvOS 27.0 beta 3"


### PR DESCRIPTION
Add:
- iOS 26.6 beta 5
- macOS 14.8.8 RC 5, macOS 15.7.8 RC 5, macOS 26.6 beta 5
- tvOS 26.6 beta 5
- visionOS 26.6 beta 5
- watchOS 26.6 beta 5