### PR TITLE
feat: add Location Visit, App Location Activity, Camera AutoFocus ROI and Energy Mode artifacts

### DIFF
--- a/scripts/artifacts/biomeAppLocationActivity.py
+++ b/scripts/artifacts/biomeAppLocationActivity.py
@@ -1,0 +1,120 @@
+__artifacts_v2__ = {
+    "get_biomeAppLocationActivity": {
+        "name": "Biome - App Location Activity",
+        "description": "Parses NSUserActivity records that carry place details from the "
+                       "App.LocationActivity biome stream: the donating app, the activity type "
+                       "and payload, the web page or item involved, and the associated street "
+                       "address, city and postal code. TIMESTAMP CAUTION: the place details in "
+                       "this stream are reliable but the timestamps are not. Records are "
+                       "written in batches, so the SEGB record time is a write time rather than "
+                       "the moment of the activity, and the other timestamp on the record is an "
+                       "expiry roughly 30 days ahead. Corroborate any time here against another "
+                       "source before relying on it.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Same NSUserActivity record shape as the App.Activity stream, extended with "
+                 "place fields. In the sample data the SEGB write times were identical across "
+                 "records and fell on an exact minute boundary, which is a further sign they "
+                 "are batch write times and not activity times. The expiration timestamp sits "
+                 "about 30 days after the SEGB write, matching the NSUserActivity default seen "
+                 "in App.Activity. Payload strings are URL-decoded for display.",
+        "paths": ('*/streams/*/App.LocationActivity/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+from urllib.parse import unquote
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<Q', value & 0xFFFFFFFFFFFFFFFF))[0]
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeAppLocationActivity(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'App Location Activity: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                address = _to_str(protostuff.get('29', b''))
+                city = _to_str(protostuff.get('26', b''))
+                postal = _to_str(protostuff.get('32', b''))
+
+                data_list.append((ts, _unix_double(protostuff.get('5')), record.state.name,
+                                  _to_str(protostuff.get('1', b'')),
+                                  _to_str(protostuff.get('2', b'')),
+                                  _to_str(protostuff.get('34', b'')),
+                                  address, city, postal,
+                                  _to_str(protostuff.get('9', b'')),
+                                  _to_str(protostuff.get('35', b'')),
+                                  unquote(_to_str(protostuff.get('14', b''))),
+                                  _to_str(protostuff.get('19', b'')),
+                                  _to_str(protostuff.get('15', b'')),
+                                  _to_str(protostuff.get('16', b'')),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None,
+                                  None, None, None, None, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Write Timestamp', 'datetime'), ('Expiration Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Activity Type', 'Title', 'Street Address',
+                    'City', 'Postal Code', 'URL', 'Place URL', 'Payload', 'Donation Type',
+                    'Activity UUID', 'Source', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeCameraAutoFocusROI.py
+++ b/scripts/artifacts/biomeCameraAutoFocusROI.py
@@ -1,0 +1,113 @@
+__artifacts_v2__ = {
+    "get_biomeCameraAutoFocusROI": {
+        "name": "Biome - Camera Auto Focus ROI",
+        "description": "Parses camera autofocus region of interest events from the "
+                       "CameraCapture.AutoFocusROI biome stream. Each record marks the camera "
+                       "being used and which lens it was using, so the stream evidences camera "
+                       "activity even where no resulting photo or video survives.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Only the camera port (for example PortTypeBack) is self describing. The "
+                 "remaining fields are capture parameters whose units the sample data does not "
+                 "confirm, so they are reported raw; field 8 is a 32 bit float and is also "
+                 "shown decoded.",
+        "paths": ('*/streams/*/CameraCapture.AutoFocusROI/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "camera",
+    }
+}
+
+
+import os
+import struct
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {
+    '1': {'type': 'str', 'name': ''},
+    '2': {'type': 'int', 'name': ''},
+    '3': {'type': 'int', 'name': ''},
+    '4': {'type': 'int', 'name': ''},
+    '5': {'type': 'int', 'name': ''},
+    '6': {'type': 'int', 'name': ''},
+    '7': {'type': 'int', 'name': ''},
+    '9': {'type': 'int', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _float32(value):
+    if not isinstance(value, int):
+        return ''
+    try:
+        return round(struct.unpack('<f', struct.pack('<I', value & 0xFFFFFFFF))[0], 3)
+    except struct.error:
+        return ''
+
+
+@artifact_processor
+def get_biomeCameraAutoFocusROI(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Camera Auto Focus ROI: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                data_list.append((ts, record.state.name,
+                                  _to_str(protostuff.get('1', b'')),
+                                  _float32(protostuff.get('8')),
+                                  protostuff.get('2', ''), protostuff.get('3', ''),
+                                  protostuff.get('4', ''), protostuff.get('5', ''),
+                                  protostuff.get('6', ''), protostuff.get('7', ''),
+                                  protostuff.get('9', ''), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, None, None,
+                                  None, None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Camera Port',
+                    'Field 8 (float)', 'Field 2 (raw)', 'Field 3 (raw)', 'Field 4 (raw)',
+                    'Field 5 (raw)', 'Field 6 (raw)', 'Field 7 (raw)', 'Field 9 (raw)',
+                    'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -201,6 +201,22 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 514 rows",
         },
     },
+    "get_biomeEnergyMode": {
+        "name": "Biome - Energy Mode",
+        "description": "Parses energy mode changes from the Device.Power.EnergyMode biome "
+                       "stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Both fields are reported raw: the sample data does not confirm which energy "
+                 "mode each value denotes. Field 1 was observed as 1 or 2 and field 2 as 1, 3 "
+                 "or 7.",
+        "paths": ('*/streams/*/Device.Power.EnergyMode/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "zap",
+    },
     "get_biomeSilentMode": {
         "name": "Biome - Silent Mode",
         "description": "Parses ringer switch and silent mode changes from the "
@@ -421,4 +437,19 @@ def get_biomeSilentMode(context):
         data_list.append((ts, record.state.name, SILENT.get(raw, ''), raw,
                           _to_str(protostuff.get('4', b'')), protostuff.get('2', ''), filename,
                           record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeEnergyMode(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Field 1 (raw)',
+                    'Field 2 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _records(context, 'Energy Mode'):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, filename,
+                              record.data_start_offset))
+            continue
+        data_list.append((ts, record.state.name, protostuff.get('1', ''),
+                          protostuff.get('2', ''), filename, record.data_start_offset))
     return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeLocationVisit.py
+++ b/scripts/artifacts/biomeLocationVisit.py
@@ -1,0 +1,148 @@
+__artifacts_v2__ = {
+    "get_biomeLocationVisit": {
+        "name": "Biome - Location Visit",
+        "description": "Parses visited places from the Location.Visit biome stream: coordinates "
+                       "with horizontal accuracy, arrival and departure times, and the matched "
+                       "point of interest (name, address and category) when iOS identified one. "
+                       "TIMESTAMP CAUTION: the coordinates in this stream are reliable but the "
+                       "timestamps are not. Records are written to the stream in batches long "
+                       "after the visit, so the SEGB record time is a write time, not a visit "
+                       "time, and the detection timestamp does not consistently line up with "
+                       "the arrival and departure pair. Treat every time in this artifact as "
+                       "an indication that needs corroborating from another source before it "
+                       "is relied on.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Timestamp reliability, observed in the sample data: every record in a stream "
+                 "file shared one identical SEGB write time while the visits themselves spanned "
+                 "weeks, so the whole batch was flushed at once. The detection timestamp "
+                 "(field 1) ran from hours to more than a day after the recorded departure and "
+                 "up to 28 days before the SEGB write. Arrival and departure are internally "
+                 "consistent (arrival always precedes departure, spans from about half an hour "
+                 "to just over a day) and are the most usable pair, but they are still not "
+                 "independently verified. The coordinates, accuracy and point of interest "
+                 "details are reliable. Latitude, longitude, horizontal accuracy in metres and "
+                 "confidence are stored as doubles; vertical accuracy of -1 means unavailable.",
+        "paths": ('*/streams/*/Location.Visit/local/*',),
+        "output_types": ["html", "tsv", "timeline", "lava", "kml"],
+        "artifact_icon": "map-pin",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _double(value):
+    """Doubles are carried as fixed64 and surface as unsigned ints."""
+    if isinstance(value, float):
+        return value
+    if not isinstance(value, int):
+        return None
+    return struct.unpack('<d', struct.pack('<Q', value & 0xFFFFFFFFFFFFFFFF))[0]
+
+
+def _timestamp(value):
+    seconds = _double(value)
+    if seconds is None or not seconds:
+        return None
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _rounded(value, digits):
+    return round(value, digits) if isinstance(value, float) else ''
+
+
+@artifact_processor
+def get_biomeLocationVisit(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Location Visit: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                geo = protostuff.get('3', {})
+                if not isinstance(geo, dict):
+                    geo = {}
+                latitude = _double(geo.get('1'))
+                longitude = _double(geo.get('2'))
+                horizontal = _double(geo.get('3'))
+                altitude = _double(geo.get('4'))
+                vertical = _double(geo.get('5'))
+
+                place = protostuff.get('8', {})
+                if not isinstance(place, dict):
+                    place = {}
+                detail = place.get('5', {})
+                if not isinstance(detail, dict):
+                    detail = {}
+
+                data_list.append((
+                    _timestamp(protostuff.get('4')), _timestamp(protostuff.get('5')),
+                    _timestamp(protostuff.get('1')), ts, record.state.name,
+                    _rounded(latitude, 6), _rounded(longitude, 6), _rounded(horizontal, 2),
+                    _rounded(altitude, 2), _rounded(vertical, 2),
+                    _rounded(_double(protostuff.get('6')), 3),
+                    _to_str(detail.get('2', b'')), _to_str(detail.get('3', b'')),
+                    _to_str(detail.get('4', b'')), _to_str(detail.get('1', b'')),
+                    _to_str(place.get('1', b'')), filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((None, None, None, ts, record.state.name, None, None, None,
+                                  None, None, None, None, None, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (
+        ('Arrival Timestamp', 'datetime'), ('Departure Timestamp', 'datetime'),
+        ('Detection Timestamp', 'datetime'), ('SEGB Write Timestamp', 'datetime'),
+        'SEGB State', 'Latitude', 'Longitude', 'Horizontal Accuracy (m)', 'Altitude',
+        'Vertical Accuracy', 'Confidence', 'Place Name', 'Place Address', 'Place Category',
+        'Place ID', 'Visit ID', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -9,14 +9,13 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-25",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Field mapped from sample data provided by Mattia Epifani (iOS 26 era; the "
-                 "stream is absent from iOS 17/18 test images). The stream folder name on disk "
-                 "is singular: Wallet.Transaction.",
+        "notes": "Field mapped from a private sample of this stream; the stream is absent from "
+                 "the iOS 17 and iOS 18 test images. The stream folder name on disk is "
+                 "singular: Wallet.Transaction.",
         "paths": ('*/streams/*/Wallet.Transaction/local/*',),
         "output_types": "standard",
         "artifact_icon": "credit-card",
         "sample_data": {
-            "epifani_ios26": "iOS 26 era, version unconfirmed | 768 rows",
             "hc_ios18_7": "iOS 18.7.8 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 0 rows",
         },


### PR DESCRIPTION
## What

Closes the four Biome streams that were previously unparsable because every record in our available images was deleted. `@mattiaepi` (Mattia Epifani) is co-author.

| Artifact | Stream |
|---|---|
| Biome - Location Visit | `Location.Visit` |
| Biome - App Location Activity | `App.LocationActivity` |
| Biome - Camera Auto Focus ROI | `CameraCapture.AutoFocusROI` |
| Biome - Energy Mode | `Device.Power.EnergyMode` |

**Location Visit** is the substantial one: latitude, longitude, horizontal accuracy, altitude, arrival and departure times, a detection time, a confidence value, and the matched point of interest (name, address, category) where iOS identified one. It uses the exact column names `Latitude` and `Longitude` so `kmlgen` picks them up, and opts into `kml` output — a KML export is produced and was verified.

**App Location Activity** is the `App.Activity` NSUserActivity shape extended with place fields (street address, city, postal code, title, page URL).

## Timestamps in the location streams are not reliable — and the artifacts say so

This is the important part for examiners. Both location artifacts carry the caveat in their **description** and **notes**, because someone reading a timestamp column has no other way to know. What the sample data shows:

- Every record in a stream file shared **one identical SEGB write time** while the visits themselves spanned **weeks** — the batch was flushed at once, so the SEGB time is a *write* time, not a visit time.
- The detection timestamp ran from **hours to more than a day after** the recorded departure, and up to **28 days before** the SEGB write.
- Arrival and departure are at least internally consistent (arrival always precedes departure, spans from about half an hour to just over a day), making them the most usable pair — but still not independently verified.
- The **coordinates, accuracy and place details are reliable.** The problem is purely temporal.

Beyond the prose, the column names carry the warning into the table itself: the timestamps are named `Arrival`, `Departure` and `Detection` rather than a single ambiguous "Timestamp", and the record time is labelled **`SEGB Write Timestamp`** instead of the usual `SEGB Timestamp` so its batch-write meaning is visible at a glance.

Fields whose meaning the sample does not confirm are surfaced raw rather than guessed at: all Energy Mode values, and the capture parameters in Camera Auto Focus ROI.

## Test data — deliberately not registered, and no `sample_data`

These were built from a **private sample containing real personal information**. Unlike the other batches today:

- it is **not** registered in the local corpus,
- there are **no `sample_data` entries** on these four artifacts, since a corpus key and row counts would be a reference back to that data,
- and nothing derived from its contents — no coordinates, addresses, place names, URLs or identifiers — appears anywhere in this repository, in the code, the commit message or this description.

Verified by scanning the diff for sample-derived values before pushing.

## Validation

Harness run on the real sample: 4/4 artifacts, header/row width verified on every row, arrival/departure ordering checked, coordinates confirmed to fall in valid latitude and longitude ranges. Full `ileapp.py` run completes and all four populate, with the KML export generated for Location Visit. `pylint --disable=C,R` reports **10.00/10** and the blackboxprotobuf guard test passes — both checked before pushing this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)