### PR TITLE
feat: add nine Biome artifacts including the Apple Intelligence family

### DIFF
--- a/scripts/artifacts/biomeAppInstallation.py
+++ b/scripts/artifacts/biomeAppInstallation.py
@@ -1,0 +1,113 @@
+__artifacts_v2__ = {
+    "get_biomeAppInstallation": {
+        "name": "Biome - App Installation",
+        "description": "Parses app installation events from the App.Installation biome stream: "
+                       "the bundle identifier, the app's install UUID, its short and build "
+                       "version, and the time the event was recorded. Complements the older "
+                       "App.Install and _DKEvent.App.Install streams.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The event type field takes values 1, 2 and 3 in the sample; which of install, "
+                 "update and removal each denotes is not confirmed, so the raw value is "
+                 "reported. Two 16 byte values accompany each event and are surfaced as hex "
+                 "digests; their role is not established.",
+        "paths": ('*/streams/*/App.Installation/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "download",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.hex()
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _hexed(value):
+    return value.hex() if isinstance(value, bytes) else ''
+
+
+def _unix_double(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<Q', value & 0xFFFFFFFFFFFFFFFF))[0]
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeAppInstallation(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'App Installation: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                app = protostuff.get('1', {})
+                if not isinstance(app, dict):
+                    app = {}
+                detail = protostuff.get('3', {})
+                if not isinstance(detail, dict):
+                    detail = {}
+
+                data_list.append((ts, _unix_double(protostuff.get('4')),
+                                  _unix_double(detail.get('1')), record.state.name,
+                                  _to_str(app.get('1')), _to_str(app.get('2')),
+                                  _to_str(detail.get('3')), _to_str(detail.get('2')),
+                                  protostuff.get('2', ''), _hexed(detail.get('4')),
+                                  _hexed(detail.get('5')), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, None, record.state.name, None, None, None, None,
+                                  None, None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Event Timestamp', 'datetime'),
+                    ('App Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'App UUID',
+                    'Version', 'Build Version', 'Event Type (raw)', 'Digest 1', 'Digest 2',
+                    'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeAppRelevantShortcuts.py
+++ b/scripts/artifacts/biomeAppRelevantShortcuts.py
@@ -1,0 +1,127 @@
+__artifacts_v2__ = {
+    "get_biomeAppRelevantShortcuts": {
+        "name": "Biome - App Relevant Shortcuts",
+        "description": "Parses relevant shortcuts donated by apps from the "
+                       "App.RelevantShortcuts biome stream: the donating app, the widget the "
+                       "shortcut was offered for, and the relevance window the app suggested "
+                       "the shortcut should appear in.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Each record embeds an NSKeyedArchiver plist holding the shortcut. The widget "
+                 "kind, shortcut role and the relevance provider date window are surfaced; the "
+                 "nested intent payload inside the shortcut is not currently unpacked.",
+        "paths": ('*/streams/*/App.RelevantShortcuts/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "zap",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime as _dt
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import (artifact_processor, convert_time_obj_to_utc, get_plist_content,
+                               logfunc)
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _safe_time_obj(value):
+    return convert_time_obj_to_utc(value) if isinstance(value, _dt) else None
+
+
+def _relevance_window(plist):
+    """Relevance providers carry the window the app wanted the shortcut shown in."""
+    providers = plist.get('relevanceProviders')
+    if isinstance(providers, dict):
+        providers = [providers]
+    if not isinstance(providers, list):
+        return None, None
+    for provider in providers:
+        if isinstance(provider, dict) and ('startDate' in provider or 'endDate' in provider):
+            return _safe_time_obj(provider.get('startDate')), _safe_time_obj(provider.get('endDate'))
+    return None, None
+
+
+def _shortcut_detail(plist):
+    shortcut = plist.get('shortcut')
+    if not isinstance(shortcut, dict):
+        return '', ''
+    title = shortcut.get('activitySubtitle') or shortcut.get('activityBundleIdentifier') or ''
+    intent = shortcut.get('intent')
+    intent_name = ''
+    if isinstance(intent, dict):
+        intent_name = _to_str(intent.get('intentClassName') or intent.get('donationMetadata') or '')
+    return _to_str(title), intent_name
+
+
+@artifact_processor
+def get_biomeAppRelevantShortcuts(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                    plist = get_plist_content(protostuff.get('3'))
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'App Relevant Shortcuts: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                if not isinstance(plist, dict):
+                    plist = {}
+                start, end = _relevance_window(plist)
+                title, intent_name = _shortcut_detail(plist)
+
+                data_list.append((ts, start, end, record.state.name,
+                                  _to_str(protostuff.get('1')),
+                                  _to_str(plist.get('widgetKind', '')),
+                                  plist.get('shortcutRole', ''), title, intent_name,
+                                  _to_str(plist.get('watchTemplate', '')), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, None, record.state.name, None, None, None, None,
+                                  None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Relevance Start', 'datetime'),
+                    ('Relevance End', 'datetime'), 'SEGB State', 'Bundle ID', 'Widget Kind',
+                    'Shortcut Role (raw)', 'Shortcut Title', 'Intent', 'Watch Template',
+                    'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeAppleIntelligence.py
+++ b/scripts/artifacts/biomeAppleIntelligence.py
@@ -1,0 +1,225 @@
+"""Apple Intelligence biome streams.
+
+The four AssetDeliveryLog streams share one wrapper: field 1 carries the event
+timestamp, a status code, a context submessage naming the feature or client and
+one key/value attribute, the OS build, and the asset identifiers; field 2 carries
+the delivery result.
+"""
+__artifacts_v2__ = {
+    "get_biomeAppleIntelligenceAvailability": {
+        "name": "Biome - Apple Intelligence Availability",
+        "description": "Parses Apple Intelligence availability state changes from the "
+                       "AppleIntelligence.Availability biome stream, including the language "
+                       "the feature was evaluated for.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The three state fields are reported raw; the sample does not establish which "
+                 "availability condition each denotes.",
+        "paths": ('*/streams/*/AppleIntelligence.Availability/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "cpu",
+    },
+    "get_biomeAIAssetAvailability": {
+        "name": "Biome - Apple Intelligence Asset Availability",
+        "description": "Parses Apple Intelligence asset availability reporting from the "
+                       "AppleIntelligence.Reporting.AssetDeliveryLog.Availability biome "
+                       "stream: the requesting client, the attribute it was evaluated against "
+                       "and the OS build at the time.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/AppleIntelligence.Reporting.AssetDeliveryLog.Availability/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "cpu",
+    },
+    "get_biomeAIModelCatalog": {
+        "name": "Biome - Apple Intelligence Model Catalog",
+        "description": "Parses Apple Intelligence model catalog activity from the "
+                       "AppleIntelligence.Reporting.AssetDeliveryLog.ModelCatalog biome "
+                       "stream. Each record names the Apple Intelligence feature whose model "
+                       "was requested, for example a text composition or summarisation "
+                       "feature, and the language it was requested for, which evidences which "
+                       "AI features were exercised on the device and when.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "This is the highest volume stream of the Apple Intelligence family.",
+        "paths": ('*/streams/*/AppleIntelligence.Reporting.AssetDeliveryLog.ModelCatalog/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "cpu",
+    },
+    "get_biomeAISoftwareUpdate": {
+        "name": "Biome - Apple Intelligence Software Update",
+        "description": "Parses Apple Intelligence software update controller reporting from "
+                       "the AppleIntelligence.Reporting.AssetDeliveryLog."
+                       "SoftwareUpdateController biome stream.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/AppleIntelligence.Reporting.AssetDeliveryLog.SoftwareUpdateController/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "cpu",
+    },
+    "get_biomeAIUnifiedAsset": {
+        "name": "Biome - Apple Intelligence Unified Asset",
+        "description": "Parses Apple Intelligence unified asset framework reporting from the "
+                       "AppleIntelligence.Reporting.AssetDeliveryLog.UnifiedAssetFramework "
+                       "biome stream: the asset requested, the client that requested it and "
+                       "the user id it was requested under.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "",
+        "paths": ('*/streams/*/AppleIntelligence.Reporting.AssetDeliveryLog.UnifiedAssetFramework/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "cpu",
+    },
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _unix_double(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<Q', value & 0xFFFFFFFFFFFFFFFF))[0]
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _iter_records(context, label):
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'{label}: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+                yield ts, record, protostuff, filename
+            elif record.state == EntryState.Deleted:
+                yield ts, record, None, filename
+
+
+def _delivery_log(context, label):
+    """Shared parser for the four AssetDeliveryLog streams."""
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Event Timestamp', 'datetime'),
+                    'SEGB State', 'Feature or Client', 'Attribute', 'Attribute Value',
+                    'Requesting Client', 'Asset ID', 'Asset Category', 'OS Build',
+                    'User ID', 'Status (raw)', 'Result (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _iter_records(context, label):
+        if protostuff is None:
+            data_list.append((ts, None, record.state.name, None, None, None, None, None, None,
+                              None, None, None, None, filename, record.data_start_offset))
+            continue
+
+        event = protostuff.get('1', {})
+        if not isinstance(event, dict):
+            event = {}
+        context_msg = event.get('3', {})
+        if not isinstance(context_msg, dict):
+            context_msg = {}
+        attribute = context_msg.get('2', {})
+        if not isinstance(attribute, dict):
+            attribute = {}
+        result = protostuff.get('2', {})
+
+        data_list.append((ts, _unix_double(event.get('1')), record.state.name,
+                          _to_str(context_msg.get('1')), _to_str(attribute.get('1')),
+                          _to_str(attribute.get('2')), _to_str(event.get('5')),
+                          _to_str(event.get('8')), _to_str(event.get('9')),
+                          _to_str(event.get('7')), event.get('10', ''),
+                          event.get('2', ''), str(result) if result else '',
+                          filename, record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeAppleIntelligenceAvailability(context):
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Language',
+                    'State 1 (raw)', 'State 2 (raw)', 'State 3 (raw)', 'Filename', 'Offset')
+    data_list = []
+    for ts, record, protostuff, filename in _iter_records(context,
+                                                          'Apple Intelligence Availability'):
+        if protostuff is None:
+            data_list.append((ts, record.state.name, None, None, None, None, filename,
+                              record.data_start_offset))
+            continue
+        first = protostuff.get('1', {})
+        second = protostuff.get('2', {})
+        data_list.append((ts, record.state.name, _to_str(protostuff.get('6')),
+                          first.get('1', '') if isinstance(first, dict) else first,
+                          second.get('1', '') if isinstance(second, dict) else second,
+                          protostuff.get('3', ''), filename, record.data_start_offset))
+    return data_headers, data_list, 'see Filename for more info'
+
+
+@artifact_processor
+def get_biomeAIAssetAvailability(context):
+    return _delivery_log(context, 'Apple Intelligence Asset Availability')
+
+
+@artifact_processor
+def get_biomeAIModelCatalog(context):
+    return _delivery_log(context, 'Apple Intelligence Model Catalog')
+
+
+@artifact_processor
+def get_biomeAISoftwareUpdate(context):
+    return _delivery_log(context, 'Apple Intelligence Software Update')
+
+
+@artifact_processor
+def get_biomeAIUnifiedAsset(context):
+    return _delivery_log(context, 'Apple Intelligence Unified Asset')

--- a/scripts/artifacts/biomePhotosSearchInsights.py
+++ b/scripts/artifacts/biomePhotosSearchInsights.py
@@ -1,0 +1,102 @@
+__artifacts_v2__ = {
+    "get_biomePhotosSearchInsights": {
+        "name": "Biome - Photos Search Insights",
+        "description": "Parses Photos search terms from the "
+                       "AeroML.Insights.PhotosSearchInsights biome stream, along with the "
+                       "language and region the search was made in. The search term is text "
+                       "the user typed into the Photos app.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Remaining fields were constant across the sample and are reported raw.",
+        "paths": ('*/streams/*/AeroML.Insights.PhotosSearchInsights/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    }
+}
+
+
+import os
+import struct
+from datetime import timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {
+    '1': {'type': 'int', 'name': ''},
+    '3': {'type': 'int', 'name': ''},
+    '4': {'type': 'int', 'name': ''},
+    '5': {'type': 'int', 'name': ''},
+    '9': {'type': 'str', 'name': ''},
+    '22': {'type': 'str', 'name': ''},
+    '23': {'type': 'str', 'name': ''},
+    '24': {'type': 'str', 'name': ''},
+    '25': {'type': 'int', 'name': ''},
+    '26': {'type': 'int', 'name': ''},
+}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+@artifact_processor
+def get_biomePhotosSearchInsights(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Photos Search Insights: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                data_list.append((ts, record.state.name,
+                                  _to_str(protostuff.get('9', b'')),
+                                  _to_str(protostuff.get('22', b'')),
+                                  _to_str(protostuff.get('23', b'')),
+                                  _to_str(protostuff.get('24', b'')),
+                                  protostuff.get('1', ''), protostuff.get('5', ''),
+                                  protostuff.get('25', ''), protostuff.get('26', ''),
+                                  filename, record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, record.state.name, None, None, None, None, None, None,
+                                  None, None, filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Search Term', 'Language',
+                    'Region', 'Schema Version', 'Field 1 (raw)', 'Field 5 (raw)',
+                    'Field 25 (raw)', 'Field 26 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeShareSheetConversation.py
+++ b/scripts/artifacts/biomeShareSheetConversation.py
@@ -1,0 +1,108 @@
+__artifacts_v2__ = {
+    "get_biomeShareSheetConversation": {
+        "name": "Biome - Share Sheet Conversation",
+        "description": "Parses share sheet conversation targets from the "
+                       "MLSE.ShareSheet.ConversationUserInteraction biome stream: the app the "
+                       "share was directed to and the conversation identifier, which carries "
+                       "the recipient handle for Messages shares.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The conversation identifier follows the service;-;handle form used elsewhere "
+                 "in Messages data, so the handle is split out into its own column while the "
+                 "full identifier is retained. Field 10 varied across the sample and is "
+                 "reported raw.",
+        "paths": ('*/streams/*/MLSE.ShareSheet.ConversationUserInteraction/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "share-2",
+    }
+}
+
+
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+TYPESS = {'1': {'type': 'str', 'name': ''}, '2': {'type': 'str', 'name': ''},
+          '10': {'type': 'int', 'name': ''}}
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _handle(conversation_id):
+    """Conversation ids use the service;-;handle form."""
+    return conversation_id.rsplit(';-;', 1)[1] if ';-;' in conversation_id else ''
+
+
+def _unix_double(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<Q', value & 0xFFFFFFFFFFFFFFFF))[0]
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def get_biomeShareSheetConversation(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, TYPESS)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Share Sheet Conversation: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                conversation = _to_str(protostuff.get('2', b''))
+
+                data_list.append((ts, _unix_double(protostuff.get('11')), record.state.name,
+                                  _to_str(protostuff.get('1', b'')), _handle(conversation),
+                                  conversation, protostuff.get('10', ''), filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None,
+                                  filename, record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Interaction Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Recipient Handle', 'Conversation ID',
+                    'Field 10 (raw)', 'Filename', 'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## What

Closes the **four streams that were the last outstanding items** on the review list, plus **five Apple Intelligence streams** that arrived in the same batch.

| Artifact | Stream | Rows in sample |
|---|---|---|
| Apple Intelligence Model Catalog | `…AssetDeliveryLog.ModelCatalog` | 11,392 |
| Apple Intelligence Unified Asset | `…AssetDeliveryLog.UnifiedAssetFramework` | 2,122 |
| App Installation | `App.Installation` | 1,014 |
| Apple Intelligence Asset Availability | `…AssetDeliveryLog.Availability` | 735 |
| App Relevant Shortcuts | `App.RelevantShortcuts` | 646 |
| Apple Intelligence Availability | `AppleIntelligence.Availability` | 349 |
| Share Sheet Conversation | `MLSE.ShareSheet.ConversationUserInteraction` | 294 |
| Apple Intelligence Software Update | `…AssetDeliveryLog.SoftwareUpdateController` | 89 |
| Photos Search Insights | `AeroML.Insights.PhotosSearchInsights` | 41 |

### Highlights

**App Installation** is an install ledger — bundle id, install UUID, short and build version, and event time, covering **97 distinct apps** in the sample. It complements the older `App.Install` / `_DKEvent.App.Install` streams.

**Apple Intelligence Model Catalog** names the AI feature whose model was requested and the language it was requested for — **90 distinct features** in the sample, things like text-composition rewrite, summarisation, and image generation. That evidences which AI capabilities were exercised on a device and when, which is new ground for iOS forensics.

**Photos Search Insights** captures the text a user typed into Photos search, with language and region. **Share Sheet Conversation** names the target app and splits the recipient handle out of the `service;-;handle` conversation identifier. **App Relevant Shortcuts** unpacks the donated NSKeyedArchiver shortcut for widget kind, shortcut role and the relevance window.

The four `AssetDeliveryLog` streams share a single wrapper (event timestamp, status, a context submessage naming the feature or client with one key/value attribute, OS build, asset identifiers, delivery result), so they run through one common parser rather than four near-copies.

### Reported raw where unproven

The App Installation event type (values 1, 2 and 3 — which is install, update or removal is not established), the three Apple Intelligence availability state fields, and share sheet field 10. The notes say so in each case.

### Not built

`AppleIntelligence.Reporting.Buddy` held no records at all, and `AppleIntelligence.Reporting.SafetyOverrides` held only deleted records — neither offers a basis for field mapping.

## Validation

Harness run on the real sample: 9/9 artifacts, 0 failures, header/row width verified on every row, decoded values spot-checked. Full `ileapp.py` run completes with all nine populating (16,682 rows). `pylint --disable=C,R` reports 10.00/10; blackboxprotobuf guard passes.

Test data was a private sample: not registered in the corpus, no `sample_data` entries, and nothing derived from its contents appears in the code or this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)