### PR TITLE
Update voiceRecordings.py - Fix issue #1717

### DIFF
--- a/scripts/artifacts/voiceRecordings.py
+++ b/scripts/artifacts/voiceRecordings.py
@@ -1,16 +1,21 @@
+"""
+Extracts Voice Memo recordings and metadata from iOS devices.
+"""
+
 __artifacts_v2__ = {
-    "voiceRecordings": {
-        "name": "Voice Recordings",
+    "voice_memos": {
+        "name": "Voice Memos",
         "description": "Extracts Voice Memo recordings and metadata.",
-        "author": "@Anna-Mariya Mateyna",
+        "author": "@Anna-Mariya Mateyna - @Johann-PLW",
         "creation_date": "2020-12-21",
-        "last_update_date": "2025-11-21",
+        "last_update_date": "2026-07-15",
         "requirements": "none",
         "category": "Audio",
-        "notes": "",
+        "notes": "2026-07-14 Update: Rewriting the artifact to use the recording database and fix issue #1717.",
         "paths": (
-            '*/Recordings/*.composition/manifest.plist',
-            '*/Recordings/*.m4a'
+            "*/Recordings/*Recordings.db*",
+            "*/Recordings/*.m4a",
+            "*/Recordings/*.qta",
             ),
         "output_types": "standard",
         "artifact_icon": "microphone",
@@ -20,70 +25,61 @@ __artifacts_v2__ = {
             "otto_ios17": "iOS 17.5.1 | com.apple.VoiceMemos | 3 rows",
             "abe_ios16": "iOS 16.5 | 30 rows",
         }
-    }   
+    }
 }
 
-import os
 from scripts.ilapfuncs import (
-    logfunc,
-    artifact_processor,
-    get_plist_file_content,
-    check_in_media,
-    convert_cocoa_core_data_ts_to_utc
+    artifact_processor, get_file_path, get_sqlite_db_records,
+    convert_cocoa_core_data_ts_to_utc, check_in_media
 )
 
 
 @artifact_processor
-def voiceRecordings(context):
+def voice_memos(context):
+    """See artifact description"""
     files_found = context.get_files_found()
+    cloud_recordings_source_path = get_file_path(files_found, "CloudRecordings.db")
+    recordings_source_path = get_file_path(files_found, "Recordings.db")
+
+    source_path = ""
+    query = ""
     data_list = []
-    plist_files = [str(f) for f in files_found if str(f).endswith('manifest.plist')]
 
-    audio_files_map = {os.path.basename(str(f)): str(f) for f in files_found if str(f).endswith('.m4a')}
+    if cloud_recordings_source_path:
+        source_path = cloud_recordings_source_path
+        query = """
+        SELECT
+            ZDATE,
+            time(ZDURATION, 'unixepoch') as ZDURATION,
+            ZCUSTOMLABELFORSORTING,
+            ZPATH
+        FROM ZCLOUDRECORDING
+        """
+    elif recordings_source_path:
+        source_path = recordings_source_path
+        query = """
+        SELECT
+            ZDATE,
+            time(ZDURATION, 'unixepoch') as ZDURATION,
+            ZCUSTOMLABEL,
+            ZPATH
+        FROM ZRECORDING
+        """
 
-    for plist_path in plist_files:
-        try:
-            pl = get_plist_file_content(plist_path)
-            if not pl:
-                continue
-
-            creation_time = convert_cocoa_core_data_ts_to_utc(pl.get('RCSavedRecordingCreationTime'))
-            title = pl.get('RCSavedRecordingTitle', 'No Title')
-            internal_path = pl.get('RCComposedAVURL', '')
-
-            composition_folder_name = os.path.basename(os.path.dirname(plist_path))
-            expected_audio_name = composition_folder_name.replace('.composition', '.m4a')
-
-            audio_id = None
-
-            if expected_audio_name in audio_files_map:
-                real_audio_path = audio_files_map[expected_audio_name]
-
-                audio_id = check_in_media(real_audio_path)
+    if source_path:
+        db_records = get_sqlite_db_records(source_path, query)
+        for record in db_records:
+            timestamp = convert_cocoa_core_data_ts_to_utc(record["ZDATE"])
+            if record["ZPATH"]:
+                storage = "On the device"
+                audio_file = check_in_media(record["ZPATH"])
             else:
-                internal_audio_path = os.path.join(os.path.dirname(plist_path), expected_audio_name)
-                if os.path.exists(internal_audio_path):
-                    audio_id = check_in_media(internal_audio_path)
-
-            data_list.append((
-                creation_time,
-                title,
-                internal_path,
-                audio_id,
-                plist_path
-            ))
-
-        except (OSError, TypeError, ValueError, KeyError) as e:
-            logfunc(f"Error processing {plist_path}: {e}")
+                storage = "In iCloud"
+                audio_file = ""
+            data_list.append((timestamp, record["ZDURATION"], record["ZCUSTOMLABELFORSORTING"],
+                              storage, audio_file))
 
     data_headers = (
-        ('Creation Date', 'datetime'),
-        'Title',
-        'Internal Path Info',
-        ('Audio File', 'media'),
-        'File Name'
-    )
-
-    source_path = plist_files[0] if plist_files else ''
+        ("Date and time", "datetime"), "Duration", "Title", "Storage", ("Audio File", "media"))
 
     return data_headers, data_list, source_path


### PR DESCRIPTION
Initially, the artifact simply searched for all m4a and plist files in the `Recordings` directory, processing only those that had title and creation date information in the corresponding manifest.plist file. 
Now, instead, it uses the app's database and all the files (also q4a files since iOS 26)  are now displayed correctly in the different outputs..
