### PR TITLE
feat: add Biome Boot Session and Emoji Engagement artifacts

### DIFF
--- a/scripts/artifacts/biomeBootSession.py
+++ b/scripts/artifacts/biomeBootSession.py
@@ -1,0 +1,102 @@
+__artifacts_v2__ = {
+    "get_biomeBootSession": {
+        "name": "Biome - Boot Session",
+        "description": "Parses boot session records from the Device.BootSession biome stream. "
+                       "Each boot closes the previous session identifier and opens a new one, "
+                       "so the stream reconstructs when the device started and stopped running "
+                       "and, where a close and the following open are separated in time, how "
+                       "long the device was powered off.",
+        "author": "@abrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Session state 1 is the opening of a session and 0 its close, established by "
+                 "the record pattern across four test images: a close and an open share a "
+                 "timestamp at a reboot, and each session identifier appears exactly twice, "
+                 "once opened and once closed. A close with no open at the same instant marks "
+                 "a shutdown, and the gap to the next open is the period the device was off. "
+                 "Sort by timestamp and pair on Session ID to measure uptime.",
+        "paths": ('*/streams/*/Device.BootSession/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "power",
+        "sample_data": {
+            "dexter_ios18": "iOS 18.3.2 | 43 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 134 rows",
+            "iphone12_ios18": "iOS 18.7 | 13 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 11 rows",
+        },
+    }
+}
+
+
+import os
+import struct
+import uuid
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''}}
+
+SESSION_STATE = {0: 'Session End', 1: 'Session Start'}
+
+
+def _session_id(value):
+    """Field 1 is a raw 16 byte UUID."""
+    if isinstance(value, bytes) and len(value) == 16:
+        try:
+            return str(uuid.UUID(bytes=value))
+        except ValueError:
+            return value.hex()
+    if isinstance(value, bytes):
+        return value.hex()
+    return '' if value is None else str(value)
+
+
+@artifact_processor
+def get_biomeBootSession(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Boot Session: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                raw_state = protostuff.get('2', '')
+                data_list.append((ts, record.state.name, SESSION_STATE.get(raw_state, ''),
+                                  raw_state, _session_id(protostuff.get('1')), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Session State',
+                    'Session State (raw)', 'Session ID', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeEmojiEngagement.py
+++ b/scripts/artifacts/biomeEmojiEngagement.py
@@ -1,0 +1,119 @@
+__artifacts_v2__ = {
+    "get_biomeEmojiEngagement": {
+        "name": "Biome - Emoji Engagement",
+        "description": "Parses emoji usage from the Emoji.Engagement biome stream. Each record "
+                       "holds the emoji the user engaged with, along with the Unicode code "
+                       "points so that skin tone modifiers, variation selectors and zero width "
+                       "joiner sequences stay visible in the report.",
+        "author": "@abrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The context field decodes to a four character ASCII string that resembles a "
+                 "trailing locale fragment (values seen: n_US and n-US, consistent with en_US "
+                 "and en-US); it is reported both raw and decoded because that reading is not "
+                 "confirmed. Field 2 was 1 on every record observed and field 4 varied from 1 "
+                 "to 4; both are reported raw.",
+        "paths": ('*/streams/*/Emoji.Engagement/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "smile",
+        "sample_data": {
+            "dexter_ios18": "iOS 18.3.2 | 4 rows",
+            "iphone11_ios17": "iOS 17.3 | 20 rows",
+            "iphone12_ios18": "iOS 18.7 | 16 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 4 rows",
+            "otto_ios17": "iOS 17.5.1 | 46 rows",
+        },
+    }
+}
+
+
+import os
+import struct
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''},
+          '4': {'type': 'int', 'name': ''}}
+
+
+def _emoji(value):
+    if not isinstance(value, bytes):
+        return '' if value is None else str(value)
+    try:
+        return value.decode('utf-8')
+    except UnicodeDecodeError:
+        return value.decode('latin-1', 'replace')
+
+
+def _code_points(text):
+    return ' '.join(f'U+{ord(ch):04X}' for ch in text)
+
+
+def _context_ascii(value):
+    """The context integer spells four ASCII characters when read big endian."""
+    if not isinstance(value, int):
+        return ''
+    try:
+        decoded = struct.pack('>I', value & 0xFFFFFFFF).decode('ascii')
+    except (struct.error, UnicodeDecodeError):
+        return ''
+    return decoded if decoded.isprintable() else ''
+
+
+@artifact_processor
+def get_biomeEmojiEngagement(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Emoji Engagement: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                emoji = _emoji(protostuff.get('1'))
+
+                sub = protostuff.get('3', {})
+                if not isinstance(sub, dict):
+                    sub = {}
+                context_raw = sub.get('12', '')
+
+                data_list.append((ts, record.state.name, emoji, _code_points(emoji),
+                                  _context_ascii(context_raw), context_raw,
+                                  protostuff.get('2', ''), protostuff.get('4', ''),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, None, None,
+                                  filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Emoji', 'Code Points',
+                    'Context (decoded)', 'Context (raw)', 'Field 2 (raw)', 'Field 4 (raw)',
+                    'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## What

Two new Biome artifacts for streams that had data across the registered corpora but no parser.

| Artifact | Stream | Corpora with data |
|---|---|---|
| Biome - Boot Session | `Device.BootSession` | dexter 18.3.2, hc 18.7.8, iPhone 12 18.7, iPhone 14 Plus 18.0 |
| Biome - Emoji Engagement | `Emoji.Engagement` | otto 17.5.1, iPhone 11 17.3, dexter 18.3.2, iPhone 12 18.7, iPhone 14 Plus 18.0 |

### Boot Session is a device power ledger

Each record pairs a 16-byte session UUID with a state flag. The pattern across four independent images makes the semantics unambiguous: at a reboot the previous session is **closed and a new one opened at the same instant**, and every session id appears exactly twice — once opened, once closed (verified 23 starts / 23 ends in the combined sample). So state `1` opens a session and `0` closes it, which gives **device start and stop times**.

The forensically interesting case is when a close and the following open are *not* simultaneous: that gap is the period the device was powered off. One test image shows a close at 13:37:54 and the next open ~24 hours later. The notes tell an examiner to sort by timestamp and pair on Session ID to derive uptime.

### Emoji Engagement

Records the emoji a user engaged with. The emoji is reported **alongside its Unicode code points**, so skin-tone modifiers, variation selectors and ZWJ sequences stay visible instead of collapsing into one glyph in a report — e.g. a thumbs-up with a light skin tone shows as `U+1F44D U+1F3FB`, and a chef shows its ZWJ sequence.

The context field decodes to four printable ASCII characters resembling a trailing locale fragment (`n_US`, `n-US` — consistent with `en_US`/`en-US`). That reading is **not** confirmed, so it is reported both raw and decoded, as are the two integer fields the samples don't explain.

## Validation

Harness run on real samples from five corpora: header/row width verified, boot sessions confirmed to pair exactly, emoji round-tripped through UTF-8 with code points intact. Full `ileapp.py` run completes and both populate (201 and 90 rows on the combined test input). `pylint --disable=C,R` reports **10.00/10** and the blackboxprotobuf guard passes.

## Coverage note

This came out of checking eight streams. `App.Intent` was already covered by Biome - Intents. The remaining five — `AeroML.Insights.PhotosSearchInsights`, `App.Installation`, `App.RelevantShortcuts`, `MLSE.ShareSheet.ConversationUserInteraction`, `CommCenter.Call.EmergencyVoiceCall` — are absent from **all sixteen** registered corpora (iOS 12 through 18.7.8, including a full scan of the 16 GB iOS 15 image), so they remain blocked on sample data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)