### PR TITLE
fix: stop reporting every notification three times

### DIFF
--- a/scripts/artifacts/notificationsXII.py
+++ b/scripts/artifacts/notificationsXII.py
@@ -12,20 +12,20 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "bell",
         "sample_data": {
-            "ctf2020_ios12": "iOS 12.4 | 258 rows",
-            "dexter_ios18": "iOS 18.3.2 | 153 rows",
-            "felix_ios17": "iOS 17.6.1 | 45 rows",
-            "fsfull002_ios17": "iOS 17.1 | 12 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 72 rows",
-            "iphone11_ios17": "iOS 17.3 | 894 rows",
-            "iphone12_ios18": "iOS 18.7 | 60 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 30 rows",
-            "otto_ios17": "iOS 17.5.1 | 1137 rows",
-            "abe_ios16": "iOS 16.5 | 426 rows",
-            "felix23_ios16": "iOS 16.5 | 9 rows",
-            "hickman_ios13": "iOS 13.3.1 | 249 rows",
-            "hickman_ios14": "iOS 14.3 | 12 rows",
-            "jess_ios15": "iOS 15.0.2 | 126 rows",
+            "ctf2020_ios12": "iOS 12.4 | 86 rows",
+            "dexter_ios18": "iOS 18.3.2 | 51 rows",
+            "felix_ios17": "iOS 17.6.1 | 15 rows",
+            "fsfull002_ios17": "iOS 17.1 | 4 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 24 rows",
+            "iphone11_ios17": "iOS 17.3 | 298 rows",
+            "iphone12_ios18": "iOS 18.7 | 20 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 10 rows",
+            "otto_ios17": "iOS 17.5.1 | 379 rows",
+            "abe_ios16": "iOS 16.5 | 142 rows",
+            "felix23_ios16": "iOS 16.5 | 3 rows",
+            "hickman_ios13": "iOS 13.3.1 | 83 rows",
+            "hickman_ios14": "iOS 14.3 | 4 rows",
+            "jess_ios15": "iOS 15.0.2 | 42 rows",
             "magnet_ios16": "iOS 16.1.1 | 0 rows",
         }
     }
@@ -197,13 +197,19 @@ def notificationsXII(context):
     data_list = []
     sources = []
 
-    plist_files = []
+    # The path glob matches the UserNotifications folder, each per-bundle folder
+    # inside it and the files themselves, so walking every matched directory
+    # reaches the same plist once per ancestor plus once directly. Without the
+    # dedupe every notification is reported three times over.
+    seen_paths = {}
     for fp in context.get_files_found():
         fp = str(fp)
         if os.path.isdir(fp):
-            plist_files.extend(str(x) for x in glob.iglob(os.path.join(fp, '**'), recursive=True))
+            for found in glob.iglob(os.path.join(fp, '**'), recursive=True):
+                seen_paths.setdefault(os.path.realpath(found), str(found))
         else:
-            plist_files.append(fp)
+            seen_paths.setdefault(os.path.realpath(fp), fp)
+    plist_files = list(seen_paths.values())
 
     bundle_info = _bundle_info(plist_files)
     attachment_index = _attachment_index(plist_files)


### PR DESCRIPTION
Found while checking whether the artifact still yields useful data on recent iOS. It does, but it was reporting three times as much of it as exists.

## The bug

`paths` is `*/mobile/Library/UserNotifications*`. On Otto that glob matches 2,709 entries: 265 directories and 2,444 files, including the 115 `DeliveredNotifications.plist` files. The artifact then walked **every matched directory** recursively *and* appended the matched files directly, so each plist was reached:

```
filesystem1/private/var/mobile/Library/UserNotifications/                    <- glob ** finds it
filesystem1/private/var/mobile/Library/UserNotifications/<bundle>/           <- glob ** finds it again
filesystem1/private/var/mobile/Library/UserNotifications/<bundle>/Delivered… <- appended directly
```

Two ancestor directories plus the file itself: exactly three reads, and three identical rows per notification.

`select count(*) / count(distinct …)` on the Otto output returns exactly **3.00**.

## Impact

Otto reported **1,137** notifications against **379** real ones. Every recorded `sample_data` count was inflated by the same factor of three, so they are corrected here as well. Overstating how much notification traffic a device carried is not a cosmetic problem for a forensic tool.

Media check-in was already deduping by source path, so the **file** counts were always right (149 on Otto). The **reference** counts were not: Otto now links 172 references to those 149 files rather than 516.

## Fix

Deduplicate the collected paths, keyed on `os.path.realpath`, so a symlinked duplicate collapses too.

## Verification

Ran the artifact post-fix and cross-checked against an independent read of `DeliveredNotifications.plist` straight out of each image, which never touches iLEAPP's file-collection code:

| image | iOS | was | now | independent count |
|---|---|---|---|---|
| Otto | 17.5.1 | 1137 | **379** | 379 |
| Abe | 16.5 | 426 | **142** | 142 |
| HC | 18.7.8 | 72 | **24** | 24 |
| CTF2020 | 12.4 | 258 | **86** | 86 |

All four agree exactly. The remaining `sample_data` entries are corrected from the same independent read, and every one of the fifteen was precisely 3×, which is what the mechanism predicts.

Duplicate ratio on Otto after the fix: **1.00**.

## Related

`notificationsXI.py` shares the same walk but globs `*PushStore*`, which matches files rather than nested folders, so it is likely unaffected. There is no iOS 11 image in the corpus to confirm that, so it is left alone rather than changed blind.

pylint 10.00/10, `python -m unittest discover -s admin/test/scripts` 24/24 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)