### PR TITLE
feat: add five device power and lock state Biome artifacts, and fix today's CI lint failures

### DIFF
--- a/scripts/artifacts/biomeAppActivity.py
+++ b/scripts/artifacts/biomeAppActivity.py
@@ -29,9 +29,13 @@ from datetime import datetime, timezone
 from urllib.parse import unquote
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 # Pin flat fields so payload/URI strings are never eagerly decoded as nested protobuf.
 TYPESS = {
@@ -92,7 +96,7 @@ def get_biomeAppActivity(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'App Activity: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeAppIntentsTranscript.py
+++ b/scripts/artifacts/biomeAppIntentsTranscript.py
@@ -28,9 +28,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 
 def _to_str(value):
@@ -115,7 +119,7 @@ def get_biomeAppIntentsTranscript(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'App Intents Transcript: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeAudioMediaRoutes.py
+++ b/scripts/artifacts/biomeAudioMediaRoutes.py
@@ -48,12 +48,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 AUDIO_TYPESS = {
     '1': {'type': 'int', 'name': ''},
@@ -94,7 +99,7 @@ def _iter_records(context, label, typess=None):
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, typess) \
                         if typess else blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'{label}: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeAutonamingMessageIds.py
+++ b/scripts/artifacts/biomeAutonamingMessageIds.py
@@ -27,9 +27,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 # Pin flat fields so GUID/chat id strings are never eagerly decoded as nested protobuf.
 TYPESS = {
@@ -85,7 +89,7 @@ def get_biomeAutonamingMessageIds(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Autonaming Message IDs: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeClockAlarm.py
+++ b/scripts/artifacts/biomeClockAlarm.py
@@ -24,12 +24,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 TYPESS = {
     '1': {'type': 'int', 'name': ''},
@@ -71,7 +76,7 @@ def get_biomeClockAlarm(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Clock Alarm: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeDKEventStreams.py
+++ b/scripts/artifacts/biomeDKEventStreams.py
@@ -144,12 +144,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timedelta, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc, webkit_timestampsconv
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 TYPESS = {
     '1': {
@@ -256,7 +261,7 @@ def _parse(context, label, value_map):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'{label}: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeDeviceMetadata.py
+++ b/scripts/artifacts/biomeDeviceMetadata.py
@@ -23,12 +23,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 # Pin flat fields so build strings are never eagerly decoded as nested protobuf.
 TYPESS = {
@@ -71,7 +76,7 @@ def get_biomeDeviceMetadata(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Device Metadata: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -118,6 +118,110 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 0 rows",
         },
     },
+    "get_biomeScreenLocked": {
+        "name": "Biome - Screen Locked",
+        "description": "Parses screen lock and unlock events from the Device.ScreenLocked "
+                       "biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Lock polarity validated against the _DKEvent.Device.IsLockedImputed stream "
+                 "on the same device: 146 of 148 overlapping records agree, the exceptions "
+                 "falling on interval boundaries. A small number of records carry a two byte "
+                 "empty payload and are reported with no value.",
+        "paths": ('*/streams/*/Device.ScreenLocked/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "lock",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 932 rows",
+            "iphone11_ios17": "iOS 17.3 | 703 rows",
+        },
+    },
+    "get_biomeKeybagLocked": {
+        "name": "Biome - Keybag Locked",
+        "description": "Parses keybag lock state changes from the Device.KeybagLocked biome "
+                       "stream. The keybag holds the class keys that protect file data, so its "
+                       "state tracks whether the device was unlocked after first unlock.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Lock polarity validated against the _DKEvent.Keybag.IsLocked stream on the "
+                 "same device: 124 of 128 overlapping records agree, the exceptions falling on "
+                 "interval boundaries. Modern counterpart of that stream, parsed by "
+                 "Biome - Keybag.",
+        "paths": ('*/streams/*/Device.KeybagLocked/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "lock",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 308 rows",
+            "iphone11_ios17": "iOS 17.3 | 292 rows",
+        },
+    },
+    "get_biomeBatteryLevel": {
+        "name": "Biome - Battery Level",
+        "description": "Parses battery level samples from the Device.Power.BatteryLevel biome "
+                       "stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The level is a percentage stored as a double (observed range 1.0 to 100.0). "
+                 "Modern counterpart of the _DKEvent.Device.BatteryPercentage stream parsed by "
+                 "Biome - Battery Percentage.",
+        "paths": ('*/streams/*/Device.Power.BatteryLevel/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "battery",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 583 rows",
+            "iphone11_ios17": "iOS 17.3 | 2945 rows",
+        },
+    },
+    "get_biomeDevicePluggedIn": {
+        "name": "Biome - Power Plugged In",
+        "description": "Parses charger connect and disconnect events from the "
+                       "Device.Power.PluggedIn biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Field 3 is populated only while plugged in and is reported raw as its "
+                 "meaning is not confirmed. Modern counterpart of the "
+                 "_DKEvent.Device.IsPluggedIn stream parsed by Biome - Device Plugged In.",
+        "paths": ('*/streams/*/Device.Power.PluggedIn/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "battery-charging",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 771 rows",
+            "iphone11_ios17": "iOS 17.3 | 514 rows",
+        },
+    },
+    "get_biomeSilentMode": {
+        "name": "Biome - Silent Mode",
+        "description": "Parses ringer switch and silent mode changes from the "
+                       "Device.SilentMode biome stream, including the reason the state was "
+                       "recorded (a physical ringer switch event, or the session manager "
+                       "reading the switch position at startup).",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Reasons observed: RingerSwitchEvent and 'MXSessionManager startup HID ringer "
+                 "switch state'. Field 2 is reported raw as its meaning is not confirmed.",
+        "paths": ('*/streams/*/Device.SilentMode/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "bell-off",
+        "sample_data": {
+            "hc_ios18_7": "iOS 18.7.8 | 73 rows",
+            "iphone11_ios17": "iOS 17.3 | 35 rows",
+        },
+    },
 }
 
 
@@ -130,15 +234,34 @@ from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
 
 TYPESS = {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}
+BATTERY_TYPESS = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'int', 'name': ''}}
+SILENT_TYPESS = {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''},
+                 '4': {'type': 'str', 'name': ''}}
+PLUGGED_TYPESS = {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''},
+                  '3': {'type': 'int', 'name': ''}}
 
 ON_OFF = {0: 'Off', 1: 'On'}
 ENABLED = {0: 'Disabled', 1: 'Enabled'}
 CONNECTED = {0: 'Not Connected', 1: 'Connected'}
+LOCKED = {0: 'Unlocked', 1: 'Locked'}
+PLUGGED = {0: 'Not Plugged In', 1: 'Plugged In'}
+SILENT = {0: 'Ringer On', 1: 'Silent'}
 INTERFACE_ORIENTATION = {0: 'Unknown', 1: 'Portrait', 2: 'Portrait Upside Down',
                          3: 'Landscape Left', 4: 'Landscape Right'}
 
 
-def _records(context, label):
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _records(context, label, typess=TYPESS):
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -154,7 +277,7 @@ def _records(context, label):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
             if record.state == EntryState.Written:
                 try:
-                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
                 except Exception as ex:
                     logfunc(f'{label}: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
@@ -229,4 +352,67 @@ def get_biomeBatteryTemperature(context):
         celsius = round(raw / 100, 2) if isinstance(raw, int) else ''
         data_list.append((ts, record.state.name, celsius, raw, protostuff.get('2', ''),
                           filename, record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeScreenLocked(context):
+    return _parse_state(context, 'Screen Locked', LOCKED)
+
+
+@artifact_processor
+def get_biomeKeybagLocked(context):
+    return _parse_state(context, 'Keybag Locked', LOCKED)
+
+
+@artifact_processor
+def get_biomeBatteryLevel(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Battery Level (%)',
+                    'Field 2 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, 'Battery Level', BATTERY_TYPESS):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, filename,
+                              record.data_start_offset))
+            continue
+        level = protostuff.get('1', '')
+        if isinstance(level, float):
+            level = round(level, 2)
+        data_list.append((ts, record.state.name, level, protostuff.get('2', ''), filename,
+                          record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeDevicePluggedIn(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Power State', 'State (raw)',
+                    'Field 2 (raw)', 'Field 3 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, 'Device Plugged In',
+                                                     PLUGGED_TYPESS):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, None, filename,
+                              record.data_start_offset))
+            continue
+        raw = protostuff.get('1', '')
+        data_list.append((ts, record.state.name, PLUGGED.get(raw, ''), raw,
+                          protostuff.get('2', ''), protostuff.get('3', ''), filename,
+                          record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeSilentMode(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Ringer State', 'State (raw)',
+                    'Reason', 'Field 2 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, 'Silent Mode', SILENT_TYPESS):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, None, filename,
+                              record.data_start_offset))
+            continue
+        raw = protostuff.get('1', '')
+        data_list.append((ts, record.state.name, SILENT.get(raw, ''), raw,
+                          _to_str(protostuff.get('4', b'')), protostuff.get('2', ''), filename,
+                          record.data_start_offset))
     return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -226,12 +226,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 TYPESS = {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}
 BATTERY_TYPESS = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'int', 'name': ''}}
@@ -261,7 +266,8 @@ def _to_str(value):
     return str(value)
 
 
-def _records(context, label, typess=TYPESS):
+def _records(context, label, typess=None):
+    typess = TYPESS if typess is None else typess
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -278,7 +284,7 @@ def _records(context, label, typess=TYPESS):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'{label}: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -28,9 +28,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 TYPESS = {
     '2': {'type': 'str', 'name': ''},
@@ -86,7 +90,7 @@ def get_biomeFrontBoardDisplayElement(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'FrontBoard Display Element: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeSafariNavigations.py
+++ b/scripts/artifacts/biomeSafariNavigations.py
@@ -29,9 +29,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 # Pin flat fields so host/URL strings are never eagerly decoded as nested protobuf.
 TYPESS = {
@@ -89,7 +93,7 @@ def get_biomeSafariNavigations(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Safari Navigations: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeSafariWebPagePerformance.py
+++ b/scripts/artifacts/biomeSafariWebPagePerformance.py
@@ -29,9 +29,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 
 def _to_str(value):
@@ -77,7 +81,7 @@ def get_biomeSafariWebPagePerformance(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Safari Web Page Performance: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -25,12 +25,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 TYPESS = {
     '2': {'type': 'str', 'name': ''},
@@ -75,7 +80,7 @@ def get_biomeShareSheetFeedback(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Share Sheet Feedback: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeSiriRemembersCallHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersCallHistory.py
@@ -32,9 +32,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 DIRECTIONS = {0: 'Unspecified', 1: 'Incoming', 2: 'Outgoing'}
 
@@ -129,7 +133,7 @@ def get_biomeSiriRemembersCallHistory(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Siri Remembers Call History: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
@@ -34,9 +34,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 
 def _to_str(value):
@@ -125,7 +129,7 @@ def get_biomeSiriRemembersInteractionHistory(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Siri Remembers Interaction History: could not decode record at '
                             f'offset {record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -33,9 +33,13 @@ import struct
 from datetime import datetime, timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 DIRECTIONS = {0: 'Unspecified', 1: 'Incoming', 2: 'Outgoing'}
 
@@ -130,7 +134,7 @@ def get_biomeSiriRemembersMessageHistory(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Siri Remembers Message History: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeSystemSettingsSearchTerms.py
+++ b/scripts/artifacts/biomeSystemSettingsSearchTerms.py
@@ -22,12 +22,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 
 def _to_str(value):
@@ -63,7 +68,7 @@ def get_biomeSystemSettingsSearchTerms(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'System Settings Search Terms: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue

--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -25,12 +25,17 @@ __artifacts_v2__ = {
 
 
 import os
+import struct
 from datetime import timezone
 
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
 
 # Pin flat fields so card/pass strings are never eagerly decoded as nested protobuf.
 TYPESS = {
@@ -75,7 +80,7 @@ def get_biomeWalletTransaction(context):
             if record.state == EntryState.Written:
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
-                except Exception as ex:
+                except _DECODE_ERRORS as ex:
                     logfunc(f'Wallet Transactions: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')
                     continue


### PR DESCRIPTION
## What

Reviewed the 10 requested streams. Three were already covered by today's earlier work (`Device.Display.Backlight`, `Device.Metadata`, `Device.TimeZone`), five are new here, and two have no usable data (see bottom). All five extend the existing `biomeDeviceStateStreams.py` module rather than adding new files, since they share its flat single-value shape. `@mattiaepi` (Mattia Epifani) is co-author.

| Artifact | Stream | iOS 18.7.8 | iOS 17.3 |
|---|---|---|---|
| Biome - Screen Locked | `Device.ScreenLocked` | 932 rows | 703 rows |
| Biome - Keybag Locked | `Device.KeybagLocked` | 308 rows | 292 rows |
| Biome - Battery Level | `Device.Power.BatteryLevel` | 583 rows | 2,945 rows |
| Biome - Power Plugged In | `Device.Power.PluggedIn` | 771 rows | 514 rows |
| Biome - Silent Mode | `Device.SilentMode` | 73 rows | 35 rows |

All five live under `/private/var/db/biome/` (lowercase), which the tier-wildcard globs already handle.

## Lock polarity was verified, not assumed

Rather than guess which of 0/1 means locked, each flat record was matched against the DKEvent interval covering its timestamp on the same device:

- `Device.ScreenLocked` vs `_DKEvent.Device.IsLockedImputed` — **146 of 148** overlapping records agree
- `Device.KeybagLocked` vs `_DKEvent.Keybag.IsLocked` — **124 of 128** agree

Both sets of exceptions fall on interval boundaries, which is the expected artefact of comparing an instant against a span. So `0 = Unlocked`, `1 = Locked`, and the artifact notes record the check and its numbers.

## Other findings

- **Battery level is a percentage, not a fraction.** Field 1 is a double, but the observed range is 1.0–100.0, so it is reported directly as a percentage.
- **Silent Mode carries a reason string**: `RingerSwitchEvent` (the user physically flipped the switch) versus the session manager reading the switch position at startup. That distinguishes a deliberate user action from a boot-time observation.
- **`Device.ScreenLocked` emits a few two-byte empty payloads** (7 in the 18.7.8 image). These are reported with no value rather than dropped or mislabelled as unlocked.
- Fields the sample data does not explain are surfaced raw, as in the previous batches: PluggedIn field 3 (populated only while plugged in) and SilentMode field 2.

## Naming

The new plugged-in artifact is **"Biome - Power Plugged In"**, not "Biome - Device Plugged In" — that name is already taken by `biomeDevplugin.py`, and iLEAPP rejects duplicate artifact names at load time. The full pipeline run caught this.

## Validation

Harness run on real samples: 5/5 artifacts, 0 failures, header/row width verified, values spot-checked. Regression-checked the six artifacts already in this module. Full `ileapp.py` runs completed clean on both image zips, and the `sample_data` counts above come from those runs.

## Not built — no usable data

- `CommCenter.Call.EmergencyVoiceCall` — stream folder absent from both test images
- `Device.Power.EnergyMode` — folder present but all 11 records are deleted, so no field mapping is possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: CI lint fix for all of today's Biome artifacts

The Python Lint job runs `pylint --disable=C,R`, so **warnings fail the build**. Every Biome artifact added today wrapped `blackboxprotobuf.decode_message` in a bare `except Exception`, which trips **W0718 (broad-exception-caught)** — that failed CI on PRs #1751, #1753, #1754, #1755 and this one. Those were merged without the check being looked at; this commit repairs main.

All 17 affected modules now use the convention already present in `biomeStreams.py` and `biomeSetsStores.py`:

```python
_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError, IndexError)
```

Also fixes **W0102 (dangerous-default-value)** on the `_records` helper in `biomeDeviceStateStreams.py`, which took the shared `TYPESS` dict as a default argument.

**No behaviour change:** a full iLEAPP run over the same combined Biome input yields identical row counts for every pre-existing artifact, the only differences being the five artifacts this branch adds. `pylint` now reports **10.00/10** with no messages across all changed files, and the CI job passes.