### PR TITLE
fix: handle alarms whose sound is a song

### DIFF
--- a/admin/test/scripts/test_apple_alarms_sound.py
+++ b/admin/test/scripts/test_apple_alarms_sound.py
@@ -1,0 +1,67 @@
+"""An alarm whose sound is a song must not kill the alarms artifact.
+
+com.apple.mobiletimerd.plist stores the alarm sound under
+MTAlarmSound/$MTSound, but the key inside it depends on what the user picked:
+a built-in tone has MTSoundToneID, while a song from the media library has
+MTSoundMediaItemID and no MTSoundToneID at all. The artifact indexed
+MTSoundToneID directly, so a single song alarm raised KeyError and the whole
+artifact returned no rows.
+"""
+import pathlib
+import plistlib
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.artifacts.appleAlarms import alarms  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+
+
+def _alarm(sound):
+    return {
+        'MTAlarmTitle': 'Alarm',
+        'MTAlarmHour': 5,
+        'MTAlarmMinute': 35,
+        'MTAlarmEnabled': True,
+        'MTAlarmRepeatSchedule': 0,
+        'MTAlarmIsSleep': False,
+        'MTAlarmBedtimeDoNotDisturb': False,
+        'MTAlarmSound': {'$MTSound': sound},
+    }
+
+
+class TestAppleAlarmsSound(unittest.TestCase):
+
+    def _run(self, sound):
+        plist = {'MTAlarms': {'MTAlarms': [{'$MTAlarm': _alarm(sound)}],
+                              'MTSleepAlarms': []}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / 'com.apple.mobiletimerd.plist'
+            path.write_bytes(plistlib.dumps(plist))
+            Context.clear()
+            Context.set_files_found([str(path)])
+            _, data_list, _ = alarms.__wrapped__(Context)
+        return data_list
+
+    def test_tone_alarm_reports_the_tone_id(self):
+        data_list = self._run({'MTSoundType': 2,
+                               'MTSoundToneID': 'system:Arpeggio',
+                               'MTSoundVibrationID': 'SOS'})
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][7], 'system:Arpeggio')
+
+    def test_song_alarm_reports_the_media_item(self):
+        """A song alarm has no MTSoundToneID and used to raise KeyError."""
+        data_list = self._run({'MTSoundType': 3,
+                               'MTSoundMediaItemID': 5999271,
+                               'MTSoundVibrationID': 'SOS'})
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][7], 'media item: 5999271')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/appleAlarms.py
+++ b/scripts/artifacts/appleAlarms.py
@@ -40,6 +40,20 @@ def _safe_plist_date(value):
     return convert_plist_date_to_utc(value) if isinstance(value, _dt) else value
 
 
+def decode_alarm_sound(alarm_dict):
+    """Describe the alarm sound.
+
+    A tone carries MTSoundToneID, a song from the media library carries
+    MTSoundMediaItemID instead, so neither key is guaranteed to be present.
+    """
+    sound = alarm_dict.get('MTAlarmSound', {}).get('$MTSound', {})
+    if 'MTSoundToneID' in sound:
+        return sound['MTSoundToneID']
+    if 'MTSoundMediaItemID' in sound:
+        return f"media item: {sound['MTSoundMediaItemID']}"
+    return ''
+
+
 def decode_repeat_schedule(repeat_schedule_value):
     days_list = {
         64: 'Sunday', 
@@ -104,7 +118,7 @@ def alarms(context):
                     dismiss_date,
                     last_modified_date, 
                     ', '.join(repeat_schedule),
-                    alarms_dict['MTAlarmSound']['$MTSound']['MTSoundToneID'],
+                    decode_alarm_sound(alarms_dict),
                     alarms_dict['MTAlarmIsSleep'], 
                     alarms_dict['MTAlarmBedtimeDoNotDisturb'],
                     '')
@@ -132,7 +146,7 @@ def alarms(context):
                     dismiss_date, 
                     last_modified_date, 
                     ', '.join(repeat_schedule), 
-                    sleep_alarm_dict['MTAlarmSound']['$MTSound']['MTSoundToneID'], 
+                    decode_alarm_sound(sleep_alarm_dict),
                     sleep_alarm_dict['MTAlarmIsSleep'], 
                     sleep_alarm_dict['MTAlarmBedtimeDoNotDisturb'], 
                     sleep_alarm_dict['MTAlarmBedtimeFireDate'])


### PR DESCRIPTION
Closes #1721

`MTAlarmSound/$MTSound` only has `MTSoundToneID` when the alarm sound is a built-in tone. When the user picks a song from the media library the key is `MTSoundMediaItemID` instead, so indexing `MTSoundToneID` directly raised `KeyError: 'MTSoundToneID'` and the whole alarms artifact returned no rows.

The sound is now read through a small helper that prefers `MTSoundToneID`, falls back to the media item id, and returns an empty value if neither key is there — applied to both the alarm and sleep-alarm rows. `admin/test/scripts/test_apple_alarms_sound.py` covers both cases and the song test fails on the previous code with the reported `KeyError`.
