### PR TITLE
GUI: hide the keychain picker on the processing/results screen

### DIFF
--- a/ileappGUI.py
+++ b/ileappGUI.py
@@ -509,6 +509,7 @@ def process(casedata):
         mlist_frame.pack_forget()
         output_frame.pack_forget()
         input_frame.pack_forget()
+        keychain_frame.pack_forget()
         logtext_frame.pack(padx=8, pady=4, expand=True, fill='both')
         progress_bar_frame.pack(padx=2, pady=2, ipady=2, fill='x')
 


### PR DESCRIPTION
The optional **keychain file** picker was added to the input screen, but it wasn't included in the `pack_forget()` block that hides the input controls (input/output/module list/bottom bar) when a run starts. So once processing begins it **lingers at the top of the log/results view** — a pre-run input shown where it can no longer be used (visible in the attached screenshot after `Processes completed`).

**Fix:** one line — `keychain_frame.pack_forget()` alongside `input_frame.pack_forget()` in the run→results transition. Now it hides with the rest of the input controls, exactly like the file/output pickers.

No behavior change to parsing or keychain handling; purely the GUI layout state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)