### PR TITLE
feat: add Biome - Siri Remembers Audio History

### DIFF
--- a/scripts/artifacts/biomeSiriRemembersAudioHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersAudioHistory.py
@@ -1,0 +1,160 @@
+__artifacts_v2__ = {
+    "get_biomeSiriRemembersAudioHistory": {
+        "name": "Biome - Siri Remembers Audio History",
+        "description": "Parses media playback intents from the Siri.Remembers.AudioHistory "
+                       "biome stream: the app that played the media, the title, artist and "
+                       "media type of what was played, and the app's own identifier for it. "
+                       "Audiobook and music playback both appear.",
+        "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Biome",
+        "notes": "Shares the intent record shape of the other Siri.Remembers streams. The "
+                 "media details come from a JSON attribute on the item entity; title, artist "
+                 "and media type were present on every record in the sample, with mediaName "
+                 "appearing on some. The media identifier is the playing app's own catalogue "
+                 "id, so for Audible it is the ASIN. The stream syncs between devices, so the "
+                 "Sync Origin column separates local records from ones received elsewhere.",
+        "paths": (
+            '*/streams/*/Siri.Remembers.AudioHistory/local/*',
+            '*/streams/*/Siri.Remembers.AudioHistory/remote/*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "headphones",
+    }
+}
+
+
+import json
+import os
+import struct
+from datetime import datetime, timezone
+
+from scripts import blackboxprotobuf
+from google.protobuf.message import DecodeError
+from scripts.ccl_segb.ccl_segb import read_segb_file
+from scripts.ccl_segb.ccl_segb_common import EntryState
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
+                  IndexError)
+
+
+def _to_str(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    if value is None or isinstance(value, (dict, list)):
+        return ''
+    return str(value)
+
+
+def _intent_timestamp(value):
+    if not isinstance(value, int) or value == 0:
+        return None
+    seconds = struct.unpack('<d', struct.pack('<Q', value & 0xFFFFFFFFFFFFFFFF))[0]
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _as_list(value):
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _media_details(protostuff):
+    """Media metadata rides as a JSON attribute on the item entity."""
+    titles, artists, kinds, item_ids = [], [], [], []
+    for slot in _as_list(protostuff.get('2')):
+        if not isinstance(slot, dict):
+            continue
+        for entity in _as_list(slot.get('2')):
+            if not isinstance(entity, dict):
+                continue
+            item_id = _to_str(entity.get('1'))
+            if item_id:
+                item_ids.append(item_id)
+            try:
+                attrs = json.loads(_to_str(entity.get('4')) or '{}')
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(attrs, dict):
+                continue
+            title = attrs.get('title') or attrs.get('mediaName')
+            if title:
+                titles.append(str(title))
+            if attrs.get('artist'):
+                artists.append(str(attrs['artist']))
+            if attrs.get('mediaType'):
+                kinds.append(str(attrs['mediaType']))
+    return ('; '.join(titles), '; '.join(artists), '; '.join(kinds), '; '.join(item_ids))
+
+
+def _sync_origin(file_found):
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
+
+
+@artifact_processor
+def get_biomeSiriRemembersAudioHistory(context):
+
+    data_list = []
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        filename = os.path.basename(file_found)
+        if filename.startswith('.'):
+            continue
+        if os.path.isfile(file_found):
+            if 'tombstone' in file_found:
+                continue
+        else:
+            continue
+        origin = _sync_origin(file_found)
+
+        for record in read_segb_file(file_found):
+            ts = record.timestamp1.replace(tzinfo=timezone.utc)
+
+            if record.state == EntryState.Written:
+                try:
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                except _DECODE_ERRORS as ex:
+                    logfunc(f'Siri Remembers Audio History: could not decode record at offset '
+                            f'{record.data_start_offset} in {filename}: {ex}')
+                    continue
+
+                metadata = protostuff.get('1', {})
+                if not isinstance(metadata, dict):
+                    continue
+                title, artist, media_type, item_ids = _media_details(protostuff)
+
+                data_list.append((ts, _intent_timestamp(metadata.get('8')), record.state.name,
+                                  title, artist, media_type,
+                                  _to_str(metadata.get('4')), _to_str(metadata.get('12')),
+                                  item_ids, _to_str(metadata.get('2')),
+                                  _to_str(metadata.get('1')), origin, filename,
+                                  record.data_start_offset))
+
+            elif record.state == EntryState.Deleted:
+                data_list.append((ts, None, record.state.name, None, None, None, None, None,
+                                  None, None, None, origin, filename,
+                                  record.data_start_offset))
+
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Playback Timestamp', 'datetime'),
+                    'SEGB State', 'Title', 'Artist', 'Media Type', 'Bundle ID', 'Media ID',
+                    'Item ID', 'Intent Class', 'Intent UUID', 'Sync Origin', 'Filename',
+                    'Offset')
+
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## What

Parses `Siri.Remembers.AudioHistory` — media playback intents with the **title, artist and media type** of what was played, the app that played it, and that app's own catalogue identifier for the item.

This stream was empty in the earlier batch and so could not be mapped. A sample with records is now available: **216 written, 225 deleted**, covering audiobook playback from Audible and music from Spotify.

| Column | Populated |
|---|---|
| Title | 216/216 |
| Artist | 216/216 |
| Media Type | 216/216 |
| Playback Timestamp | 216/216 |
| Media ID | 214/216 |

It shares the intent record shape of the other `Siri.Remembers` streams, but the media details ride as a **JSON attribute on the item entity** rather than as protobuf fields, so they are parsed out into their own columns instead of being dumped as a blob. `mediaName` is used as the title where `title` is absent.

The stream syncs between devices, so a **Sync Origin** column separates local records from ones received from another device.

The media identifier is the playing app's own catalogue id — for Audible that is the ASIN, which resolves directly to a specific published title.

## Validation

Harness run on the real sample: 441 rows, header/row width verified on every row, field population and media-type distribution checked. Full `ileapp.py` run completes and the artifact populates. `pylint --disable=C,R` reports 10.00/10; blackboxprotobuf guard passes.

Private sample: not registered in the corpus, no `sample_data` entry, nothing derived from its contents in the code or this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)