### PR TITLE
feat: add six Biome stream artifacts reported by Mattia Epifani

### DIFF
--- a/scripts/artifacts/biomeAppActivity.py
+++ b/scripts/artifacts/biomeAppActivity.py
@@ -1,0 +1,119 @@
+__artifacts_v2__ = {
+    "get_biomeAppActivity": {
+        "name": "Biome - App Activity",
+        "description": "Parses NSUserActivity records from the App.Activity biome stream: bundle id, "
+                       "activity type, linked item URI and an activity payload that can embed content "
+                       "such as note titles or map activity details.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The expiration timestamp was observed to be exactly 30 days after the record "
+                 "timestamp (the NSUserActivity default). Payload strings are URL-decoded for "
+                 "display.",
+        "paths": ('*/streams/*/App.Activity/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+from urllib.parse import unquote
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Pin flat fields so payload/URI strings are never eagerly decoded as nested protobuf.
+TYPESS = {
+    '1': {'type': 'str', 'name': ''},
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'int', 'name': ''},
+    '8': {'type': 'str', 'name': ''},
+    '10': {'type': 'str', 'name': ''},
+    '14': {'type': 'str', 'name': ''},
+    '15': {'type': 'str', 'name': ''},
+    '16': {'type': 'str', 'name': ''},
+    '17': {'type': 'str', 'name': ''},
+    '18': {'type': 'str', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    # Unix epoch double stored in a fixed64.
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeAppActivity(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'App Activity: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                expiration = _unix_double(protostuff.get('5'))
+                bundle_id = _to_str(protostuff.get('1', b''))
+                activity_type = _to_str(protostuff.get('2', b''))
+                status_raw = protostuff.get('3', '')
+                activity_uuid = _to_str(protostuff.get('8', b''))
+                item_uri = _to_str(protostuff.get('10', b''))
+                payload = unquote(_to_str(protostuff.get('14', b'')))
+                session_uuid = _to_str(protostuff.get('15', b''))
+                source = _to_str(protostuff.get('16', b''))
+
+                data_list.append((ts, expiration, record.state.name, bundle_id, activity_type,
+                                  payload, item_uri, activity_uuid, session_uuid, source,
+                                  status_raw, filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None, None,
+                                  None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Expiration Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Activity Type', 'Payload', 'Item URI',
+                    'Activity UUID', 'Session UUID', 'Source', 'Status (raw)', 'Filename',
+                    'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeAutonamingMessageIds.py
+++ b/scripts/artifacts/biomeAutonamingMessageIds.py
@@ -1,0 +1,104 @@
+__artifacts_v2__ = {
+    "get_biomeAutonamingMessageIds": {
+        "name": "Biome - Autonaming Message IDs",
+        "description": "Parses message references (message GUID, conversation identifier and message "
+                       "date) from the Autonaming.Messages.MessageIds biome stream, used by Messages "
+                       "conversation auto-naming.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Message GUIDs and Unix epoch double dates validated against sms.db (guid, date) "
+                 "from the same iOS 18.7 test extraction.",
+        "paths": ('*/streams/*/Autonaming.Messages.MessageIds/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Pin flat fields so GUID/chat id strings are never eagerly decoded as nested protobuf.
+TYPESS = {
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'str', 'name': ''},
+    '4': {'type': 'str', 'name': ''},
+    '6': {'type': 'str', 'name': ''},
+    '7': {'type': 'str', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    # Unix epoch double stored in a fixed64.
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeAutonamingMessageIds(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'Autonaming Message IDs: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                message_ts = _unix_double(protostuff.get('10'))
+                bundle_id = _to_str(protostuff.get('2', b''))
+                chat_id = _to_str(protostuff.get('3', b'')) or _to_str(protostuff.get('7', b''))
+                message_guid = _to_str(protostuff.get('4', b'')) or _to_str(protostuff.get('6', b''))
+
+                data_list.append((ts, message_ts, record.state.name, bundle_id, chat_id,
+                                  message_guid, filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Message Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Chat ID', 'Message GUID', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDevTimeZone.py
+++ b/scripts/artifacts/biomeDevTimeZone.py
@@ -1,14 +1,15 @@
 __artifacts_v2__ = {
     "get_biomeDevTimeZone": {
         "name": "Biome - Device TimeZone",
-        "description": "Parses the device time zone from biomes",
-        "author": "Cynthia van Dorp",
+        "description": "Parses historical device time zone changes from the Device.TimeZone biome "
+                       "stream",
+        "author": "Cynthia van Dorp, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-09",
-        "last_update_date": "2026-07-09",
+        "last_update_date": "2026-07-25",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/biome/streams/restricted/Device.TimeZone/local/*'),
+        "paths": ('*/streams/*/Device.TimeZone/local/*',),
         "output_types": "standard",
         "artifact_icon": "map-pin"
     }

--- a/scripts/artifacts/biomeDeviceMetadata.py
+++ b/scripts/artifacts/biomeDeviceMetadata.py
@@ -1,0 +1,89 @@
+__artifacts_v2__ = {
+    "get_biomeDeviceMetadata": {
+        "name": "Biome - Device Metadata",
+        "description": "Parses OS build records from the Device.Metadata biome stream. Each record "
+                       "captures the OS build at the time it was written, producing an iOS "
+                       "version/update history that can span years.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Observed builds spanning iOS 16 through 18 in test extractions (e.g. 20B110, "
+                 "21D50, 22H31).",
+        "paths": ('*/streams/*/Device.Metadata/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    }
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Pin flat fields so build strings are never eagerly decoded as nested protobuf.
+TYPESS = {
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'int', 'name': ''},
+    '4': {'type': 'str', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+@artifact_processor
+def get_biomeDeviceMetadata(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'Device Metadata: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                os_build = _to_str(protostuff.get('2', b''))
+                os_build_alt = _to_str(protostuff.get('4', b''))
+                record_type = protostuff.get('3', '')
+
+                data_list.append((ts, record.state.name, os_build, os_build_alt, record_type,
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'OS Build',
+                    'OS Build (Field 4)', 'Type (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeSafariNavigations.py
+++ b/scripts/artifacts/biomeSafariNavigations.py
@@ -1,0 +1,108 @@
+__artifacts_v2__ = {
+    "get_biomeSafariNavigations": {
+        "name": "Biome - Safari Navigations",
+        "description": "Parses Safari navigation events from the Safari.Navigations biome stream: "
+                       "host, full URL (observed on iOS 18+; earlier versions record the host only) "
+                       "and country code. Complements App.WebUsage and _DKEvent.Safari.History, and "
+                       "records were observed to remain after the matching History.db visits were "
+                       "gone.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The rounded timestamp is the record timestamp rounded up to the next 30 minute "
+                 "boundary (observed consistently on iOS 17 and 18.7 samples).",
+        "paths": ('*/streams/*/Safari.Navigations/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "compass",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Pin flat fields so host/URL strings are never eagerly decoded as nested protobuf.
+TYPESS = {
+    '1': {'type': 'str', 'name': ''},
+    '2': {'type': 'double', 'name': ''},
+    '3': {'type': 'int', 'name': ''},
+    '4': {'type': 'int', 'name': ''},
+    '5': {'type': 'str', 'name': ''},
+    '8': {'type': 'str', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    # Unix epoch double stored in a fixed64.
+    if isinstance(value, int) and value > 10 ** 15:
+        value = struct.unpack('<d', struct.pack('<q', value))[0]
+    if not isinstance(value, (int, float)) or not value:
+        return None
+    try:
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeSafariNavigations(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'Safari Navigations: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                rounded_ts = _unix_double(protostuff.get('2'))
+                host = _to_str(protostuff.get('1', b''))
+                url = _to_str(protostuff.get('8', b''))
+                country = _to_str(protostuff.get('5', b''))
+
+                data_list.append((ts, rounded_ts, record.state.name, host, url, country,
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Rounded Timestamp (30 min)', 'datetime'),
+                    'SEGB State', 'Host', 'URL', 'Country', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeSiriRemembersCallHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersCallHistory.py
@@ -1,0 +1,170 @@
+__artifacts_v2__ = {
+    "get_biomeSiriRemembersCallHistory": {
+        "name": "Biome - Siri Remembers Call History",
+        "description": "Parses call records (timestamps, direction, contacts and handles, conversation "
+                       "identifiers) from the Siri.Remembers.CallHistory biome stream. Covers cellular "
+                       "and third party VoIP calls (WhatsApp, Messenger, LINE, imo and others observed).",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Direction and call timestamps validated against CallHistory.storedata (ZORIGINATED, "
+                 "ZDATE) from the same iOS 17 test extraction (5/5 matches). In this stream direction "
+                 "1 = Incoming and 2 = Outgoing, matching the Siri.Remembers.MessageHistory convention.",
+        "paths": (
+            '*/streams/*/Siri.Remembers.CallHistory/local/*',
+            '*/streams/*/Siri.Remembers.CallHistory/remote/*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+    }
+}
+
+
+import json
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+DIRECTIONS = {0: 'Unspecified', 1: 'Incoming', 2: 'Outgoing'}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _call_timestamp(value):
+    # Field 8 holds the call date as a Unix epoch double stored in a fixed64.
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _entity_display(entity):
+    # Entity value plus display name from its JSON attributes, when available.
+    value = _to_str(entity.get('1', b''))
+    name = ''
+    attrs = _to_str(entity.get('4', b''))
+    if attrs:
+        try:
+            name = json.loads(attrs).get('name', '')
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            name = ''
+    if name and name != value:
+        return f'{value} ({name})' if value else name
+    return value
+
+
+def _participants(protostuff):
+    # Repeated field 2 items pair a parameter name (contacts, contactHandles,
+    # speakableGroupName) with an entity.
+    params = {}
+    entities = protostuff.get('2', [])
+    if isinstance(entities, dict):
+        entities = [entities]
+    for item in entities:
+        if not isinstance(item, dict):
+            continue
+        param = _to_str(item.get('1', b''))
+        entity = item.get('2', {})
+        if not isinstance(entity, dict):
+            continue
+        display = _entity_display(entity)
+        if display:
+            params.setdefault(param, []).append(display)
+    return {key: '; '.join(values) for key, values in params.items()}
+
+
+def _sync_origin(file_found):
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
+
+
+@artifact_processor
+def get_biomeSiriRemembersCallHistory(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+        origin = _sync_origin(file_found)
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'Siri Remembers Call History: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                metadata = protostuff.get('1', {})
+                if not isinstance(metadata, dict):
+                    continue
+
+                call_ts = _call_timestamp(metadata.get('8'))
+                direction = metadata.get('6')
+                direction = DIRECTIONS.get(direction, str(direction) if direction is not None else '')
+                bundle_id = _to_str(metadata.get('4', b''))
+                intent_class = _to_str(metadata.get('2', b''))
+                conversation_id = _to_str(metadata.get('12', b''))
+                call_guid = _to_str(metadata.get('13', b''))
+
+                is_group = ''
+                group_metadata = _to_str(metadata.get('11', b''))
+                if group_metadata:
+                    try:
+                        is_group = str(json.loads(group_metadata).get('isGroup', ''))
+                    except (json.JSONDecodeError, AttributeError, TypeError):
+                        is_group = ''
+
+                params = _participants(protostuff)
+
+                data_list.append((ts, call_ts, record.state.name, direction, bundle_id,
+                                  params.get('contacts', ''), params.get('contactHandles', ''),
+                                  params.get('speakableGroupName', ''), is_group, conversation_id,
+                                  call_guid, intent_class, origin, filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None, None,
+                                  None, None, None, origin, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Call Timestamp', 'datetime'), 'SEGB State',
+                    'Direction', 'Bundle ID', 'Contacts', 'Contact Handles', 'Group Name',
+                    'Is Group', 'Conversation ID', 'Call GUID', 'Intent Class', 'Sync Origin',
+                    'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeSystemSettingsSearchTerms.py
+++ b/scripts/artifacts/biomeSystemSettingsSearchTerms.py
@@ -1,0 +1,94 @@
+__artifacts_v2__ = {
+    "get_biomeSystemSettingsSearchTerms": {
+        "name": "Biome - System Settings Search Terms",
+        "description": "Parses searches typed in the Settings app from the "
+                       "SystemSettings.SearchTerms biome stream, including the settings pane the "
+                       "user selected from the results.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/SystemSettings.SearchTerms/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    }
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+@artifact_processor
+def get_biomeSystemSettingsSearchTerms(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'System Settings Search Terms: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                search_term = _to_str(protostuff.get('1', b''))
+
+                results = protostuff.get('2', [])
+                if isinstance(results, dict):
+                    results = [results]
+                result_uris = []
+                result_labels = []
+                for result in results:
+                    if not isinstance(result, dict):
+                        continue
+                    uri = _to_str(result.get('1', b''))
+                    label = _to_str(result.get('2', b''))
+                    if uri:
+                        result_uris.append(uri)
+                    if label:
+                        result_labels.append(label)
+
+                data_list.append((ts, record.state.name, search_term, '; '.join(result_uris),
+                                  '; '.join(result_labels), filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Search Term',
+                    'Selected Result URI', 'Selected Result Label', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## What

Six new Biome stream artifacts from Mattia Epifani's report (`@mattiaepi` credited as co-author on each), plus a glob hardening for Device TimeZone. Every field mapping comes from decoding real SEGB data — HC iOS 18.7 and Josh Hickman iOS 17 extractions — with cross-validation against sibling databases from the same images.

| Artifact | Stream | Key evidence |
|---|---|---|
| Siri Remembers Call History | `Siri.Remembers.CallHistory` (local+remote) | Cellular + WhatsApp/Messenger/LINE/imo calls, contacts with names. Direction validated **5/5 against CallHistory.storedata `ZORIGINATED`**: `1` = Incoming, `2` = Outgoing (matches MessageHistory convention, inverted vs siriremembers.sqlite3) |
| App Activity | `App.Activity` | NSUserActivity records; payload embeds content (note titles, Maps place names — "Silver Sands State Park"). Expiration field is exactly +30 days on all 33 written records. 1,495 deleted-state records in one test file |
| Autonaming Message IDs | `Autonaming.Messages.MessageIds` | Message GUID + chat id + Unix-double date; validated against `sms.db` (guid → date matches to the second) |
| System Settings Search Terms | `SystemSettings.SearchTerms` | Search text plus the `settings-navigation://` pane selected |
| Safari Navigations | `Safari.Navigations` | Host, full URL (iOS 18+; iOS 17 records host only), country. Second timestamp = record time **rounded up to the next 30-minute boundary** (consistent across both images). The tested June 13 navigation has no surviving History.db visit — the stream outlives history deletion |
| Device Metadata | `Device.Metadata` | OS build history: `20B110` (2023) → `21D50` (2024) on the iOS 17 device; `22H31` → `22H352` on the 18.7 device. Lives under `/private/var/db/biome/` |

**Device TimeZone**: replaced the lowercase-only `*/biome/streams/restricted/...` glob with the tier-wildcard `*/streams/*/Device.TimeZone/local/*` (a strict superset — the old pattern missed nothing here but was case-fragile since iLEAPP matching is case-sensitive off Windows).

All artifacts use pinned blackboxprotobuf type maps for flat string fields, after observing an iOS 17 Safari host (`apple.com`) get eagerly mis-decoded as nested protobuf.

## Validation

- End-to-end harness on real SEGB samples for all six: header/row width, direction counts, timestamp conversions, and the database cross-checks above.
- Globs validated case-sensitively against the iOS 15/16.3/17 filepath lists and the 18.7 zip: hits exactly where streams exist, zero false positives.

## Not included (no local data)

`Wallet.Transactions` and `MLSE.ShareSheet.ConversationUserInteraction` from the same report exist in no locally available extraction (absent from iOS 17 and 18.7 images; likely newer iOS). Parsers deferred until sample SEGB data is available — a copy of those stream folders from any test extraction is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)