### PR TITLE
fix: prevent SMS chat rendering crash for missing attachment paths

### DIFF
--- a/scripts/chat_rendering.py
+++ b/scripts/chat_rendering.py
@@ -171,6 +171,9 @@ def render_js_chat(chat_json):
 
 def integrateAtt(rec):
     """Render a message body together with its attachment markup."""
+    if not isinstance(rec["file-path"], str) or not rec["file-path"]:
+        return rec["message"] if isinstance(rec["message"], str) else ''
+
     if rec["file-path"]:
         # When every row's mime type is NULL, pandas types the column as float64
         # and hands back NaN here. NaN is truthy, so it has to be filtered by


### PR DESCRIPTION
The SMS chat renderer was crashing when a message had no valid attachment path because pandas could pass a non-string value such as NaN into the path handling logic. The new guard checks whether the attachment path is a real string before trying to build the attachment markup, so messages without attachments are handled safely and the report continues to render normally.

Before, if rec["file-path"] is NaN or some other non-string value, `filename = os.path.basename(rec["file-path"])` raises:
`TypeError: expected str, bytes or os.PathLike object, not float`

traceback:
```
Error was expected str, bytes or os.PathLike object, not float
Exception Traceback: Traceback (most recent call last): 
File "E:\github\iLEAPP\ileapp.py", line 536, in crunch_artifacts plugin.method(files_found, category_folder, seeker, wrap_text, time_offset) ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "E:\github\iLEAPP\scripts\ilapfuncs.py", line 527, in wrapper data_headers, data_list, source_path = func(Context) ~~~~^^^^^^^^^ 
File "E:\github\iLEAPP\scripts\artifacts\sms.py", line 213, in sms report.add_script(render_chat(sms_df)) ~~~~~~~~~~~^^^^^^^^ 
File "E:\github\iLEAPP\scripts\chat_rendering.py", line 221, in render_chat df["body_to_render"] = df.apply(integrateAtt, axis=1) ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^ 
File "E:\github\iLEAPP\venv\Lib\site-packages\pandas\core\frame.py", line 12437, in apply return op.apply().__finalize__(self, method="apply") ~~~~~~~~^^ 
File "E:\github\iLEAPP\venv\Lib\site-packages\pandas\core\apply.py", line 1015, in apply return self.apply_standard() ~~~~~~~~~~~~~~~~~~~^^ 
File "E:\github\iLEAPP\venv\Lib\site-packages\pandas\core\apply.py", line 1167, in apply_standard results, res_index = self.apply_series_generator() ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^ 
File "E:\github\iLEAPP\venv\Lib\site-packages\pandas\core\apply.py", line 1183, in apply_series_generator results[i] = self.func(v, *self.args, **self.kwargs) ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "E:\github\iLEAPP\scripts\chat_rendering.py", line 180, in integrateAtt filename = os.path.basename(rec["file-path"]) File "", line 256, in basename File "", line 227, in split TypeError: expected str, bytes or os.PathLike object, not float
```