### PR TITLE
feat: check in notification attachments as media

### DIFF
--- a/scripts/artifacts/notificationsXII.py
+++ b/scripts/artifacts/notificationsXII.py
@@ -4,10 +4,10 @@ __artifacts_v2__ = {
         "description": "iOS 12+ delivered notifications (DeliveredNotifications.plist)",
         "author": "",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Notifications",
-        "notes": "",
+        "notes": "Notification attachments (images stored under the Attachments folder) are checked in as media and linked to the notification that referenced them.",
         "paths": ('*/mobile/Library/UserNotifications*',),
         "output_types": "standard",
         "artifact_icon": "bell",
@@ -37,7 +37,55 @@ from datetime import datetime, timezone
 
 import nska_deserialize as nd
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc
+
+
+def _attachment_index(plist_files):
+    """Map each notification attachment file name to its path on disk.
+
+    Attachments are stored beside the notification plists under an Attachments
+    folder, named by a hash rather than by anything meaningful, so an index by
+    file name is enough to resolve them later.
+    """
+    index = {}
+    for filepath in plist_files:
+        if os.path.isfile(filepath) and f'{os.sep}Attachments{os.sep}' in filepath:
+            index.setdefault(os.path.basename(filepath), filepath)
+    return index
+
+
+def _notification_media(item, attachment_index, seen):
+    """Check in the attachments of one notification, returning media references.
+
+    The plist records both an AttachmentIdentifier, which is the logical name
+    the app chose, and an AttachmentURL pointing at the stored copy. Only the
+    URL matches what is on disk, so resolve by that and keep the identifier as
+    the display name. The identifier is not trustworthy as a file name though:
+    apps hand out things like "image.gif" for what is really a JPEG, so the
+    extension comes from the stored file instead of from the identifier.
+    """
+    references = []
+    for attachment in item.get('AppNotificationAttachments') or []:
+        if not isinstance(attachment, dict):
+            continue
+        url = attachment.get('AttachmentURL')
+        relative = url.get('NS.relative', '') if isinstance(url, dict) else str(url or '')
+        stored_name = relative.rsplit('/', 1)[-1]
+        path = attachment_index.get(stored_name)
+        if not path:
+            continue
+        extension = os.path.splitext(stored_name)[1]
+        try:
+            reference = check_in_media(path,
+                                       name=attachment.get('AttachmentIdentifier') or stored_name,
+                                       force_extension=extension or None)
+        except Exception as error:  # pylint: disable=broad-except
+            logfunc(f'Notifications: could not check in {stored_name}: {error}')
+            continue
+        if reference:
+            references.append(reference)
+            seen.add(path)
+    return references
 
 
 def _bundle_info(plist_files):
@@ -56,7 +104,7 @@ def _bundle_info(plist_files):
 @artifact_processor
 def notificationsXII(context):
     data_headers = (('Creation Time', 'datetime'), 'Bundle', 'Title[Subtitle]', 'Message',
-                    'Other Details')
+                    ('Attachments', 'media'), 'Attachment Count', 'Other Details')
     data_list = []
     sources = []
 
@@ -69,6 +117,9 @@ def notificationsXII(context):
             plist_files.append(fp)
 
     bundle_info = _bundle_info(plist_files)
+    attachment_index = _attachment_index(plist_files)
+    checked_in = 0
+    seen_attachments = set()
 
     for filepath in plist_files:
         if not (os.path.isfile(filepath) and filepath.endswith('DeliveredNotifications.plist')):
@@ -98,10 +149,19 @@ def notificationsXII(context):
                     title = v
                 elif k == 'AppNotificationSubtitle':
                     subtitle = v
-                else:
+                elif k != 'AppNotificationAttachments':
                     other_dict[k] = str(v)
             if subtitle:
                 title = f'{title}[{subtitle}]'
-            data_list.append((creation_date, bundle_name, title, message, str(other_dict)))
+            # A notification can carry several attachments, so the media cell takes a list
+            media = _notification_media(item, attachment_index, seen_attachments)
+            checked_in += len(media)
+            data_list.append((creation_date, bundle_name, title, message, media or '',
+                              len(media), str(other_dict)))
+
+    if checked_in:
+        # Apps reuse one stored file across many notifications, so the two counts differ
+        logfunc(f'Notifications: linked {checked_in} attachment reference(s) to '
+                f'{len(seen_attachments)} stored file(s)')
 
     return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## What

Delivered notifications can carry an image. iOS stores it beside the notification plists under an `Attachments` folder, named by hash. No artifact was picking those up, so the images sat in the extraction unreferenced and unviewable.

This adds an `Attachments` media column and an `Attachment Count` column to the Notifications artifact, linking each image to the notification that referenced it.

## How the link is made

Each entry in `AppNotificationAttachments` has two names:

| field | example | matches on disk |
|---|---|---|
| `AttachmentIdentifier` | `avatar_912f2cab….png` | 0/30 |
| `AttachmentURL` → `NS.relative` basename | `1330118793f2cf81….jpeg` | 30/30 |

So the URL basename resolves the file, and the identifier is kept as the display name.

## Extension handling

The identifier is not usable as a file name. Apps hand out labels like `image.gif` for content that is really a JPEG, and `check_in_media` derives the extracted file's suffix from `name`. Passing the identifier straight through renamed 6 correctly-named `.jpeg` files to `.jpg` and would misname more. The extension is now forced from the stored file, so the extracted media mirrors exactly what the device wrote (74 gif / 51 jpeg / 24 png on Otto). Where the device's own extension disagrees with the content — 78 of 149 files on Otto, all `.gif` holding JPEG data — LAVA's mimetype column still records the sniffed truth.

`AppNotificationAttachments` is also dropped from the `Other Details` blob now that it has its own column.

## Testing

Run against the corpus with a notifications-only profile:

| image | rows | references | distinct files |
|---|---|---|---|
| Otto (iOS 17.5.1) | 1137 | 516 | 149 |
| Abe (iOS 16.5) | 426 | 195 | 65 |
| HC (iOS 18.7.8) | 72 | 0 | 0 |
| Felix23 (iOS 16.5) | 9 | 0 | 0 |
| Magnet (iOS 16.1.1) | 0 | 0 | 0 |

Row counts are unchanged from the recorded `sample_data` on every image, so nothing regressed for extractions without attachments. Apps reuse one stored image across many notifications, which is why references outnumber files.

pylint 10.00/10, `python -m unittest discover -s admin/test/scripts` 24/24 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)