### PR TITLE
feat: add a pure-python SQLCipher reader

### DIFF
--- a/admin/test/scripts/test_sqlcipher_decrypt.py
+++ b/admin/test/scripts/test_sqlcipher_decrypt.py
@@ -1,0 +1,155 @@
+"""Regression tests for the pure-python SQLCipher reader.
+
+The reader's scheme correctness was established against real encrypted
+databases: Signal for Android, which keeps its salt in the file, and Signal for
+iOS, which keeps a plaintext header and an external salt. Those files cannot be
+committed, so these tests encrypt known page-aligned content in the same
+on-disk layout and check the reader returns it byte for byte, guarding the
+page, HMAC, WAL and plaintext-header handling against future edits.
+
+The comparison is at byte level rather than by opening the result with sqlite3.
+A real SQLCipher database reserves the tail of every page for the IV and HMAC,
+so its pages are laid out differently from one written by plain sqlite3, and a
+fixture built with sqlite3 would not survive the reserved-tail carve-out.
+"""
+import hashlib
+import hmac
+import os
+import pathlib
+import struct
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from Crypto.Cipher import AES  # noqa: E402  pylint: disable=wrong-import-position
+
+from scripts.sqlcipher_decrypt import decrypt_sqlcipher_db  # noqa: E402  pylint: disable=wrong-import-position
+
+PAGE_SIZE = 4096
+IV_LENGTH = 16
+HMAC_LENGTHS = {'sha1': 20, 'sha256': 32, 'sha512': 64}
+
+
+def reserve_for(hmac_name):
+    return ((IV_LENGTH + HMAC_LENGTHS[hmac_name] + 15) // 16) * 16
+
+
+def build_page_content(page_count, reserve, plaintext_header_size=0):
+    """Pages shaped like a SQLCipher database: content followed by a reserved tail."""
+    usable = PAGE_SIZE - reserve
+    pages = []
+    for index in range(page_count):
+        body = bytes([(index + 1) % 251]) * usable
+        if index == 0:
+            prefix = (b'H' * plaintext_header_size if plaintext_header_size
+                      else b'SQLite format 3\x00')
+            body = prefix + body[len(prefix):]
+        pages.append(body + b'\x00' * reserve)
+    return b''.join(pages)
+
+
+def encrypt_like_sqlcipher(content, out_path, key, salt, hmac_name='sha1',
+                           plaintext_header_size=0):
+    """Write content in the SQLCipher on-disk layout: ciphertext, then IV, then HMAC."""
+    mac_length = HMAC_LENGTHS[hmac_name]
+    reserve = reserve_for(hmac_name)
+    hmac_key = hashlib.pbkdf2_hmac(hmac_name, key, bytes(b ^ 0x3A for b in salt), 2, 32)
+    digest = getattr(hashlib, hmac_name)
+    clear_size = plaintext_header_size or 16
+
+    out = bytearray()
+    for index in range(len(content) // PAGE_SIZE):
+        page = content[index * PAGE_SIZE:(index + 1) * PAGE_SIZE]
+        if index == 0:
+            # Page 1 keeps a prefix in the clear: the salt, or the plaintext header
+            clear = page[:clear_size] if plaintext_header_size else salt
+            body = page[clear_size:PAGE_SIZE - reserve]
+        else:
+            clear = b''
+            body = page[:PAGE_SIZE - reserve]
+
+        iv = os.urandom(IV_LENGTH)
+        cipher = AES.new(key, AES.MODE_CBC, iv).encrypt(body)
+        # The HMAC covers the ciphertext and IV, never the cleartext prefix
+        mac = hmac.new(hmac_key, cipher + iv + (index + 1).to_bytes(4, 'little'),
+                       digest).digest()
+        out += clear + cipher + iv + mac + b'\x00' * (reserve - IV_LENGTH - mac_length)
+    pathlib.Path(out_path).write_bytes(bytes(out))
+
+
+class TestSqlcipherDecrypt(unittest.TestCase):
+
+    def _roundtrip(self, hmac_name, plaintext_header_size, pages=6):
+        reserve = reserve_for(hmac_name)
+        content = build_page_content(pages, reserve, plaintext_header_size)
+        key, salt = os.urandom(32), os.urandom(16)
+        with tempfile.TemporaryDirectory() as folder:
+            encrypted = os.path.join(folder, 'enc.db')
+            recovered = os.path.join(folder, 'out.db')
+            encrypt_like_sqlcipher(content, encrypted, key, salt, hmac_name,
+                                   plaintext_header_size)
+            decrypted, verified = decrypt_sqlcipher_db(
+                encrypted, key, recovered, raw_key=True,
+                external_salt=salt if plaintext_header_size else None,
+                plaintext_header_size=plaintext_header_size,
+                hmac_algorithm=hmac_name, kdf_algorithm=hmac_name)
+            self.assertEqual(decrypted, pages)
+            self.assertEqual(verified, pages, 'every page should authenticate')
+            self.assertEqual(pathlib.Path(recovered).read_bytes(), content,
+                             'decrypted bytes should match the original content')
+
+    def test_roundtrip_salt_in_file(self):
+        """The Android shape: salt stored in the file, sha1 HMAC."""
+        self._roundtrip('sha1', plaintext_header_size=0)
+
+    def test_roundtrip_plaintext_header_and_external_salt(self):
+        """The iOS shape: 32 byte plaintext header, salt supplied separately, sha512."""
+        self._roundtrip('sha512', plaintext_header_size=32)
+
+    def test_roundtrip_sha256(self):
+        """The HMAC choice drives the reserved size, so cover the middle option too."""
+        self._roundtrip('sha256', plaintext_header_size=0)
+
+    def test_wrong_key_authenticates_nothing(self):
+        """A wrong key must report zero verified pages rather than raising."""
+        reserve = reserve_for('sha1')
+        content = build_page_content(4, reserve)
+        with tempfile.TemporaryDirectory() as folder:
+            encrypted = os.path.join(folder, 'enc.db')
+            encrypt_like_sqlcipher(content, encrypted, os.urandom(32), os.urandom(16))
+            _, verified = decrypt_sqlcipher_db(encrypted, os.urandom(32),
+                                               os.path.join(folder, 'out.db'), raw_key=True)
+            self.assertEqual(verified, 0)
+
+    def test_short_file_is_handled(self):
+        """A truncated file must return zeros, not raise."""
+        with tempfile.TemporaryDirectory() as folder:
+            encrypted = os.path.join(folder, 'tiny.db')
+            pathlib.Path(encrypted).write_bytes(b'\x00' * 100)
+            self.assertEqual(
+                decrypt_sqlcipher_db(encrypted, os.urandom(32),
+                                     os.path.join(folder, 'out.db'), raw_key=True),
+                (0, 0))
+
+    def test_malformed_wal_is_ignored(self):
+        """A WAL without the expected magic must be skipped, leaving the main image."""
+        reserve = reserve_for('sha1')
+        content = build_page_content(4, reserve)
+        key, salt = os.urandom(32), os.urandom(16)
+        with tempfile.TemporaryDirectory() as folder:
+            encrypted = os.path.join(folder, 'enc.db')
+            recovered = os.path.join(folder, 'out.db')
+            encrypt_like_sqlcipher(content, encrypted, key, salt)
+            pathlib.Path(encrypted + '-wal').write_bytes(
+                struct.pack('>I', 0xDEADBEEF) + b'\x00' * 60)
+            pages, verified = decrypt_sqlcipher_db(encrypted, key, recovered, raw_key=True)
+            self.assertEqual(pages, verified)
+            self.assertEqual(pathlib.Path(recovered).read_bytes(), content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/sqlcipher_decrypt.py
+++ b/scripts/sqlcipher_decrypt.py
@@ -1,0 +1,173 @@
+"""Minimal pure-python SQLCipher reader.
+
+Implemented with PyCryptodome (already an iLEAPP requirement) rather than a
+native SQLCipher build, so packaged/frozen iLEAPP builds keep working without
+an extra binary dependency.
+
+Only the subset needed to read an encrypted database is implemented: the file
+is decrypted to a plaintext copy which callers open with the stdlib sqlite3.
+"""
+import hashlib
+import hmac
+import os
+import struct
+
+from Crypto.Cipher import AES
+
+DEFAULT_PAGE_SIZE = 4096
+IV_LENGTH = 16
+FAST_KDF_ITER = 2  # SQLCipher's iteration count for the HMAC subkey
+
+HMAC_LENGTHS = {'sha1': 20, 'sha256': 32, 'sha512': 64}
+
+WAL_HEADER_SIZE = 32
+WAL_FRAME_HEADER_SIZE = 24
+WAL_MAGIC = (0x377F0682, 0x377F0683)
+
+
+def _reserve_size(hmac_length):
+    """Bytes reserved at the end of each page: IV + HMAC, padded to an AES block."""
+    return ((IV_LENGTH + hmac_length + 15) // 16) * 16
+
+
+def _decrypt_page(page, page_number, encryption_key, hmac_key, digest, hmac_length, reserve,
+                  page_size, plaintext_header_size=0):
+    """Decrypt one SQLCipher page. Returns (plaintext_body, hmac_verified)."""
+    # Page 1 starts after whatever is stored in the clear: either the salt, or a
+    # plaintext header when the database keeps one
+    body_start = (plaintext_header_size or 16) if page_number == 1 else 0
+    body_end = page_size - reserve
+    iv = page[body_end:body_end + IV_LENGTH]
+    stored_hmac = page[body_end + IV_LENGTH:body_end + IV_LENGTH + hmac_length]
+    calculated = hmac.new(hmac_key,
+                          page[body_start:body_end + IV_LENGTH]
+                          + page_number.to_bytes(4, 'little'),
+                          digest).digest()
+    body = AES.new(encryption_key, AES.MODE_CBC, iv).decrypt(page[body_start:body_end])
+    if page_number == 1:
+        # Restore the bytes that were never encrypted
+        body = (page[:plaintext_header_size] if plaintext_header_size
+                else b'SQLite format 3\x00') + body
+    return body + b'\x00' * reserve, hmac.compare_digest(calculated, stored_hmac)
+
+
+def _wal_pages(wal_path, page_size):
+    """Yield (page_number, raw_encrypted_page) for the committed frames of a SQLCipher WAL.
+
+    SQLCipher leaves the WAL and frame headers readable and encrypts only the page
+    payloads, so frames can be located without the key. Later frames supersede
+    earlier ones for the same page; anything after the final commit frame is an
+    incomplete transaction and is ignored.
+    """
+    with open(wal_path, 'rb') as wal_file:
+        wal = wal_file.read()
+    if len(wal) < WAL_HEADER_SIZE:
+        return {}, 0
+    if struct.unpack('>I', wal[0:4])[0] not in WAL_MAGIC:
+        return {}, 0
+
+    header_salts = wal[16:24]
+    frame_size = WAL_FRAME_HEADER_SIZE + page_size
+    frame_count = (len(wal) - WAL_HEADER_SIZE) // frame_size
+
+    latest = {}
+    committed = {}
+    database_pages = 0
+    for index in range(frame_count):
+        offset = WAL_HEADER_SIZE + index * frame_size
+        frame_header = wal[offset:offset + WAL_FRAME_HEADER_SIZE]
+        if frame_header[8:16] != header_salts:
+            continue  # frame belongs to an earlier WAL generation
+        page_number = struct.unpack('>I', frame_header[0:4])[0]
+        commit_size = struct.unpack('>I', frame_header[4:8])[0]
+        latest[page_number] = wal[offset + WAL_FRAME_HEADER_SIZE:offset + frame_size]
+        if commit_size:
+            # Transaction boundary: everything seen so far is durable
+            committed = dict(latest)
+            database_pages = commit_size
+    return committed, database_pages
+
+
+def decrypt_sqlcipher_db(encrypted_path, passphrase, output_path, page_size=DEFAULT_PAGE_SIZE,
+                         kdf_iterations=1, hmac_algorithm='sha1', kdf_algorithm='sha1',
+                         raw_key=False, apply_wal=True, plaintext_header_size=0,
+                         external_salt=None):
+    """Decrypt a SQLCipher database to a plaintext SQLite file.
+
+    Args:
+        encrypted_path: path to the encrypted database.
+        passphrase: passphrase string, or hex string when raw_key is True.
+        output_path: where the decrypted database is written.
+        page_size: SQLCipher page size.
+        kdf_iterations: PBKDF2 iterations for the encryption key. Signal uses 1
+            because its key is already random.
+        hmac_algorithm: 'sha1', 'sha256' or 'sha512'.
+        kdf_algorithm: PBKDF2 hash, usually matching hmac_algorithm.
+        raw_key: treat passphrase as a hex-encoded key used directly (PRAGMA
+            key = "x'..'") instead of deriving it.
+        apply_wal: replay a sibling '-wal' file over the database image. Without
+            this, recent records that have not been checkpointed are missed.
+        plaintext_header_size: bytes at the start of the file left unencrypted.
+            Apps that need the file to stay recognisable as SQLite set this,
+            usually to 32.
+        external_salt: the 16 byte salt, when it is not stored in the file. A
+            non-zero plaintext header displaces the salt, so it is kept with the
+            key instead (Signal for iOS stores both together in the keychain).
+
+    Returns:
+        (pages_decrypted, pages_whose_hmac_verified), counting replayed WAL frames
+        as well as main-image pages. Equal values mean everything authenticated;
+        0 verified means the passphrase or settings are wrong.
+    """
+    hmac_length = HMAC_LENGTHS[hmac_algorithm]
+    reserve = _reserve_size(hmac_length)
+
+    with open(encrypted_path, 'rb') as encrypted_file:
+        raw = encrypted_file.read()
+    if len(raw) < page_size:
+        return 0, 0
+
+    salt = external_salt if external_salt else raw[:16]
+    if raw_key:
+        encryption_key = passphrase if isinstance(passphrase, (bytes, bytearray)) \
+            else bytes.fromhex(passphrase)
+    else:
+        encryption_key = hashlib.pbkdf2_hmac(kdf_algorithm, passphrase.encode(), salt,
+                                             kdf_iterations, 32)
+    hmac_key = hashlib.pbkdf2_hmac(kdf_algorithm, encryption_key,
+                                   bytes(byte ^ 0x3A for byte in salt), FAST_KDF_ITER, 32)
+
+    digest = getattr(hashlib, hmac_algorithm)
+    decrypted_pages = verified = 0
+
+    pages = []
+    for page_index in range(len(raw) // page_size):
+        body, page_ok = _decrypt_page(raw[page_index * page_size:(page_index + 1) * page_size],
+                                      page_index + 1, encryption_key, hmac_key, digest,
+                                      hmac_length, reserve, page_size, plaintext_header_size)
+        pages.append(body)
+        decrypted_pages += 1
+        verified += page_ok
+
+    # Recent activity often lives only in the write-ahead log, so replay it over
+    # the main database image before handing the file to sqlite3
+    if apply_wal:
+        wal_path = encrypted_path + '-wal'
+        if os.path.exists(wal_path):
+            wal_pages, database_pages = _wal_pages(wal_path, page_size)
+            for page_number, encrypted_page in sorted(wal_pages.items()):
+                body, page_ok = _decrypt_page(encrypted_page, page_number, encryption_key,
+                                              hmac_key, digest, hmac_length, reserve, page_size,
+                                              plaintext_header_size)
+                while len(pages) < page_number:
+                    pages.append(b'\x00' * page_size)
+                pages[page_number - 1] = body
+                decrypted_pages += 1
+                verified += page_ok
+            if database_pages:
+                pages = pages[:database_pages]
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'wb') as output_file:
+        output_file.write(b''.join(pages))
+    return decrypted_pages, verified


### PR DESCRIPTION
Batch 2 of Signal for iOS support, after #1762 added the keychain input. Independently revertible: nothing consumes this yet.

## What it is

The SQLCipher reader from ALEAPP, where it already decrypts Signal for Android. Built on **PyCryptodome, already in iLEAPP's requirements**, rather than a native SQLCipher build, so packaged builds need no extra binary.

It handles both on-disk shapes:

| Shape | Salt | HMAC | Used by |
|---|---|---|---|
| Salt in the file | first 16 bytes | SHA1 | Signal for Android |
| Plaintext header | supplied separately | SHA512 | Signal for iOS |

It also replays a SQLCipher write-ahead log. That is not optional in practice: on an Android image the WAL held messages, a contact, attachments **and a schema migration** that the main image alone did not have.

## Tests

Six regression tests covering both shapes, all three HMAC sizes, a wrong key, a truncated file and a malformed WAL.

They encrypt known page-aligned content rather than shipping a fixture. A real SQLCipher page reserves its tail for the IV and HMAC, so a database written by plain sqlite3 does not survive that carve-out — my first attempt did exactly that and produced a malformed result, which is why the tests compare bytes rather than opening the output with sqlite3.

## Verification

- The 6 new tests pass, and the full `admin/test/scripts` suite is 22 tests green on Python 3.10
- iLEAPP's copy decrypts a **real iOS Signal database**: 326 of 326 pages authenticate, 38 tables read
- pylint clean at 10.00/10 with the CI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)