### PR TITLE
feat: add 21 Biome stream artifacts closing coverage gaps

### DIFF
--- a/scripts/artifacts/biomeAppActivity.py
+++ b/scripts/artifacts/biomeAppActivity.py
@@ -15,6 +15,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/App.Activity/local/*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 1528 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeAppIntentsTranscript.py
+++ b/scripts/artifacts/biomeAppIntentsTranscript.py
@@ -15,6 +15,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/App.Intents.Transcript/local/*',),
         "output_types": "standard",
         "artifact_icon": "bolt",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 41 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeAppIntentsTranscript.py
+++ b/scripts/artifacts/biomeAppIntentsTranscript.py
@@ -1,0 +1,152 @@
+__artifacts_v2__ = {
+    "get_biomeAppIntentsTranscript": {
+        "name": "Biome - App Intents Transcript",
+        "description": "Parses donated App Intents from the App.Intents.Transcript biome "
+                       "stream: the donating app, the intent class, the intent parameter and "
+                       "the human readable entity title shown to the user (for example a "
+                       "Settings destination or a Focus filter target).",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Each record also embeds an NSKeyedArchiver plist holding the full entity "
+                 "payload; that blob is not currently parsed.",
+        "paths": ('*/streams/*/App.Intents.Transcript/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "bolt",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _as_list(value):
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _intent_details(intent):
+    """Pull parameter names, entity types and display titles out of an intent message."""
+    params, entity_types, titles, urls = [], [], [], []
+    for slot in _as_list(intent.get('7')):
+        if not isinstance(slot, dict):
+            continue
+        name = _to_str(slot.get('1', b''))
+        if name:
+            params.append(name)
+        payload = slot.get('2', {})
+        if not isinstance(payload, dict):
+            continue
+        descriptor = payload.get('1', {})
+        if isinstance(descriptor, dict):
+            type_info = descriptor.get('3', {})
+            if isinstance(type_info, dict):
+                entity_type = _to_str(type_info.get('1', b''))
+                if entity_type:
+                    entity_types.append(entity_type)
+        display = payload.get('3', {})
+        if isinstance(display, dict):
+            inner = display.get('1', {})
+            if isinstance(inner, dict):
+                title = _to_str(inner.get('1', b''))
+                if title:
+                    titles.append(title)
+                url = _to_str(inner.get('4', b''))
+                if url:
+                    urls.append(url)
+    return params, entity_types, titles, urls
+
+
+@artifact_processor
+def get_biomeAppIntentsTranscript(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'App Intents Transcript: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                intent = protostuff.get('5', {})
+                if not isinstance(intent, dict):
+                    intent = protostuff.get('6', {})
+                if not isinstance(intent, dict):
+                    intent = {}
+
+                params, entity_types, titles, urls = _intent_details(intent)
+
+                # Field 8 carries the phrase template shown for the intent.
+                template = ''
+                phrase = protostuff.get('8', {})
+                if isinstance(phrase, dict):
+                    display = phrase.get('2', {})
+                    if isinstance(display, dict):
+                        inner = display.get('1', {})
+                        if isinstance(inner, dict):
+                            template = _to_str(inner.get('1', b''))
+
+                data_list.append((ts, _unix_double(protostuff.get('4')), record.state.name,
+                                  _to_str(protostuff.get('1', b'')),
+                                  _to_str(intent.get('1', b'')),
+                                  '; '.join(params), '; '.join(entity_types),
+                                  '; '.join(titles), template, '; '.join(sorted(set(urls))),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None,
+                                  None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Intent Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Intent Class', 'Parameters', 'Entity Types',
+                    'Entity Titles', 'Phrase Template', 'App URL', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeAudioMediaRoutes.py
+++ b/scripts/artifacts/biomeAudioMediaRoutes.py
@@ -1,0 +1,134 @@
+"""Biome audio and media route streams.
+
+Both streams record the route in use when audio or media plays. Bluetooth and
+CarPlay routes carry the accessory MAC address and name, which places a specific
+accessory with the device at a specific time.
+"""
+__artifacts_v2__ = {
+    "get_biomeAudioRoute": {
+        "name": "Biome - Audio Route",
+        "description": "Parses audio route changes from the Audio.Route biome stream: the "
+                       "route name, its port type and the port name (for example Built-In "
+                       "Microphone / MicrophoneBuiltIn / iPhone Microphone).",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Field 6 distinguishes input from output routes in observed data (1 with "
+                 "microphone routes, 2 with speaker and receiver routes) but is reported raw "
+                 "as the mapping is not confirmed.",
+        "paths": ('*/streams/*/Audio.Route/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "headphones",
+    },
+    "get_biomeMediaRoute": {
+        "name": "Biome - Media Route",
+        "description": "Parses media output route changes from the Media.Route biome stream. "
+                       "Bluetooth and AirPlay routes carry the accessory identifier and name.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/Media.Route/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "speaker",
+    },
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+AUDIO_TYPESS = {
+    '1': {'type': 'int', 'name': ''},
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'str', 'name': ''},
+    '4': {'type': 'str', 'name': ''},
+    '5': {'type': 'int', 'name': ''},
+    '6': {'type': 'int', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _iter_records(context, label, typess=None):
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, typess) \
+                        if typess else blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'{label}: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+                yield ts, record, protostuff, filename
+            elif record.state == EntryState.Deleted:
+                yield ts, record, None, filename
+
+
+@artifact_processor
+def get_biomeAudioRoute(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Route Name', 'Port Type',
+                    'Port Name', 'Field 1 (raw)', 'Field 5 (raw)', 'Field 6 (raw)', 'Filename',
+                    'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _iter_records(context, 'Audio Route', AUDIO_TYPESS):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, None, None, None,
+                              filename, record.data_start_offset))
+            continue
+        data_list.append((ts, record.state.name, _to_str(protostuff.get('2', b'')),
+                          _to_str(protostuff.get('3', b'')), _to_str(protostuff.get('4', b'')),
+                          protostuff.get('1', ''), protostuff.get('5', ''),
+                          protostuff.get('6', ''), filename, record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeMediaRoute(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Route Name',
+                    'Route Identifier', 'Route Type (raw)', 'Route Subtype (raw)',
+                    'Field 1 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _iter_records(context, 'Media Route'):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, None, None, filename,
+                              record.data_start_offset))
+            continue
+        detail = protostuff.get('4', {})
+        if not isinstance(detail, dict):
+            detail = {}
+        data_list.append((ts, record.state.name, _to_str(protostuff.get('2', b'')),
+                          _to_str(detail.get('1', b'')), detail.get('2', ''),
+                          detail.get('3', ''), protostuff.get('1', ''), filename,
+                          record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeAudioMediaRoutes.py
+++ b/scripts/artifacts/biomeAudioMediaRoutes.py
@@ -21,6 +21,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Audio.Route/local/*',),
         "output_types": "standard",
         "artifact_icon": "headphones",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 3833 rows",
+            "iphone11_ios17": "iOS 17.3 | 2261 rows",
+        },
     },
     "get_biomeMediaRoute": {
         "name": "Biome - Media Route",
@@ -35,6 +39,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Media.Route/local/*',),
         "output_types": "standard",
         "artifact_icon": "speaker",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 2061 rows",
+            "iphone11_ios17": "iOS 17.3 | 225 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/biomeAutonamingMessageIds.py
+++ b/scripts/artifacts/biomeAutonamingMessageIds.py
@@ -14,6 +14,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Autonaming.Messages.MessageIds/local/*',),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 54 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "felix23_ios16": "iOS 16.5 | 3738 rows",
             "jess_ios15": "iOS 15.0.2 | 607 rows",
             "magnet_ios16": "iOS 16.1.1 | 659 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 3455 rows",
+            "iphone11_ios17": "iOS 17.3 | 8107 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeClockAlarm.py
+++ b/scripts/artifacts/biomeClockAlarm.py
@@ -15,6 +15,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Clock.Alarm/local/*',),
         "output_types": "standard",
         "artifact_icon": "clock",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 27 rows",
+            "iphone11_ios17": "iOS 17.3 | 12 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeClockAlarm.py
+++ b/scripts/artifacts/biomeClockAlarm.py
@@ -1,0 +1,86 @@
+__artifacts_v2__ = {
+    "get_biomeClockAlarm": {
+        "name": "Biome - Clock Alarm",
+        "description": "Parses alarm state changes from the Clock.Alarm biome stream, including "
+                       "the alarm identifier, which can be correlated with the Clock app alarm "
+                       "list and with the _DKEvent.Clock.Alarm stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Raw state values observed: 0, 1, 2 and 4. Apple describes this stream as "
+                 "capturing alarm states such as firing and snoozed; exact value semantics are "
+                 "not confirmed, so the raw value is reported.",
+        "paths": ('*/streams/*/Clock.Alarm/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "clock",
+    }
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+TYPESS = {
+    '1': {'type': 'int', 'name': ''},
+    '2': {'type': 'int', 'name': ''},
+    '3': {'type': 'str', 'name': ''},
+    '4': {'type': 'int', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+@artifact_processor
+def get_biomeClockAlarm(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'Clock Alarm: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                data_list.append((ts, record.state.name, _to_str(protostuff.get('3', b'')),
+                                  protostuff.get('2', ''), protostuff.get('1', ''),
+                                  protostuff.get('4', ''), filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Alarm ID', 'State (raw)',
+                    'Field 1 (raw)', 'Field 4 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDKEventStreams.py
+++ b/scripts/artifacts/biomeDKEventStreams.py
@@ -1,0 +1,287 @@
+"""Biome _DKEvent.* streams that share the DuetKnowledge event wrapper schema.
+
+Every record carries: the event stream name (field 1.1), a start and end
+timestamp (fields 2 and 3, Cocoa epoch doubles), the event value (field 4.4),
+an event GUID (field 5) and the device UTC offset in seconds (field 10).
+Field 7 holds optional metadata entries, each pairing a numeric key with a
+string or integer value (for example the audio route name, or the alarm
+identifier).
+"""
+__artifacts_v2__ = {
+    "get_biomeDKAudioInputRoute": {
+        "name": "Biome - Audio Input Route DKEvent",
+        "description": "Parses audio input route changes (built-in microphone, headset, "
+                       "Bluetooth device) from the _DKEvent.Audio.InputRoute biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/_DKEvent.Audio.InputRoute/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "mic",
+    },
+    "get_biomeDKAudioOutputRoute": {
+        "name": "Biome - Audio Output Route DKEvent",
+        "description": "Parses audio output route changes (speaker, receiver, CarPlay, "
+                       "Bluetooth device) from the _DKEvent.Audio.OutputRoute biome stream. "
+                       "Bluetooth routes carry the device MAC address and name.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/_DKEvent.Audio.OutputRoute/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "volume-2",
+    },
+    "get_biomeDKClockAlarm": {
+        "name": "Biome - Clock Alarm DKEvent",
+        "description": "Parses alarm state changes from the _DKEvent.Clock.Alarm biome stream. "
+                       "Metadata carries the alarm identifier, which can be correlated with the "
+                       "Clock app alarm list.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Raw state values observed: 0, 1, 2 and 4. Apple's plist describes this stream "
+                 "as capturing alarm states such as firing and snoozed; exact value semantics "
+                 "are not confirmed, so the raw value is reported.",
+        "paths": ('*/streams/*/_DKEvent.Clock.Alarm/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "clock",
+    },
+    "get_biomeDKDeviceIsLockedImputed": {
+        "name": "Biome - Screen Lock Imputed DKEvent",
+        "description": "Parses imputed screen lock state changes from the "
+                       "_DKEvent.Device.IsLockedImputed biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "This is the imputed variant of the screen lock stream: iOS fills in lock "
+                 "state transitions it did not observe directly.",
+        "paths": ('*/streams/*/_DKEvent.Device.IsLockedImputed/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "lock",
+    },
+    "get_biomeDKDeviceLowPowerMode": {
+        "name": "Biome - Low Power Mode DKEvent",
+        "description": "Parses Low Power Mode transitions from the _DKEvent.Device.LowPowerMode "
+                       "biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/_DKEvent.Device.LowPowerMode/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "battery-charging",
+    },
+    "get_biomeDKDisplayOrientation": {
+        "name": "Biome - Display Orientation DKEvent",
+        "description": "Parses device orientation changes from the _DKEvent.Display.Orientation "
+                       "biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Value follows the UIDeviceOrientation enumeration; the raw value is reported "
+                 "alongside the label.",
+        "paths": ('*/streams/*/_DKEvent.Display.Orientation/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    },
+    "get_biomeDKSettingsDoNotDisturb": {
+        "name": "Biome - Do Not Disturb DKEvent",
+        "description": "Parses Do Not Disturb state changes from the "
+                       "_DKEvent.Settings.DoNotDisturb biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/_DKEvent.Settings.DoNotDisturb/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "moon",
+    },
+}
+
+
+import os
+from datetime import timedelta, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc, webkit_timestampsconv
+
+TYPESS = {
+    '1': {
+        'type': 'message',
+        'message_typedef': {
+            '1': {'type': 'str', 'name': ''},
+            '2': {
+                'type': 'message',
+                'message_typedef': {
+                    '1': {'type': 'int', 'name': ''},
+                    '2': {'type': 'int', 'name': ''},
+                },
+                'name': '',
+            },
+        },
+        'name': '',
+    },
+    '2': {'type': 'double', 'name': ''},
+    '3': {'type': 'double', 'name': ''},
+    '5': {'type': 'bytes', 'name': ''},
+    '10': {'type': 'int', 'name': ''},
+}
+
+ON_OFF = {0: 'Off', 1: 'On'}
+LOCKED = {0: 'Unlocked', 1: 'Locked'}
+ORIENTATION = {0: 'Unknown', 1: 'Portrait', 2: 'Portrait Upside Down', 3: 'Landscape Left',
+               4: 'Landscape Right', 5: 'Face Up', 6: 'Face Down'}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _cocoa(value):
+    if not isinstance(value, (int, float)) or not value:
+        return None
+    try:
+        return webkit_timestampsconv(value)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _metadata(protostuff):
+    # Field 7 entries pair a numeric key (7.N.3) with a string (7.N.2.3) or int (7.N.2.4) value.
+    entries = protostuff.get('7', [])
+    if isinstance(entries, dict):
+        entries = [entries]
+    parts = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get('3', '')
+        payload = entry.get('2', {})
+        if not isinstance(payload, dict):
+            continue
+        if '3' in payload:
+            value = _to_str(payload.get('3'))
+        elif '4' in payload:
+            value = _to_str(payload.get('4'))
+        else:
+            continue
+        if value:
+            parts.append(f'{key}={value}')
+    return '; '.join(parts)
+
+
+def _utc_offset(value):
+    if not isinstance(value, int):
+        return ''
+    delta = timedelta(seconds=value)
+    sign = '-' if delta.total_seconds() < 0 else '+'
+    hours, remainder = divmod(abs(delta).seconds + abs(delta).days * 86400, 3600)
+    minutes = remainder // 60
+    return f'UTC{sign}{hours:02d}:{minutes:02d}'
+
+
+def _parse(context, label, value_map):
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Start Timestamp', 'datetime'),
+                    ('End Timestamp', 'datetime'), 'SEGB State', 'Value', 'Value (raw)',
+                    'Metadata', 'Event', 'GUID', 'Device UTC Offset', 'Filename', 'Offset')
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1
+            ts = ts.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'{label}: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                event = _to_str(protostuff.get('1', {}).get('1', b'')) \
+                    if isinstance(protostuff.get('1'), dict) else ''
+                raw_value = protostuff.get('4', {}).get('4', '') \
+                    if isinstance(protostuff.get('4'), dict) else ''
+                value = value_map.get(raw_value, '') if value_map else ''
+
+                data_list.append((ts, _cocoa(protostuff.get('2')), _cocoa(protostuff.get('3')),
+                                  record.state.name, value, raw_value, _metadata(protostuff),
+                                  event, _to_str(protostuff.get('5', b'')),
+                                  _utc_offset(protostuff.get('10')), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, None, record.state.name, None, None, None, None,
+                                  None, None, filename, record.data_start_offset))
+
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeDKAudioInputRoute(context):
+    return _parse(context, 'Audio Input Route DKEvent', None)
+
+
+@artifact_processor
+def get_biomeDKAudioOutputRoute(context):
+    return _parse(context, 'Audio Output Route DKEvent', None)
+
+
+@artifact_processor
+def get_biomeDKClockAlarm(context):
+    return _parse(context, 'Clock Alarm DKEvent', None)
+
+
+@artifact_processor
+def get_biomeDKDeviceIsLockedImputed(context):
+    return _parse(context, 'Screen Lock Imputed DKEvent', LOCKED)
+
+
+@artifact_processor
+def get_biomeDKDeviceLowPowerMode(context):
+    return _parse(context, 'Low Power Mode DKEvent', ON_OFF)
+
+
+@artifact_processor
+def get_biomeDKDisplayOrientation(context):
+    return _parse(context, 'Display Orientation DKEvent', ORIENTATION)
+
+
+@artifact_processor
+def get_biomeDKSettingsDoNotDisturb(context):
+    return _parse(context, 'Do Not Disturb DKEvent', ON_OFF)

--- a/scripts/artifacts/biomeDKEventStreams.py
+++ b/scripts/artifacts/biomeDKEventStreams.py
@@ -21,6 +21,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Audio.InputRoute/local/*',),
         "output_types": "standard",
         "artifact_icon": "mic",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 260 rows",
+            "iphone11_ios17": "iOS 17.3 | 360 rows",
+        },
     },
     "get_biomeDKAudioOutputRoute": {
         "name": "Biome - Audio Output Route DKEvent",
@@ -36,6 +40,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Audio.OutputRoute/local/*',),
         "output_types": "standard",
         "artifact_icon": "volume-2",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 1475 rows",
+            "iphone11_ios17": "iOS 17.3 | 546 rows",
+        },
     },
     "get_biomeDKClockAlarm": {
         "name": "Biome - Clock Alarm DKEvent",
@@ -53,6 +61,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Clock.Alarm/local/*',),
         "output_types": "standard",
         "artifact_icon": "clock",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 12 rows",
+            "iphone11_ios17": "iOS 17.3 | 5 rows",
+        },
     },
     "get_biomeDKDeviceIsLockedImputed": {
         "name": "Biome - Screen Lock Imputed DKEvent",
@@ -68,6 +80,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Device.IsLockedImputed/local/*',),
         "output_types": "standard",
         "artifact_icon": "lock",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 920 rows",
+            "iphone11_ios17": "iOS 17.3 | 700 rows",
+        },
     },
     "get_biomeDKDeviceLowPowerMode": {
         "name": "Biome - Low Power Mode DKEvent",
@@ -82,6 +98,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Device.LowPowerMode/local/*',),
         "output_types": "standard",
         "artifact_icon": "battery-charging",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 21 rows",
+            "iphone11_ios17": "iOS 17.3 | 2 rows",
+        },
     },
     "get_biomeDKDisplayOrientation": {
         "name": "Biome - Display Orientation DKEvent",
@@ -97,6 +117,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Display.Orientation/local/*',),
         "output_types": "standard",
         "artifact_icon": "smartphone",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 94 rows",
+            "iphone11_ios17": "iOS 17.3 | 85 rows",
+        },
     },
     "get_biomeDKSettingsDoNotDisturb": {
         "name": "Biome - Do Not Disturb DKEvent",
@@ -111,6 +135,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/_DKEvent.Settings.DoNotDisturb/local/*',),
         "output_types": "standard",
         "artifact_icon": "moon",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 586 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/biomeDevTimeZone.py
+++ b/scripts/artifacts/biomeDevTimeZone.py
@@ -11,7 +11,11 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/streams/*/Device.TimeZone/local/*',),
         "output_types": "standard",
-        "artifact_icon": "map-pin"
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 30 rows",
+            "iphone11_ios17": "iOS 17.3 | 27 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeDeviceMetadata.py
+++ b/scripts/artifacts/biomeDeviceMetadata.py
@@ -14,6 +14,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Device.Metadata/local/*',),
         "output_types": "standard",
         "artifact_icon": "smartphone",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 3 rows",
+            "iphone11_ios17": "iOS 17.3 | 2 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -1,0 +1,208 @@
+"""Biome device state streams that record a single value per event.
+
+These streams are the modern, flat counterparts to the older _DKEvent.* wrappers
+and coexist with them on the same device. Each record is a state transition
+stamped with the SEGB record timestamp.
+"""
+__artifacts_v2__ = {
+    "get_biomeInterfaceOrientation": {
+        "name": "Biome - Interface Orientation",
+        "description": "Parses interface orientation changes from the "
+                       "Device.Display.InterfaceOrientation biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Value follows the UIInterfaceOrientation enumeration; the raw value is "
+                 "reported alongside the label.",
+        "paths": ('*/streams/*/Device.Display.InterfaceOrientation/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    },
+    "get_biomeLowPowerMode": {
+        "name": "Biome - Low Power Mode",
+        "description": "Parses Low Power Mode transitions from the Device.Power.LowPowerMode "
+                       "biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/Device.Power.LowPowerMode/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "battery-charging",
+    },
+    "get_biomeAirplaneModeWireless": {
+        "name": "Biome - Airplane Mode",
+        "description": "Parses Airplane Mode transitions from the Device.Wireless.AirplaneMode "
+                       "biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Modern counterpart of the _DKEvent.System.AirplaneMode stream parsed by "
+                 "Biome - Airplane Mode DKEvent.",
+        "paths": ('*/streams/*/Device.Wireless.AirplaneMode/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "airplay",
+    },
+    "get_biomeCellularDataEnabled": {
+        "name": "Biome - Cellular Data Enabled",
+        "description": "Parses cellular data enable and disable events from the "
+                       "Device.Wireless.CellularDataEnabled biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/Device.Wireless.CellularDataEnabled/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "wifi",
+    },
+    "get_biomeCarPlayConnected": {
+        "name": "Biome - CarPlay Connected",
+        "description": "Parses CarPlay connection state changes from the CarPlay.Connected "
+                       "biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Modern counterpart of the _DKEvent.Carplay.IsConnected stream parsed by "
+                 "Biome - Carplay.",
+        "paths": ('*/streams/*/CarPlay.Connected/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "truck",
+    },
+    "get_biomeBatteryTemperature": {
+        "name": "Biome - Battery Temperature",
+        "description": "Parses battery temperature samples from the "
+                       "Device.Thermals.BatteryTemperature biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The raw value is temperature in hundredths of a degree Celsius (observed "
+                 "range 1900-3700, i.e. 19.00-37.00 C); both the converted and raw values are "
+                 "reported. Field 2 is reported raw as its meaning is not confirmed.",
+        "paths": ('*/streams/*/Device.Thermals.BatteryTemperature/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "thermometer",
+    },
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+TYPESS = {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}
+
+ON_OFF = {0: 'Off', 1: 'On'}
+ENABLED = {0: 'Disabled', 1: 'Enabled'}
+CONNECTED = {0: 'Not Connected', 1: 'Connected'}
+INTERFACE_ORIENTATION = {0: 'Unknown', 1: 'Portrait', 2: 'Portrait Upside Down',
+                         3: 'Landscape Left', 4: 'Landscape Right'}
+
+
+def _records(context, label):
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'{label}: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+                yield ts, record, protostuff, filename
+            elif record.state == EntryState.Deleted:
+                yield ts, record, None, filename
+
+
+def _parse_state(context, label, value_map):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Value', 'Value (raw)',
+                    'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, label):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, filename,
+                              record.data_start_offset))
+            continue
+        raw = protostuff.get('1', '')
+        data_list.append((ts, record.state.name, value_map.get(raw, ''), raw, filename,
+                          record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeInterfaceOrientation(context):
+    return _parse_state(context, 'Interface Orientation', INTERFACE_ORIENTATION)
+
+
+@artifact_processor
+def get_biomeLowPowerMode(context):
+    return _parse_state(context, 'Low Power Mode', ON_OFF)
+
+
+@artifact_processor
+def get_biomeAirplaneModeWireless(context):
+    return _parse_state(context, 'Airplane Mode', ON_OFF)
+
+
+@artifact_processor
+def get_biomeCellularDataEnabled(context):
+    return _parse_state(context, 'Cellular Data Enabled', ENABLED)
+
+
+@artifact_processor
+def get_biomeCarPlayConnected(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'CarPlay State',
+                    'State (raw)', 'Field 2 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, 'CarPlay Connected'):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, filename,
+                              record.data_start_offset))
+            continue
+        raw = protostuff.get('1', '')
+        data_list.append((ts, record.state.name, CONNECTED.get(raw, ''), raw,
+                          protostuff.get('2', ''), filename, record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeBatteryTemperature(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Temperature (C)',
+                    'Temperature (raw)', 'Field 2 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, 'Battery Temperature'):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, filename,
+                              record.data_start_offset))
+            continue
+        raw = protostuff.get('1', '')
+        celsius = round(raw / 100, 2) if isinstance(raw, int) else ''
+        data_list.append((ts, record.state.name, celsius, raw, protostuff.get('2', ''),
+                          filename, record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -19,6 +19,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Device.Display.InterfaceOrientation/local/*',),
         "output_types": "standard",
         "artifact_icon": "smartphone",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 308 rows",
+            "iphone11_ios17": "iOS 17.3 | 110 rows",
+        },
     },
     "get_biomeLowPowerMode": {
         "name": "Biome - Low Power Mode",
@@ -33,6 +37,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Device.Power.LowPowerMode/local/*',),
         "output_types": "standard",
         "artifact_icon": "battery-charging",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 76 rows",
+            "iphone11_ios17": "iOS 17.3 | 16 rows",
+        },
     },
     "get_biomeAirplaneModeWireless": {
         "name": "Biome - Airplane Mode",
@@ -48,6 +56,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Device.Wireless.AirplaneMode/local/*',),
         "output_types": "standard",
         "artifact_icon": "airplay",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 98 rows",
+            "iphone11_ios17": "iOS 17.3 | 23 rows",
+        },
     },
     "get_biomeCellularDataEnabled": {
         "name": "Biome - Cellular Data Enabled",
@@ -62,6 +74,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Device.Wireless.CellularDataEnabled/local/*',),
         "output_types": "standard",
         "artifact_icon": "wifi",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 200 rows",
+            "iphone11_ios17": "iOS 17.3 | 19 rows",
+        },
     },
     "get_biomeCarPlayConnected": {
         "name": "Biome - CarPlay Connected",
@@ -77,6 +93,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/CarPlay.Connected/local/*',),
         "output_types": "standard",
         "artifact_icon": "truck",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 24 rows",
+            "iphone11_ios17": "iOS 17.3 | 36 rows",
+        },
     },
     "get_biomeBatteryTemperature": {
         "name": "Biome - Battery Temperature",
@@ -93,6 +113,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Device.Thermals.BatteryTemperature/local/*',),
         "output_types": "standard",
         "artifact_icon": "thermometer",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 817 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -1,0 +1,114 @@
+__artifacts_v2__ = {
+    "get_biomeFrontBoardDisplayElement": {
+        "name": "Biome - FrontBoard Display Element",
+        "description": "Parses app scene display events from the FrontBoard.DisplayElement "
+                       "biome stream: which app scene was shown on which display and when. "
+                       "This is a high volume stream that can reconstruct fine grained app "
+                       "foreground activity.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Records with an empty bundle id are system or home screen scenes. Numeric "
+                 "state fields are reported raw as their semantics are not confirmed.",
+        "paths": ('*/streams/*/FrontBoard.DisplayElement/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "layers",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+TYPESS = {
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'str', 'name': ''},
+    '4': {'type': 'int', 'name': ''},
+    '5': {'type': 'int', 'name': ''},
+    '6': {'type': 'int', 'name': ''},
+    '7': {'type': 'int', 'name': ''},
+    '8': {'type': 'int', 'name': ''},
+    '10': {'type': 'int', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeFrontBoardDisplayElement(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'FrontBoard Display Element: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                display = protostuff.get('9', {})
+                if not isinstance(display, dict):
+                    display = {}
+
+                data_list.append((ts, _unix_double(protostuff.get('1')), record.state.name,
+                                  _to_str(protostuff.get('3', b'')),
+                                  _to_str(protostuff.get('2', b'')),
+                                  _to_str(display.get('2', b'')),
+                                  _to_str(display.get('3', b'')),
+                                  protostuff.get('4', ''), protostuff.get('5', ''),
+                                  protostuff.get('6', ''), protostuff.get('7', ''),
+                                  protostuff.get('8', ''), protostuff.get('10', ''),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None,
+                                  None, None, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Event Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Scene ID', 'Display Type', 'Display Role',
+                    'Field 4 (raw)', 'Field 5 (raw)', 'Field 6 (raw)', 'Field 7 (raw)',
+                    'Field 8 (raw)', 'Field 10 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -15,6 +15,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/FrontBoard.DisplayElement/local/*',),
         "output_types": "standard",
         "artifact_icon": "layers",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 7762 rows",
+            "iphone11_ios17": "iOS 17.3 | 5234 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "hickman_ios14": "iOS 14.3 | 277 rows",
             "jess_ios15": "iOS 15.0.2 | 30 rows",
             "magnet_ios16": "iOS 16.1.1 | 38 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 17 rows",
+            "iphone11_ios17": "iOS 17.3 | 90 rows",
         },
     }
 }

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "felix23_ios16": "iOS 16.5 | 0 rows",
             "jess_ios15": "iOS 15.0.2 | 68 rows",
             "magnet_ios16": "iOS 16.1.1 | 22 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 14 rows",
+            "iphone11_ios17": "iOS 17.3 | 242 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeSafariNavigations.py
+++ b/scripts/artifacts/biomeSafariNavigations.py
@@ -16,6 +16,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Safari.Navigations/local/*',),
         "output_types": "standard",
         "artifact_icon": "compass",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 10 rows",
+            "iphone11_ios17": "iOS 17.3 | 2 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeSafariWebPagePerformance.py
+++ b/scripts/artifacts/biomeSafariWebPagePerformance.py
@@ -1,0 +1,96 @@
+__artifacts_v2__ = {
+    "get_biomeSafariWebPagePerformance": {
+        "name": "Biome - Safari Web Page Performance",
+        "description": "Parses Safari page load performance events from the "
+                       "Safari.WebPagePerformance biome stream. Each record marks Safari web "
+                       "activity in a rounded time bucket and complements Safari.Navigations "
+                       "and App.WebUsage.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Like Safari.Navigations, the second timestamp is rounded up to the next 30 "
+                 "minute boundary. Remaining fields are performance counters and are reported "
+                 "raw as their units are not confirmed.",
+        "paths": ('*/streams/*/Safari.WebPagePerformance/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "compass",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    if isinstance(value, int) and value > 10 ** 15:
+        value = struct.unpack('<d', struct.pack('<q', value))[0]
+    if not isinstance(value, (int, float)) or not value:
+        return None
+    try:
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeSafariWebPagePerformance(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'Safari Web Page Performance: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                detail = protostuff.get('1', {})
+                detail = _to_str(detail) if not isinstance(detail, (dict, list)) else str(detail)
+
+                data_list.append((ts, _unix_double(protostuff.get('2')), record.state.name,
+                                  detail, protostuff.get('3', ''), protostuff.get('4', ''),
+                                  protostuff.get('5', ''), filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None,
+                                  filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Rounded Timestamp (30 min)', 'datetime'),
+                    'SEGB State', 'Detail (raw)', 'Field 3 (raw)', 'Field 4 (raw)',
+                    'Field 5 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeSafariWebPagePerformance.py
+++ b/scripts/artifacts/biomeSafariWebPagePerformance.py
@@ -16,6 +16,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Safari.WebPagePerformance/local/*',),
         "output_types": "standard",
         "artifact_icon": "compass",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 2 rows",
+            "iphone11_ios17": "iOS 17.3 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -1,0 +1,99 @@
+__artifacts_v2__ = {
+    "get_biomeShareSheetFeedback": {
+        "name": "Biome - Share Sheet Feedback",
+        "description": "Parses share sheet activity from the ShareSheet.Feedback biome stream: "
+                       "the app the content was shared from, the activity the user chose (for "
+                       "example copy to pasteboard, save photo, open in Safari) and the full "
+                       "list of share targets that were offered.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The offered candidates list names third party apps installed at the time of "
+                 "the share, which can evidence app presence even after removal. Field 4 holds "
+                 "an NSKeyedArchiver plist that is not currently parsed.",
+        "paths": ('*/streams/*/ShareSheet.Feedback/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "share-2",
+    }
+}
+
+
+import os
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+TYPESS = {
+    '2': {'type': 'str', 'name': ''},
+    '3': {'type': 'str', 'name': ''},
+    '4': {'type': 'bytes', 'name': ''},
+    '5': {'type': 'str', 'name': ''},
+    '11': {'type': 'str', 'name': ''},
+    '15': {'type': 'str', 'name': ''},
+    '16': {'type': 'str', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+@artifact_processor
+def get_biomeShareSheetFeedback(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except Exception as ex:
+                    logfunc(f'Share Sheet Feedback: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                candidates = _to_str(protostuff.get('11', b'')).replace(',', ', ')
+
+                data_list.append((ts, record.state.name,
+                                  _to_str(protostuff.get('15', b'')),
+                                  _to_str(protostuff.get('16', b'')),
+                                  _to_str(protostuff.get('2', b'')),
+                                  candidates,
+                                  _to_str(protostuff.get('5', b'')),
+                                  _to_str(protostuff.get('3', b'')),
+                                  protostuff.get('17', ''), protostuff.get('20', ''),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, None, None,
+                                  None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Source App',
+                    'Chosen Activity', 'Activity Type', 'Offered Candidates', 'Event UUID',
+                    'Session ID', 'Field 17 (raw)', 'Field 20 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -16,6 +16,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/ShareSheet.Feedback/local/*',),
         "output_types": "standard",
         "artifact_icon": "share-2",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 4 rows",
+            "iphone11_ios17": "iOS 17.3 | 17 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeSiriRemembersCallHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersCallHistory.py
@@ -18,6 +18,10 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 22 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
@@ -1,0 +1,150 @@
+__artifacts_v2__ = {
+    "get_biomeSiriRemembersInteractionHistory": {
+        "name": "Biome - Siri Remembers Interaction History",
+        "description": "Parses app interaction intents from the "
+                       "Siri.Remembers.InteractionHistory biome stream: note creation, calendar "
+                       "event creation, alarm create and update, media playback and similar "
+                       "donated intents, with the app that donated them.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Shares the intent record schema of the Siri.Remembers.MessageHistory and "
+                 "Siri.Remembers.CallHistory streams. Intent classes observed include "
+                 "INCreateNoteIntent, EKUICreateEventIntent, MTCreateAlarmIntent, "
+                 "MTUpdateAlarmIntent and INPlayMediaIntent.",
+        "paths": (
+            '*/streams/*/Siri.Remembers.InteractionHistory/local/*',
+            '*/streams/*/Siri.Remembers.InteractionHistory/remote/*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "zap",
+    }
+}
+
+
+import json
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _intent_timestamp(value):
+    # Field 8 holds the intent date as a Unix epoch double stored in a fixed64.
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<q', value))[0] if value > 10 ** 15 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _entity_display(entity):
+    value = _to_str(entity.get('1', b''))
+    name = ''
+    attrs = _to_str(entity.get('4', b''))
+    if attrs:
+        try:
+            name = json.loads(attrs).get('name', '')
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            name = ''
+    if name and name != value:
+        return f'{value} ({name})' if value else name
+    return value
+
+
+def _parameters(protostuff):
+    entities = protostuff.get('2', [])
+    if isinstance(entities, dict):
+        entities = [entities]
+    parts = []
+    for item in entities:
+        if not isinstance(item, dict):
+            continue
+        param = _to_str(item.get('1', b''))
+        entity = item.get('2', {})
+        if not isinstance(entity, dict):
+            continue
+        display = _entity_display(entity)
+        if display:
+            parts.append(f'{param}: {display}' if param else display)
+    return '; '.join(parts)
+
+
+def _sync_origin(file_found):
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
+
+
+@artifact_processor
+def get_biomeSiriRemembersInteractionHistory(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+        origin = _sync_origin(file_found)
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except Exception as ex:
+                    logfunc(f'Siri Remembers Interaction History: could not decode record at '
+                            f'offset {record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                metadata = protostuff.get('1', {})
+                if not isinstance(metadata, dict):
+                    continue
+
+                data_list.append((ts, _intent_timestamp(metadata.get('8')), record.state.name,
+                                  _to_str(metadata.get('4', b'')),
+                                  _to_str(metadata.get('2', b'')),
+                                  _to_str(metadata.get('3', b'')),
+                                  _parameters(protostuff),
+                                  _to_str(metadata.get('1', b'')),
+                                  _to_str(metadata.get('13', b'')), origin, filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None,
+                                  None, origin, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Intent Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Intent Class', 'Domain', 'Parameters',
+                    'Intent UUID', 'Item GUID', 'Sync Origin', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
@@ -20,6 +20,10 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "zap",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 1 row",
+            "iphone11_ios17": "iOS 17.3 | 27 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -19,6 +19,10 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 14 rows",
+            "iphone11_ios17": "iOS 17.3 | 560 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeSystemSettingsSearchTerms.py
+++ b/scripts/artifacts/biomeSystemSettingsSearchTerms.py
@@ -13,6 +13,10 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/SystemSettings.SearchTerms/local/*',),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 14 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "felix23_ios16": "iOS 16.5 | 166 rows",
             "jess_ios15": "iOS 15.0.2 | 72 rows",
             "magnet_ios16": "iOS 16.1.1 | 131 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 101 rows",
+            "iphone11_ios17": "iOS 17.3 | 450 rows",
         }
     }
 }

--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -15,6 +15,11 @@ __artifacts_v2__ = {
         "paths": ('*/streams/*/Wallet.Transaction/local/*',),
         "output_types": "standard",
         "artifact_icon": "credit-card",
+        "sample_data": {
+            "epifani_ios26": "iOS 26 era, version unconfirmed | 768 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+        },
     }
 }
 


### PR DESCRIPTION
## What

A coverage sweep of 38 Biome streams found **24 with data on hand but no parser**. This PR adds **21 artifacts** (the other 3 are explained below), all field-mapped from real SEGB data in the HC iOS 18.7.8 and Josh Hickman iOS 17.3 extractions. It also **backfills `sample_data` on every Biome artifact touched today** (34 in total, including ones merged earlier in #1750–#1754). `@mattiaepi` (Mattia Epifani) is co-author throughout — the stream list came from his research.

### `biomeDKEventStreams.py` — 7 artifacts, one shared schema
`_DKEvent.Audio.InputRoute`, `_DKEvent.Audio.OutputRoute`, `_DKEvent.Clock.Alarm`, `_DKEvent.Device.IsLockedImputed`, `_DKEvent.Device.LowPowerMode`, `_DKEvent.Display.Orientation`, `_DKEvent.Settings.DoNotDisturb`

All share the DuetKnowledge wrapper: start/end timestamps (Cocoa doubles), event value, GUID, device UTC offset, plus the **field 7 metadata entries** that previous `_DKEvent` artifacts drop. That metadata is where the value is — an output-route record reads `8001=CarPlay; 8002=<accessory MAC>-Audio-AudioMain-<id>`, placing a specific car with the device at a specific minute.

### `biomeDeviceStateStreams.py` — 6 artifacts
`Device.Display.InterfaceOrientation`, `Device.Power.LowPowerMode`, `Device.Wireless.AirplaneMode`, `Device.Wireless.CellularDataEnabled`, `CarPlay.Connected`, `Device.Thermals.BatteryTemperature`

These are the modern flat streams that **coexist with** the `_DKEvent.*` variants (both populated on the same device — they are not renames). Battery temperature's raw value is hundredths of a degree Celsius, observed 1900–3700 → 19.00–37.00 °C.

### Remaining modules
| Artifact | Stream | Notes |
|---|---|---|
| Audio Route / Media Route | `Audio.Route`, `Media.Route` | route + port names; BT/AirPlay accessory identifiers |
| Clock Alarm | `Clock.Alarm` | alarm UUID, correlatable with the `_DKEvent` variant |
| FrontBoard Display Element | `FrontBoard.DisplayElement` | app scene foreground activity — **7,762 rows** on the 18.7.8 image |
| Share Sheet Feedback | `ShareSheet.Feedback` | source app, chosen activity, and the full offered-candidate list (evidences installed apps, ~38 bundles in one record) |
| Safari Web Page Performance | `Safari.WebPagePerformance` | same 30-min rounded bucket as Safari.Navigations |
| Siri Remembers Interaction History | `Siri.Remembers.InteractionHistory` | same intent schema as the Message/Call History streams |
| App Intents Transcript | `App.Intents.Transcript` | donating app, intent class, parameter, entity type, user-visible title/phrase template |

## `sample_data` backfill

Every Biome artifact touched today now records what it was tested against, using the repo's existing corpus keys. Counts come from running **each image separately** through iLEAPP and reading the LAVA artifact tables, so they are real report output, not harness estimates:

- `hc_ios18_7` — iOS 18.7.8, build 22H352
- `iphone11_ios17` — iOS 17.3, build 21D50
- `epifani_ios26` — the Wallet.Transaction sample (no OS metadata in the sample, so the entry says the version is unconfirmed rather than asserting iOS 26)

Both versions were read from each extraction's `SystemVersion.plist` and match the corpus keys already used across the repo. **Zero-row results are recorded too**, so a later reader can tell "tested, stream absent on this OS" apart from "never tested". Pre-existing entries on Intents, Backlight, Now Playing and User Activity Metadata are preserved and the new keys appended.

## Validation

Harness run over the real samples — **21/21 artifacts, 0 failures**, header/row width verified on every row, decoded values spot-checked (Do Not Disturb On/Off, Locked/Unlocked, temperatures, route names, scene IDs, share candidates, intent titles). Full iLEAPP pipeline runs completed clean on all three inputs.

Honesty note: where a field's semantics are **not** confirmed by the sample data, the raw value is surfaced rather than guessed at, and the artifact notes say so (Clock.Alarm state codes, ShareSheet fields 17/20, FrontBoard numeric state fields).

## Not built — need data

**Stream folder absent from every local image:** `AeroML.Insights.PhotosSearchInsights`, `App.Installation`, `App.RelevantShortcuts`, `MLSE.ShareSheet.ConversationUserInteraction`

**Folder present but every SEGB record is deleted**, so no field mapping is possible: `App.LocationActivity`, `CameraCapture.AutoFocusROI`, `Location.Visit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
