### PR TITLE
feat: add Biome - Apple Intelligence Safety Overrides

### DIFF
--- a/scripts/artifacts/biomeAppleIntelligence.py
+++ b/scripts/artifacts/biomeAppleIntelligence.py
@@ -71,6 +71,29 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "cpu",
     },
+    "get_biomeAISafetyOverrides": {
+        "name": "Biome - Apple Intelligence Safety Overrides",
+        "description": "Parses Apple Intelligence safety override reporting from the "
+                       "AppleIntelligence.Reporting.SafetyOverrides biome stream. Records mark "
+                       "the times safety override reporting occurred, which is worth noting "
+                       "even where the payload itself no longer survives.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "The sample for this stream held only deleted records, so the written record "
+                 "layout is not confirmed. It is read with the shared AssetDeliveryLog parser "
+                 "because the partially recoverable deleted payloads carry the same field 1 "
+                 "event and field 3 context structure as the rest of that family; if a future "
+                 "sample shows a different layout the detail columns will be empty while the "
+                 "timestamps stay correct. Deleted payloads in the sample were largely "
+                 "overwritten and did not decode, but their SEGB timestamps are intact and "
+                 "still evidence that reporting occurred at those times.",
+        "paths": ('*/streams/*/AppleIntelligence.Reporting.SafetyOverrides/local/*',),
+        "output_types": "standard",
+        "artifact_icon": "shield",
+    },
     "get_biomeAIUnifiedAsset": {
         "name": "Biome - Apple Intelligence Unified Asset",
         "description": "Parses Apple Intelligence unified asset framework reporting from the "
@@ -223,3 +246,8 @@ def get_biomeAISoftwareUpdate(context):
 @artifact_processor
 def get_biomeAIUnifiedAsset(context):
     return _delivery_log(context, 'Apple Intelligence Unified Asset')
+
+
+@artifact_processor
+def get_biomeAISafetyOverrides(context):
+    return _delivery_log(context, 'Apple Intelligence Safety Overrides')


### PR DESCRIPTION
## What

Completes the `AppleIntelligence.Reporting.*` family started in #1783.

The sample for this stream held **only deleted records**, so the written-record layout is not confirmed. It is read with the shared `AssetDeliveryLog` parser because the partially recoverable deleted payloads carry the same field 1 event and field 3 context structure as the rest of that family. If a future sample shows a different layout the detail columns will be empty while the timestamps stay correct — the notes state this plainly rather than implying the mapping is settled.

Only 3 of 17 deleted payloads decoded at all, the rest having been overwritten. **The SEGB timestamps are intact regardless**, so the artifact still evidences that safety-override reporting occurred at those times and was subsequently purged — which is the useful part of a deleted-only stream.

`AppleIntelligence.Reporting.Buddy`, from the same batch, contains no records whatsoever and so remains unbuilt.

## Validation

17 rows parsed from the sample, header/row width verified, timestamps correct. `pylint --disable=C,R` reports 10.00/10.

Private sample: not registered in the corpus, no `sample_data` entry, nothing derived from its contents in the code or here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)