### PR TITLE
ci: guard against PyPI-style blackboxprotobuf imports

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -35,6 +35,10 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python -m pip install -r requirements.txt
 
+      - name: Guard against PyPI blackboxprotobuf imports
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/test/scripts/test_no_pypi_blackboxprotobuf.py
+
       - name: Run on changed files
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: |

--- a/admin/test/scripts/test_no_pypi_blackboxprotobuf.py
+++ b/admin/test/scripts/test_no_pypi_blackboxprotobuf.py
@@ -1,0 +1,40 @@
+"""Guard against reintroducing the PyPI blackboxprotobuf package.
+
+iLEAPP vendors blackboxprotobuf at scripts/blackboxprotobuf because the PyPI
+release pins protobuf==3.10.0, which force-downgrades the protobuf runtime
+below the security pin in requirements.txt (see that file's comments).
+
+A top-level `import blackboxprotobuf` slips in easily: contributions branched
+before the vendoring, or new artifacts copied from old examples. It fails soft
+at load time (the artifact is skipped with a loader warning), so review can
+miss it. This test fails CI instead. The correct import is:
+
+    from scripts import blackboxprotobuf
+"""
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+VENDORED_DIR = REPO_ROOT / 'scripts' / 'blackboxprotobuf'
+STALE_IMPORT = re.compile(r'^\s*(import blackboxprotobuf|from blackboxprotobuf\b)')
+
+
+class TestNoPypiBlackboxprotobuf(unittest.TestCase):
+    def test_no_stale_blackboxprotobuf_imports(self):
+        offenders = []
+        for py_file in (REPO_ROOT / 'scripts').rglob('*.py'):
+            if VENDORED_DIR in py_file.parents:
+                continue
+            for line_number, line in enumerate(
+                    py_file.read_text(encoding='utf-8', errors='replace').splitlines(), 1):
+                if STALE_IMPORT.match(line):
+                    offenders.append(f'{py_file.relative_to(REPO_ROOT)}:{line_number}: {line.strip()}')
+        self.assertEqual(
+            offenders, [],
+            'PyPI-style blackboxprotobuf import found; use "from scripts import '
+            'blackboxprotobuf" instead (see requirements.txt):\n' + '\n'.join(offenders))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a CI check failing any `import blackboxprotobuf` / `from blackboxprotobuf` outside the vendored `scripts/blackboxprotobuf` package.

**Why:** the PyPI blackboxprotobuf pins protobuf==3.10.0 (below our security pin, see requirements.txt). A stale import from a pre-vendoring branch or an old example fails *soft* at load time (artifact skipped with a loader warning), so it is easy to miss in review. PR #1748 hit exactly this and needed a maintainer fix.

**How:** `admin/test/scripts/test_no_pypi_blackboxprotobuf.py` plus a step in the existing lint workflow (iLEAPP has no unittest-discover job). Verified it passes on the clean tree and reports file:line on a planted violation.

Companion ALEAPP PR: abrignoni/ALEAPP#978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)