### PR TITLE
chore: credit Mattia Epifani on renamed-stream and Message History artifacts

### DIFF
--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_biomeBacklight": {
         "name": "Biome - Backlight",
         "description": "Parses backlight entries from biomes",
-        "author": "@JohnHyla",
+        "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
         "last_update_date": "2026-07-25",
         "requirements": "none",

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_biomeIntents": {
         "name": "Biome - Intents",
         "description": "Parses app intent entries from biomes",
-        "author": "@JohnHyla",
+        "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
         "last_update_date": "2026-07-25",
         "requirements": "none",

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_biomeNowplaying": {
         "name": "Biome - Now Playing",
         "description": "Parses Now Playing entries from biomes",
-        "author": "@JohnHyla",
+        "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
         "last_update_date": "2026-07-25",
         "requirements": "none",

--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "identifiers) from the Siri.Remembers.MessageHistory biome stream. The stream "
                        "records message activity for Messages and third party messaging apps but does "
                        "not store message body content.",
-        "author": "@abrignoni",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
         "last_update_date": "2026-07-25",
         "requirements": "none",

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_biomeUseractmeta": {
         "name": "Biome - User Activity Metadata",
         "description": "Parses user activity metadata entries from biomes",
-        "author": "@JohnHyla",
+        "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
         "last_update_date": "2026-07-25",
         "requirements": "none",


### PR DESCRIPTION
Adds `@mattiaepi` (Mattia Epifani) as co-author in the artifact metadata of:

- Biome - Intents, Backlight, Now Playing, User Activity Metadata (renamed-stream path fixes, #1750)
- Biome - Siri Remembers Message History (#1751)

Mattia reported the iOS 17+ Biome stream renames and flagged the unparsed `Siri.Remembers.MessageHistory` stream. Handle verified via RealityNet/iOS-Forensics-References contributor history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)