### PR TITLE
fix: reject non-keychain files instead of crashing on them

### DIFF
--- a/ileapp.py
+++ b/ileapp.py
@@ -23,6 +23,7 @@ from scripts.version_info import leapp_name, leapp_version, check_runtime_depend
 from time import process_time, gmtime, strftime, perf_counter
 from scripts.lavafuncs import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from scripts.context import Context
+from scripts.ios_keychain import report_supplied_keychain
 from scripts.lavafuncs import lava_json_name
 
 
@@ -376,6 +377,7 @@ def crunch_artifacts(
     logfunc('By: Alexis Brignoni | @AlexisBrignoni | abrignoni.com')
     logfunc('By: Yogesh Khatri   | @SwiftForensics | swiftforensics.com\n')
     logdevinfo()
+    report_supplied_keychain()
     seeker = None
     password = itunes_backup_password
     try:

--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -606,7 +606,7 @@ def select_keychain():
     keychain_filename = tk_filedialog.askopenfilename(
         parent=main_window,
         title='Select a keychain file',
-        filetypes=(('Keychain files', '*.plist *.xml *.json'), ('All files', '*.*')))
+        filetypes=(('Keychain files', '*.plist *.xml'), ('All files', '*.*')))
     if keychain_filename:
         keychain_entry.delete(0, 'end')
         keychain_entry.insert(0, keychain_filename)

--- a/scripts/artifacts/keychain.py
+++ b/scripts/artifacts/keychain.py
@@ -249,11 +249,18 @@ def _decode_der(data: bytes) -> dict:
         except UnicodeDecodeError:
             return base64.b64encode(data).decode('utf-8')
 
+    if not data:
+        return result
+
     # Skip outer container (SET or SEQUENCE), and bound iteration to its declared content
     end_pos = len(data)
     if data[pos] in (0x30, 0x31):  # SEQUENCE or SET
         pos += 1
-        outer_length, pos = read_length(data, pos)
+        try:
+            outer_length, pos = read_length(data, pos)
+        except DerParseError as e:
+            logfunc(f"Error parsing DER container: {e}")
+            return result
         end_pos = min(pos + outer_length, len(data))
 
     # Parse all items in the container
@@ -358,6 +365,10 @@ def _find_keychain_for_zip(zip_path: Path) -> Path | None:
 
 def _decrypt_itb_key(data, decryption_keys) -> bytes | None:
     """Decrypt a key from the iTunes backup using the provided decryption keys and custom gcm."""
+
+    if len(data) < 12:
+        logfunc("Keychain item is too short to hold a wrapped key header, skipping it")
+        return None
 
     _, key_class, key_klen = struct.unpack("<III", data[:12])
     key_dkey = decryption_keys[0].get(key_class)
@@ -531,7 +542,11 @@ def _parse_itunes_keychain(source_path, decryption_keys) -> tuple[list[dict], li
     keys_records = []
 
     for blob_key, record_list in (("inet", inet_records), ("genp", genp_records), ("keys", keys_records)):
-        for item in keychain_plist.get(blob_key, []):
+        items = keychain_plist.get(blob_key, [])
+        if not isinstance(items, list):
+            logfunc(f"Unexpected {blob_key} format in {source_path}, expected a list.")
+            continue
+        for item in items:
             if not isinstance(item, dict):
                 continue
             item_data = item.get("v_Data")
@@ -558,13 +573,17 @@ def _parse_teamred_keychain(source_path, keychain_db_path=None) -> tuple[list[di
     genp_records = []
     keys_records = []
 
-    class_keys = keychain_plist["classKeyIdxToUnwrappedMetadataClassKey"]
+    class_keys = keychain_plist.get("classKeyIdxToUnwrappedMetadataClassKey")
 
     if not isinstance(class_keys, dict):
         logfunc(f"Unexpected class key format in {source_path}, expected a dictionary for classKeyIdxToUnwrappedMetadataClassKey.")
         return [], [], []
 
-    keychain_entries = keychain_plist["keychainEntries"]
+    keychain_entries = keychain_plist.get("keychainEntries")
+
+    if not isinstance(keychain_entries, list):
+        logfunc(f"Unexpected keychain format in {source_path}, expected a list for keychainEntries.")
+        return [], [], []
 
     # Define this here, but it will be lazy loaded only if needed
     uuid_type_map = None
@@ -583,7 +602,13 @@ def _parse_teamred_keychain(source_path, keychain_db_path=None) -> tuple[list[di
             logfunc(f"Class key for index {class_key_idx} not found, unable to decrypt metadata")
             continue
 
-        metadata_wrapped_key_raw = entry["metadata"]["wrappedKey"]
+        entry_metadata = entry.get("metadata")
+        entry_data = entry.get("data")
+        if not isinstance(entry_metadata, dict) or not isinstance(entry_data, dict):
+            logfunc(f"Entry {entry.get('rowID')} has no metadata/data pair, skipping entry")
+            continue
+
+        metadata_wrapped_key_raw = entry_metadata.get("wrappedKey")
         metadata_wrapped_key_plist = get_plist_content(metadata_wrapped_key_raw)
 
         if not isinstance(metadata_wrapped_key_plist, dict):
@@ -599,10 +624,10 @@ def _parse_teamred_keychain(source_path, keychain_db_path=None) -> tuple[list[di
         metadata_key = _decrypt_data(key_ct, class_key, key_iv, key_tag)
 
         if metadata_key is None:
-            logfunc(f"Failed to decrypt metadata key for entry {entry['rowID']}, skipping entry")
+            logfunc(f"Failed to decrypt metadata key for entry {entry.get('rowID')}, skipping entry")
             continue
 
-        metadata_ciphertext_raw = entry["metadata"]["ciphertext"]
+        metadata_ciphertext_raw = entry_metadata.get("ciphertext")
         metadata_ciphertext_plist = get_plist_content(metadata_ciphertext_raw)
 
         if not isinstance(metadata_ciphertext_plist, dict):
@@ -617,12 +642,12 @@ def _parse_teamred_keychain(source_path, keychain_db_path=None) -> tuple[list[di
 
         decrypted_metadata = _decrypt_data(meta_ct, metadata_key, meta_iv, meta_tag)
         if decrypted_metadata is None:
-            logfunc(f"Failed to decrypt metadata for entry {entry['rowID']}, skipping entry")
+            logfunc(f"Failed to decrypt metadata for entry {entry.get('rowID')}, skipping entry")
             continue
         metadata = _decode_der(decrypted_metadata)
 
-        data_key = entry["data"]["unwrappedKey"]
-        data_ciphertext = entry["data"]["ciphertext"]
+        data_key = entry_data.get("unwrappedKey")
+        data_ciphertext = entry_data.get("ciphertext")
         data_ciphertext_plist = get_plist_content(data_ciphertext)
 
         if not isinstance(data_ciphertext_plist, dict):
@@ -635,9 +660,12 @@ def _parse_teamred_keychain(source_path, keychain_db_path=None) -> tuple[list[di
         if not isinstance(data_iv, bytes) or not isinstance(data_ct, bytes) or not isinstance(data_tag, bytes):
             continue
 
+        if not isinstance(data_key, bytes):
+            continue
+
         decrypted_data = _decrypt_data(data_ct, data_key, data_iv, data_tag)
         if decrypted_data is None:
-            logfunc(f"Failed to decrypt data for entry {entry['rowID']}, skipping entry")
+            logfunc(f"Failed to decrypt data for entry {entry.get('rowID')}, skipping entry")
             continue
         data_obj = _decode_der(decrypted_data)
 

--- a/scripts/ios_keychain.py
+++ b/scripts/ios_keychain.py
@@ -76,10 +76,18 @@ def _der_fields(plaintext):
 
 def _decrypt_wrapped_entries(parsed, keychain_path):
     """Convert UFED's encrypted keychain entries into decrypted genp-style dicts."""
-    class_keys = parsed.get(METADATA_CLASS_KEYS_KEY) or {}
+    class_keys = parsed.get(METADATA_CLASS_KEYS_KEY)
+    if not isinstance(class_keys, dict):
+        class_keys = {}
+    wrapped = parsed.get(ENCRYPTED_ENTRIES_KEY)
+    if not isinstance(wrapped, list):
+        logfunc(f'Keychain: {keychain_path} is not a supported keychain dump '
+                '(its encrypted entries are not a list)')
+        return []
+
     entries = []
     failures = 0
-    for entry in parsed.get(ENCRYPTED_ENTRIES_KEY) or []:
+    for entry in wrapped:
         # Entries stored in the clear carry rawData instead of an encrypted pair
         if not isinstance(entry, dict) or 'rawData' in entry:
             continue
@@ -123,7 +131,12 @@ def load_keychain_entries(keychain_path):
     try:
         with open(keychain_path, 'rb') as keychain_file:
             parsed = plistlib.load(keychain_file)
-    except (OSError, ValueError) as error:
+    except Exception as error:  # pylint: disable=broad-except
+        # The file is whatever the examiner pointed at, and plistlib does not funnel
+        # every way it can fail into one exception type: a truncated binary plist
+        # raises InvalidFileException, a malformed XML one raises ExpatError from
+        # expat, and a deeply nested one raises RecursionError. Anything unreadable
+        # means the same thing here, so report it rather than letting it escape.
         logfunc(f'Keychain: could not read {keychain_path}: {error}')
         return _cache[keychain_path]
 
@@ -132,8 +145,13 @@ def load_keychain_entries(keychain_path):
         return _cache[keychain_path]
 
     if GENERIC_PASSWORD_KEY in parsed:
-        entries = parsed.get(GENERIC_PASSWORD_KEY) or []
+        entries = parsed.get(GENERIC_PASSWORD_KEY)
+        if not isinstance(entries, list):
+            logfunc(f'Keychain: {keychain_path} is not a supported keychain dump '
+                    '(its generic password entries are not a list)')
+            return _cache[keychain_path]
         _cache[keychain_path] = [entry for entry in entries if isinstance(entry, dict)]
+        logfunc(f'Keychain: read {len(_cache[keychain_path])} entries from {keychain_path}')
     elif ENCRYPTED_ENTRIES_KEY in parsed:
         _cache[keychain_path] = _decrypt_wrapped_entries(parsed, keychain_path)
     else:
@@ -200,6 +218,22 @@ def _discover_keychain():
 def active_keychain_path():
     """The keychain to read: the supplied one, else one found in the extraction."""
     return Context.get_keychain_path() or _discover_keychain()
+
+
+def report_supplied_keychain():
+    """Record the examiner-supplied keychain in the log at the start of a run.
+
+    Reading it here rather than waiting for an artifact to ask for a secret gives
+    the report a note of which keychain was used, and tells the examiner straight
+    away when the file they picked is not a keychain at all. Without this, a run
+    where no keychain-reading artifact happens to fire says nothing either way.
+    """
+    keychain_path = Context.get_keychain_path()
+    if not keychain_path:
+        return  # nothing supplied; a keychain carried by the extraction is found later
+    if not load_keychain_entries(keychain_path):
+        logfunc('Keychain: the supplied file yielded no usable entries, so artifacts '
+                'that need the keychain will report their data as still encrypted.')
 
 
 def get_app_secret(access_group, account=None, service=None, expected_length=None):


### PR DESCRIPTION
## Problem

The keychain input path only checked that the file exists. Nothing checked that it was a keychain. An examiner who pointed `--keychain` (or the GUI field) at the wrong file, or whose extraction carried a truncated keychain export, got a traceback instead of an answer.

Most junk input was already handled well: a random binary blob, a text file, a SQLite database, a PNG, an empty file, and a valid-but-unrelated plist all came back cleanly with a log line. The gaps were narrower but reachable.

## Crashes fixed

**Malformed XML.** `load_keychain_entries` caught `OSError` and `ValueError`, which covers a truncated binary plist, but not a malformed XML one. Expat raises `ExpatError`, which escaped and took the calling artifact down with it. This is a realistic input, since an interrupted export or a partial file copy produces exactly that. It now catches anything the parse can raise, because an unreadable file means the same thing here however it failed.

**Unguarded indexing in the artifact parser.** `_parse_teamred_keychain` checked that the plist root was a dict and then indexed straight into `classKeyIdxToUnwrappedMetadataClassKey`, `keychainEntries`, `metadata` and `data`, so a partial UFED KeychainDump raised `KeyError`. This one needs nothing unusual from the examiner, since the artifact selects the file by name and path.

**Found by a fuzz sweep over keychain-shaped plists:** non-list values where lists were expected (an integer under `keychainEntries` passed through `parsed.get(...) or []` because it is truthy, then failed on iteration), an empty DER blob indexing past the end of its buffer, and an iTunes item too short to hold its wrapped-key header.

All of these now log what was wrong with the file and skip it.

## Provenance

Nothing recorded which keychain a run used. On the decrypted path the loader logged nothing at all, and validation only happened when some artifact first asked for a secret, so a run where no keychain-reading artifact fired said nothing either way. The supplied keychain is now read and reported once at the start of processing, in the path both the CLI and the GUI share:

```
Keychain: read 1062 entries from <path>
```

and when the file is not a keychain:

```
Keychain: could not read <path>: Invalid file
Keychain: the supplied file yielded no usable entries, so artifacts that need the
keychain will report their data as still encrypted.
```

Also drops `*.json` from the GUI file picker, which offered a format the loader has never been able to read.

## Testing

- Twelve hand-built bogus files (random binary, text, JSON, SQLite, PNG, empty, truncated XML, non-plist XML, array-root plist, and several keychain-shaped fakes) all reject cleanly with no exception.
- A randomized sweep across 8 seeds, each generating 400 keychain-shaped plists plus 2000 random DER blobs, run against all four parsers: 0 crashes. It reported 4 before these changes.
- Happy path regression over 5 real keychains from local test extractions: 3603 entries parsed in total, Signal key lookups still resolving in 4 of the 5.
- Two end-to-end runs, one with a random binary file and one with the truncated XML that used to crash, both finish at exit 0 with no traceback.
- Diff-aware lint reports 25 pre-existing warnings before and after, so no new ones. All 33 runtime contract tests pass.

## Not addressed

There is still no check that the keychain belongs to the same device as the extraction. Signal catches a mismatch cryptographically through SQLCipher HMAC verification and says so explicitly, but that protection lives in Signal's code, so a future artifact that reads a secret without a verification step inherits nothing. Doing it properly means finding a device identifier in the keychain to compare against the extraction, which is a larger change and worth deciding on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)