### PR TITLE
fix: add renamed iOS 17+ Biome stream paths to four artifacts

### DIFF
--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -4,11 +4,14 @@ __artifacts_v2__ = {
         "description": "Parses backlight entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-25",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/public/Backlight/local/*'),
+        "paths": (
+            '*/Biome/streams/public/Backlight/local/*',
+            '*/streams/*/Device.Display.Backlight/local/*',
+        ),
         "output_types": "standard",
         "artifact_icon": "sun",
         "sample_data": {

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -1,14 +1,17 @@
 __artifacts_v2__ = {
     "get_biomeIntents": {
         "name": "Biome - Intents",
-        "description": "Parses battery percentage entries from biomes",
+        "description": "Parses app intent entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-25",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/AppIntent/local/*'),
+        "paths": (
+            '*/AppIntent/local/*',
+            '*/streams/*/App.Intent/local/*',
+        ),
         "html_columns": ["Data"],
         "output_types": "standard",
         "artifact_icon": "bolt",

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -4,11 +4,14 @@ __artifacts_v2__ = {
         "description": "Parses Now Playing entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-25",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/public/NowPlaying/local/*'),
+        "paths": (
+            '*/Biome/streams/public/NowPlaying/local/*',
+            '*/streams/*/Media.NowPlaying/local/*',
+        ),
         "output_types": "standard",
         "artifact_icon": "music",
         "sample_data": {

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -1,14 +1,17 @@
 __artifacts_v2__ = {
     "get_biomeUseractmeta": {
         "name": "Biome - User Activity Metadata",
-        "description": "Parses battery percentage entries from biomes",
+        "description": "Parses user activity metadata entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-25",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/restricted/UserActivityMetadata/local*'),
+        "paths": (
+            '*/Biome/streams/restricted/UserActivityMetadata/local*',
+            '*/streams/*/UniversalRecents.UserActivity.Metadata/local/*',
+        ),
         "output_types": "standard",
         "artifact_icon": "activity",
         "sample_data": {


### PR DESCRIPTION
## What

Adds the renamed Biome stream search paths to four artifacts, keeping the legacy paths so older iOS extractions keep parsing. Rename report courtesy of Mattia Epifani.

| Artifact | Legacy stream (kept) | Renamed stream (added) |
|---|---|---|
| Biome - Intents | `AppIntent` | `App.Intent` |
| Biome - Backlight | `public/Backlight` | `Device.Display.Backlight` |
| Biome - Now Playing | `public/NowPlaying` | `Media.NowPlaying` |
| Biome - User Activity Metadata | `restricted/UserActivityMetadata` | `UniversalRecents.UserActivity.Metadata` |

## Why the new globs look the way they do

Verified against the Josh Hickman iOS 17 filepath list in `admin/data/filepath-lists/`:

- The renamed streams are literal dotted folder names, e.g. `.../Biome/streams/restricted/App.Intent/local/<segb>`.
- The streams changed tier (e.g. NowPlaying was `public/`, `Media.NowPlaying` is `restricted/`), so the new patterns wildcard the tier: `*/streams/*/Media.NowPlaying/local/*`.
- `Device.Display.Backlight` moved out of `/var/mobile/Library/Biome/` entirely and now lives at `/private/var/db/biome/streams/restricted/...` (lowercase `biome`). Since fnmatch is case-sensitive on macOS/Linux, the new patterns drop the `Biome` anchor.

All eight patterns (4 old + 4 new) were validated with case-sensitive fnmatch against the iOS 15, iOS 16.3, and iOS 17 image filepath lists: old patterns hit only the pre-rename images, new patterns hit only the iOS 17 image, including the `var/db/biome` Backlight location.

Also fixes copy-pasted descriptions in biomeIntents and biomeUseractmeta ("Parses battery percentage entries" -> intents / user activity metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)