### PR TITLE
fix(cloudkitSharing): log the NoteStore.sqlite files skipped for missing schema

### DIFF
--- a/admin/test/scripts/test_cloudkit_sharing_missing_table.py
+++ b/admin/test/scripts/test_cloudkit_sharing_missing_table.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
@@ -65,6 +66,45 @@ class TestCloudkitSharingMissingTable(unittest.TestCase):
     def test_participants_skips_notestore_without_the_table(self):
         _headers, data_list, _source = cloudkit_participants.__wrapped__(Context)
         self.assertEqual(data_list, [])
+
+    def _skip_messages(self, processor):
+        """Run a processor and return only its 'skipped' log lines."""
+        with mock.patch('scripts.artifacts.cloudkitSharing.logfunc') as logged:
+            processor.__wrapped__(Context)
+        return [call.args[0] for call in logged.call_args_list
+                if 'no ZICCLOUDSYNCINGOBJECT table' in call.args[0]]
+
+    def test_sharing_logs_the_file_it_skipped(self):
+        """Skipping silently would hide a damaged db, so the skip has to be visible."""
+        messages = self._skip_messages(cloudkit_sharing)
+        self.assertEqual(len(messages), 1)
+        self.assertIn(str(self.empty_db), messages[0])
+        self.assertIn('(0 bytes)', messages[0])
+
+    def test_participants_logs_the_file_it_skipped(self):
+        messages = self._skip_messages(cloudkit_participants)
+        self.assertEqual(len(messages), 1)
+        self.assertIn(str(self.empty_db), messages[0])
+
+    def test_the_real_database_is_never_reported_as_skipped(self):
+        messages = self._skip_messages(cloudkit_sharing)
+        self.assertNotIn(str(self.populated_db), ' '.join(messages))
+
+    def test_a_truncated_database_is_logged_with_its_real_size(self):
+        """The case the log line exists for: not a placeholder, a damaged database.
+
+        A zero-byte skip is routine, but a NoteStore.sqlite with real bytes in it and
+        no schema means the examiner lost data they should know about. The size is in
+        the message so the two are distinguishable at a glance in the run log.
+        """
+        truncated = pathlib.Path(self.tmpdir) / 'Backups' / '2026-07-19' / 'NoteStore.sqlite'
+        truncated.parent.mkdir(parents=True)
+        truncated.write_bytes(b'SQLite format 3\x00' + b'\x00' * 100)
+        Context.set_files_found([str(truncated)])
+
+        messages = self._skip_messages(cloudkit_sharing)
+        self.assertEqual(len(messages), 1)
+        self.assertIn('(116 bytes)', messages[0])
 
 
 if __name__ == '__main__':

--- a/scripts/artifacts/cloudkitSharing.py
+++ b/scripts/artifacts/cloudkitSharing.py
@@ -65,7 +65,7 @@ __artifacts_v2__ = {
 import os
 import io
 import nska_deserialize as nd
-from scripts.ilapfuncs import (artifact_processor, does_table_exist_in_db,
+from scripts.ilapfuncs import (artifact_processor, does_table_exist_in_db, logfunc,
                                open_sqlite_db_readonly)
 
 
@@ -94,6 +94,22 @@ def as_list(data):
     return []
 
 
+def has_cloudkit_table(file_found):
+    """Report whether a NoteStore.sqlite carries the CloudKit schema.
+
+    iOS leaves zero-byte NoteStore.sqlite placeholders under Backups/<date>/ and
+    sqlite3 opens those as empty databases, so the table has to be checked before
+    querying one. Skipping is right for a placeholder but would also hide a truncated
+    or unreadable database, so every skip names the file and its size.
+    """
+    if does_table_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT'):
+        return True
+    size = os.path.getsize(file_found) if os.path.isfile(file_found) else 0
+    logfunc(f'cloudkitSharing: skipped {file_found} ({size} bytes), '
+            'no ZICCLOUDSYNCINGOBJECT table')
+    return False
+
+
 def write_debug_bplist(report_folder, prefix, z_pk, data):
     """Writes extracted blobs to the report folder for validation."""
     filename = os.path.join(report_folder, f'{prefix}_{z_pk}.bplist')
@@ -110,7 +126,7 @@ def cloudkit_sharing(context):
         file_found = str(file_found)
         if not file_found.endswith('NoteStore.sqlite'):
             continue
-        if not does_table_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT'):
+        if not has_cloudkit_table(file_found):
             continue
 
         # Dictionary to merge share and record data by Z_PK
@@ -215,7 +231,7 @@ def cloudkit_participants(context):
         file_found = str(file_found)
         if not file_found.endswith('NoteStore.sqlite'):
             continue
-        if not does_table_exist_in_db(file_found, 'ZICCLOUDSYNCINGOBJECT'):
+        if not has_cloudkit_table(file_found):
             continue
 
         db = open_sqlite_db_readonly(file_found)


### PR DESCRIPTION
Follow-up to #1773 (which closed #1726).

#1773 guards both CloudKit processors with `does_table_exist_in_db()` so the zero-byte `NoteStore.sqlite` placeholders iOS leaves under `group.com.apple.notes/Backups/<date>/` no longer abort the artifact. That fix is correct, but the guard skips silently — right for a placeholder, and wrong for a truncated or otherwise unreadable database, where the examiner would get no CloudKit shares and nothing in the run log to explain why. That is the same failure mode as #1726, just quieter.

Both call sites now go through `has_cloudkit_table()`, which logs the file and its size on the way out:

```
cloudkitSharing: skipped .../Backups/2026-07-18/NoteStore.sqlite (0 bytes), no ZICCLOUDSYNCINGOBJECT table
```

A 0-byte skip reads as routine; a skip with real bytes in the file is a flag that something the examiner cares about did not parse. No change to which files are processed.

`admin/test/scripts/test_cloudkit_sharing_missing_table.py` gains four tests: both processors log the placeholder they skipped, the real schema-bearing database is never reported as skipped, and a truncated 116-byte database is logged with its real size rather than being mistaken for a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)