### PR TITLE
addressBook: fix empty-column pruning (dropping real columns / emitting garbage)

### DIFF
--- a/scripts/artifacts/addressBook.py
+++ b/scripts/artifacts/addressBook.py
@@ -43,15 +43,8 @@ def clean_label(data):
 
 def remove_unused_rows(data, count_rows):
     data_count_rows = count_rows[0]
-    rows_to_remove = []
-    # for i in range(len(data_count_rows)):
-    #     if data_count_rows[i] == 0:
-    #         rows_to_remove.append(i)
-    for i, data in enumerate(data_count_rows):
-        if data == 0:
-            rows_to_remove.append(i)
-    data = ( i for r, i in enumerate(data) if r not in rows_to_remove )
-    return tuple(data)
+    rows_to_remove = [i for i, count in enumerate(data_count_rows) if count == 0]
+    return tuple(value for i, value in enumerate(data) if i not in rows_to_remove)
 
 
 @artifact_processor
@@ -259,6 +252,7 @@ def addressBook(context):
     remove_empty_cols_query = '''
     SELECT 
         'Create', 
+        'Modif', 
         count(ABI.ABThumbnailImage.data), 
         count(ABI.ABFullSizeImage.data), 
         count(ABPerson.Prefix), 
@@ -305,8 +299,7 @@ def addressBook(context):
         count(ABPerson.Note), 
         count(ABPerson.Birthday), 
         count(ABGroupMembers.member_id), 
-        'Store', 
-        'Modif'
+        'Store'
     FROM ABPerson
     LEFT JOIN ABGroupMembers ON ABPerson.ROWID = ABGroupMembers.member_id
     LEFT JOIN ABI.ABThumbnailImage ON ABPerson.ROWID = ABI.ABThumbnailImage.record_id


### PR DESCRIPTION
Fixes **#1731**. Investigating @novkostya's report turned up **two** bugs in the Address Book empty-column removal — the reported misalignment, plus a more severe one underneath it.

## Bug 1 — `remove_unused_rows` variable shadowing (the dominant one)
`for i, data in enumerate(data_count_rows)` clobbers the `data` parameter, so the next line iterates the **last count value** instead of the header/row list. On real data it returns the *characters* of the last SELECT literal — the artifact's actual output was `['S','t']`: two single-character columns, identical for every contact. The whole feature was broken at runtime.

## Bug 2 — `remove_empty_cols_query` misalignment (#1731, as reported)
The count SELECT had **no slot for Modification Date** (`'Create'` → straight to `count(Thumbnail)`) with a stray `'Modif'` at the end, offsetting every check by one from index 1: **Last Name** governed by `count(Suffix)` (dropped whenever suffixes are empty — nearly always), Company by `count(Department)`, etc. Realigned by inserting the `'Modif'` slot after `'Create'` and dropping the trailing one.

**Both are required** — fixing only the query still returns garbage (shadowing); fixing only the shadowing prunes the *wrong* columns (misalignment).

## Validation (real `AddressBook.sqlitedb`)
Before: `data_headers = ['S','t']`, every row `['S','t']`.
After: correct schema with genuinely-empty columns pruned —
`Creation Date, Modification Date, First Name, Last Name, Phone Numbers, Storage Place`; **Last Name = 'White' present**, Suffix + Last Name Phonetic (empty) dropped, Modification Date kept.
pylint `--disable=C,R` = **10.00**; PluginLoader 626.

Thanks @novkostya for the report (found while using iLEAPP as a differential oracle) — solid catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)