### PR TITLE
fix: keep Biome - Intents data column safe for delimited export

### DIFF
--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -46,9 +46,23 @@ _RECORD_ERRORS = (DecodeError, struct.error, AttributeError, KeyError, ValueErro
                   TypeError, IndexError, UnicodeDecodeError)
 
 
+_CONTROL_MAP = str.maketrans({'\t': '\\t', '\r': '\\r', '\n': '\\n', '\x00': ''})
+
+
 def _safe_time_obj(value):
     """Set UTC tzinfo on datetime objects; pass strings/None through unchanged."""
     return convert_time_obj_to_utc(value) if isinstance(value, _dt) else value
+
+
+def _delimited_safe(value):
+    """Keep intent payloads on one line and free of NULs.
+
+    Intent data is an app-authored blob, so it can carry tabs, line breaks and
+    NUL bytes. Those are legal in the HTML report but break or disfigure the TSV
+    export, and a writer configured without quoting rejects them outright.
+    Tabs and line breaks become their printable escapes so no content is lost.
+    """
+    return value.translate(_CONTROL_MAP) if isinstance(value, str) else value
 
 
 def _intent_payload(deserialized_plist):
@@ -230,7 +244,7 @@ def _parse_record(protostuff, filename, offset):
         datoshtml = 'Intent data could not be parsed.'
 
     row = (startdate, enddate, durationinterval, donatedbysiri, appid, classname, action,
-           direction, groupid, datos, filename, offset)
+           direction, groupid, _delimited_safe(datos), filename, offset)
     row_html = (startdate, enddate, durationinterval, donatedbysiri, appid, classname, action,
                 direction, groupid, datoshtml, filename, offset)
     return row, row_html


### PR DESCRIPTION
## The report

Mattia Epifani's run found all 2,358 records and then failed on export:

```
Found 2,358 records for Biome - Intents
Reading get_biomeIntents artifact had errors!
Error was need to escape, but no escapechar set
  File "scripts\ilapfuncs.py", line 847, in tsv
    tsv_writer.writerow(i)
_csv.Error: need to escape, but no escapechar set
```

Parsing was fine — I reproduced his exact record count from the same stream.

## What this fixes

The intent data column is an app-authored blob rendered with `str(protostuffinner)`, so it can carry raw control characters, and in his sample it did:

| Character | Cells |
|---|---|
| line break | 34 |
| NUL byte | 26 |
| tab | 7 |
| carriage return | 1 |

A tab **is** the TSV delimiter and a line break ends the record. Even when the writer quotes them the export is painful to consume — records span multiple physical lines, so any line-based tooling miscounts — and NUL bytes corrupt many downstream readers outright.

Tabs, carriage returns and line breaks in the plain-text column are now written as printable escapes and NUL bytes are dropped, so every record occupies exactly one line and no content is lost. **The HTML column is untouched**: the HTML report escapes it already and reads better with the original formatting.

Verified on the reported sample: the emitted TSV holds 2,358 records on 2,358 lines, consistent column counts, zero NUL bytes.

## Honest caveat: this may not be his whole root cause

The specific exception is raised **only** when the writer uses `csv.QUOTE_NONE`. I tested every trigger character against both dialects:

| Input | QUOTE_MINIMAL (what main uses) | QUOTE_NONE |
|---|---|---|
| tab / newline / CR / quote | quoted, fine | **need to escape, but no escapechar set** |

iLEAPP builds its writer as `csv.writer(tsvfile, delimiter='\t')` — the default `excel` dialect, `QUOTE_MINIMAL`. `QUOTE_NONE` has never appeared in `ilapfuncs.py` in its entire history, there is only one `tsv()` definition and one `csv.writer` in the tree, and nothing registers or overrides a dialect. On current main the same 2,358 rows export without error.

So this change removes three of the four trigger classes and is worth having regardless, but the double quotes in JSON payloads remain legitimate content that a correctly configured writer handles. **To close it out we need line 843 of the reporter's `scripts/ilapfuncs.py`** — if it differs from `csv.writer(tsvfile, delimiter='\t')`, that is the cause; if it matches, something in that environment is overriding the csv dialect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)