### PR TITLE
fix: chrome bookmarks keyerror and index bug

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1147,13 +1147,13 @@ def chromeBookmarks(context):
                             if keyb == 'children':
                                 if len(valueb) > 0:
                                     for index in range(len(valueb)):
-                                        url = valueb[index]['url']
-                                        dateadd = valueb[index]['date_added']
+                                        url = valueb[index].get('url', '')
+                                        dateadd = valueb[index].get('date_added', 0)
                                         dateaddconv = datetime.datetime(1601, 1, 1) + datetime.timedelta(
                                             microseconds=int(dateadd))
                                         added_dt = dateaddconv
-                                        name = valueb[0]['name']
-                                        typed = valueb[0]['type']
+                                        name = valueb[index].get('name', '')
+                                        typed = valueb[index].get('type', '')
                                         children_items.append((url, dateadd, dateaddconv, added_dt, name, typed))
                             if keyb == 'name' and len(children_items) > 0:
                                 parent = valueb


### PR DESCRIPTION
Fixed:
- Prevent KeyError on missing bookmarks JSON fields (url, date_added, name, type) by using .get() with defaults. 
Traceback:
```
Reading chromeBookmarks artifact had errors!
Error was 'url'
Exception Traceback: Traceback (most recent call last): 
File "e:\github\iLEAPP\ileapp.py", line 536, in crunch_artifacts plugin.method(files_found, category_folder, seeker, wrap_text, time_offset) ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "e:\github\iLEAPP\scripts\ilapfuncs.py", line 527, in wrapper data_headers, data_list, source_path = func(Context) ~~~~^^^^^^^^^ 
File "E:\github\iLEAPP\scripts\artifacts\chrome.py", line 1150, in chromeBookmarks url = valueb[index]['url'] ~~~~~~~~~~~~~^^^^^^^ KeyError: 'url'
```
- Fix bug where valueb[0] was always used instead of valueb[index], causing all bookmarks to incorrectly share the first item's name and type values.