### PR TITLE
fix: silence the deserializer's unhashable key chatter

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -1,8 +1,10 @@
 # common standard imports
 import codecs  # pylint: disable=unused-import  # re-exported
+import contextlib
 import csv
 import hashlib
 import inspect
+import io
 import json
 import math
 import nska_deserialize
@@ -659,11 +661,25 @@ def get_txt_file_content(file_path):
         logfunc(f"Unexpected error reading file {file_path}: {str(e)}")
     return []
 
+def _deserialize_nska(data):
+    """Deserialize an NSKeyedArchiver payload without the dependency's console noise.
+
+    ccl_bplist.convert_NSMutableDictionary prints the exception whenever an
+    archived dictionary uses an unhashable key, despite its own comment saying it
+    ignores the condition. One artifact reading a few thousand such records emits
+    tens of thousands of lines, which buries the real log and, on a Windows
+    console, is slow enough to look like a hang. The condition is not actionable
+    from here, so the chatter is dropped while real errors still raise.
+    """
+    with contextlib.redirect_stdout(io.StringIO()):
+        return nska_deserialize.deserialize_plist_from_string(data)
+
+
 def get_plist_content(data):
     try:
         plist_content = plistlib.loads(data)
         if isinstance(plist_content, dict) and plist_content.get('$archiver', '') == 'NSKeyedArchiver':
-            return nska_deserialize.deserialize_plist_from_string(data)
+            return _deserialize_nska(data)
         return plist_content
     except plistlib.InvalidFileException:
         logfunc("Error: Invalid plist data")


### PR DESCRIPTION
## The report

Mattia Epifani's log was filled with bare lines like:

```
unhashable type: 'list'
unhashable type: 'list'
... (repeated)
Found 2,358 records for Biome - Intents
```

## Where it comes from

`ccl_bplist.convert_NSMutableDictionary`, reached via `nska_deserialize`. When an archived dictionary uses an unhashable key it prints the exception — directly contradicting its own comment:

```python
except (ValueError, TypeError) as ex:
    # Sometimes k is a dict, just silently ignore the TypeError about not being able to hash..
    print (ex)
```

It's a third-party package, not vendored here, so it can't be fixed in this tree.

## Why it matters

Measured on the reported sample: **one artifact reading 2,358 records emitted 13,121 of these lines.** That buries real log entries, and on a Windows console the sheer write volume is slow enough to look like a hang — which matches the "system looked frozen" part of the report, separate from the TSV failure fixed in #1785.

The message text varies by Python version (`unhashable type: 'list'` on his build, `cannot use 'list' as a dict key (unhashable type: 'list')` on 3.14), so this suppresses by capturing the stream rather than matching text.

## The change

`get_plist_content` routes the NSKeyedArchiver path through a small helper that discards the dependency's stdout. **Exceptions are untouched** — real deserialization failures still surface through the existing handlers — and the unhashable-key condition isn't actionable from iLEAPP anyway.

## Validation

- Noise on the reported sample: **13,121 lines → 0**, with the same 2,358 rows returned.
- Behaviour neutral: a full run over the public Biome corpora gives **identical row counts for every pre-existing artifact**; the only differences are artifacts added since that baseline.
- `pylint --disable=C,R` on the changed file: 10.00/10.

This touches shared code used by every artifact that reads NSKeyedArchiver plists, which is deliberate — they all currently inherit the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)