### PR TITLE
feat: Notes - Password Protected artifact (hint + recoverability triage)

### DIFF
--- a/scripts/artifacts/biomeBootSession.py
+++ b/scripts/artifacts/biomeBootSession.py
@@ -1,0 +1,102 @@
+__artifacts_v2__ = {
+    "get_biomeBootSession": {
+        "name": "Biome - Boot Session",
+        "description": "Parses boot session records from the Device.BootSession biome stream. "
+                       "Each boot closes the previous session identifier and opens a new one, "
+                       "so the stream reconstructs when the device started and stopped running "
+                       "and, where a close and the following open are separated in time, how "
+                       "long the device was powered off.",
+        "author": "@abrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Session state 1 is the opening of a session and 0 its close, established by "
+                 "the record pattern across four test images: a close and an open share a "
+                 "timestamp at a reboot, and each session identifier appears exactly twice, "
+                 "once opened and once closed. A close with no open at the same instant marks "
+                 "a shutdown, and the gap to the next open is the period the device was off. "
+                 "Sort by timestamp and pair on Session ID to measure uptime.",
+        "paths": ('*/streams/*/Device.BootSession/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "power",
+        "sample_data": {
+            "dexter_ios18": "iOS 18.3.2 | 43 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 134 rows",
+            "iphone12_ios18": "iOS 18.7 | 13 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 11 rows",
+        },
+    }
+}
+
+
+import os
+import struct
+import uuid
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''}}
+
+SESSION_STATE = {0: 'Session End', 1: 'Session Start'}
+
+
+def _session_id(value):
+    """Field 1 is a raw 16 byte UUID."""
+    if isinstance(value, bytes) and len(value) == 16:
+        try:
+            return str(uuid.UUID(bytes=value))
+        except ValueError:
+            return value.hex()
+    if isinstance(value, bytes):
+        return value.hex()
+    return '' if value is None else str(value)
+
+
+@artifact_processor
+def get_biomeBootSession(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Boot Session: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                raw_state = protostuff.get('2', '')
+                data_list.append((ts, record.state.name, SESSION_STATE.get(raw_state, ''),
+                                  raw_state, _session_id(protostuff.get('1')), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Session State',
+                    'Session State (raw)', 'Session ID', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeEmojiEngagement.py
+++ b/scripts/artifacts/biomeEmojiEngagement.py
@@ -1,0 +1,119 @@
+__artifacts_v2__ = {
+    "get_biomeEmojiEngagement": {
+        "name": "Biome - Emoji Engagement",
+        "description": "Parses emoji usage from the Emoji.Engagement biome stream. Each record "
+                       "holds the emoji the user engaged with, along with the Unicode code "
+                       "points so that skin tone modifiers, variation selectors and zero width "
+                       "joiner sequences stay visible in the report.",
+        "author": "@abrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The context field decodes to a four character ASCII string that resembles a "
+                 "trailing locale fragment (values seen: n_US and n-US, consistent with en_US "
+                 "and en-US); it is reported both raw and decoded because that reading is not "
+                 "confirmed. Field 2 was 1 on every record observed and field 4 varied from 1 "
+                 "to 4; both are reported raw.",
+        "paths": ('*/streams/*/Emoji.Engagement/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "smile",
+        "sample_data": {
+            "dexter_ios18": "iOS 18.3.2 | 4 rows",
+            "iphone11_ios17": "iOS 17.3 | 20 rows",
+            "iphone12_ios18": "iOS 18.7 | 16 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 4 rows",
+            "otto_ios17": "iOS 17.5.1 | 46 rows",
+        },
+    }
+}
+
+
+import os
+import struct
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''},
+          '4': {'type': 'int', 'name': ''}}
+
+
+def _emoji(value):
+    if not isinstance(value, bytes):
+        return '' if value is None else str(value)
+    try:
+        return value.decode('utf-8')
+    except UnicodeDecodeError:
+        return value.decode('latin-1', 'replace')
+
+
+def _code_points(text):
+    return ' '.join(f'U+{ord(ch):04X}' for ch in text)
+
+
+def _context_ascii(value):
+    """The context integer spells four ASCII characters when read big endian."""
+    if not isinstance(value, int):
+        return ''
+    try:
+        decoded = struct.pack('>I', value & 0xFFFFFFFF).decode('ascii')
+    except (struct.error, UnicodeDecodeError):
+        return ''
+    return decoded if decoded.isprintable() else ''
+
+
+@artifact_processor
+def get_biomeEmojiEngagement(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Emoji Engagement: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                emoji = _emoji(protostuff.get('1'))
+
+                sub = protostuff.get('3', {})
+                if not isinstance(sub, dict):
+                    sub = {}
+                context_raw = sub.get('12', '')
+
+                data_list.append((ts, record.state.name, emoji, _code_points(emoji),
+                                  _context_ascii(context_raw), context_raw,
+                                  protostuff.get('2', ''), protostuff.get('4', ''),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, None, None,
+                                  filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Emoji', 'Code Points',
+                    'Context (decoded)', 'Context (raw)', 'Field 2 (raw)', 'Field 4 (raw)',
+                    'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/notesPasswordProtected.py
+++ b/scripts/artifacts/notesPasswordProtected.py
@@ -1,0 +1,152 @@
+__artifacts_v2__ = {
+    "notesPasswordProtected": {
+        "name": "Notes - Password Protected",
+        "description": "Locked Apple Notes: the password hint and the encryption scheme guarding "
+                       "each note, so an examiner can tell at a glance which locked notes are "
+                       "recoverable and which are not.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Notes",
+        "notes": "The main Notes artifact reports that a note is locked but not how it is locked. "
+                 "This surfaces ZPASSWORDHINT and classifies the per-note crypto: a 24-byte "
+                 "wrapped key with a PBKDF2 iteration count is the documented scheme "
+                 "(PBKDF2-SHA256 -> AES Key Wrap -> AES-GCM) and is recoverable with the note "
+                 "password; a 16-byte wrapped key is the revised scheme seen from iOS 16 onward "
+                 "and is not recoverable with that method. The scheme tracks how the note was "
+                 "locked, not the iOS version, so both appear across the same releases. Note body "
+                 "and title stay encrypted; this artifact does not attempt to decrypt them.",
+        "paths": ('*/NoteStore.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "lock",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 0 rows",
+            "hickman_ios13": "iOS 13.3.1 | 2 rows (classic)",
+            "hickman_ios14": "iOS 14.3 | 0 rows (no crypto columns)",
+            "jess_ios15": "iOS 15.0.2 | 0 rows",
+            "hickman_ios15": "iOS 15 | 5 rows (classic)",
+            "abe_ios16": "iOS 16.5 | 2 rows (revised)",
+            "felix23_ios16": "iOS 16.5 | 0 rows",
+            "magnet_ios16": "iOS 16.1.1 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 7 rows (revised)",
+            "otto_ios17": "iOS 17.5.1 | 5 rows (classic)",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 2 rows (revised)",
+            "iphone12_ios18": "iOS 18.7 | 19 rows (revised)",
+            "hc_ios18_7": "iOS 18.7.8 | 9 rows (revised)",
+        }
+    }
+}
+
+from scripts.ilapfuncs import (artifact_processor, convert_cocoa_core_data_ts_to_utc,
+                               does_table_exist_in_db, get_sqlite_db_records, logfunc)
+
+TABLE = 'ZICCLOUDSYNCINGOBJECT'
+
+# The documented scheme wraps a 16-byte note key with AES Key Wrap, which is 24 bytes
+# on disk, and derives the wrapping key with PBKDF2. The revised scheme, seen from
+# iOS 16 onward, stores a 16-byte wrapped key with the iteration count zeroed.
+CLASSIC_WRAPPED_LEN = 24
+REVISED_WRAPPED_LEN = 16
+
+
+def _existing_columns(file_found):
+    """Return the set of ZICCLOUDSYNCINGOBJECT column names present in this db."""
+    return {row[0] for row in get_sqlite_db_records(
+        file_found, f"SELECT name FROM pragma_table_info('{TABLE}')")}
+
+
+def _first_present(columns, *candidates):
+    """First candidate column that exists, or 'NULL' so the SELECT still binds."""
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+    return 'NULL'
+
+
+def _classify(wrapped_len):
+    """Name the encryption scheme and say whether the note is recoverable.
+
+    The wrapped-key length is the reliable discriminator: AES Key Wrap of a
+    16-byte note key is 24 bytes, while the revised scheme stores 16. The
+    iteration count moves with it (20000 vs 0) but is reported as data rather
+    than used to classify, since only the length is load-bearing.
+    """
+    if wrapped_len == CLASSIC_WRAPPED_LEN:
+        return ('Classic (PBKDF2-SHA256 + AES Key Wrap)',
+                'Recoverable with the note password')
+    if wrapped_len == REVISED_WRAPPED_LEN:
+        return ('Revised (iOS 16+), 16-byte wrapped key',
+                'Not recoverable with the published method')
+    if wrapped_len:
+        return (f'Unrecognized ({wrapped_len}-byte wrapped key)', 'Unknown')
+    # A locked note always carries a wrapped key; a hint with no key is the
+    # password-group definition row rather than an encrypted note.
+    return ('Password group definition (no per-note key)', 'n/a')
+
+
+@artifact_processor
+def notesPasswordProtected(context):
+    data_headers = (
+        ('Creation Date', 'datetime'), ('Last Modified', 'datetime'), 'Note Title',
+        'Password Hint', 'Encryption Scheme', 'KDF Iterations', 'Wrapped Key Bytes',
+        'Recoverability', 'Note Row ID')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.sqlite'):
+            continue
+        if not does_table_exist_in_db(file_found, TABLE):
+            continue
+
+        columns = _existing_columns(file_found)
+        if 'ZISPASSWORDPROTECTED' not in columns:
+            continue  # schema predates locked notes; nothing to report
+
+        creation = _first_present(columns, 'ZCREATIONDATE3', 'ZCREATIONDATE2',
+                                  'ZCREATIONDATE1', 'ZCREATIONDATE')
+        modified = _first_present(columns, 'ZMODIFICATIONDATE3', 'ZMODIFICATIONDATE2',
+                                  'ZMODIFICATIONDATE1', 'ZMODIFICATIONDATE')
+        title = _first_present(columns, 'ZTITLE1', 'ZTITLE2', 'ZTITLE')
+        hint = _first_present(columns, 'ZPASSWORDHINT')
+        wrapped = _first_present(columns, 'ZCRYPTOWRAPPEDKEY')
+        iterations = _first_present(columns, 'ZCRYPTOITERATIONCOUNT')
+
+        query = f'''
+            SELECT {creation}, {modified}, {title}, {hint},
+                   LENGTH({wrapped}), {iterations}, Z_PK
+            FROM {TABLE}
+            WHERE ZISPASSWORDPROTECTED = 1
+              AND ({wrapped} IS NOT NULL OR {hint} IS NOT NULL)
+            ORDER BY {creation}
+        '''
+        rows = list(get_sqlite_db_records(file_found, query))
+        if not rows:
+            continue
+
+        for created, changed, note_title, note_hint, wrapped_len, iters, row_id in rows:
+            scheme, recoverability = _classify(wrapped_len or 0)
+            data_list.append((
+                convert_cocoa_core_data_ts_to_utc(created) if created else '',
+                convert_cocoa_core_data_ts_to_utc(changed) if changed else '',
+                note_title or '',            # title is itself encrypted, so usually blank
+                note_hint or '',
+                scheme,
+                iters if iters is not None else '',
+                wrapped_len if wrapped_len else '',
+                recoverability,
+                row_id))
+
+        sources.append(context.get_relative_path(file_found))
+
+    if data_list:
+        recoverable = sum(1 for row in data_list if row[7].startswith('Recoverable'))
+        logfunc(f'Notes: {len(data_list)} password-protected note(s), '
+                f'{recoverable} in the recoverable scheme')
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## What

The existing Notes artifact tells you a note is locked, but not *how* it's locked — so an examiner can't tell a recoverable note from an unrecoverable one without opening `NoteStore.sqlite` by hand. This adds a focused triage artifact.

Per locked note it reports the password hint (`ZPASSWORDHINT`), the encryption scheme (classified from `LENGTH(ZCRYPTOWRAPPEDKEY)`), the KDF iteration count, the wrapped-key length, a recoverability verdict, and creation/modified/row-id for correlation with the main Notes artifact.

## Why the wrapped-key length is the discriminator

The documented Apple Notes scheme derives a KEK with PBKDF2-SHA256, unwraps a 16-byte note key with AES Key Wrap (**24 bytes** on disk), and decrypts the body with AES-GCM. A second scheme stores a **16-byte** wrapped key with the iteration count zeroed. The 24-byte scheme is openable with the note password; the 16-byte one is not, with the published method.

Auditing all 15 corpus images showed this **tracks how the note was locked, not the iOS version**: the 24-byte scheme appears on iOS 13, 15 and 17.5, while the 16-byte scheme appears from iOS 16.5 through 18.7. Classifying per note rather than per release is therefore deliberate.

## Verification

Run through iLEAPP on every corpus image with locked notes; `sample_data` counts are the observed values:

| image | iOS | rows | scheme |
|---|---|---|---|
| hickman | 13.3.1 | 2 | classic (recoverable) |
| hickman | 15 | 5 | classic |
| abe | 16.5 | 2 | revised |
| iphone11 | 17.3 | 7 | revised |
| otto | 17.5.1 | 5 | classic |
| dexter | 18.3.2 | 2 | revised |
| iphone12 | 18.7 | 19 | revised |
| hc | 18.7.8 | 9 | revised |

otto's five notes are marked recoverable with hint `same phone pwd`; iphone12 shows 18 revised notes marked not-recoverable plus one password-group definition row, all hinted `bake`. Note titles and bodies stay encrypted — this reports *about* the locked notes, it does not decrypt them.

Schema drift across iOS versions (creation/modification/title column suffixes) is handled by probing which column exists, and the artifact no-ops cleanly on schemas that predate locked notes.

pylint 10.00/10, `python -m unittest discover -s admin/test/scripts` 33/33 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)