### PR TITLE
feat: add Biome - Siri Remembers Message History artifact

### DIFF
--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -1,0 +1,173 @@
+__artifacts_v2__ = {
+    "get_biomeSiriRemembersMessageHistory": {
+        "name": "Biome - Siri Remembers Message History",
+        "description": "Parses message exchange records (timestamps, participants, chat and message "
+                       "identifiers) from the Siri.Remembers.MessageHistory biome stream. The stream "
+                       "records message activity for Messages and third party messaging apps but does "
+                       "not store message body content.",
+        "author": "@abrignoni",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Direction values and message timestamps validated against sms.db (is_from_me, date) "
+                 "from the same iOS 18.7 test extraction. In this stream direction 1 = Incoming and "
+                 "2 = Outgoing, inverted from the siriremembers.sqlite3 convention.",
+        "paths": (
+            '*/streams/*/Siri.Remembers.MessageHistory/local/*',
+            '*/streams/*/Siri.Remembers.MessageHistory/remote/*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
+}
+
+
+import json
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+DIRECTIONS = {0: 'Unspecified', 1: 'Incoming', 2: 'Outgoing'}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _message_timestamp(value):
+    # Field 8 holds the message date as a Unix epoch double stored in a fixed64.
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _entity_display(entity):
+    # Entity value plus display name from its JSON attributes, when available.
+    value = _to_str(entity.get('1', b''))
+    name = ''
+    attrs = _to_str(entity.get('4', b''))
+    if attrs:
+        try:
+            name = json.loads(attrs).get('name', '')
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            name = ''
+    if name and name != value:
+        return f'{value} ({name})' if value else name
+    return value
+
+
+def _participants(protostuff):
+    # Repeated field 2 items pair a parameter name (sender, senderHandle, recipients,
+    # recipientHandles, speakableGroupName, sentMessages) with an entity.
+    params = {}
+    entities = protostuff.get('2', [])
+    if isinstance(entities, dict):
+        entities = [entities]
+    for item in entities:
+        if not isinstance(item, dict):
+            continue
+        param = _to_str(item.get('1', b''))
+        entity = item.get('2', {})
+        if not isinstance(entity, dict):
+            continue
+        display = _entity_display(entity)
+        if display:
+            params.setdefault(param, []).append(display)
+    return {key: '; '.join(values) for key, values in params.items()}
+
+
+def _sync_origin(file_found):
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
+
+
+@artifact_processor
+def get_biomeSiriRemembersMessageHistory(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+        origin = _sync_origin(file_found)
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'Siri Remembers Message History: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                metadata = protostuff.get('1', {})
+                if not isinstance(metadata, dict):
+                    continue
+
+                message_ts = _message_timestamp(metadata.get('8'))
+                direction = metadata.get('6')
+                direction = DIRECTIONS.get(direction, str(direction) if direction is not None else '')
+                bundle_id = _to_str(metadata.get('4', b''))
+                intent_class = _to_str(metadata.get('2', b''))
+                chat_id = _to_str(metadata.get('12', b''))
+                message_guid = _to_str(metadata.get('13', b''))
+
+                is_group = ''
+                group_metadata = _to_str(metadata.get('11', b''))
+                if group_metadata:
+                    try:
+                        is_group = str(json.loads(group_metadata).get('isGroup', ''))
+                    except (json.JSONDecodeError, AttributeError, TypeError):
+                        is_group = ''
+
+                params = _participants(protostuff)
+
+                data_list.append((ts, message_ts, record.state.name, direction, bundle_id,
+                                  params.get('sender', ''), params.get('senderHandle', ''),
+                                  params.get('recipients', ''), params.get('recipientHandles', ''),
+                                  params.get('speakableGroupName', ''), is_group, chat_id,
+                                  message_guid, intent_class, origin, filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None, None,
+                                  None, None, None, None, None, origin, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Message Timestamp', 'datetime'), 'SEGB State',
+                    'Direction', 'Bundle ID', 'Sender', 'Sender Handle', 'Recipients',
+                    'Recipient Handles', 'Group Name', 'Is Group', 'Chat ID', 'Message GUID',
+                    'Intent Class', 'Sync Origin', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## What

New artifact **Biome - Siri Remembers Message History** parsing the `Siri.Remembers.MessageHistory` biome stream (SEGB v2), present since roughly iOS 17. Each record is one message exchange event:

| Column | Source |
|---|---|
| SEGB Timestamp | SEGB record timestamp1 (UTC) |
| Message Timestamp | protobuf field `1.8`, Unix-epoch double in a fixed64 |
| Direction | field `1.6` — `1` = Incoming, `2` = Outgoing |
| Bundle ID | field `1.4` (`com.apple.MobileSMS`, Discord observed, etc.) |
| Sender / Sender Handle / Recipients / Recipient Handles / Group Name | repeated field `2` parameter+entity pairs (`sender`, `senderHandle`, `recipients`, `recipientHandles`, `speakableGroupName`), with display names pulled from entity JSON attributes |
| Is Group | field `1.11` JSON `{"isGroup": ...}` |
| Chat ID | field `1.12` (e.g. `SMS;-;+1518...`) |
| Message GUID | field `1.13` |
| Intent Class | field `1.2` (`INSendMessageIntent`) |
| Sync Origin | `local` vs `remote (<device UUID>)` from the file path |

No message body content exists in this stream — it is participant/metadata evidence.

## Validation

Developed against the HC iOS 18.7 test extraction (`hc_ios18_7` corpus). Every message GUID from the stream that still exists in `sms.db` was cross-checked: **direction matches `is_from_me` and the decoded timestamp matches `message.date` to the second, 6/6 verified, 0 mismatches.**

Two findings worth reviewer eyes:

- **Direction is inverted vs `siriremembers.sqlite3`**: in the DB (SiriRemembers.py), `1` = outgoing / `2` = incoming; in this biome stream the sms.db cross-check proves `1` = Incoming / `2` = Outgoing. Documented in the artifact notes.
- **Records persist after deletion from sms.db**: several stream GUIDs have no surviving sms.db row.

Path globs `*/streams/*/Siri.Remembers.MessageHistory/{local,remote}/*` were validated case-sensitively against the iOS 15/16.3/17 filepath lists and the iOS 18.7 zip: hits only where the stream exists (iOS 17: 3 local files + tombstone, iOS 18.7: 1 file), zero false positives. The `remote/` glob covers synced records from other devices (populated in recent extractions; a Sync Origin column distinguishes them).

Related: complements the `siriremembers.sqlite3` artifacts (SiriRemembers.py, James McGee research) — same intent/entity model, different storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)