### PR TITLE
feat: use a keychain the extraction already carries

### DIFF
--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -907,7 +907,7 @@ input_folder_button.pack(side='left', padx=5, pady=4)
 # that keep their database key in the keychain need it supplied here
 keychain_frame = ttk.LabelFrame(
     main_window,
-    text=' Optional: select a keychain file captured from the device (used to decrypt apps such as Signal): ')
+    text=' Optional: keychain file captured from the device, used to decrypt apps such as Signal. Leave blank to use one the extraction carries: ')
 keychain_frame.pack(padx=14, pady=2, fill='x')
 keychain_entry = ttk.Entry(keychain_frame)
 keychain_entry.pack(side='left', padx=5, pady=4, fill='x', expand=True)

--- a/scripts/artifacts/signalIOS.py
+++ b/scripts/artifacts/signalIOS.py
@@ -8,7 +8,10 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Signal",
         "notes": "Signal encrypts its database with a key held in the iOS keychain. The keychain is captured separately from the file system extraction, so supply it with --keychain or the keychain field in the GUI.",
-        "paths": ('*/AppGroup/*/grdb*/signal.sqlite*',),
+        "paths": ('*/AppGroup/*/grdb*/signal.sqlite*',
+                  # so a keychain the extraction carries is available to decrypt with
+                  '*/extra/KeychainDump/backup_keychain_v2.plist',
+                  '*/keychain-backup.plist'),
         "output_types": "standard",
         "artifact_icon": "message-circle",
     },
@@ -21,7 +24,10 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Signal",
         "notes": "Requires the keychain, supplied with --keychain or the keychain field in the GUI.",
-        "paths": ('*/AppGroup/*/grdb*/signal.sqlite*',),
+        "paths": ('*/AppGroup/*/grdb*/signal.sqlite*',
+                  # so a keychain the extraction carries is available to decrypt with
+                  '*/extra/KeychainDump/backup_keychain_v2.plist',
+                  '*/keychain-backup.plist'),
         "output_types": "standard",
         "artifact_icon": "users",
     },
@@ -34,7 +40,10 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Signal",
         "notes": "Requires the keychain, supplied with --keychain or the keychain field in the GUI.",
-        "paths": ('*/AppGroup/*/grdb*/signal.sqlite*',),
+        "paths": ('*/AppGroup/*/grdb*/signal.sqlite*',
+                  # so a keychain the extraction carries is available to decrypt with
+                  '*/extra/KeychainDump/backup_keychain_v2.plist',
+                  '*/keychain-backup.plist'),
         "output_types": "standard",
         "artifact_icon": "message-square",
     },
@@ -45,8 +54,7 @@ import os
 import sqlite3
 import tempfile
 
-from scripts.context import Context
-from scripts.ios_keychain import get_app_secret
+from scripts.ios_keychain import get_app_secret, active_keychain_path
 from scripts.sqlcipher_decrypt import decrypt_sqlcipher_db
 from scripts.ilapfuncs import artifact_processor, logfunc, convert_unix_ts_to_utc
 
@@ -79,12 +87,13 @@ def _decrypted_database(database_path):
     key_spec = get_app_secret(SIGNAL_ACCESS_GROUP, KEY_SPEC_ACCOUNT,
                               expected_length=KEY_SPEC_LENGTH)
     if not key_spec:
-        if Context.get_keychain_path():
-            logfunc('Signal: the supplied keychain has no Signal database key, '
+        if active_keychain_path():
+            logfunc('Signal: the keychain in use has no Signal database key, '
                     'the database stays encrypted')
         else:
-            logfunc('Signal: found an encrypted database but no keychain was supplied. '
-                    'Pass one with --keychain, or the keychain field in the GUI, to decrypt it.')
+            logfunc('Signal: found an encrypted database but no keychain is available. '
+                    'The extraction does not carry one, so supply it with --keychain or the '
+                    'keychain field in the GUI.')
         return None
 
     digest = hashlib.sha1(database_path.encode('utf-8', 'replace')).hexdigest()[:12]

--- a/scripts/ios_keychain.py
+++ b/scripts/ios_keychain.py
@@ -30,6 +30,7 @@ Smith, whose UFED keychain decrypter described it. This is an independent
 implementation using iLEAPP's existing dependencies.
 """
 import io
+import os
 import plistlib
 
 import nska_deserialize
@@ -43,7 +44,16 @@ GENERIC_PASSWORD_KEY = 'genp'
 ENCRYPTED_ENTRIES_KEY = 'keychainEntries'
 METADATA_CLASS_KEYS_KEY = 'classKeyIdxToUnwrappedMetadataClassKey'
 
+# Some extractions carry a keychain dump of their own. These are the locations
+# worth looking in when the examiner did not supply one, matching the paths the
+# keychain artifact already uses.
+IN_EXTRACTION_KEYCHAIN_GLOBS = (
+    '*/extra/KeychainDump/backup_keychain_v2.plist',
+    '*/keychain-backup.plist',
+)
+
 _cache = {}
+_discovered = {}
 
 
 def _decrypt_gcm(archived_blob, key):
@@ -152,6 +162,46 @@ def find_keychain_secrets(keychain_path, access_group=None, account=None, servic
     return matches
 
 
+def _discover_keychain():
+    """Look for a keychain the extraction carries, when none was supplied.
+
+    Returns a path, or None. The result is cached, including the negative case,
+    so the search runs once per run rather than once per artifact.
+    """
+    if 'path' in _discovered:
+        return _discovered['path']
+    _discovered['path'] = None
+
+    try:
+        seeker = Context.get_seeker()
+    except Exception:  # pylint: disable=broad-except
+        return None  # called outside an artifact, nothing to search
+    if seeker is None:
+        return None
+
+    for glob in IN_EXTRACTION_KEYCHAIN_GLOBS:
+        try:
+            found = [str(path) for path in seeker.search(glob)]
+        except Exception:  # pylint: disable=broad-except
+            continue
+        for candidate in found:
+            if not os.path.isfile(candidate):
+                continue
+            logfunc('Keychain: no keychain was supplied, trying the one carried by the '
+                    f'extraction at {candidate}')
+            # Only accept it if it actually yields entries we can read
+            if load_keychain_entries(candidate):
+                _discovered['path'] = candidate
+                return candidate
+            logfunc('Keychain: that keychain yielded no readable entries, ignoring it')
+    return None
+
+
+def active_keychain_path():
+    """The keychain to read: the supplied one, else one found in the extraction."""
+    return Context.get_keychain_path() or _discover_keychain()
+
+
 def get_app_secret(access_group, account=None, service=None, expected_length=None):
     """Return one secret for an app from the examiner-supplied keychain, or None.
 
@@ -167,11 +217,11 @@ def get_app_secret(access_group, account=None, service=None, expected_length=Non
     Returns:
         The secret as bytes, or None when no keychain was supplied or nothing matched.
     """
-    keychain_path = Context.get_keychain_path()
-    if not keychain_path:
+    path = active_keychain_path()
+    if not path:
         return None
 
-    matches = find_keychain_secrets(keychain_path, access_group, account, service)
+    matches = find_keychain_secrets(path, access_group, account, service)
     if expected_length is not None:
         matches = [secret for secret in matches if len(secret) == expected_length]
     if not matches:


### PR DESCRIPTION
Follow-up to #1766. Removes a manual step for every extraction that ships its own keychain.

## Problem

Six corpus images carry a keychain at `extra/KeychainDump/backup_keychain_v2.plist`, and since #1766 iLEAPP can read that format. But the examiner still had to notice it was there, extract it from the archive by hand, and pass `--keychain`. Most people would never realise it was possible.

## Change

When no keychain is supplied, look for one in the extraction and use it if it yields readable entries.

- **An explicit `--keychain` always wins**, so nothing changes for existing workflows
- The result is cached, including the negative case, so the search runs once per run rather than once per artifact
- Searches the same locations the keychain artifact already uses: `*/extra/KeychainDump/backup_keychain_v2.plist` and `*/keychain-backup.plist`
- The Signal artifacts now list those paths in `paths`, so the file is genuinely **extracted** from zip inputs rather than only searched for — the same trap that previously hid the WAL and `app_parts`
- The GUI field is relabelled: *"Leave blank to use one the extraction carries"*

## Verification on corpus images

| Case | Result |
|---|---|
| **No argument at all** | Finds the keychain, decrypts 1284 entries, **151 messages / 582 contacts / 17 conversations** |
| **Explicit `--keychain`** | Still used, zero discovery attempts, all three artifacts populated |
| **No keychain anywhere** | Reports how to supply one, three artifacts report no data, no crash |

Full suite green on Python 3.10, pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)