### PR TITLE
Security: escape evidence in html_columns report cells

### DIFF
--- a/scripts/artifacts/BeReal.py
+++ b/scripts/artifacts/BeReal.py
@@ -239,6 +239,7 @@ from base64 import standard_b64decode
 from urllib.parse import urlparse, urlunparse
 from scripts.ilapfuncs import get_file_path, get_sqlite_db_records, get_plist_content, get_plist_file_content, convert_unix_ts_to_utc, \
     convert_cocoa_core_data_ts_to_utc, check_in_embedded_media, artifact_processor, logfunc, is_platform_windows
+from scripts.html_safe import esc, safe_url, safe_join
 
 
 
@@ -369,7 +370,7 @@ def generic_url(value, html_format=False):
         if not bool(u[0]) and u[2].startswith('www'):
             u = u._replace(scheme='http')
         url = urlunparse(u)
-        return value if not html_format else f'<a href="{url}" target="_blank">{value}</>'
+        return value if not html_format else safe_url(url, value)
     else:
         return None
 
@@ -403,7 +404,8 @@ def get_realmojis(obj, html_format=False):
             real_moji = real_mojis[i]
             # emoji->url
             url_moji = generic_url(real_moji.get('media', {}).get('url'), html_format)
-            all_mojis.append(f"{real_moji.get('emoji')} {url_moji}")
+            emoji = esc(real_moji.get('emoji')) if html_format else real_moji.get('emoji')
+            all_mojis.append(f"{emoji} {url_moji}")
         if html_format:
             return '<br />'.join(all_mojis)
         else:
@@ -424,7 +426,8 @@ def get_realmojis(obj, html_format=False):
             #reaction_date = convert_cocoa_core_data_ts_to_utc(real_moji.get('date'))
             # emoji->uri
             uri_moji = generic_url(real_moji.get('uri'), html_format)
-            all_mojis.append(f"{real_moji.get('emoji')} {uri_moji}")
+            emoji = esc(real_moji.get('emoji')) if html_format else real_moji.get('emoji')
+            all_mojis.append(f"{emoji} {uri_moji}")
 
         return '<br />'.join(all_mojis) if html_format else '\n'.join(all_mojis)
     # none
@@ -482,7 +485,7 @@ def get_tags(obj, html_format=False, user_map=None):
                     user = f"{tag_id} ({username})"
 
             if bool(user):
-                tag_list.append(user)
+                tag_list.append(esc(user) if html_format else user)
                 
 
     return '<br />'.join(tag_list) if html_format else '\n'.join(tag_list)
@@ -601,10 +604,10 @@ def bereal_accounts(context):
             dev_info = '\n'.join(dev_info)
             app_ver = '\n'.join(app_ver)
             timezone = '\n'.join(timezone)
-            dev_uid_html = '<br />'.join(dev_uid_html)
-            dev_info_html = '<br />'.join(dev_info_html)
-            app_ver_html = '<br />'.join(app_ver_html)
-            timezone_html = '<br />'.join(timezone_html)
+            dev_uid_html = safe_join(dev_uid_html, '<br />')
+            dev_info_html = safe_join(dev_info_html, '<br />')
+            app_ver_html = safe_join(app_ver_html, '<br />')
+            timezone_html = safe_join(timezone_html, '<br />')
             # is private?
             is_private = account.get('isPrivate')
             # realmojis
@@ -1082,7 +1085,7 @@ def bereal_posts(context):
                     # html row
                     data_list_html.append((taken_at, moment_at, post_type, author, p_mt, p_url_html, s_mt, s_url_html,
                                            None, None, caption, latitude, longitude, retake_counter, late_secs, tags_html,
-                                           moment_id, bereal_id, file_rel_path, location))
+                                           moment_id, bereal_id, esc(file_rel_path), location))
                     # lava row
                     data_list.append((taken_at, moment_at, post_type, author, p_mt, p_url, s_mt, s_url,
                                       None, None, caption, latitude, longitude, retake_counter, late_secs, tags,
@@ -1167,7 +1170,7 @@ def bereal_posts(context):
                         # html row
                         data_list_html.append((taken_at, moment_at, post_type, author, p_mt, p_url_html, s_mt, s_url_html,
                                                t_mt, t_url_html, caption, latitude, longitude, retake_counter, late_secs, tags_html,
-                                               moment_id, bereal_id, file_rel_path, location))
+                                               moment_id, bereal_id, esc(file_rel_path), location))
                         # lava row
                         data_list.append((taken_at, moment_at, post_type, author, p_mt, p_url, s_mt, s_url,
                                           t_mt, t_url, caption, latitude, longitude, retake_counter, late_secs, tags,
@@ -1245,7 +1248,7 @@ def bereal_posts(context):
                             # html row
                             data_list_html.append((taken_at, moment_at, post_type, author, p_mt, p_url_html, s_mt, s_url_html,
                                                    t_mt, t_url_html, caption, latitude, longitude, retake_counter, late_secs, tags_html,
-                                                   moment_id, bereal_id, file_rel_path, location))
+                                                   moment_id, bereal_id, esc(file_rel_path), location))
                             # lava row
                             data_list.append((taken_at, moment_at, post_type, author, p_mt, p_url, s_mt, s_url,
                                               t_mt, t_url, caption, latitude, longitude, retake_counter, late_secs, tags,
@@ -1299,7 +1302,7 @@ def bereal_pinned_memories(context):
 
         # html row
         data_list_html.append((taken_at, moment_day, post_type, author_id, p_mt, p_url_html, s_mt, s_url_html,
-                               moment_id, pin_id, file_rel_path, location))
+                               moment_id, pin_id, esc(file_rel_path), esc(location)))
         # lava row
         data_list.append((taken_at, moment_day, post_type, author_id, p_mt, p_url, s_mt, s_url,
                           moment_id, pin_id, file_rel_path, location))
@@ -1977,7 +1980,7 @@ def bereal_chat_list(context):
             admins_list.append(format_userid(a, user_map=user_map))
         if bool(admins_list):
             admins = '\n'.join(admins_list)
-        admins_html = admins.replace('\n', '<br />')
+        admins_html = esc(admins).replace('\n', '<br />')
 
         # participants (plist)
         participants = get_plist_content(record[7])
@@ -1986,7 +1989,7 @@ def bereal_chat_list(context):
             participants_list.append(format_userid(p, user_map=user_map))
         if bool(participants_list):
             participants = '\n'.join(participants_list)
-        participants_html = participants.replace('\n', '<br />')
+        participants_html = esc(participants).replace('\n', '<br />')
 
         # body
         body = record[8].decode('utf-8') if bool(record[8]) else record[8]

--- a/scripts/artifacts/Oura.py
+++ b/scripts/artifacts/Oura.py
@@ -221,6 +221,7 @@ import plistlib
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, logfunc
+from scripts.html_safe import esc
 
 # Cocoa/NSDate epoch (2001-01-01 UTC) as Unix seconds.
 COCOA_EPOCH = 978307200
@@ -553,7 +554,7 @@ def oura_find_my_ring_location(context):
     if isinstance(loc, dict) and "latitude" in loc and "longitude" in loc:
         lat = loc.get("latitude", "")
         lon = loc.get("longitude", "")
-        map_link = (f'<a href="https://www.google.com/maps?q={lat},{lon}" '
+        map_link = (f'<a href="https://www.google.com/maps?q={esc(lat)},{esc(lon)}" '
                     f'target="_blank">View on map</a>') if lat != "" and lon != "" else ""
         data_list.append((
             ts_cocoa(loc.get("timestamp")),

--- a/scripts/artifacts/appleMapsTrips.py
+++ b/scripts/artifacts/appleMapsTrips.py
@@ -98,20 +98,23 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+from scripts.html_safe import esc
 
 def get_google_map_link(latitude_value, longitude_value):
     if latitude_value is None or longitude_value is None:
         return ""
-    
-    return f"<a href='https://www.google.com/maps?q={latitude_value},{longitude_value}' target='_blank'>https://www.google.com/maps?q={latitude_value},{longitude_value}</a>"
+
+    lat = esc(latitude_value)
+    lon = esc(longitude_value)
+    return f"<a href='https://www.google.com/maps?q={lat},{lon}' target='_blank'>https://www.google.com/maps?q={lat},{lon}</a>"
 
 def get_google_dir_link(o_latitude_value, o_longitude_value, d_latitude_value, d_longitude_value, mode):
     if o_latitude_value is None or o_longitude_value is None or d_latitude_value is None or d_longitude_value is None:
         return ""
-    
+
     base_url = "https://www.google.com/maps/dir/?api=1"
-    origin = f"&origin={o_latitude_value},{o_longitude_value}"
-    destination = f"&destination={d_latitude_value},{d_longitude_value}"
+    origin = f"&origin={esc(o_latitude_value)},{esc(o_longitude_value)}"
+    destination = f"&destination={esc(d_latitude_value)},{esc(d_longitude_value)}"
 
     # Travel mode
     if mode == 1:

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -27,6 +27,7 @@ import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import convert_time_obj_to_utc, get_plist_content, logfunc, artifact_processor
+from scripts.html_safe import esc, safe_source
 
 from datetime import datetime as _dt
 
@@ -115,16 +116,19 @@ def get_biomeIntents(context):
                 if typeofintent == 'com.burbn.instagram':
                     datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
                     datos = datoshtml
+                    datoshtml = safe_source(datoshtml)
 
                 #snapchat
                 elif typeofintent == 'com.toyopagroup.picaboo':
                     datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
                     datos = datoshtml
+                    datoshtml = safe_source(datoshtml)
 
                 #notes
                 elif typeofintent == 'com.apple.assistant_service':
                     datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
                     datos = datoshtml
+                    datoshtml = safe_source(datoshtml)
 
                 #notes
                 elif typeofintent == 'com.apple.mobilenotes':
@@ -133,12 +137,13 @@ def get_biomeIntents(context):
                     c = (protostuffinner['2']['2']) #message
 
                     datos = f'Action: {a}, Data Field 1: {b}, Data Field 2: {c}'
-                    datoshtml = (datos.replace(',', '<br>'))
+                    datoshtml = (esc(datos).replace(',', '<br>'))
 
                 #telegraph
                 elif typeofintent == 'ph.telegra.Telegraph':
                     datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
                     datos = datoshtml
+                    datoshtml = safe_source(datoshtml)
 
                 #calls
                 elif typeofintent == 'com.apple.InCallService':
@@ -151,16 +156,18 @@ def get_biomeIntents(context):
                         #print(protostuffinner)
 
                     datos = f'Number: {a}'
-                    datoshtml = (datos.replace(',', '<br>'))
+                    datoshtml = (esc(datos).replace(',', '<br>'))
 
                 #whatsapp
                 elif typeofintent == 'net.whatsapp.WhatsApp':
                     datoshtml = str(protostuffinner)
                     datos = datoshtml
+                    datoshtml = safe_source(datoshtml)
 
                 elif typeofintent == 'org.whispersystems.signal':
                     datoshtml = str(protostuffinner)
                     datos = datoshtml
+                    datoshtml = safe_source(datoshtml)
 
                 #sms
                 elif typeofintent == 'com.apple.MobileSMS':
@@ -181,7 +188,7 @@ def get_biomeIntents(context):
                             d = ''
 
                         datos = f'Thread ID: {b}, Sender ID: {c}, Content:, {a}'
-                        datoshtml = (datos.replace(',', '<br>'))
+                        datoshtml = (esc(datos).replace(',', '<br>'))
                     else:
                         print('Mobile SMS' + str(protostuffinner))
                 #maps
@@ -201,7 +208,7 @@ def get_biomeIntents(context):
                         h = (protostuffinner['4'][2]['2']['2']['2'].decode()) #value of above
 
                         datos = f'{a}: {b}, {c}: {d}, {e}: {f}, {g}: {h}'
-                        datoshtml = (datos.replace(',', '<br>'))
+                        datoshtml = (esc(datos).replace(',', '<br>'))
 
                     else:
                         datos = ''
@@ -218,7 +225,7 @@ def get_biomeIntents(context):
                                 b = loopy['2']
                             datos = datos + f'{a}: {b},'
 
-                        datoshtml = (datos.replace(',', '<br>'))
+                        datoshtml = (esc(datos).replace(',', '<br>'))
 
                         #logfunc('Maps' + str(protostuffinner))
 

--- a/scripts/artifacts/biomeNotes.py
+++ b/scripts/artifacts/biomeNotes.py
@@ -29,6 +29,7 @@ import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import webkit_timestampsconv, artifact_processor
+from scripts.html_safe import safe_source
 
 @artifact_processor
 def get_biomeNotes(context):
@@ -69,7 +70,7 @@ def get_biomeNotes(context):
                 identifier1 = protostuff['1']
                 identifier2 = protostuff['2']
                 message = protostuff['5']
-                messagehtml = (message.replace('\n', '<br>'))
+                messagehtml = safe_source(message)
                 data_list.append((ts, time, record.state.name, record_counter, identifier1, identifier2, message, filename, record.data_start_offset))
                 data_list_html.append((ts, time, record.state.name, record_counter, identifier1, identifier2, messagehtml, filename, record.data_start_offset))
 

--- a/scripts/artifacts/booking.py
+++ b/scripts/artifacts/booking.py
@@ -192,6 +192,7 @@ import pytz
 from scripts.ilapfuncs import get_sqlite_db_records, \
     get_plist_content, get_plist_file_content, convert_plist_date_to_utc, \
     convert_unix_ts_to_utc, check_in_media, artifact_processor, logfunc
+from scripts.html_safe import esc, safe_join
 
 def _safe_plist_date(value):
     """Convert plist <date> objects to UTC; pass strings/None through unchanged."""
@@ -259,9 +260,9 @@ def unordered_list(values: list[str] | None, html_format: bool = False) -> str |
     """
     Format a list of strings as an unordered list.
     - If the input list is None or empty, return None.
-    - If html_format=True, join items using <br> tags.
-    - Otherwise, join items using line breaks.
-   
+    - If html_format=True, HTML-escape each evidence value and join with <br> tags.
+    - Otherwise, join items using line breaks (plain text / TSV path, not escaped).
+
     Args:
         values: A list of string items to format.
         html_format: If True, format output for HTML.
@@ -273,9 +274,14 @@ def unordered_list(values: list[str] | None, html_format: bool = False) -> str |
     if not values:
         return None
 
-    separator = HTML_LINE_BREAK if html_format else LINE_BREAK
+    # HTML path: escape each dynamic value so evidence cannot inject markup/script.
+    if html_format:
+        if isinstance(values, list):
+            return safe_join(values, HTML_LINE_BREAK)
+        return esc(values)
 
-    return separator.join(values) if isinstance(values, list) else values
+    # Plain text / TSV path: left unescaped by design.
+    return LINE_BREAK.join(values) if isinstance(values, list) else values
 
 
 # Pattern to normalize timezone offsets from +HHMM -> +HH:MM
@@ -1864,13 +1870,16 @@ def _format_routes(routes: list) -> tuple:
                 meta_p.append(dst_p)
             results_plain.append(unordered_list(meta_p, html_format=False))
 
-            # Reconstruct the data hierarchy for HTML
-            meta_h = [f"Route {i} - {r_date}"]
+            # Reconstruct the data hierarchy for HTML. src_h/dst_h are already
+            # escaped HTML fragments from _format_airports; the header holds only a
+            # loop index and a date object. Escape the header and join without
+            # re-escaping the fragments (unordered_list would double-escape them).
+            meta_h = [esc(f"Route {i} - {r_date}")]
             if src_h:
                 meta_h.append(src_h)
             if dst_h:
                 meta_h.append(dst_h)
-            results_html.append(unordered_list(meta_h, html_format=True))
+            results_html.append(HTML_LINE_BREAK.join(meta_h))
 
         except (TypeError, ValueError):
             # Gracefully skip routes with malformed or missing dates

--- a/scripts/artifacts/burnerCache.py
+++ b/scripts/artifacts/burnerCache.py
@@ -100,6 +100,7 @@ import sqlite3
 from pathlib import Path
 from scripts.ilapfuncs import get_file_path, open_sqlite_db_readonly, lava_get_full_media_info, \
     convert_unix_ts_to_utc, check_in_media, check_in_embedded_media, artifact_processor, logfunc
+from scripts.html_safe import esc, safe_join, safe_url
 
 
 # <id, phone number (display name)> shared across the artifacts below.
@@ -205,7 +206,10 @@ def unordered_list(values, html_format=False):
     if not bool(values):
         return None
 
-    return HTML_LINE_BREAK.join(values) if html_format else LINE_BREAK.join(values)
+    # HTML path: escape each evidence value; plain/TSV path left unescaped by design.
+    if html_format:
+        return safe_join(values, HTML_LINE_BREAK)
+    return LINE_BREAK.join(values)
 
 
 # generic url
@@ -219,7 +223,10 @@ def generic_url(value, html_format=False):
         if not bool(u.scheme) and u.path.startswith('www'):
             u = u._replace(scheme='http')
         url = urlunparse(u)
-        result =  f'<a href="{url}" target="_blank">{value}</a>' if html_format else url
+        # HTML path: build a scheme-checked, escaped anchor so a crafted media
+        # URL cannot inject markup/script or a javascript:/data: link; plain path
+        # returns the raw URL.
+        result = safe_url(url, value) if html_format else url
 
     return result
 
@@ -314,7 +321,7 @@ def burnerCache_accounts(context):
                 location = COMMA_SEP.join(location)
 
                 # html row
-                data_list_html.append((last_updated, created, phone_number, country_code, carrier_name, total_number_burners, user_id, source_file_name_html, location))
+                data_list_html.append((last_updated, created, phone_number, country_code, carrier_name, total_number_burners, user_id, source_file_name_html, esc(location)))
                 # lava row
                 data_list.append((last_updated, created, phone_number, country_code, carrier_name, total_number_burners, user_id, source_file_name, location))
         # account
@@ -332,7 +339,7 @@ def burnerCache_accounts(context):
             location = COMMA_SEP.join(location)
 
             # html row
-            data_list_html.append((last_updated, created, phone_number, country_code, carrier_name, total_number_burners, user_id, source_file_name_html, location))
+            data_list_html.append((last_updated, created, phone_number, country_code, carrier_name, total_number_burners, user_id, source_file_name_html, esc(location)))
             # lava row
             data_list.append((last_updated, created, phone_number, country_code, carrier_name, total_number_burners, user_id, source_file_name, location))
 
@@ -434,7 +441,7 @@ def burnerCache_contacts(context):
                 location = COMMA_SEP.join(location)
 
                 # html row
-                data_list_html.append((created, phone_number, display_name, notes, verified, blocked, muted, burner_ids, contact_id, source_file_name_html, location))
+                data_list_html.append((created, phone_number, display_name, notes, verified, blocked, muted, burner_ids, contact_id, source_file_name_html, esc(location)))
                 # lava row
                 data_list.append((created, phone_number, display_name, notes, verified, blocked, muted, burner_ids, contact_id, source_file_name, location))
 
@@ -452,7 +459,7 @@ def burnerCache_contacts(context):
             location = COMMA_SEP.join(location)
 
             # html row
-            data_list_html.append((created, phone_number, display_name, notes, verified, blocked, muted, burner_ids, contact_id, source_file_name_html, location))
+            data_list_html.append((created, phone_number, display_name, notes, verified, blocked, muted, burner_ids, contact_id, source_file_name_html, esc(location)))
             # lava row
             data_list.append((created, phone_number, display_name, notes, verified, blocked, muted, burner_ids, contact_id, source_file_name, location))
 
@@ -607,7 +614,7 @@ def burnerCache_numbers(context):
 
                 # html row
                 data_list_html.append((created, burner_number, display_name, expires, version, notifications, inbound_caller_id, voip, auto_reply_enabled, auto_reply_text,
-                                       rt_minutes, rt_texts, user_phone_number, user_id, burner_id, source_file_name_html, location))
+                                       rt_minutes, rt_texts, user_phone_number, user_id, burner_id, source_file_name_html, esc(location)))
                 # lava row
                 data_list.append((created, burner_number, display_name, expires, version, notifications, inbound_caller_id, voip, auto_reply_enabled, auto_reply_text,
                                   rt_minutes, rt_texts, user_phone_number, user_id, burner_id, source_file_name, location))
@@ -628,7 +635,7 @@ def burnerCache_numbers(context):
 
             # html row
             data_list_html.append((created, burner_number, display_name, expires, version, notifications, inbound_caller_id, voip, auto_reply_enabled, auto_reply_text,
-                                   rt_minutes, rt_texts, user_phone_number, user_id, burner_id, source_file_name_html, location))
+                                   rt_minutes, rt_texts, user_phone_number, user_id, burner_id, source_file_name_html, esc(location)))
             # lava row
             data_list.append((created, burner_number, display_name, expires, version, notifications, inbound_caller_id, voip, auto_reply_enabled, auto_reply_text,
                               rt_minutes, rt_texts, user_phone_number, user_id, burner_id, source_file_name, location))
@@ -876,7 +883,7 @@ def burnerCache_messages(context):
 
                 # html row
                 data_list_html.append((thread, created, direction, read, sender, recipient, body, message_type, media_ref_id, media_url_html,
-                                       message_id, source_file_name_html, location))
+                                       message_id, source_file_name_html, esc(location)))
                 # lava row
                 data_list.append((thread, created, direction, read, sender, recipient, body, message_type, media_ref_id, media_url,
                                   message_id, source_file_name, location))
@@ -905,7 +912,7 @@ def burnerCache_messages(context):
 
             # html row
             data_list_html.append((thread, created, direction, read, sender, recipient, body, message_type, media_ref_id, media_url_html,
-                                   message_id, source_file_name_html, location))
+                                   message_id, source_file_name_html, esc(location)))
             # lava row
             data_list.append((thread, created, direction, read, sender, recipient, body, message_type, media_ref_id, media_url,
                               message_id, source_file_name, location))

--- a/scripts/artifacts/calendarAll.py
+++ b/scripts/artifacts/calendarAll.py
@@ -97,6 +97,7 @@ __artifacts_v2__ = {
 from urllib.parse import unquote
 from scripts.ilapfuncs import open_sqlite_db_readonly, does_table_exist_in_db, does_column_exist_in_db,\
     convert_ts_human_to_utc, artifact_processor, get_birthdate
+from scripts.html_safe import esc
 
 
 def get_sharees(cursor):
@@ -115,6 +116,7 @@ def get_sharees(cursor):
     all_rows = cursor.fetchall()
     usageentries = len(all_rows)
     data_dict = {}
+    data_dict_csv = {}
     if usageentries > 0:
         for row in all_rows:
             key = row[0]
@@ -122,14 +124,24 @@ def get_sharees(cursor):
             name = f' ({row[2]})' if row[2] else ''
             participant = f'{address}{name}'
             sharing_participant = f'''{participant} -> {row[3]}'''
+            participant_html = f'{esc(address)}{esc(name)}'
+            sharing_participant_html = f'''{participant_html} -> {esc(row[3])}'''
+
             sharing_participants = data_dict.get(key, '')
             if sharing_participants:
-                sharing_participants += f',<br>{sharing_participant}'
+                sharing_participants += f',<br>{sharing_participant_html}'
             else:
-                sharing_participants = sharing_participant
+                sharing_participants = sharing_participant_html
             data_dict[key] = sharing_participants
 
-    return data_dict
+            sharing_participants_csv = data_dict_csv.get(key, '')
+            if sharing_participants_csv:
+                sharing_participants_csv += f', {sharing_participant}'
+            else:
+                sharing_participants_csv = sharing_participant
+            data_dict_csv[key] = sharing_participants_csv
+
+    return data_dict, data_dict_csv
 
 
 def get_invitees(cursor):
@@ -158,6 +170,7 @@ def get_invitees(cursor):
         for row in all_rows:
             key = row[0]
             participant = f'{row[1]} - {row[2]}' if row[1] else row[2]
+            participant_html = f'{esc(row[1])} - {esc(row[2])}' if row[1] else esc(row[2])
             status = row[3]
             if status == 'No response':
                 html_status = '<span style="color: gray;" title="No response">&#11044;</span>'
@@ -169,7 +182,7 @@ def get_invitees(cursor):
                 html_status = '<span style="color: orange;" title="Maybe">&#11044;</span>'
             else:
                 html_status = ''
-            sharing_participant = f'{html_status} {participant}'
+            sharing_participant = f'{html_status} {participant_html}'
 
             sharing_participants = data_dict.get(key, '')
             if sharing_participants:
@@ -190,9 +203,9 @@ def get_invitees(cursor):
 
 def get_calendar_name(name, color):
     if color:
-        calendar_name = f'<span style="color: {color};">&#9673; </span>{name}'
+        calendar_name = f'<span style="color: {esc(color)};">&#9673; </span>{esc(name)}'
     else:
-        calendar_name = f'&#9711; {name}'
+        calendar_name = f'&#9711; {esc(name)}'
     return calendar_name
 
 @artifact_processor
@@ -296,8 +309,8 @@ def calendarEvents(context):
 
                     if latitude and longitude:
                         location_coordinates_tag = f'''
-                        {location_coordinates} &nbsp; 
-                        <a href="https://www.openstreetmap.org/?lat={latitude}&lon=%20{longitude}&zoom=17&layers=M" target="_blank">
+                        {esc(location_coordinates)} &nbsp;
+                        <a href="https://www.openstreetmap.org/?lat={esc(latitude)}&lon=%20{esc(longitude)}&zoom=17&layers=M" target="_blank">
                         &#x1F5FA;</a>
                         '''
                     else:
@@ -406,15 +419,15 @@ def calendarList(context):
             usageentries = len(all_rows)
             if usageentries > 0:
 
-                sharees = get_sharees(cursor)
+                sharees_html, sharees_csv = get_sharees(cursor)
                 for row in all_rows:
                     calendar_name = row[1]
                     calendar_name_tag = get_calendar_name(row[1], row[2])
                     owner_email = row[6].replace('mailto:', '') if row[6] else ''
                     owner_email = unquote(owner_email)
-                    if sharees:
-                        sharing_participants_html = sharees.get(row[0], '')
-                        sharing_participants = sharees.get(row[0], '').replace('<br>', ' ')
+                    if sharees_html:
+                        sharing_participants_html = sharees_html.get(row[0], '')
+                        sharing_participants = sharees_csv.get(row[0], '')
                         data_list_html.append((calendar_name_tag, row[3], row[4], row[5], owner_email, row[7],
                                           sharing_participants_html, row[8], context.get_relative_path(file_found)))
                         data_list.append((calendar_name, row[3], row[4], row[5], owner_email, row[7],

--- a/scripts/artifacts/foursquareSwarm.py
+++ b/scripts/artifacts/foursquareSwarm.py
@@ -331,6 +331,7 @@ from scripts.filetype import get_type
 from scripts.ilapfuncs import get_sqlite_db_records, open_sqlite_db_readonly, \
     does_column_exist_in_db, get_plist_content, check_in_embedded_media, \
     convert_unix_ts_to_utc, get_birthdate, check_in_media, artifact_processor, logfunc
+from scripts.html_safe import safe_join
 
 # Constants
 COMMA_SEP = ', '
@@ -3940,15 +3941,15 @@ def foursquare_swarm_feed(context):
             # Extract social intelligence
             participants = _extract_zblob_participants(entities_blob, target_blob)
             p_participants = LIST_SEP.join(participants)
-            h_participants = HTML_LINE_BREAK.join(participants)
+            h_participants = safe_join(participants, HTML_LINE_BREAK)
 
             replies = _extract_zblob_replies(entities_blob, target_blob)
             p_replies = LIST_SEP.join(replies)
-            h_replies = HTML_LINE_BREAK.join(replies)
+            h_replies = safe_join(replies, HTML_LINE_BREAK)
 
             social_actors = _extract_zblob_social_actors(entities_blob, target_blob)
             p_social_actors = LIST_SEP.join(social_actors)
-            h_social_actors = HTML_LINE_BREAK.join(social_actors)
+            h_social_actors = safe_join(social_actors, HTML_LINE_BREAK)
 
             # Fallback mechanism: extract strings directly from the decoded Core Data object
             if not text:

--- a/scripts/artifacts/splitwise.py
+++ b/scripts/artifacts/splitwise.py
@@ -100,6 +100,7 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, convert_unix_ts_to_utc
+from scripts.html_safe import esc
 
 @artifact_processor
 def splitwiseUsers(context):
@@ -323,7 +324,7 @@ def splitwiseGroups(context):
             (created_ts, updated_ts, record[2], members, record[4], group_title, record[6], 
              record[7], record[8], record[9]))
         data_list_html.append(
-            (created_ts, updated_ts, record[2], members.replace(chr(13), '<br>')[:-2], record[4], 
+            (created_ts, updated_ts, record[2], esc(members).replace(chr(13), '<br>')[:-2], record[4],
              group_title, record[6], record[7], record[8], record[9]))
 
     return data_headers, (data_list, data_list_html), source_path
@@ -354,7 +355,7 @@ def splitwiseNotifications(context):
 
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
-        data_list_html.append((created_ts, record[1], record[2], record[3]))
+        data_list_html.append((created_ts, esc(record[1]), record[2], record[3]))
         remove_html = record[1].replace('<strong>', '').replace('</strong>', '')
         data_list.append((created_ts, remove_html, record[2], record[3]))
 

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -22,6 +22,7 @@ from scripts.ilapfuncs import (
     artifact_processor,
     convert_unix_ts_to_utc
     )
+from scripts.html_safe import esc
 
 
 @artifact_processor
@@ -56,14 +57,14 @@ def torrent_resume_info(context):
                     if x_str == 'pieces':
                         pass
                     else:
-                        aggregate += f'{x_str}: {y} <br>'
+                        aggregate += f'{esc(x_str)}: {esc(y)} <br>'
             elif key_str == 'pieces':
                 pass
             elif key_str == 'creation date':
                 ts_val = convert_unix_ts_to_utc(value)
-                aggregate += f'{key_str}: {ts_val} <br>'
+                aggregate += f'{esc(key_str)}: {esc(ts_val)} <br>'
             else:
-                aggregate += f'{key_str}: {value} <br>' 
+                aggregate += f'{esc(key_str)}: {esc(value)} <br>'
         wrapped_path = textwrap.fill(context.get_relative_path(file_found), width=50)
         data_list.append((wrapped_path, infohash, aggregate.strip()))
 

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -69,6 +69,7 @@ from scripts.ilapfuncs import (
     artifact_processor,
     logfunc
     )
+from scripts.html_safe import esc
 
 ASCII_STRINGS_RE = re.compile(rb'[\x20-\x7e]{4,}')
 _extraction_cache = {}
@@ -155,8 +156,8 @@ def process_journal_files(context):
             f'{os.path.basename(report_folder)}/{output_filename}'
         )
         report_link = (
-            f'<a href="{relative_output_path}" target="_blank" '
-            f'style="color:blue">{journal_name}</a>'
+            f'<a href="{esc(relative_output_path)}" target="_blank" '
+            f'style="color:blue">{esc(journal_name)}</a>'
         )
         summary_row = (
             relative_output_path,

--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -1,0 +1,74 @@
+"""Helpers for safely emitting evidence-derived values into ``html_columns`` cells.
+
+Columns listed in an artifact's ``__artifacts_v2__`` ``html_columns`` are written to
+the HTML report **without** the framework's ``html.escape`` (see
+``scripts/artifact_report.py`` ``write_artifact_data_table`` -- the ``html_no_escape``
+branch). Any evidence-derived text placed in such a cell is therefore an
+HTML/JavaScript injection sink: malicious content in a parsed return renders live in
+the examiner's report (stored XSS, CWE-79).
+
+Route every evidence-derived value in an ``html_columns`` cell through these helpers so
+the dynamic parts are escaped while the tool's own structural markup (``<a>``, ``<br>``,
+``<table>``) is preserved.
+"""
+
+import html
+from urllib.parse import urlparse
+
+# Schemes we are willing to turn into a live <a href>. Anything else (notably
+# javascript: and data:) is rendered as escaped text, never as a clickable link.
+ALLOWED_URL_SCHEMES = ('http', 'https', 'mailto', 'tel', 'ftp', 'ftps')
+
+
+def esc(value):
+    """HTML-escape a single evidence value for safe use in text or an attribute.
+
+    ``None`` becomes ``''``. ``quote=True`` escapes ``"`` and ``'`` as well, so the
+    result is safe in both element-text and double-quoted-attribute contexts.
+    """
+    if value is None:
+        return ''
+    return html.escape(str(value), quote=True)
+
+
+def safe_url(url, text=None, target='_blank'):
+    """Build an ``<a href>`` anchor with an escaped, scheme-checked href.
+
+    Returns the escaped visible text with **no** anchor when the URL is empty or its
+    scheme is not allowlisted, so ``javascript:``/``data:`` URLs never become live
+    links. ``text`` (the visible label) defaults to the URL itself.
+    """
+    url = '' if url is None else str(url).strip()
+    label = esc(text if text is not None else url)
+    if not url:
+        return label
+    try:
+        scheme = urlparse(url).scheme.lower()
+    except ValueError:
+        return label
+    if scheme not in ALLOWED_URL_SCHEMES:
+        return label
+    rel = ' rel="noopener noreferrer"' if target == '_blank' else ''
+    return f'<a href="{esc(url)}" target="{esc(target)}"{rel}>{label}</a>'
+
+
+def safe_join(values, sep='<br>'):
+    """Escape each evidence value and join with a tool-controlled separator.
+
+    The separator is emitted verbatim (it is tool-owned markup, default ``<br>``);
+    every joined value is escaped.
+    """
+    return sep.join(esc(v) for v in values)
+
+
+def safe_source(text):
+    """Escape an evidence text/document body for display as source.
+
+    Real newlines become ``<br>`` for readability *after* escaping, so any markup in
+    the evidence (including a literal ``<br>``) is shown inert as text. Use for
+    Tier-1 raw bodies -- message/email bodies, whole return pages, notes -- per the
+    escape-to-source policy.
+    """
+    if text is None:
+        return ''
+    return esc(text).replace('\n', '<br>')


### PR DESCRIPTION
Fixes stored HTML/JS injection (CWE-79, **GHSA-45q2-q93c-cfv2**) in iLEAPP `html_columns` cells — the sibling of RLEAPP #374, same shared `scripts/html_safe.py` pattern.

## What
12 modules routed through `html_safe` (esc / safe_url / safe_join / safe_source):
- **Tier 1 (escape-to-source):** biomeNotes, biomeIntents, splitwiseNotifications.
- **Tier 2 (escape dynamic parts, keep structure):** BeReal (generic_url + device/realmoji/tag/participant lists), booking + burnerCache (unordered_list + generic_url), calendarAll (name/coords/invitees/sharees), appleMapsTrips + Oura (map coords), foursquare_swarm_feed (participants/replies/social actors), splitwiseGroups, torrentResumeinfo, walStrings.

Only the HTML-rendered value is escaped; the plain `data_list` (TSV/timeline/LAVA) stays raw. `safe_url` allowlists schemes (no live `javascript:`/`data:`).

## Not touched
Already-safe columns (foursquareSwarm URL/profile/entities via `format_url`+`html.escape`, booking URL columns, media-typed + numeric columns). **nsVault "Attachment"** is deferred to the framework `html_media_tag` fix (unescaped evidence filename in `title=`, tool-wide).

## Validation
pylint `--disable=C,R` = **10.00** on all changed files; py_compile clean; PluginLoader loads all plugins; helper-level payload tests confirm `<script>`/`<img onerror>`/`javascript:` come out escaped (and never linkified) in the HTML branch while the plain branch stays byte-raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)