### PR TITLE
CI: run the runtime contract on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # The versions README.md tells users to run
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Releases are the easiest way to run iLEAPP. Use source if you are developing mod
 
 ### Requirements
 
-- Python 3.10, 3.11, or 3.12
+- Python 3.10 to 3.14
 - Git
 
 ### Setup


### PR DESCRIPTION
Python 3.13 and 3.14 support shipped in v2026.2.0 and is announced in the release notes, but the runtime-contract matrix and README still stopped at 3.12. A 3.13-only or 3.14-only break (like the earlier `datetime.UTC` regression) would pass CI unseen.

- Matrix: `['3.10', '3.11', '3.12']` becomes `['3.10', '3.11', '3.12', '3.13', '3.14']`
- README requirements line: "Python 3.10, 3.11, or 3.12" becomes "Python 3.10 to 3.14", matching the release notes and requirements.txt (version-gated numpy, cp313/cp314 pyliblzfse wheels already present)

The workflow triggers on changes to itself and to README.md, so this PR runs the expanded matrix: green checks below on 3.13 and 3.14 are the proof this works, not a promise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>