### PR TITLE
ci: fail lint only on warnings a change introduces

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -39,10 +39,14 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/test/scripts/test_no_pypi_blackboxprotobuf.py
 
+      # Fails only on warnings this pull request introduces. Long-lived modules carry
+      # deliberate pre-existing warnings (ileapp.py's wildcard imports, ilapfuncs.py's
+      # backward-compat re-exports), and failing on those pushed contributors toward
+      # unrelated refactors or blanket file-level disables. See the script's docstring.
       - name: Run on changed files
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: |
-          echo "Linting the following files:"
-          echo "${{ steps.changed-files-py.outputs.all_changed_files }}"
-          
-          PYTHONPATH=. pylint ${{ steps.changed-files-py.outputs.all_changed_files }} --disable=C,R
+          BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          echo "Comparing against merge base $BASE"
+          python admin/scripts/lint_changed.py --base-ref "$BASE" \
+            ${{ steps.changed-files-py.outputs.all_changed_files }}

--- a/admin/scripts/lint_changed.py
+++ b/admin/scripts/lint_changed.py
@@ -1,0 +1,119 @@
+"""Fail CI only on pylint warnings a change actually introduces.
+
+The lint job runs pylint over the files a pull request touches. Several long-lived
+modules carry pre-existing warnings that are deliberate rather than fixable --
+`ileapp.py` uses wildcard imports as its module architecture, `scripts/ilapfuncs.py`
+re-exports names it does not itself use so that older artifact modules keep importing
+them. Any pull request that touches one of those files therefore went red for reasons
+that had nothing to do with the change, which pushes contributors toward either
+unrelated refactors or blanket file-level `# pylint: disable` comments. Both are worse
+than the debt.
+
+This script lints the same file set twice, once at the merge base and once at the
+change, and fails only when a (file, warning) pair appears more often than it did
+before. New code is held to the full standard; existing debt neither blocks a pull
+request nor gets silently widened.
+
+Two details matter for a stable comparison, both learned the hard way:
+
+* pylint's results depend on which files are analysed together, because it infers
+  across the set. Both runs therefore lint the same list of paths.
+* pylint caches results between runs and will otherwise report stale data, so both
+  runs pass --persistent=no.
+
+Usage:
+    python admin/scripts/lint_changed.py --base-ref <sha> <file> [<file> ...]
+"""
+
+import argparse
+import collections
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+PYLINT_ARGS = ['--disable=C,R', '--persistent=no', '--output-format=json']
+
+
+def run_pylint(repo_dir, paths):
+    """Return Counter keyed by (path, symbol) for paths that exist in repo_dir."""
+    present = [p for p in paths if os.path.exists(os.path.join(repo_dir, p))]
+    if not present:
+        return collections.Counter()
+
+    env = dict(os.environ, PYTHONPATH='.')
+    result = subprocess.run(
+        [sys.executable, '-m', 'pylint', *present, *PYLINT_ARGS],
+        cwd=repo_dir, env=env, capture_output=True, text=True, check=False)
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        # No JSON at all means pylint failed to start rather than finding nothing.
+        if result.returncode not in (0,):
+            print(f'pylint produced no output (exit {result.returncode}):\n{result.stderr}',
+                  file=sys.stderr)
+            sys.exit(2)
+        return collections.Counter()
+
+    try:
+        messages = json.loads(stdout)
+    except json.JSONDecodeError:
+        print(f'could not parse pylint output:\n{stdout[:2000]}', file=sys.stderr)
+        sys.exit(2)
+
+    return collections.Counter((m['path'], m['symbol']) for m in messages)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--base-ref', required=True,
+                        help='commit to compare against, normally the merge base')
+    parser.add_argument('paths', nargs='*', help='changed Python files')
+    args = parser.parse_args()
+
+    paths = [p for p in args.paths if p.endswith('.py')]
+    if not paths:
+        print('No Python files changed.')
+        return 0
+
+    print('Linting:\n' + '\n'.join(f'  {p}' for p in paths) + '\n')
+    after = run_pylint('.', paths)
+
+    # A detached worktree gives the base revision with full repo context, so pylint
+    # resolves imports there the same way it does for the change.
+    with tempfile.TemporaryDirectory() as tmp:
+        base_dir = os.path.join(tmp, 'base')
+        subprocess.run(['git', 'worktree', 'add', '--detach', '--quiet', base_dir,
+                        args.base_ref], check=True, capture_output=True)
+        try:
+            before = run_pylint(base_dir, paths)
+        finally:
+            subprocess.run(['git', 'worktree', 'remove', '--force', base_dir],
+                           check=False, capture_output=True)
+
+    introduced = {key: count - before.get(key, 0)
+                  for key, count in after.items() if count > before.get(key, 0)}
+
+    total_before, total_after = sum(before.values()), sum(after.values())
+    print(f'pre-existing warnings in these files: {total_before}')
+    print(f'warnings now:                         {total_after}')
+
+    if not introduced:
+        removed = total_before - total_after
+        if removed > 0:
+            print(f'\nNo new warnings introduced ({removed} fewer than before). PASS')
+        else:
+            print('\nNo new warnings introduced. PASS')
+        return 0
+
+    print('\nThis change introduces new pylint warnings:\n')
+    for (path, symbol), count in sorted(introduced.items()):
+        print(f'  {path}: {symbol} (+{count})')
+    print('\nRe-run locally with:')
+    print(f'  PYTHONPATH=. python -m pylint {" ".join(paths)} {" ".join(PYLINT_ARGS[:2])}')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`python_lint.yml` runs `pylint <changed files> --disable=C,R`, and pylint exits non-zero on warnings. That is the right standard for new code, but several long-lived modules carry warnings that are deliberate rather than fixable:

| file | warnings | why they are not "fixable" |
|---|---|---|
| `ileapp.py` | 19 | `wildcard-import` / `unused-wildcard-import` — `from scripts.ilapfuncs import *` is the module architecture |
| `scripts/ilapfuncs.py` | 10 | `unused-import` — deliberate backward-compat re-exports; removing them breaks third-party artifact modules |

Because CI lints only *changed* files, that debt is invisible until someone edits one of those files — and then their PR goes red for reasons that have nothing to do with their change. The two ways out are both worse than the debt: an unrelated refactor bundled into a bug fix, or a blanket file-level `# pylint: disable` that also hides genuinely new problems.

## Change

`admin/scripts/lint_changed.py` lints the same file set twice — once at the merge base, once at the change — and fails only when a `(file, warning)` pair appears **more often** than it did before.

New code is still held to the full standard. Existing debt neither blocks a PR nor can be silently widened: adding a second `bare-except` to a file that already has one still fails.

No source file changes, and no `.pylintrc`. A project-wide config would lower the bar for every new file, which is the opposite of the goal.

## Two details that make the comparison stable

Both were found empirically while building this, and both are documented in the script:

- **pylint infers across the analysed set.** `scripts/lavafuncs.py` alone reports 0 warnings; linted together with `ileapp.py` it contributes several. Both runs therefore lint the identical path list.
- **pylint caches between runs** and will otherwise report stale results — it even prints a "previous run" score. Both runs pass `--persistent=no`. Without this the comparison is not reproducible.

The base revision is materialised as a detached `git worktree` rather than by copying files, so imports resolve with full repo context exactly as they do for the change.

## Verification

| case | expected | result |
|---|---|---|
| Unchanged files carrying 30 pre-existing warnings | pass | pass |
| Clean file with a new `bare-except` and `f-string-without-interpolation` | fail, both named | fail, both named |
| Brand-new file containing a warning | fail | fail |
| Brand-new clean file | pass | pass |
| No Python files in the diff | pass | pass |

Repeated runs give identical counts. The script itself scores 10.00/10.

## Effect on open PRs

abrignoni/iLEAPP#1759 currently fails this job on the pre-existing `ileapp.py` and `ilapfuncs.py` warnings listed above. With this merged it goes green without touching a line of its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)