### PR TITLE
feat: add Biome - Wallet Transactions artifact

### DIFF
--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -1,0 +1,94 @@
+__artifacts_v2__ = {
+    "get_biomeWalletTransaction": {
+        "name": "Biome - Wallet Transactions",
+        "description": "Parses Apple Pay transaction events from the Wallet.Transaction biome "
+                       "stream: transaction time, the card used (name as shown in Wallet), the "
+                       "pass identifier and a per-transaction UUID.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Field mapped from sample data provided by Mattia Epifani (iOS 26 era; the "
+                 "stream is absent from iOS 17/18 test images). The stream folder name on disk "
+                 "is singular: Wallet.Transaction.",
+        "paths": ('*/streams/*/Wallet.Transaction/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "credit-card",
+    }
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Pin flat fields so card/pass strings are never eagerly decoded as nested protobuf.
+TYPESS = {
+    '1': {'type': 'str', 'name': ''},
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'int', 'name': ''},
+    '4': {'type': 'str', 'name': ''},
+    '5': {'type': 'int', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+@artifact_processor
+def get_biomeWalletTransaction(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'Wallet Transactions: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                card_name = _to_str(protostuff.get('2', b''))
+                pass_id = _to_str(protostuff.get('1', b''))
+                transaction_uuid = _to_str(protostuff.get('4', b''))
+                field3 = protostuff.get('3', '')
+                field5 = protostuff.get('5', '')
+
+                data_list.append((ts, record.state.name, card_name, pass_id, transaction_uuid,
+                                  field3, field5, filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Card Name', 'Pass ID',
+                    'Transaction UUID', 'Field 3 (raw)', 'Field 5 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## What

New artifact **Biome - Wallet Transactions** for the `Wallet.Transaction` biome stream — note the folder name is **singular** on disk. Per record: transaction time (SEGB timestamp), the card used (the card name as displayed in Wallet), the pass identifier, and a per-transaction UUID. Deleted-state SEGB records are reported too (the sample carries 710 of them alongside 58 written).

## Data & validation

Field mapping comes from sample SEGB data provided by Mattia Epifani (`@mattiaepi`, co-author) from an iOS 26-era device — this stream exists in neither the iOS 17 nor the iOS 18.7 local test images, so his sample is currently the only ground truth. Fields 3 and 5 are constant (1 and 0) across all 58 written records and are surfaced as raw research columns.

- End-to-end harness run: 768 rows, header/row width verified, card names and UUIDs render correctly.
- Flat string fields pinned via a blackboxprotobuf type map, consistent with the rest of the recent Biome batch.
- Glob `*/streams/*/Wallet.Transaction/local/*` verified against the real device path layout.

This closes out Mattia's stream report except `MLSE.ShareSheet.ConversationUserInteraction`, which still has no sample data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
