### PR TITLE
fix: stop one malformed record from emptying Biome - Intents

### DIFF
--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -4,10 +4,14 @@ __artifacts_v2__ = {
         "description": "Parses app intent entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Biome",
-        "notes": "",
+        "notes": "Each record is parsed independently: a record that cannot be decoded is "
+                 "logged with its file and offset and skipped, so one malformed entry no "
+                 "longer discards the rest of the stream. Intent payloads are app-authored "
+                 "and their inner shape varies by app and iOS version, so an app branch that "
+                 "cannot read its own payload still emits the record metadata.",
         "paths": (
             '*/AppIntent/local/*',
             '*/streams/*/App.Intent/local/*',
@@ -28,7 +32,9 @@ __artifacts_v2__ = {
 }
 
 import os
+import struct
 from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import convert_time_obj_to_utc, get_plist_content, logfunc, artifact_processor
@@ -36,9 +42,198 @@ from scripts.html_safe import esc, safe_source
 
 from datetime import datetime as _dt
 
+_RECORD_ERRORS = (DecodeError, struct.error, AttributeError, KeyError, ValueError,
+                  TypeError, IndexError, UnicodeDecodeError)
+
+
 def _safe_time_obj(value):
     """Set UTC tzinfo on datetime objects; pass strings/None through unchanged."""
     return convert_time_obj_to_utc(value) if isinstance(value, _dt) else value
+
+
+def _intent_payload(deserialized_plist):
+    """Return the raw inner intent protobuf bytes, or None when absent."""
+    intent = deserialized_plist.get('intent')
+    backing_store = intent.get('backingStore') if isinstance(intent, dict) else None
+    raw = backing_store.get('bytes') if isinstance(backing_store, dict) else None
+    return raw if isinstance(raw, bytes) else None
+
+
+def _notes_data(protostuffinner):
+    """Notes intents carry field 2 either as a submessage or as raw bytes."""
+    first = protostuffinner.get('1')
+    action = first.get('16') if isinstance(first, dict) else None
+    action = action.decode() if isinstance(action, bytes) else ('' if action is None else action)
+    second = protostuffinner.get('2')
+    if isinstance(second, dict):
+        field_one, field_two = second.get('1'), second.get('2')
+    else:
+        field_one = second.decode('latin-1') if isinstance(second, bytes) else second
+        field_two = ''
+    return f'Action: {action}, Data Field 1: {field_one}, Data Field 2: {field_two}'
+
+
+def _parse_record(protostuff, filename, offset):
+    """Build the plain and HTML rows for one intent record, or None to skip it."""
+    typeofintent = protostuff.get('2', '')
+    try:
+        typeofintent = typeofintent.decode()
+    except (AttributeError, UnicodeDecodeError):
+        logfunc(f'Biome Intents: record at offset {offset} in {filename} skipped, '
+                'app id is not a decodable string')
+        return None
+    appid = typeofintent
+
+    classname = (protostuff.get('4', ''))
+    try:
+        classname = classname.decode()
+    except (AttributeError, UnicodeDecodeError):
+        pass
+
+    action = protostuff.get('5')
+
+    deserialized_plist = get_plist_content(protostuff.get('8'))
+    if not deserialized_plist or not isinstance(deserialized_plist, dict):
+        logfunc(f'Biome Intents: record at offset {offset} in {filename} skipped, '
+                'intent plist could not be deserialized')
+        return None
+
+    date_interval = deserialized_plist.get('dateInterval')
+    if not isinstance(date_interval, dict):
+        date_interval = {}
+    startdate = _safe_time_obj(date_interval.get('NS.startDate'))
+    enddate = _safe_time_obj(date_interval.get('NS.endDate'))
+    durationinterval = date_interval.get('NS.duration')
+
+    donatedbysiri = 'True' if deserialized_plist.get('_donatedBySiri') else 'False'
+    groupid = deserialized_plist.get('groupIdentifier', '')
+
+    direction = deserialized_plist.get('direction')
+    if direction == 0:
+        direction = 'Unspecified'
+    elif direction == 1:
+        direction = 'Outgoing'
+    elif direction == 2:
+        direction = 'Incoming'
+
+    raw_intent = _intent_payload(deserialized_plist)
+    if raw_intent is None:
+        logfunc(f'Biome Intents: record at offset {offset} in {filename} skipped, '
+                'intent backing store holds no bytes')
+        return None
+    protostuffinner, _ = blackboxprotobuf.decode_message(raw_intent)
+
+    # Defaults, so an app branch that cannot read its own payload still returns a row
+    # carrying the record metadata instead of raising.
+    datos = ''
+    datoshtml = 'Unsupported intent.'
+
+    try:
+        #Instagram
+        if typeofintent == 'com.burbn.instagram':
+            datos = raw_intent.decode('latin-1')
+            datoshtml = safe_source(datos)
+
+        #snapchat
+        elif typeofintent == 'com.toyopagroup.picaboo':
+            datos = raw_intent.decode('latin-1')
+            datoshtml = safe_source(datos)
+
+        #notes
+        elif typeofintent == 'com.apple.assistant_service':
+            datos = raw_intent.decode('latin-1')
+            datoshtml = safe_source(datos)
+
+        #notes
+        elif typeofintent == 'com.apple.mobilenotes':
+            datos = _notes_data(protostuffinner)
+            datoshtml = (esc(datos).replace(',', '<br>'))
+
+        #telegraph
+        elif typeofintent == 'ph.telegra.Telegraph':
+            datos = raw_intent.decode('latin-1')
+            datoshtml = safe_source(datos)
+
+        #calls
+        elif typeofintent == 'com.apple.InCallService':
+            a = ''
+            try:
+                a = (protostuffinner['5']['1']['4'].decode()) #content number
+            except (KeyError, TypeError, AttributeError, UnicodeDecodeError):
+                pass
+
+            datos = f'Number: {a}'
+            datoshtml = (esc(datos).replace(',', '<br>'))
+
+        #whatsapp
+        elif typeofintent == 'net.whatsapp.WhatsApp':
+            datos = str(protostuffinner)
+            datoshtml = safe_source(datos)
+
+        elif typeofintent == 'org.whispersystems.signal':
+            datos = str(protostuffinner)
+            datoshtml = safe_source(datos)
+
+        #sms
+        elif typeofintent == 'com.apple.MobileSMS':
+            if protostuffinner.get('5', '') != '':
+                if type(protostuffinner['5']['1']['2']) is not dict:
+                    a = protostuffinner['5']['1']['2'].decode()
+                else:
+                    a = protostuffinner['5']['1']['2']
+
+                b = (protostuffinner.get('8', ''))#threadid
+
+                c = (protostuffinner.get('15', ''))#senderid if not binary show dict
+
+                datos = f'Thread ID: {b}, Sender ID: {c}, Content:, {a}'
+                datoshtml = (esc(datos).replace(',', '<br>'))
+
+        #maps
+        elif typeofintent == 'com.apple.Maps':
+            if (protostuffinner['4'][0]['2']['2']['2']) == b'com.apple.Maps':
+                a = (protostuffinner['3'].decode()) #action
+                b = (protostuffinner['1']['16'].decode()) #value
+
+                c = (protostuffinner['4'][0]['1'].decode())#source
+                d = (protostuffinner['4'][0]['2']['2']['2'].decode()) #value of above
+
+                e = (protostuffinner['4'][1]['1'].decode()) #nav_identifier
+                f = (protostuffinner['4'][1]['2']['2']['2'].decode()) #value of above
+
+                g = (protostuffinner['4'][2]['1'].decode()) #navigation_type
+                h = (protostuffinner['4'][2]['2']['2']['2'].decode()) #value of above
+
+                datos = f'{a}: {b}, {c}: {d}, {e}: {f}, {g}: {h}'
+                datoshtml = (esc(datos).replace(',', '<br>'))
+
+            else:
+                datos = ''
+                a = (protostuffinner['3'].decode()) #action
+                b = (protostuffinner['1']['16'].decode()) #value
+
+                datos = datos + f'{a}: {b},'
+
+                for loopy in protostuffinner['4']:
+                    a = loopy['1'].decode()
+                    try:
+                        b = loopy['2']['2']['2']
+                    except (KeyError, TypeError):
+                        b = loopy['2']
+                    datos = datos + f'{a}: {b},'
+
+                datoshtml = (esc(datos).replace(',', '<br>'))
+    except _RECORD_ERRORS as ex:
+        logfunc(f'Biome Intents: record at offset {offset} in {filename} kept without intent '
+                f'data, {appid} payload could not be read, {type(ex).__name__}: {ex}')
+        datos = ''
+        datoshtml = 'Intent data could not be parsed.'
+
+    row = (startdate, enddate, durationinterval, donatedbysiri, appid, classname, action,
+           direction, groupid, datos, filename, offset)
+    row_html = (startdate, enddate, durationinterval, donatedbysiri, appid, classname, action,
+                direction, groupid, datoshtml, filename, offset)
+    return row, row_html
 
 
 @artifact_processor
@@ -63,182 +258,20 @@ def get_biomeIntents(context):
             continue
 
         for record in read_segb_file(file_found):
-            if record.state == EntryState.Written:
+            if record.state != EntryState.Written:
+                continue
+            offset = record.data_start_offset
+            try:
                 protostuff, _ = blackboxprotobuf.decode_message(record.data)
-                offset = record.data_start_offset
+                parsed = _parse_record(protostuff, filename, offset)
+            except _RECORD_ERRORS as ex:
+                logfunc(f'Biome Intents: record at offset {offset} in {filename} skipped, '
+                        f'{type(ex).__name__}: {ex}')
+                continue
+            if parsed is None:
+                continue
+            row, row_html = parsed
+            data_list.append(row)
+            data_list_html.append(row_html)
 
-                typeofintent = protostuff.get('2','')
-                try:
-                    typeofintent = typeofintent.decode()
-                except (AttributeError, UnicodeDecodeError):
-                    break
-                appid = typeofintent
-
-                #print(protostuff['3']) #always says intents
-
-                classname = (protostuff.get('4',''))
-                try:
-                    classname = classname.decode()
-                except (AttributeError, UnicodeDecodeError):
-                    pass
-
-                if protostuff.get('5') is not None:
-                    action = protostuff.get('5')
-                else:
-                    action = protostuff.get('5')
-                #print(protostuff['6']) #unknown
-                #print(protostuff['7']) #unknown
-
-                #deserialized_plist = nd.deserialize_plist_from_string(protostuff['8'])
-                deserialized_plist = get_plist_content(protostuff['8'])
-                if not deserialized_plist or not isinstance(deserialized_plist, dict):
-                    logfunc('Problemitas')
-                    continue
-
-                startdate = (deserialized_plist['dateInterval']['NS.startDate'])
-                startdate = _safe_time_obj(startdate)
-
-                enddate = (deserialized_plist['dateInterval']['NS.endDate'])
-                enddate = _safe_time_obj(enddate)
-
-                durationinterval = (deserialized_plist['dateInterval']['NS.duration'])
-                donatedbysiri = 'True' if deserialized_plist['_donatedBySiri'] else 'False'
-                groupid = (deserialized_plist['groupIdentifier'])
-                #ident = (deserialized_plist['identifier'])
-                direction = (deserialized_plist['direction'])
-                if direction == 0:
-                    direction = 'Unspecified'
-                elif direction == 1:
-                    direction = 'Outgoing'
-                elif direction == 2:
-                    direction = 'Incoming'
-
-                protostuffinner = (deserialized_plist['intent']['backingStore']['bytes'])
-                protostuffinner, _ = blackboxprotobuf.decode_message(protostuffinner)
-
-
-                #Instagram
-                if typeofintent == 'com.burbn.instagram':
-                    datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
-                    datos = datoshtml
-                    datoshtml = safe_source(datoshtml)
-
-                #snapchat
-                elif typeofintent == 'com.toyopagroup.picaboo':
-                    datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
-                    datos = datoshtml
-                    datoshtml = safe_source(datoshtml)
-
-                #notes
-                elif typeofintent == 'com.apple.assistant_service':
-                    datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
-                    datos = datoshtml
-                    datoshtml = safe_source(datoshtml)
-
-                #notes
-                elif typeofintent == 'com.apple.mobilenotes':
-                    a = (protostuffinner['1']['16'].decode()) #create
-                    b = (protostuffinner['2']['1']) #message
-                    c = (protostuffinner['2']['2']) #message
-
-                    datos = f'Action: {a}, Data Field 1: {b}, Data Field 2: {c}'
-                    datoshtml = (esc(datos).replace(',', '<br>'))
-
-                #telegraph
-                elif typeofintent == 'ph.telegra.Telegraph':
-                    datoshtml = deserialized_plist['intent']['backingStore']['bytes'].decode('latin-1')
-                    datos = datoshtml
-                    datoshtml = safe_source(datoshtml)
-
-                #calls
-                elif typeofintent == 'com.apple.InCallService':
-                    #print(protostuffinner)
-                    a = ''
-                    try:
-                        a = (protostuffinner['5']['1']['4'].decode()) #content number
-                    except (KeyError, TypeError, AttributeError, UnicodeDecodeError):
-                        pass
-                        #print(protostuffinner)
-
-                    datos = f'Number: {a}'
-                    datoshtml = (esc(datos).replace(',', '<br>'))
-
-                #whatsapp
-                elif typeofintent == 'net.whatsapp.WhatsApp':
-                    datoshtml = str(protostuffinner)
-                    datos = datoshtml
-                    datoshtml = safe_source(datoshtml)
-
-                elif typeofintent == 'org.whispersystems.signal':
-                    datoshtml = str(protostuffinner)
-                    datos = datoshtml
-                    datoshtml = safe_source(datoshtml)
-
-                #sms
-                elif typeofintent == 'com.apple.MobileSMS':
-                    if protostuffinner.get('5', '') != '':
-                        if type(protostuffinner['5']['1']['2']) is not dict:
-                            a = protostuffinner['5']['1']['2'].decode()
-                        else:
-                            a = protostuffinner['5']['1']['2']
-
-                        #a = (protostuffinner['5']['1']['2']) #content
-
-                        b = (protostuffinner.get('8', ''))#threadid
-
-                        c = (protostuffinner.get('15', ''))#senderid if not binary show dict
-                        try:
-                            d = (protostuffinner['2']['1']['4'])
-                        except (KeyError, TypeError):
-                            d = ''
-
-                        datos = f'Thread ID: {b}, Sender ID: {c}, Content:, {a}'
-                        datoshtml = (esc(datos).replace(',', '<br>'))
-                    else:
-                        print('Mobile SMS' + str(protostuffinner))
-                #maps
-                elif typeofintent == 'com.apple.Maps':
-                    #print(protostuffinner)
-                    if (protostuffinner['4'][0]['2']['2']['2']) == b'com.apple.Maps':
-                        a = (protostuffinner['3'].decode()) #action
-                        b = (protostuffinner['1']['16'].decode()) #value
-
-                        c = (protostuffinner['4'][0]['1'].decode())#source
-                        d = (protostuffinner['4'][0]['2']['2']['2'].decode()) #value of above
-
-                        e = (protostuffinner['4'][1]['1'].decode()) #nav_identifier
-                        f = (protostuffinner['4'][1]['2']['2']['2'].decode()) #value of above
-
-                        g = (protostuffinner['4'][2]['1'].decode()) #navigation_type
-                        h = (protostuffinner['4'][2]['2']['2']['2'].decode()) #value of above
-
-                        datos = f'{a}: {b}, {c}: {d}, {e}: {f}, {g}: {h}'
-                        datoshtml = (esc(datos).replace(',', '<br>'))
-
-                    else:
-                        datos = ''
-                        a = (protostuffinner['3'].decode()) #action
-                        b = (protostuffinner['1']['16'].decode()) #value
-
-                        datos = datos + f'{a}: {b},'
-
-                        for loopy in protostuffinner['4']:
-                            a = loopy['1'].decode()
-                            try:
-                                b = loopy['2']['2']['2']
-                            except (KeyError, TypeError):
-                                b = loopy['2']
-                            datos = datos + f'{a}: {b},'
-
-                        datoshtml = (esc(datos).replace(',', '<br>'))
-
-                        #logfunc('Maps' + str(protostuffinner))
-
-                else:
-                    datos = ''
-                    datoshtml = 'Unsupported intent.'
-
-                data_list_html.append((startdate, enddate, durationinterval, donatedbysiri, appid, classname, action, direction, groupid, datoshtml, filename, offset))
-                data_list.append((startdate, enddate, durationinterval, donatedbysiri, appid, classname, action, direction, groupid, datos, filename, offset))
-    
     return data_headers, (data_list, data_list_html), 'see Filename for more info'


### PR DESCRIPTION
## The report

Mattia Epifani hit this on his own extraction: the run log showed `23 files for regex */streams/*/App.Intent/local/*`, so discovery worked, but **Biome - Intents produced no output** and so did not appear in the report at all.

## The cause

The per-record work ran unguarded inside the file loop, so the first record that did not match an app branch's assumed shape raised and **aborted the whole artifact**. On this data the culprit was the `com.apple.mobilenotes` branch:

```python
b = (protostuffinner['2']['1'])   # field 2 was raw bytes, not a submessage
# TypeError: byte indices must be integers or slices, not str
```

**Eight such records out of 5,073 discarded every single row.** Nothing appeared in the log because the artifact never reached its return — which is exactly why the run looked like a clean parse with no output. That is the worst failure mode for a forensic tool: silent, total, and indistinguishable from "this device has no data".

## The fix

The important change is structural, not the one-line type bug:

- Per-record parsing moved into a helper and wrapped, so **a bad record costs that record**, logged with its file and offset.
- The app-branch chain gets its own guard: a payload that cannot be read still yields a row with the record metadata and the data column marked unparsed, rather than losing the record entirely.
- `com.apple.mobilenotes` now handles field 2 as either a submessage or raw bytes.
- The app-id decode failure was a **`break`** — abandoning the rest of the file — now a logged `continue`.
- Plist keys (`dateInterval`, `_donatedBySiri`, `groupIdentifier`, `direction`) read via `.get`, and the intent backing store is type-checked, so a future layout change skips one record with a stated reason instead of raising.
- Dropped a stray debug `print` in the SMS branch that could leave `datos` undefined, plus two unused locals.

## Validation

| Input | Before | After |
|---|---|---|
| Reported sample (20 stream files, 5,073 written records) | **0 rows** (crash) | **5,073 rows** |
| iOS 18.7.8 public corpus | 17 rows | 17 rows |
| iOS 17.3 public corpus | 90 rows | 90 rows |

No records skipped and no unreadable payloads on the reported sample — the notes fix recovers all of them. Full `ileapp.py` run completes and the report carries 5,073 rows. `pylint --disable=C,R` reports 10.00/10; blackboxprotobuf guard passes.

Test data was a private sample, so it is not registered in the corpus and carries no `sample_data` entry; nothing derived from its contents appears here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)