### PR TITLE
ci: add a runtime contract job covering the supported Python versions

### DIFF
--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -1,0 +1,38 @@
+name: Python Runtime Contract
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/python_runtime_contract.yml'
+      - 'README.md'
+      - 'requirements.txt'
+      # The job runs the whole admin/test/scripts suite, so trigger on all of it
+      - 'admin/test/scripts/**'
+      # The suite imports every artifact module, which is the only check that a
+      # change parses on the oldest supported Python. Lint runs on one, newer
+      # version and cannot see this class of break.
+      - 'scripts/**'
+
+jobs:
+  runtime-contract:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The versions README.md tells users to run
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install runtime dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run admin compatibility tests
+        run: python -m unittest discover -s admin/test/scripts -p 'test_*.py'

--- a/admin/test/scripts/test_artifact_imports.py
+++ b/admin/test/scripts/test_artifact_imports.py
@@ -1,0 +1,62 @@
+# pylint: disable=broad-exception-caught
+"""Smoke test: every artifact module must import on the running Python.
+
+Run across the supported Python versions in CI, this is the only check that a
+change still parses and imports on the oldest one. Syntax accepted by a newer
+interpreter is not always accepted by an older one -- a multi-line expression
+inside an f-string, for example, needs 3.12 (PEP 701) -- and lint alone does
+not catch it because lint runs on a single, newer version.
+
+It validates *importability*, not parsing correctness (which needs sample
+data). Modules are loaded by file path -- mirroring scripts/plugin_loader.py
+-- so files with dots in their name load correctly.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ARTIFACTS_DIR = REPO_ROOT / 'scripts' / 'artifacts'
+
+# Floors, not exact counts, so ordinary additions and removals do not fail the
+# build while a collapse in what loads still does.
+MINIMUM_ARTIFACT_MODULES = 300
+MINIMUM_PLUGINS = 600
+
+
+class TestArtifactImports(unittest.TestCase):
+
+    def test_all_artifact_modules_import(self):
+        """Import every scripts/artifacts/*.py and fail on any import error."""
+        failures = []
+        count = 0
+        for py_file in sorted(ARTIFACTS_DIR.glob('*.py')):
+            if py_file.name.startswith('__'):
+                continue
+            try:
+                spec = importlib.util.spec_from_file_location(py_file.stem, py_file)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                count += 1
+            except Exception as exc:
+                failures.append(f'{py_file.name}: {type(exc).__name__}: {exc}')
+
+        self.assertEqual(failures, [],
+                         f'{len(failures)} artifact import failure(s):\n' + '\n'.join(failures))
+        self.assertGreater(count, MINIMUM_ARTIFACT_MODULES,
+                           f'Only {count} artifact modules imported - did the search path change?')
+
+    def test_plugin_loader_loads(self):
+        """The real PluginLoader must load a healthy number of plugins."""
+        from scripts.plugin_loader import PluginLoader
+        loader = PluginLoader()
+        self.assertGreater(len(loader), MINIMUM_PLUGINS,
+                           f'PluginLoader loaded only {len(loader)} plugins')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ports ALEAPP's runtime-contract protection to iLEAPP.

## Problem

iLEAPP has no job that imports artifact modules, so nothing verifies that a change still parses on the oldest Python the README tells users to run (3.10).

Syntax accepted by a newer interpreter is not always accepted by an older one. A multi-line expression inside an f-string, for instance, requires 3.12 (PEP 701). `lint-changed-files` cannot catch this because it runs on a single, newer version, and most of us develop on 3.12+.

ALEAPP hit exactly this: a 3.12-only f-string reached main and sat there until it started failing `windows-smoke` on unrelated pull requests (fixed in ALEAPP #986, with the path filter widened in ALEAPP #989).

## What this adds

- `admin/test/scripts/test_artifact_imports.py` — imports every `scripts/artifacts/*.py` and exercises the real `PluginLoader`
- `.github/workflows/python_runtime_contract.yml` — runs the `admin/test/scripts` suite on **3.10, 3.11 and 3.12**, triggered by changes under `scripts/` as well as `admin/test/scripts/`

The thresholds are floors (300 modules, 600 plugins, against 332 and 703 today) so ordinary additions and removals do not fail the build while a collapse in what loads still does.

## Verification

On a real Python 3.10 environment with `requirements.txt` installed:

- The suite passes today: **16 tests OK** (14 existing plus the 2 new)
- Injecting a multi-line f-string into an artifact **fails on 3.10** with the offending file and line, and **passes on 3.14** — which is exactly why this class of break escapes local development
- iLEAPP has no such breakage today, so this is preventive

🤖 Generated with [Claude Code](https://claude.com/claude-code)