### PR TITLE
Feat: artifact result streaming

### DIFF
--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # The versions README.md tells users to run
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Releases are the easiest way to run iLEAPP. Use source if you are developing mod
 
 ### Requirements
 
-- Python 3.10, 3.11, or 3.12
+- Python 3.10 to 3.14
 - Git
 
 ### Setup

--- a/admin/test/scripts/benchmark_perf_artifacts.py
+++ b/admin/test/scripts/benchmark_perf_artifacts.py
@@ -1,0 +1,289 @@
+"""
+Run synthetic ArtifactResult benchmark profiles and capture basic metrics.
+
+This script launches iLEAPP as a child process for each selected profile, samples
+the child process working set while it runs, and writes JSON/CSV summaries. It
+does not require psutil; on Windows it uses the process handle directly.
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+DEFAULT_INPUT = ROOT_DIR / "admin" / "test" / "perf_data" / "artifact_result_fixture"
+DEFAULT_OUTPUT = ROOT_DIR / "admin" / "test" / "perf_output"
+DEFAULT_PROFILE_DIR = ROOT_DIR / "admin" / "test" / "perf_profiles"
+DEFAULT_CUSTOM_ARTIFACTS = ROOT_DIR / "scripts" / "alternate_artifacts"
+FOUND_RECORDS_RE = re.compile(r"Found\s+([\d,]+)\s+records\s+for\s+(.+)")
+
+DEFAULT_PROFILES = (
+    "perf_narrow_legacy_list",
+    "perf_narrow_artifact_result",
+    "perf_medium_legacy_transform",
+    "perf_medium_artifact_result_transform",
+    "perf_wide_legacy_list",
+    "perf_wide_artifact_result_cursor",
+)
+
+
+def get_working_set_bytes(process):
+    """Return current process-tree working-set/RSS bytes, or None if unavailable."""
+    if os.name == "nt":
+        return get_windows_process_tree_working_set_bytes(process.pid)
+    return get_proc_status_rss(process.pid)
+
+
+def get_windows_process_tree_working_set_bytes(root_pid):
+    pids = get_windows_process_tree_pids(root_pid)
+    total = 0
+    for pid in pids:
+        working_set = get_windows_working_set_bytes(pid)
+        if working_set:
+            total += working_set
+    return total or None
+
+
+def get_windows_process_tree_pids(root_pid):
+    import ctypes
+    from ctypes import wintypes
+
+    class ProcessEntry32(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.POINTER(wintypes.ULONG)),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", wintypes.LONG),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", wintypes.WCHAR * 260),
+        ]
+
+    create_snapshot = ctypes.windll.kernel32.CreateToolhelp32Snapshot
+    process_first = ctypes.windll.kernel32.Process32FirstW
+    process_next = ctypes.windll.kernel32.Process32NextW
+    close_handle = ctypes.windll.kernel32.CloseHandle
+
+    create_snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    create_snapshot.restype = wintypes.HANDLE
+    process_first.argtypes = [wintypes.HANDLE, ctypes.POINTER(ProcessEntry32)]
+    process_first.restype = wintypes.BOOL
+    process_next.argtypes = [wintypes.HANDLE, ctypes.POINTER(ProcessEntry32)]
+    process_next.restype = wintypes.BOOL
+    close_handle.argtypes = [wintypes.HANDLE]
+
+    snapshot = create_snapshot(0x00000002, 0)
+    if snapshot == wintypes.HANDLE(-1).value:
+        return [root_pid]
+
+    parent_map = {}
+    try:
+        entry = ProcessEntry32()
+        entry.dwSize = ctypes.sizeof(entry)
+        if process_first(snapshot, ctypes.byref(entry)):
+            while True:
+                parent_map[int(entry.th32ProcessID)] = int(entry.th32ParentProcessID)
+                if not process_next(snapshot, ctypes.byref(entry)):
+                    break
+    finally:
+        close_handle(snapshot)
+
+    tree = {root_pid}
+    changed = True
+    while changed:
+        changed = False
+        for pid, parent_pid in parent_map.items():
+            if parent_pid in tree and pid not in tree:
+                tree.add(pid)
+                changed = True
+    return list(tree)
+
+
+def get_windows_working_set_bytes(pid):
+    import ctypes
+    from ctypes import wintypes
+
+    class ProcessMemoryCounters(ctypes.Structure):
+        _fields_ = [
+            ("cb", wintypes.DWORD),
+            ("PageFaultCount", wintypes.DWORD),
+            ("PeakWorkingSetSize", ctypes.c_size_t),
+            ("WorkingSetSize", ctypes.c_size_t),
+            ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+            ("PagefileUsage", ctypes.c_size_t),
+            ("PeakPagefileUsage", ctypes.c_size_t),
+        ]
+
+    open_process = ctypes.windll.kernel32.OpenProcess
+    close_handle = ctypes.windll.kernel32.CloseHandle
+    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_process.restype = wintypes.HANDLE
+    close_handle.argtypes = [wintypes.HANDLE]
+
+    process_query_information = 0x0400
+    process_vm_read = 0x0010
+    handle = open_process(process_query_information | process_vm_read, False, pid)
+    if not handle:
+        return None
+
+    counters = ProcessMemoryCounters()
+    counters.cb = ctypes.sizeof(counters)
+    get_process_memory_info = ctypes.windll.psapi.GetProcessMemoryInfo
+    get_process_memory_info.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ProcessMemoryCounters),
+        wintypes.DWORD,
+    ]
+    get_process_memory_info.restype = wintypes.BOOL
+    try:
+        ok = get_process_memory_info(handle, ctypes.byref(counters), counters.cb)
+        if not ok:
+            return None
+        return int(counters.WorkingSetSize)
+    finally:
+        close_handle(handle)
+
+
+def get_proc_status_rss(pid):
+    status_path = Path("/proc") / str(pid) / "status"
+    try:
+        for line in status_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1]) * 1024
+    except OSError:
+        return None
+    return None
+
+
+def parse_found_records(stdout):
+    matches = FOUND_RECORDS_RE.findall(stdout)
+    if not matches:
+        return None, None
+    count, artifact_name = matches[-1]
+    return int(count.replace(",", "")), artifact_name.strip()
+
+
+def run_profile(args, profile_name, run_index):
+    profile_path = args.profile_dir / f"{profile_name}.ilprofile"
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    output_folder = f"bench_{profile_name}_{run_index}_{timestamp}"
+    command = [
+        sys.executable,
+        "ileapp.py",
+        "-t",
+        "fs",
+        "-i",
+        str(args.input),
+        "-o",
+        str(args.output),
+        "-m",
+        str(profile_path),
+        "--custom_artifacts_path",
+        str(args.custom_artifacts_path),
+        "--custom_output_folder",
+        output_folder,
+    ]
+
+    started_at = time.perf_counter()
+    process = subprocess.Popen(
+        command,
+        cwd=ROOT_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    peak_working_set = 0
+    while process.poll() is None:
+        current_working_set = get_working_set_bytes(process)
+        if current_working_set:
+            peak_working_set = max(peak_working_set, current_working_set)
+        time.sleep(args.sample_interval)
+
+    stdout, _ = process.communicate()
+    current_working_set = get_working_set_bytes(process)
+    if current_working_set:
+        peak_working_set = max(peak_working_set, current_working_set)
+
+    ended_at = time.perf_counter()
+    row_count, artifact_name = parse_found_records(stdout)
+    log_path = args.output / f"{output_folder}.log"
+    log_path.write_text(stdout, encoding="utf-8")
+
+    return {
+        "profile": profile_name,
+        "artifact_name": artifact_name,
+        "run_index": run_index,
+        "return_code": process.returncode,
+        "wall_time_seconds": round(ended_at - started_at, 4),
+        "peak_working_set_bytes": peak_working_set or None,
+        "peak_working_set_mib": round(peak_working_set / 1024 / 1024, 2)
+        if peak_working_set
+        else None,
+        "row_count": row_count,
+        "output_folder": str(args.output / output_folder),
+        "log_path": str(log_path),
+    }
+
+
+def write_results(args, results):
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    json_path = args.output / f"artifact_result_benchmark_{timestamp}.json"
+    csv_path = args.output / f"artifact_result_benchmark_{timestamp}.csv"
+
+    json_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    with csv_path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=results[0].keys())
+        writer.writeheader()
+        writer.writerows(results)
+
+    return json_path, csv_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run ArtifactResult benchmark profiles.")
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--profile-dir", type=Path, default=DEFAULT_PROFILE_DIR)
+    parser.add_argument("--custom-artifacts-path", type=Path, default=DEFAULT_CUSTOM_ARTIFACTS)
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--sample-interval", type=float, default=0.1)
+    parser.add_argument("--profiles", nargs="+", default=list(DEFAULT_PROFILES))
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    results = []
+    for run_index in range(1, args.repeat + 1):
+        for profile_name in args.profiles:
+            print(f"Running {profile_name}, pass {run_index}")
+            result = run_profile(args, profile_name, run_index)
+            results.append(result)
+            print(
+                f"  rc={result['return_code']} rows={result['row_count']} "
+                f"time={result['wall_time_seconds']}s "
+                f"peak={result['peak_working_set_mib']} MiB"
+            )
+
+    json_path, csv_path = write_results(args, results)
+    print(f"Wrote {json_path}")
+    print(f"Wrote {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/admin/test/scripts/make_perf_sqlite.py
+++ b/admin/test/scripts/make_perf_sqlite.py
@@ -1,0 +1,191 @@
+"""
+Create a synthetic SQLite fixture for ArtifactResult performance testing.
+
+The generated database intentionally includes narrow, medium, and wide tables
+so benchmark runs can separate high-row-count behavior from wide-row behavior.
+The data is deterministic and contains Unicode text to exercise serialization
+without depending on real device extractions.
+"""
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = (
+    Path("admin")
+    / "test"
+    / "perf_data"
+    / "artifact_result_fixture"
+)
+
+
+def batched_rows(row_count, batch_size, row_factory):
+    """Yield lists of generated rows for efficient SQLite inserts."""
+    batch = []
+    for index in range(row_count):
+        batch.append(row_factory(index))
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def create_narrow_table(db, row_count, batch_size):
+    db.execute(
+        """
+        CREATE TABLE perf_narrow (
+            id INTEGER PRIMARY KEY,
+            event_ts INTEGER NOT NULL,
+            item_key TEXT NOT NULL,
+            item_value TEXT NOT NULL
+        )
+        """
+    )
+
+    def row_factory(index):
+        return (
+            index,
+            1700000000 + index,
+            f"key-{index % 1000:04d}",
+            f"value-{index:08d}",
+        )
+
+    for batch in batched_rows(row_count, batch_size, row_factory):
+        db.executemany("INSERT INTO perf_narrow VALUES (?, ?, ?, ?)", batch)
+
+
+def create_medium_table(db, row_count, batch_size):
+    db.execute(
+        """
+        CREATE TABLE perf_medium (
+            id INTEGER PRIMARY KEY,
+            event_ts INTEGER NOT NULL,
+            bundle_id TEXT NOT NULL,
+            item_path TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            flag INTEGER NOT NULL,
+            score REAL NOT NULL,
+            note TEXT NOT NULL,
+            source_file TEXT NOT NULL
+        )
+        """
+    )
+
+    def row_factory(index):
+        return (
+            index,
+            1700000000 + (index * 3),
+            f"com.example.app{index % 250:03d}",
+            f"/private/var/mobile/Containers/Data/Application/{index % 500:04d}/file-{index}.dat",
+            ("create", "update", "delete", "visit")[index % 4],
+            index % 2,
+            round((index % 10000) / 17.0, 4),
+            f"medium row {index} unicode snowman \u2603",
+            "leapp_perf_artifact_result.sqlite",
+        )
+
+    for batch in batched_rows(row_count, batch_size, row_factory):
+        db.executemany(
+            "INSERT INTO perf_medium VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            batch,
+        )
+
+
+def create_wide_table(db, row_count, batch_size, wide_columns):
+    column_defs = ",\n            ".join(
+        f"c{number:03d} TEXT NOT NULL" for number in range(1, wide_columns + 1)
+    )
+    db.execute(
+        f"""
+        CREATE TABLE perf_wide (
+            id INTEGER PRIMARY KEY,
+            {column_defs}
+        )
+        """
+    )
+
+    placeholders = ", ".join("?" for _ in range(wide_columns + 1))
+
+    def row_factory(index):
+        values = [index]
+        for number in range(1, wide_columns + 1):
+            values.append(
+                f"row={index:08d};column={number:03d};payload=abcdefghijklmnopqrstuvwxyz0123456789"
+            )
+        return tuple(values)
+
+    for batch in batched_rows(row_count, batch_size, row_factory):
+        db.executemany(f"INSERT INTO perf_wide VALUES ({placeholders})", batch)
+
+
+def write_metadata(db, narrow_rows, medium_rows, wide_rows, wide_columns):
+    db.execute(
+        """
+        CREATE TABLE perf_metadata (
+            name TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+    db.executemany(
+        "INSERT INTO perf_metadata VALUES (?, ?)",
+        (
+            ("narrow_rows", str(narrow_rows)),
+            ("medium_rows", str(medium_rows)),
+            ("wide_rows", str(wide_rows)),
+            ("wide_columns", str(wide_columns)),
+        ),
+    )
+
+
+def create_database(output_path, narrow_rows, medium_rows, wide_rows, wide_columns, batch_size):
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+
+    with sqlite3.connect(output_path) as db:
+        db.execute("PRAGMA journal_mode = OFF")
+        db.execute("PRAGMA synchronous = OFF")
+        db.execute("PRAGMA temp_store = MEMORY")
+        create_narrow_table(db, narrow_rows, batch_size)
+        create_medium_table(db, medium_rows, batch_size)
+        create_wide_table(db, wide_rows, batch_size, wide_columns)
+        write_metadata(db, narrow_rows, medium_rows, wide_rows, wide_columns)
+        db.commit()
+        db.execute("VACUUM")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a synthetic SQLite fixture for iLEAPP performance testing."
+    )
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--narrow-rows", type=int, default=50000)
+    parser.add_argument("--medium-rows", type=int, default=20000)
+    parser.add_argument("--wide-rows", type=int, default=5000)
+    parser.add_argument("--wide-columns", type=int, default=80)
+    parser.add_argument("--batch-size", type=int, default=1000)
+    args = parser.parse_args()
+
+    create_database(
+        args.output,
+        args.narrow_rows,
+        args.medium_rows,
+        args.wide_rows,
+        args.wide_columns,
+        args.batch_size,
+    )
+    print(f"Created {args.output}")
+    print(
+        "Rows: "
+        f"narrow={args.narrow_rows}, "
+        f"medium={args.medium_rows}, "
+        f"wide={args.wide_rows}, "
+        f"wide_columns={args.wide_columns}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/leapp_functions/app/artifact_result.py
+++ b/leapp_functions/app/artifact_result.py
@@ -1,0 +1,229 @@
+"""
+Artifact result wrapper for large LEAPP artifact outputs.
+
+Most artifact modules can keep returning the traditional
+``(headers, data_list, source_path)`` tuple. Modules that may produce very large
+outputs can return ``ArtifactResult`` instead and write rows one at a time:
+create the result, set headers and source metadata, call ``add_row()`` in the
+same loop that currently builds ``data_list``, then return the result.
+
+``ArtifactResult`` intentionally does not create a private spool format. Writer
+mode streams rows into the LAVA SQLite output in bounded batches while the
+module is still running. The core artifact processor then replays rows from
+that table for HTML, TSV, timeline, and KML outputs when those formats are
+requested. This keeps a beginner-friendly module-author contract while avoiding
+a second serialization layer.
+
+The traditional reusable list-return path remains unchanged. Advanced callers
+can still pass an iterable with ``rows=`` and let the core consume it, but the
+recommended shape for new large artifacts is ``add_row()``.
+
+Queue settings are preserved for async iterable insertion, and writer mode
+keeps its own per-result batch state so multiple results can coexist.
+"""
+
+
+class ArtifactResult:
+    """Container for artifact metadata and rows to be streamed by the core."""
+
+    def __init__(
+        self,
+        headers=None,
+        source_path=None,
+        estimated_row_count=None,
+        async_write=False,
+        queue_size=5000,
+        batch_size=10000,
+        rows=None,
+        writer_metadata=None,
+        source_path_formatter=None,
+    ):
+        self._source_path_formatter = source_path_formatter
+        self.headers = headers
+        self.source_path = self._format_source_path(source_path)
+        self.estimated_row_count = estimated_row_count
+        self.async_write = async_write
+        self.queue_size = queue_size
+        self.batch_size = batch_size
+        self.row_count = 0
+
+        self._rows = rows
+        self._closed = False
+        self._writer_metadata = writer_metadata or {}
+        self._write_batch = []
+        self._table_name = None
+        self._object_columns = None
+        self._column_map = None
+        self._is_lava_backed = False
+
+    def _format_source_path(self, source_path):
+        if source_path and self._source_path_formatter:
+            return self._source_path_formatter(source_path)
+        return source_path
+
+    def set_headers(self, headers):
+        """Set or replace the result headers."""
+        self.headers = headers
+        return self
+
+    def set_source_path(self, source_path):
+        """Set or replace the source path metadata."""
+        self.source_path = self._format_source_path(source_path)
+        return self
+
+    def set_estimated_row_count(self, estimated_row_count):
+        """Set an advisory row count for progress reporting."""
+        self.estimated_row_count = estimated_row_count
+        return self
+
+    def add_estimated_row_count(self, rows):
+        """Increase the advisory row count when a module discovers more input."""
+        if rows is None:
+            return self
+        if self.estimated_row_count is None:
+            self.estimated_row_count = 0
+        self.estimated_row_count += rows
+        return self
+
+    @property
+    def progress_ratio(self):
+        """Return best-effort row progress, or None when the estimate is unknown."""
+        if not self.estimated_row_count:
+            return None
+        return self.row_count / self.estimated_row_count
+
+    @property
+    def is_lava_backed(self):
+        """Return True when rows have already been written to the LAVA table."""
+        return self._is_lava_backed
+
+    @property
+    def table_name(self):
+        """Return the LAVA table name used by this result, if initialized."""
+        return self._table_name
+
+    @property
+    def object_columns(self):
+        """Return LAVA object column metadata for this result."""
+        return self._object_columns
+
+    @property
+    def column_map(self):
+        """Return LAVA column mapping metadata for this result."""
+        return self._column_map
+
+    def _ensure_writer(self):
+        """Create the LAVA artifact table the first time writer mode needs it."""
+        if self._is_lava_backed:
+            return
+        if self._rows is not None:
+            raise ValueError("Cannot use add_row() on an ArtifactResult created with rows=")
+        if not self.headers:
+            raise ValueError("ArtifactResult headers must be set before adding rows")
+
+        from scripts.lavafuncs import lava_process_artifact
+
+        self._table_name, self._object_columns, self._column_map = lava_process_artifact(
+            self._writer_metadata.get("category", ""),
+            self._writer_metadata.get("module_name", ""),
+            self._writer_metadata.get("artifact_name", ""),
+            self.headers,
+            None,
+            func_name=self._writer_metadata.get("func_name"),
+            data_views=self._writer_metadata.get("data_views"),
+            artifact_icon=self._writer_metadata.get("artifact_icon"),
+            source_path=self.source_path,
+        )
+        self._is_lava_backed = True
+
+    def _flush_batch(self):
+        """Write any queued rows to the LAVA table."""
+        if not self._write_batch:
+            return
+
+        from scripts.lavafuncs import lava_insert_sqlite_data
+
+        rows = self._write_batch
+        self._write_batch = []
+        inserted_count = lava_insert_sqlite_data(
+            self._table_name,
+            rows,
+            self._object_columns,
+            self.headers,
+            self._column_map,
+            batch_size=self.batch_size,
+            async_write=self.async_write,
+            queue_size=self.queue_size,
+        )
+        self.row_count += inserted_count
+
+    def add_row(self, row):
+        """Add one row to the result and flush periodically to LAVA."""
+        if self._closed:
+            raise ValueError("Cannot add a row to a closed artifact result")
+        self._ensure_writer()
+        self._write_batch.append(row)
+        if len(self._write_batch) >= self.batch_size:
+            self._flush_batch()
+        return self
+
+    def append(self, row):
+        """Alias for add_row() for modules that prefer list-like naming."""
+        return self.add_row(row)
+
+    def extend(self, rows):
+        """Add rows from an iterable."""
+        for row in rows:
+            self.add_row(row)
+        return self
+
+    def set_row_count(self, row_count):
+        """Set the exact row count after a streaming writer consumes rows."""
+        self.row_count = row_count
+        return self
+
+    def flush(self):
+        """Flush pending writer rows to LAVA."""
+        if self._is_lava_backed:
+            self._flush_batch()
+        return self
+
+    def close(self):
+        """Flush pending rows and finalize streamed LAVA metadata."""
+        if self._closed:
+            return
+        self.flush()
+        if self._is_lava_backed:
+            from scripts.lavafuncs import lava_update_artifact_record_count
+
+            lava_update_artifact_record_count(
+                self._writer_metadata.get("category", ""),
+                self._table_name,
+                self.row_count,
+            )
+        self._closed = True
+
+    def cleanup(self):
+        """Release any pending writer state."""
+        self.close()
+
+    def __len__(self):
+        if self.row_count or self._write_batch:
+            return self.row_count + len(self._write_batch)
+        if isinstance(self._rows, list):
+            return len(self._rows)
+        return self.estimated_row_count or 0
+
+    def __bool__(self):
+        if self._is_lava_backed:
+            return True
+        if self._write_batch:
+            return True
+        if self._rows is None:
+            return False
+        if isinstance(self._rows, list):
+            return bool(self._rows)
+        return True
+
+    def __iter__(self):
+        return iter(self._rows)

--- a/leapp_functions/app/artifact_result.py
+++ b/leapp_functions/app/artifact_result.py
@@ -7,12 +7,11 @@ outputs can return ``ArtifactResult`` instead and write rows one at a time:
 create the result, set headers and source metadata, call ``add_row()`` in the
 same loop that currently builds ``data_list``, then return the result.
 
-``ArtifactResult`` intentionally does not create a private spool format. Writer
-mode streams rows into the LAVA SQLite output in bounded batches while the
-module is still running. The core artifact processor then replays rows from
-that table for HTML, TSV, timeline, and KML outputs when those formats are
-requested. This keeps a beginner-friendly module-author contract while avoiding
-a second serialization layer.
+``ArtifactResult`` writer mode streams rows into the LAVA SQLite output in
+bounded batches while the module is still running. The core artifact processor
+then replays rows from that table for HTML, TSV, timeline, and KML outputs when
+those formats are requested. This keeps a beginner-friendly module-author
+contract while avoiding a second serialization layer.
 
 The traditional reusable list-return path remains unchanged. Advanced callers
 can still pass an iterable with ``rows=`` and let the core consume it, but the
@@ -166,10 +165,6 @@ class ArtifactResult:
         if len(self._write_batch) >= self.batch_size:
             self._flush_batch()
         return self
-
-    def append(self, row):
-        """Alias for add_row() for modules that prefer list-like naming."""
-        return self.add_row(row)
 
     def extend(self, rows):
         """Add rows from an iterable."""

--- a/scripts/alternate_artifacts/README.md
+++ b/scripts/alternate_artifacts/README.md
@@ -20,3 +20,14 @@ The GUI and default CLI runs never load them, so regular users are unaffected.
   - `installedappinventory`: one row per app container (bundle ID, path, UUID)
   - `appfileinventory`: every file in the extraction mapped to its app
     container (lava_only; can be hundreds of thousands of rows)
+
+- **perfArtifactResult.py** - synthetic benchmark artifacts used to compare
+  legacy list-based artifact returns with LAVA-streamed `ArtifactResult` returns.
+  Generate the fixture database with:
+
+```
+python admin/test/scripts/make_perf_sqlite.py
+```
+
+  Then run iLEAPP with `--custom_artifacts_path scripts/alternate_artifacts`
+  and one of the profiles in `admin/test/perf_profiles`.

--- a/scripts/alternate_artifacts/perfArtifactResult.py
+++ b/scripts/alternate_artifacts/perfArtifactResult.py
@@ -1,0 +1,378 @@
+"""Synthetic artifacts for comparing legacy list output with ArtifactResult."""
+
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc
+
+
+PERF_DB_NAME = "leapp_perf_artifact_result.sqlite"
+PERF_DB_PATH = f"*/{PERF_DB_NAME}"
+
+
+def _source_path(context):
+    return get_file_path(context.get_files_found(), PERF_DB_PATH)
+
+
+def _row_count(source_path, table_name):
+    records = get_sqlite_db_records(source_path, f"SELECT COUNT(*) FROM {table_name}")
+    for record in records:
+        return record[0]
+    return None
+
+
+def _datetime_from_unix(timestamp):
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+def _narrow_rows(source_path):
+    query = "SELECT id, event_ts, item_key, item_value FROM perf_narrow ORDER BY id"
+    for record in get_sqlite_db_records(source_path, query):
+        yield (
+            record["id"],
+            _datetime_from_unix(record["event_ts"]),
+            record["item_key"],
+            record["item_value"],
+        )
+
+
+def _medium_rows(source_path):
+    query = """
+    SELECT id, event_ts, bundle_id, item_path, event_type, flag, score, note, source_file
+    FROM perf_medium
+    ORDER BY id
+    """
+    for record in get_sqlite_db_records(source_path, query):
+        yield (
+            record["id"],
+            _datetime_from_unix(record["event_ts"]),
+            record["bundle_id"],
+            record["item_path"],
+            record["event_type"].upper(),
+            record["flag"],
+            record["score"],
+            record["note"],
+            record["source_file"],
+            "Enabled" if record["flag"] else "Disabled",
+        )
+
+
+NARROW_HEADERS = (
+    "ID",
+    ("Event Time", "datetime"),
+    "Item Key",
+    "Item Value",
+)
+
+MEDIUM_HEADERS = (
+    "ID",
+    ("Event Time", "datetime"),
+    "Bundle ID",
+    "Item Path",
+    "Event Type",
+    "Flag",
+    "Score",
+    "Note",
+    "Source File",
+    "Readable Flag",
+)
+
+
+def _wide_headers():
+    return ("ID",) + tuple(f"Column {number:03d}" for number in range(1, 81))
+
+
+__artifacts_v2__ = {
+    "perf_narrow_legacy_list": {
+        "name": "Performance - Narrow Legacy List",
+        "description": "Synthetic narrow rows returned as a normal in-memory list",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for ArtifactResult benchmark baselines.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_narrow_artifact_result": {
+        "name": "Performance - Narrow ArtifactResult",
+        "description": "Synthetic narrow rows returned through ArtifactResult",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for ArtifactResult benchmark comparisons.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_narrow_artifact_result_sync": {
+        "name": "Performance - Narrow ArtifactResult Sync",
+        "description": "Synthetic narrow rows streamed through ArtifactResult without async LAVA writes",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for synchronous ArtifactResult benchmark comparisons.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_medium_legacy_transform": {
+        "name": "Performance - Medium Legacy Transform",
+        "description": "Synthetic transformed rows returned as a normal in-memory list",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for transformed-row benchmark baselines.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_medium_artifact_result_transform": {
+        "name": "Performance - Medium ArtifactResult Transform",
+        "description": "Synthetic transformed rows returned through ArtifactResult",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for transformed-row ArtifactResult comparisons.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_medium_artifact_result_transform_sync": {
+        "name": "Performance - Medium ArtifactResult Transform Sync",
+        "description": "Synthetic transformed rows streamed through ArtifactResult without async LAVA writes",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for synchronous transformed-row ArtifactResult comparisons.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_wide_legacy_list": {
+        "name": "Performance - Wide Legacy List",
+        "description": "Synthetic wide rows returned as a normal in-memory list",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for wide-row benchmark baselines.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_wide_artifact_result_cursor": {
+        "name": "Performance - Wide ArtifactResult Cursor",
+        "description": "Synthetic wide rows returned through ArtifactResult from a SQLite cursor",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for direct cursor ArtifactResult comparisons.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+    "perf_wide_artifact_result_cursor_sync": {
+        "name": "Performance - Wide ArtifactResult Cursor Sync",
+        "description": "Synthetic wide rows streamed through ArtifactResult from a SQLite cursor without async LAVA writes",
+        "author": "LEAPP",
+        "creation_date": "2026-07-24",
+        "last_update_date": "2026-07-24",
+        "requirements": "none",
+        "category": "Performance Testing",
+        "notes": "Developer-only alternate artifact for synchronous direct cursor ArtifactResult comparisons.",
+        "paths": (PERF_DB_PATH,),
+        "output_types": "lava_only",
+        "artifact_icon": "activity",
+        "sample_data": {"synthetic": "configurable row count"},
+    },
+}
+
+
+@artifact_processor
+def perf_narrow_legacy_list(context):
+    source_path = _source_path(context)
+    data_list = []
+    if not source_path:
+        logfunc(f"{PERF_DB_NAME} not found")
+        return NARROW_HEADERS, data_list, source_path
+
+    query = "SELECT id, event_ts, item_key, item_value FROM perf_narrow ORDER BY id"
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append(
+            (
+                record["id"],
+                _datetime_from_unix(record["event_ts"]),
+                record["item_key"],
+                record["item_value"],
+            )
+        )
+    return NARROW_HEADERS, data_list, source_path
+
+
+@artifact_processor
+def perf_narrow_artifact_result(context):
+    return _perf_narrow_artifact_result(context, async_write=True, label="perf_narrow_artifact_result")
+
+
+@artifact_processor
+def perf_narrow_artifact_result_sync(context):
+    return _perf_narrow_artifact_result(context, async_write=False, label="perf_narrow_artifact_result_sync")
+
+
+def _perf_narrow_artifact_result(context, async_write, label):
+    source_path = _source_path(context)
+    result = context.create_artifact_result(
+        headers=NARROW_HEADERS,
+        source_path=source_path,
+        estimated_row_count=_row_count(source_path, "perf_narrow") if source_path else None,
+        rows=_narrow_rows(source_path) if source_path else None,
+        async_write=async_write,
+        label=label,
+    )
+    if not source_path:
+        logfunc(f"{PERF_DB_NAME} not found")
+    return result
+
+
+@artifact_processor
+def perf_medium_legacy_transform(context):
+    source_path = _source_path(context)
+    data_list = []
+    if not source_path:
+        logfunc(f"{PERF_DB_NAME} not found")
+        return MEDIUM_HEADERS, data_list, source_path
+
+    query = """
+    SELECT id, event_ts, bundle_id, item_path, event_type, flag, score, note, source_file
+    FROM perf_medium
+    ORDER BY id
+    """
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append(
+            (
+                record["id"],
+                _datetime_from_unix(record["event_ts"]),
+                record["bundle_id"],
+                record["item_path"],
+                record["event_type"].upper(),
+                record["flag"],
+                record["score"],
+                record["note"],
+                record["source_file"],
+                "Enabled" if record["flag"] else "Disabled",
+            )
+        )
+    return MEDIUM_HEADERS, data_list, source_path
+
+
+@artifact_processor
+def perf_medium_artifact_result_transform(context):
+    return _perf_medium_artifact_result_transform(
+        context,
+        async_write=True,
+        label="perf_medium_artifact_result_transform",
+    )
+
+
+@artifact_processor
+def perf_medium_artifact_result_transform_sync(context):
+    return _perf_medium_artifact_result_transform(
+        context,
+        async_write=False,
+        label="perf_medium_artifact_result_transform_sync",
+    )
+
+
+def _perf_medium_artifact_result_transform(context, async_write, label):
+    source_path = _source_path(context)
+    result = context.create_artifact_result(
+        headers=MEDIUM_HEADERS,
+        source_path=source_path,
+        estimated_row_count=_row_count(source_path, "perf_medium") if source_path else None,
+        rows=_medium_rows(source_path) if source_path else None,
+        async_write=async_write,
+        label=label,
+    )
+    if not source_path:
+        logfunc(f"{PERF_DB_NAME} not found")
+    return result
+
+
+@artifact_processor
+def perf_wide_legacy_list(context):
+    source_path = _source_path(context)
+    data_list = []
+    if not source_path:
+        logfunc(f"{PERF_DB_NAME} not found")
+        return _wide_headers(), data_list, source_path
+
+    columns = ", ".join(f"c{number:03d}" for number in range(1, 81))
+    query = f"SELECT id, {columns} FROM perf_wide ORDER BY id"
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append(tuple(record))
+    return _wide_headers(), data_list, source_path
+
+
+@artifact_processor
+def perf_wide_artifact_result_cursor(context):
+    return _perf_wide_artifact_result_cursor(
+        context,
+        async_write=True,
+        label="perf_wide_artifact_result_cursor",
+    )
+
+
+@artifact_processor
+def perf_wide_artifact_result_cursor_sync(context):
+    return _perf_wide_artifact_result_cursor(
+        context,
+        async_write=False,
+        label="perf_wide_artifact_result_cursor_sync",
+    )
+
+
+def _perf_wide_artifact_result_cursor(context, async_write, label):
+    source_path = _source_path(context)
+    if not source_path:
+        result = context.create_artifact_result(
+            headers=_wide_headers(),
+            source_path=source_path,
+            label=label,
+        )
+        logfunc(f"{PERF_DB_NAME} not found")
+        return result
+
+    columns = ", ".join(f"c{number:03d}" for number in range(1, 81))
+    query = f"SELECT id, {columns} FROM perf_wide ORDER BY id"
+    cursor = get_sqlite_db_records(source_path, query)
+    return context.create_artifact_result(
+        headers=_wide_headers(),
+        source_path=source_path,
+        estimated_row_count=_row_count(source_path, "perf_wide"),
+        rows=cursor,
+        async_write=async_write,
+        label=label,
+    )

--- a/scripts/artifact_report.py
+++ b/scripts/artifact_report.py
@@ -51,7 +51,8 @@ class ArtifactHtmlReport:
         table_responsive=True,
         table_style='',
         table_id='dtBasicExample',
-        html_no_escape=[]
+        html_no_escape=[],
+        row_count=None
     ):
         ''' Writes info about data, then writes the table to html file
             Parameters
@@ -77,11 +78,13 @@ class ArtifactHtmlReport:
             table_id       : Specify an identifier string, which will be referenced in javascript
 
             html_no_escape  : if html_escape=True, list of columns not to escape
+
+            row_count       : Optional precomputed row count for streaming data_list iterables
         '''
         if (not self.report_file):
             raise ValueError('Output report file is closed/unavailable!')
 
-        num_entries = len(data_list)
+        num_entries = row_count if row_count is not None else len(data_list)
         if write_total:
             self.write_minor_header(f'Total number of entries: {num_entries}', 'h6')
         if write_location:

--- a/scripts/artifacts/appGrouplisting.py
+++ b/scripts/artifacts/appGrouplisting.py
@@ -36,25 +36,31 @@ __artifacts_v2__ = {
 import pathlib
 from scripts.ilapfuncs import artifact_processor, get_plist_file_content
 
+
 @artifact_processor
 def appGrouplisting(context):
     source_path = 'Path column in the report'
-    data_list = []       
-    
+    data_headers = ('Bundle ID', 'Type', 'Directory GUID', 'Path')
+
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path=source_path,
+        estimated_row_count=len(context.get_files_found()),
+    )
+
     for file_found in context.get_files_found():
         plist = get_plist_file_content(file_found)
         # Check if plist is a valid parseable object
         if not plist or not isinstance(plist, dict):
             continue
         bundleid = plist['MCMMetadataIdentifier']
-        
+
         p = pathlib.Path(file_found)
         appgroupid = p.parent.name
         fileloc = str(p.parents[1])
         typedir = str(p.parents[1].name)
-        
-        data_list.append((bundleid, typedir, appgroupid, fileloc))
-                
-    data_headers = ('Bundle ID', 'Type', 'Directory GUID', 'Path')
-    return data_headers, data_list, source_path
+
+        results.add_row((bundleid, typedir, appgroupid, fileloc))
+
+    return results
     

--- a/scripts/artifacts/appStoreSearches.py
+++ b/scripts/artifacts/appStoreSearches.py
@@ -114,11 +114,10 @@ def appStoreSearches(context):
 @artifact_processor
 def appStoreCachedRequests(context):
     source_path = get_file_path(context.get_files_found(), 'Cache.db')
-    data_list = []
     data_headers = (
         ('Timestamp', 'datetime'), 'Host', 'Path', 'Request URL', 'Entry ID')
     if not source_path:
-        return data_headers, data_list, ''
+        return data_headers, [], ''
 
     query = '''
     SELECT entry_ID, request_key, time_stamp
@@ -126,10 +125,15 @@ def appStoreCachedRequests(context):
     ORDER BY time_stamp
     '''
 
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path=source_path,
+    )
+
     for record in get_sqlite_db_records(source_path, query):
         request_url = record['request_key'] or ''
         parsed = urllib.parse.urlparse(request_url)
-        data_list.append((
+        results.add_row((
             convert_human_ts_to_utc(record['time_stamp']),
             parsed.netloc,
             parsed.path,
@@ -137,4 +141,4 @@ def appStoreCachedRequests(context):
             record['entry_ID'],
         ))
 
-    return data_headers, data_list, source_path
+    return results

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -72,7 +72,16 @@ def _unix_double(value):
 @artifact_processor
 def get_biomeFrontBoardDisplayElement(context):
 
-    data_list = []
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Event Timestamp', 'datetime'),
+                    'SEGB State', 'Bundle ID', 'Scene ID', 'Display Type', 'Display Role',
+                    'Field 4 (raw)', 'Field 5 (raw)', 'Field 6 (raw)', 'Field 7 (raw)',
+                    'Field 8 (raw)', 'Field 10 (raw)', 'Filename', 'Offset')
+
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path='see Filename for more info',
+    )
+
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -99,7 +108,7 @@ def get_biomeFrontBoardDisplayElement(context):
                 if not isinstance(display, dict):
                     display = {}
 
-                data_list.append((ts, _unix_double(protostuff.get('1')), record.state.name,
+                results.add_row((ts, _unix_double(protostuff.get('1')), record.state.name,
                                   _to_str(protostuff.get('3', b'')),
                                   _to_str(protostuff.get('2', b'')),
                                   _to_str(display.get('2', b'')),
@@ -110,13 +119,8 @@ def get_biomeFrontBoardDisplayElement(context):
                                   filename, record.data_start_offset))
 
             elif record.state == EntryState.Deleted:
-                data_list.append((ts, None, record.state.name, None, None, None, None, None,
+                results.add_row((ts, None, record.state.name, None, None, None, None, None,
                                   None, None, None, None, None, filename,
                                   record.data_start_offset))
 
-    data_headers = (('SEGB Timestamp', 'datetime'), ('Event Timestamp', 'datetime'),
-                    'SEGB State', 'Bundle ID', 'Scene ID', 'Display Type', 'Display Role',
-                    'Field 4 (raw)', 'Field 5 (raw)', 'Field 6 (raw)', 'Field 7 (raw)',
-                    'Field 8 (raw)', 'Field 10 (raw)', 'Filename', 'Offset')
-
-    return data_headers, data_list, 'see Filename for more info'
+    return results

--- a/scripts/artifacts/cloudkit_cache.py
+++ b/scripts/artifacts/cloudkit_cache.py
@@ -191,15 +191,34 @@ def cloudkit_files(context):
     Extracts file listings associated with iCloud backup snapshots from the cloudkit_cache.db database.
     """
     files_found = context.get_files_found()
-    data_list = []
-    source_path = ""
+    data_headers = (
+        ('Modified', 'datetime'),
+        'Snapshot ID',
+        'Relative Path',
+        'File ID',
+        'File Domain',
+        'Deleted',
+        'File Type',
+        'Size',
+        'Protection Class',
+        'ManifestID'
+    )
+    source_files = [
+        str(file_found)
+        for file_found in files_found
+        if str(file_found).endswith('cloudkit_cache.db')
+    ]
+    if not source_files:
+        return data_headers, [], ''
 
-    for file_found in files_found:
-        file_found = str(file_found)
-        if not file_found.endswith('cloudkit_cache.db'):
-            continue
+    source_path = '\n'.join(context.get_relative_path(file_found) for file_found in source_files)
 
-        source_path = context.get_relative_path(file_found)
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path=source_path,
+    )
+
+    for file_found in source_files:
 
         query = '''
             SELECT 
@@ -227,7 +246,7 @@ def cloudkit_files(context):
         for record in db_records:
             modified_ts = convert_unix_ts_to_utc(record[1]) if record[1] else ""
 
-            data_list.append((
+            results.add_row((
                 modified_ts,  # Modified
                 record[0],    # Snapshot ID
                 record[2],    # Relative Path
@@ -240,17 +259,4 @@ def cloudkit_files(context):
                 record[9]     # ManifestID
             ))
 
-    data_headers = (
-        ('Modified', 'datetime'),
-        'Snapshot ID',
-        'Relative Path',
-        'File ID',
-        'File Domain',
-        'Deleted',
-        'File Type',
-        'Size',
-        'Protection Class',
-        'ManifestID'
-    )
-
-    return data_headers, data_list, source_path
+    return results

--- a/scripts/artifacts/fsCachedData.py
+++ b/scripts/artifacts/fsCachedData.py
@@ -45,21 +45,26 @@ def fsCachedData(context):
         'Mime Type',
         'Filename',
         'Path')
-    data_list = []
+    files_found = [str(file_found) for file_found in context.get_files_found()]
 
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path='',
+        estimated_row_count=len(files_found),
+    )
+
+    for file_found in files_found:
         if not os.path.isfile(file_found):
             continue
 
         modified_time = convert_unix_ts_to_utc(os.path.getmtime(file_found))
         mime = guess_mime(file_found)
         media_ref = check_in_media(file_found)
-        data_list.append((
+        results.add_row((
             modified_time,
             media_ref,
             mime,
             os.path.basename(file_found),
             context.get_relative_path(file_found)))
 
-    return data_headers, data_list, ''
+    return results

--- a/scripts/artifacts/iOSCacheLocations.py
+++ b/scripts/artifacts/iOSCacheLocations.py
@@ -36,10 +36,13 @@ from scripts.ilapfuncs import (artifact_processor, get_file_path, get_sqlite_db_
 @artifact_processor
 def CacheSQLite_Locations(context):
 
-    data_list = []
-
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, 'Cache.sqlite')
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Horizontal Accuracy (Meters)',
+        'Speed (Meters/Sec)', 'Speed (Miles/Hour)')
+    if not source_path:
+        return data_headers, [], ''
 
     query = '''
     SELECT
@@ -55,6 +58,11 @@ def CacheSQLite_Locations(context):
     FROM ZRTCLLOCATIONMO
     '''
 
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path=source_path,
+    )
+
     try:
         db_records = get_sqlite_db_records(source_path, query)
 
@@ -62,12 +70,9 @@ def CacheSQLite_Locations(context):
             unix_timestamp = record[0] + 978307200
             timestampr = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
 
-            data_list.append((timestampr, record[1], record[2], record[3], record[4], record[5]))
+            results.add_row((timestampr, record[1], record[2], record[3], record[4], record[5]))
 
     except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f'Error processing Cache.sqlite locations: {e}')
 
-    data_headers = (
-        ('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Horizontal Accuracy (Meters)', 'Speed (Meters/Sec)', 'Speed (Miles/Hour)')
-
-    return data_headers, data_list, source_path
+    return results

--- a/scripts/artifacts/mobileInstallb.py
+++ b/scripts/artifacts/mobileInstallb.py
@@ -137,11 +137,37 @@ def _parse(context):
     return rows, ', '.join(sources)
 
 
+def _add_rows(context, add_row):
+    """Add (timestamp_local, type, notice, source_rel) rows; iOS 17+ only."""
+    if version.parse(iOS.get_version()) < version.parse("17"):
+        return
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        rel = context.get_relative_path(file_found)
+        try:
+            with open(file_found, 'r', encoding='utf8', errors='ignore') as f:
+                for line in f:
+                    for marker, desc in _EVENTS.items():
+                        if marker in line:
+                            values = _line_splitting(line)
+                            if values:
+                                add_row((values[0], desc, values[1], rel))
+                            break
+        except OSError:
+            continue
+
+
 @artifact_processor
 def mobileInstallb(context):
     data_headers = ('Timestamp (Local)', 'Type', 'Notice', 'Source File')
     rows, source = _parse(context)
-    return data_headers, rows, source
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path=source,
+    )
+    for row in rows:
+        results.add_row(row)
+    return results
 
 
 @artifact_processor

--- a/scripts/artifacts/twitterX.py
+++ b/scripts/artifacts/twitterX.py
@@ -349,14 +349,18 @@ def _projected(value):
 @artifact_processor
 def twitterTweets(context):
     source_path = get_file_path(context.get_files_found(), 'modelCache.sqlite3')
-    data_list = []
     data_headers = (
         ('Posted', 'datetime'), ('Cache Updated', 'datetime'), 'Text',
         'Author User ID', 'Language', 'Replies', 'Retweets', 'Quotes',
         'Bookmarks', 'Views', 'Possibly Sensitive', 'Quoted Post URL',
         'Conversation ID', 'Post ID')
     if not source_path:
-        return data_headers, data_list, ''
+        return data_headers, [], ''
+
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path=source_path,
+    )
 
     for uid, model in _iter_cached_models(source_path, MODEL_TYPE_STATUS):
         view_count = model.get('viewCountInfo')
@@ -364,7 +368,7 @@ def twitterTweets(context):
         posted = model.get('date')
         updated = model.get('updatedTimestamp')
 
-        data_list.append((
+        results.add_row((
             convert_cocoa_core_data_ts_to_utc(posted) if isinstance(posted, (int, float)) else '',
             convert_cocoa_core_data_ts_to_utc(updated) if isinstance(updated, (int, float)) else '',
             model.get('originalText'),
@@ -381,7 +385,7 @@ def twitterTweets(context):
             uid,
         ))
 
-    return data_headers, data_list, source_path
+    return results
 
 
 @artifact_processor

--- a/scripts/artifacts/userDefaults.py
+++ b/scripts/artifacts/userDefaults.py
@@ -57,7 +57,13 @@ def clean_data(obj):
 def user_defaults(context):
     files_found = context.get_files_found()
     applications = {}
-    data_list = []
+    data_headers = (
+        "Application Bundle ID",
+        "Application Container ID",
+        "Key Name",
+        "Item",
+        "Source File",
+    )
 
     for file_found in files_found:
         file_found = str(file_found)
@@ -72,6 +78,11 @@ def user_defaults(context):
         if bundle_id:
             container_id = pathlib.Path(file_found).parent.name
             applications[container_id] = bundle_id
+
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path="Source files listed in report",
+    )
 
     for file_found in files_found:
         file_found = str(file_found)
@@ -88,7 +99,7 @@ def user_defaults(context):
 
             source_file = context.get_relative_path(file_found)
             for key, item in plist.items():
-                data_list.append((
+                results.add_row((
                     bundle_id,
                     container_id,
                     key,
@@ -96,12 +107,4 @@ def user_defaults(context):
                     source_file,
                 ))
 
-    data_headers = (
-        "Application Bundle ID",
-        "Application Container ID",
-        "Key Name",
-        "Item",
-        "Source File",
-    )
-
-    return data_headers, data_list, "Source files listed in report"
+    return results

--- a/scripts/artifacts/webkit.py
+++ b/scripts/artifacts/webkit.py
@@ -92,7 +92,6 @@ SALT_MAP = {}
 
 @artifact_processor
 def webkit_cache_records(context):
-    data_list = []
     research_mode = context.get_artifact_info().get("research_mode", False)
     data_headers = (
         'Application GUID', 'Records GUID', 'File', 'Salt', 'URI', ('Timestamp', 'datetime'), 
@@ -101,6 +100,11 @@ def webkit_cache_records(context):
     )
     if research_mode:
         data_headers = RESEARCH_HEADERS
+
+    results = context.create_artifact_result(
+        headers=data_headers,
+        source_path='see column data',
+    )
 
     for file_found in context.get_files_found():
         if file_found.endswith('salt'):
@@ -125,105 +129,105 @@ def webkit_cache_records(context):
         }
         try:
             with open(file_found, 'rb') as f:
-                file_data['Header'] = struct.unpack('<I', f.read(4))[0]
-                file_data['Partition'], file_data['Partition Flag'] = read_vf(f)
-                file_data['Type'], file_data['Type Flag'] = read_vf(f)
-                file_data['URI'], file_data['URI Flag'] = read_vf(f)
-                file_data['Salt'] = SALT_MAP.get(app_guid, '').hex()
-                file_data['Marker'] = struct.unpack('<i', f.read(4))[0]
-                file_data['Filename'] = f.read(20).hex()
-                file_data['Foldername'] = f.read(20).hex()
-                timestamp = struct.unpack('<d', f.read(8))[0]
-                file_data['Timestamp'] = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-                file_data['Meta SHA1'] = f.read(20).hex()
-                file_data['Meta Size'] = struct.unpack('<Q', f.read(8))[0]
-                file_data['Body SHA1'] = f.read(20).hex()
-                file_data['Body Size'] = struct.unpack('<Q', f.read(8))[0]
-                file_data['Is Body Inline'] = "Yes" if f.read(1) == b'\x01' else "No"
-                file_data['Unknown Hash'] = f.read(20).hex()
-
-                # Metadata Block
-                start_of_meta_pos = f.tell()
-                file_data['Start of Meta'] = f.read(1).hex()
-                file_data['Meta URI'], file_data['Meta URI Flag'] = read_vf(f)
-
-                file_data['Marker Content Type'] = struct.unpack('<I', f.read(4))[0]
-                if file_data['Marker Content Type'] < 0xFFFFFFFF:
-                    f.seek(-4, 1)  # Move back 4 bytes
-                    file_data['Content Type'], file_data['Content Type Flag'] = read_vf(f)
-                else:
-                    file_data['Content Type'], file_data['Content Type Flag'] = '', ''
-
-                file_data['Body Size 2'] = struct.unpack('<Q', f.read(8))[0]
-                if file_data['Body Size 2'] == 0xFFFFFFFFFFFFFFFF:
-                    file_data['Body Size 2'] = -1
-                file_data['Marker2'] = struct.unpack('<I', f.read(4))[0]
-
-                if file_data['Marker2'] < 0xFFFFFFFF:
-                    f.seek(-4, 1)  # Move back 4 bytes
-                    file_data['Encoding Type'], file_data['Encoding Type Flag'] = read_vf(f)
-                else:
-                    file_data['Encoding Type'], file_data['Encoding Type Flag'] = '', ''
-
-                file_data['Encoding Pad'], file_data['Encoding Pad Flag'] = read_vf(f)
-                file_data['HTTP Type'], file_data['HTTP Type Flag'] = read_vf(f)
-                file_data['HTTP Header Count'] = struct.unpack('<Q', f.read(8))[0]
-
-                if file_data['HTTP Header Count'] <= 100:
-                    http_headers = {}
-                    has_cookie = False
-                    for _ in range(file_data['HTTP Header Count']):
-                        header, _ = read_vf(f)
-                        value, _ = read_vf(f)
-                        if header is not None and value is not None:
-                            http_headers[header] = value
-                            if 'cookie' in header.lower():
-                                has_cookie = True
-                    # Sort the HTTP headers alphabetically
-                    sorted_http_headers = OrderedDict(sorted(http_headers.items()))
-                    file_data['HTTP Headers'] = json.dumps(sorted_http_headers)
-                    file_data['Has Cookie'] = 'Yes' if has_cookie else 'No'
-                    headers_read = True
-                else:
-                    file_data['HTTP Headers'] = 'Skipped due to high header count'
-                    file_data['Has Cookie'] = 'Unknown'
-                    headers_read = False
-
-                # Read trailing data
-                if headers_read:
-                    remaining_bytes = file_data['Meta Size'] + start_of_meta_pos - f.tell() - 20
-                    other_trailing_data = f.read(remaining_bytes)
-                else:
-                    f.seek(start_of_meta_pos + file_data['Meta Size'] - 92)
-                    other_trailing_data = f.read(72)
-
-                # Extract response code and unknown bytes from trailing data
-                file_data['Response Code'] = struct.unpack('<H', other_trailing_data[:2])[0]
-                file_data['U1'] = other_trailing_data[2]
-                file_data['U2'] = other_trailing_data[3]
-                file_data['U3'] = other_trailing_data[4:11].hex()
-                file_data['U4'] = other_trailing_data[11]
-                file_data['U5'] = other_trailing_data[12:19].hex()
-                file_data['U6'] = other_trailing_data[19]
-                file_data['U7'] = other_trailing_data[20:27].hex()
-                file_data['U8'] = other_trailing_data[27]
-                file_data['Other Trailing Data'] = f'"{other_trailing_data[28:].hex()}"'
-                file_data['Trailing Size'] = len(other_trailing_data)
-
-                file_data['Trailing Hash'] = f.read(20).hex()
-
-                if file_data['Content Type'].startswith('image/'):
-                    if file_data['Is Body Inline'] == 'Yes':
-                        file_data['Thumbnail'] = check_in_embedded_media(file_found,
-                                                                         f.read(),
-                                                                         name=file_data['URI'].split('/')[-1],
-                                                                         force_type=file_data['Content Type'],
-                                                                         force_extension=file_data['URI'].split('.')[-1])
+                    file_data['Header'] = struct.unpack('<I', f.read(4))[0]
+                    file_data['Partition'], file_data['Partition Flag'] = read_vf(f)
+                    file_data['Type'], file_data['Type Flag'] = read_vf(f)
+                    file_data['URI'], file_data['URI Flag'] = read_vf(f)
+                    file_data['Salt'] = SALT_MAP.get(app_guid, '').hex()
+                    file_data['Marker'] = struct.unpack('<i', f.read(4))[0]
+                    file_data['Filename'] = f.read(20).hex()
+                    file_data['Foldername'] = f.read(20).hex()
+                    timestamp = struct.unpack('<d', f.read(8))[0]
+                    file_data['Timestamp'] = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+                    file_data['Meta SHA1'] = f.read(20).hex()
+                    file_data['Meta Size'] = struct.unpack('<Q', f.read(8))[0]
+                    file_data['Body SHA1'] = f.read(20).hex()
+                    file_data['Body Size'] = struct.unpack('<Q', f.read(8))[0]
+                    file_data['Is Body Inline'] = "Yes" if f.read(1) == b'\x01' else "No"
+                    file_data['Unknown Hash'] = f.read(20).hex()
+    
+                    # Metadata Block
+                    start_of_meta_pos = f.tell()
+                    file_data['Start of Meta'] = f.read(1).hex()
+                    file_data['Meta URI'], file_data['Meta URI Flag'] = read_vf(f)
+    
+                    file_data['Marker Content Type'] = struct.unpack('<I', f.read(4))[0]
+                    if file_data['Marker Content Type'] < 0xFFFFFFFF:
+                        f.seek(-4, 1)  # Move back 4 bytes
+                        file_data['Content Type'], file_data['Content Type Flag'] = read_vf(f)
                     else:
-                        file_data['Thumbnail'] = check_in_media(file_found+"-blob",
-                                                               name=file_data['URI'].split('/')[-1],
-                                                               force_type=file_data['Content Type'],
-                                                               force_extension=file_data['URI'].split('.')[-1])
+                        file_data['Content Type'], file_data['Content Type Flag'] = '', ''
+    
+                    file_data['Body Size 2'] = struct.unpack('<Q', f.read(8))[0]
+                    if file_data['Body Size 2'] == 0xFFFFFFFFFFFFFFFF:
+                        file_data['Body Size 2'] = -1
+                    file_data['Marker2'] = struct.unpack('<I', f.read(4))[0]
+    
+                    if file_data['Marker2'] < 0xFFFFFFFF:
+                        f.seek(-4, 1)  # Move back 4 bytes
+                        file_data['Encoding Type'], file_data['Encoding Type Flag'] = read_vf(f)
+                    else:
+                        file_data['Encoding Type'], file_data['Encoding Type Flag'] = '', ''
+    
+                    file_data['Encoding Pad'], file_data['Encoding Pad Flag'] = read_vf(f)
+                    file_data['HTTP Type'], file_data['HTTP Type Flag'] = read_vf(f)
+                    file_data['HTTP Header Count'] = struct.unpack('<Q', f.read(8))[0]
+    
+                    if file_data['HTTP Header Count'] <= 100:
+                        http_headers = {}
+                        has_cookie = False
+                        for _ in range(file_data['HTTP Header Count']):
+                            header, _ = read_vf(f)
+                            value, _ = read_vf(f)
+                            if header is not None and value is not None:
+                                http_headers[header] = value
+                                if 'cookie' in header.lower():
+                                    has_cookie = True
+                        # Sort the HTTP headers alphabetically
+                        sorted_http_headers = OrderedDict(sorted(http_headers.items()))
+                        file_data['HTTP Headers'] = json.dumps(sorted_http_headers)
+                        file_data['Has Cookie'] = 'Yes' if has_cookie else 'No'
+                        headers_read = True
+                    else:
+                        file_data['HTTP Headers'] = 'Skipped due to high header count'
+                        file_data['Has Cookie'] = 'Unknown'
+                        headers_read = False
+    
+                    # Read trailing data
+                    if headers_read:
+                        remaining_bytes = file_data['Meta Size'] + start_of_meta_pos - f.tell() - 20
+                        other_trailing_data = f.read(remaining_bytes)
+                    else:
+                        f.seek(start_of_meta_pos + file_data['Meta Size'] - 92)
+                        other_trailing_data = f.read(72)
+    
+                    # Extract response code and unknown bytes from trailing data
+                    file_data['Response Code'] = struct.unpack('<H', other_trailing_data[:2])[0]
+                    file_data['U1'] = other_trailing_data[2]
+                    file_data['U2'] = other_trailing_data[3]
+                    file_data['U3'] = other_trailing_data[4:11].hex()
+                    file_data['U4'] = other_trailing_data[11]
+                    file_data['U5'] = other_trailing_data[12:19].hex()
+                    file_data['U6'] = other_trailing_data[19]
+                    file_data['U7'] = other_trailing_data[20:27].hex()
+                    file_data['U8'] = other_trailing_data[27]
+                    file_data['Other Trailing Data'] = f'"{other_trailing_data[28:].hex()}"'
+                    file_data['Trailing Size'] = len(other_trailing_data)
+    
+                    file_data['Trailing Hash'] = f.read(20).hex()
+    
+                    if file_data['Content Type'].startswith('image/'):
+                        if file_data['Is Body Inline'] == 'Yes':
+                            file_data['Thumbnail'] = check_in_embedded_media(file_found,
+                                                                             f.read(),
+                                                                             name=file_data['URI'].split('/')[-1],
+                                                                             force_type=file_data['Content Type'],
+                                                                             force_extension=file_data['URI'].split('.')[-1])
+                        else:
+                            file_data['Thumbnail'] = check_in_media(file_found+"-blob",
+                                                                   name=file_data['URI'].split('/')[-1],
+                                                                   force_type=file_data['Content Type'],
+                                                                   force_extension=file_data['URI'].split('.')[-1])
 
         except (FileNotFoundError, PermissionError, OSError, struct.error, ValueError, IndexError) as e:
             if research_mode:
@@ -231,8 +235,7 @@ def webkit_cache_records(context):
         finally:
             # Append whatever data we have, even if it's incomplete
             # If header is a tuple (e.g., ('Timestamp', 'datetime')), use header[0] for the key
-            data_list.append(
-                tuple(file_data.get(header[0] if isinstance(header, tuple) else header, '') for header in data_headers)
-            )
+            results.add_row(tuple(file_data.get(header[0] if isinstance(header, tuple) else header, '')
+                                   for header in data_headers))
 
-    return data_headers, data_list, 'see column data'
+    return results

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -5,6 +5,8 @@ import re
 from os.path import basename
 from pathlib import Path
 
+from leapp_functions.app.artifact_result import ArtifactResult
+
 
 class Context:
     """
@@ -22,6 +24,7 @@ class Context:
     _module_name = None
     _module_file_path = None
     _artifact_name = None
+    _artifact_func_name = None
     _files_found = []
     _filename_lookup_map = {}
     _data_folder = None
@@ -109,6 +112,17 @@ class Context:
         """
 
         Context._artifact_name = artifact_name
+
+    @staticmethod
+    def set_artifact_func_name(artifact_func_name):
+        """
+        Sets the function name for the current artifact in the Context.
+
+        Args:
+            artifact_func_name (str): The artifact processor function name.
+        """
+
+        Context._artifact_func_name = artifact_func_name
 
     @staticmethod
     def set_files_found(files_found):
@@ -355,6 +369,23 @@ class Context:
         return Context._artifact_name
 
     @staticmethod
+    def get_artifact_func_name():
+        """
+        Retrieves the current artifact processor function name from the Context.
+
+        Raises:
+            ValueError: If the function name has not been set in the Context.
+
+        Returns:
+            str: The function name of the current artifact.
+        """
+
+        if not Context._artifact_func_name:
+            raise ValueError("Context not set. This function should be" +
+                             " called from within an artifact.")
+        return Context._artifact_func_name
+
+    @staticmethod
     def get_files_found():
         """
         Retrieves the list of files found in the current context.
@@ -438,6 +469,50 @@ class Context:
         Returns the global extraction folder path.
         """
         return Context._data_folder
+
+    @staticmethod
+    def create_artifact_result(
+        headers=None,
+        source_path=None,
+        estimated_row_count=None,
+        async_write=False,
+        queue_size=5000,
+        batch_size=10000,
+        rows=None,
+    ):
+        """
+        Create an artifact result wrapper for modules with large row sets.
+
+        Headers, source_path, and estimated_row_count are optional and can be
+        set later by the module before returning the result.
+        """
+        artifact_info = Context._artifact_info or {}
+        source_path_formatter = Context._normalize_source_path
+        writer_metadata = {
+            "category": artifact_info.get("category", ""),
+            "module_name": Context._module_name or "",
+            "artifact_name": Context._artifact_name or Context._module_name or "",
+            "func_name": Context._artifact_func_name,
+            "data_views": artifact_info.get("data_views"),
+            "artifact_icon": artifact_info.get("artifact_icon"),
+        }
+        return ArtifactResult(
+            headers=headers,
+            source_path=source_path,
+            estimated_row_count=estimated_row_count,
+            async_write=async_write,
+            queue_size=queue_size,
+            batch_size=batch_size,
+            rows=rows,
+            writer_metadata=writer_metadata,
+            source_path_formatter=source_path_formatter,
+        )
+
+    @staticmethod
+    def _normalize_source_path(source_path):
+        """Return extraction-relative source path metadata for reports and LAVA."""
+        return '\n'.join(
+            Context.get_relative_path(p) for p in str(source_path).split('\n'))
 
     @staticmethod
     def get_relative_path(full_path):
@@ -528,5 +603,6 @@ class Context:
         Context._module_name = None
         Context._module_file_path = None
         Context._artifact_name = None
+        Context._artifact_func_name = None
         Context._files_found = []
         Context._filename_lookup_map = {}

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -44,6 +44,7 @@ from leapp_functions.app.output import (
     resolve_output_folder_name,
     validate_output_folder_available,
 )
+from leapp_functions.app.artifact_result import ArtifactResult
 # pylint: enable=unused-import
 
 _console_write = sys.stdout.write
@@ -58,7 +59,8 @@ from functools import wraps
 import binascii
 from PIL import Image
 
-from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data, lava_get_media_item, \
+from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data, lava_iter_artifact_rows, \
+    lava_update_artifact_record_count, lava_get_media_item, \
     lava_insert_sqlite_media_item, lava_insert_sqlite_media_references, lava_get_media_references, \
     lava_get_full_media_info
 
@@ -466,6 +468,56 @@ def get_data_list_with_media(media_header_info, data_list):
 
     return html_data_list, txt_data_list
 
+
+def iter_data_list_with_media(media_header_info, data_list, html_output=False):
+    """
+    Stream rows with media reference columns converted for the requested output.
+    """
+    output_params = Context.get_output_params()
+
+    for data in data_list:
+        row = list(data)
+
+        for idx, style in media_header_info.items():
+            media_ref_id_cell = row[idx]
+            if not media_ref_id_cell:
+                row[idx] = ''
+                continue
+
+            html_code = ''
+            path_list = []
+            media_ref_ids = media_ref_id_cell if isinstance(media_ref_id_cell, list) else [media_ref_id_cell]
+
+            for ref_id in media_ref_ids:
+                media_item = lava_get_full_media_info(ref_id)
+                if not (media_item and media_item['extraction_path']):
+                    continue
+
+                canonical_path = os.path.join(output_params.output_folder_base, media_item['extraction_path'])
+                html_path = os.path.join(output_params.html_media_folder, Path(canonical_path).name)
+
+                if os.path.exists(canonical_path) and not os.path.exists(html_path):
+                    try:
+                        os.link(canonical_path, html_path)
+                    except OSError:
+                        shutil.copy2(canonical_path, html_path)
+
+                if html_output:
+                    html_code += html_media_tag(
+                        media_item['extraction_path'], media_item['type'], style, media_item['name'])
+                else:
+                    path_list.append(media_item['extraction_path'])
+
+            if html_output:
+                row[idx] = html_code
+            elif isinstance(media_ref_id_cell, list):
+                row[idx] = ' | '.join(path_list)
+            else:
+                row[idx] = path_list[0] if path_list else ''
+
+        yield tuple(row)
+
+
 _reported_unsafe_report_names = set()
 
 def sanitize_report_name(name, kind='name'):
@@ -521,12 +573,27 @@ def artifact_processor(func):
         Context.set_module_name(module_name)
         Context.set_module_file_path(module_file_path)
         Context.set_artifact_name(artifact_name)
+        Context.set_artifact_func_name(func_name)
 
         sig = inspect.signature(func)
         if len(sig.parameters) == 1:
-            data_headers, data_list, source_path = func(Context)
+            artifact_result = func(Context)
         else:
-            data_headers, data_list, source_path = func(files_found, report_folder, seeker, wrap_text, timezone_offset)
+            artifact_result = func(files_found, report_folder, seeker, wrap_text, timezone_offset)
+
+        is_artifact_result = isinstance(artifact_result, ArtifactResult)
+        if is_artifact_result:
+            data_headers = artifact_result.headers
+            data_list = artifact_result
+            source_path = artifact_result.source_path
+        else:
+            data_headers, data_list, source_path = artifact_result
+            is_artifact_result = isinstance(data_list, ArtifactResult)
+            if is_artifact_result:
+                if data_list.headers is None:
+                    data_list.set_headers(data_headers)
+                if source_path and not data_list.source_path:
+                    data_list.set_source_path(source_path)
 
         if data_list and not source_path:
             logfunc("No source_path provided")
@@ -535,63 +602,118 @@ def artifact_processor(func):
             source_path = '\n'.join(
                 Context.get_relative_path(p) for p in str(source_path).split('\n'))
 
-        if len(data_list):
-            if isinstance(data_list, tuple):
-                data_list, html_data_list = data_list
-            else:
-                html_data_list = data_list
-            logfunc(f"Found {len(data_list):,} {'records' if len(data_list)>1 else 'record'} for {artifact_name}")
-            # Path separators would break (or misplace) the report files, so the HTML, TSV
-            # and KML outputs are written under a path safe name. The sidebar keys off the
-            # on-disk names, so the icon lookup has to use the same safe names.
-            safe_artifact_name = sanitize_report_name(artifact_name)
-            safe_category = sanitize_report_name(category, 'category')
-            icons.setdefault(safe_category, {safe_artifact_name: icon}).update({safe_artifact_name: icon})
+        try:
+            if data_list:
+                if data_headers is None:
+                    raise ValueError(f"No data_headers provided for {artifact_name}")
+                if isinstance(data_list, tuple):
+                    data_list, html_data_list = data_list
+                else:
+                    html_data_list = data_list
 
-            # Strip tuples from headers for HTML, TSV, and timeline
-            stripped_headers = strip_tuple_from_headers(data_headers)
+                row_count = len(data_list)
+                if row_count:
+                    logfunc(f"Found {row_count:,} {'records' if row_count>1 else 'record'} for {artifact_name}")
+                else:
+                    logfunc(f"Processing streamed records for {artifact_name}")
 
-            # Check if headers contains a 'media' type
-            media_header_info = get_media_header_info(data_headers)
-            if media_header_info:
-                html_columns.extend([data_headers[idx][0] for idx in media_header_info])
-                html_data_list, txt_data_list = get_data_list_with_media(media_header_info, data_list)
+                # Path separators would break (or misplace) report files, so
+                # file outputs use safe names while LAVA keeps display names.
+                safe_artifact_name = sanitize_report_name(artifact_name)
+                safe_category = sanitize_report_name(category, 'category')
+                icons.setdefault(safe_category, {safe_artifact_name: icon}).update({safe_artifact_name: icon})
 
-            if check_output_types('html', output_types):
-                report = artifact_report.ArtifactHtmlReport(artifact_name)
-                report.start_artifact_report(report_folder, safe_artifact_name, description)
-                report.add_script()
-                report.write_artifact_data_table(stripped_headers, html_data_list, source_path, html_no_escape=html_columns)
-                report.end_artifact_report()
+                # Strip tuples from headers for HTML, TSV, and timeline
+                stripped_headers = strip_tuple_from_headers(data_headers)
 
-            if check_output_types('tsv', output_types):
-                tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, safe_artifact_name)
+                # Check if headers contains a 'media' type
+                media_header_info = get_media_header_info(data_headers)
+                needs_text_or_html_data = any(
+                    check_output_types(output_type, output_types)
+                    for output_type in ('html', 'tsv', 'timeline', 'kml')
+                )
+                if media_header_info and needs_text_or_html_data:
+                    html_columns.extend([data_headers[idx][0] for idx in media_header_info])
+                    if not is_artifact_result:
+                        html_data_list, txt_data_list = get_data_list_with_media(media_header_info, data_list)
 
-            if check_output_types('timeline', output_types):
-                timeline(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
+                table_name = None
+                object_columns = None
+                inserted_count = row_count
+                if is_artifact_result and data_list.is_lava_backed:
+                    data_list.close()
+                    table_name = data_list.table_name
+                    object_columns = data_list.object_columns
+                    inserted_count = data_list.row_count
+                    logfunc(f"Inserted {inserted_count:,} streamed records for {artifact_name}")
+                    if is_lava_only:
+                        lava_only_info(category, artifact_name, table_name, inserted_count)
+                elif is_artifact_result or check_output_types('lava', output_types):
+                    record_count = None if is_artifact_result else len(data_list)
+                    table_name, object_columns, column_map = lava_process_artifact(category,
+                                                                                   module_name,
+                                                                                   artifact_name,
+                                                                                   data_headers,
+                                                                                   record_count,
+                                                                                   func_name=func_name,
+                                                                                   data_views=artifact_info.get("data_views"),
+                                                                                   artifact_icon=icon,
+                                                                                   source_path=source_path)
+                    inserted_count = lava_insert_sqlite_data(
+                        table_name,
+                        data_list,
+                        object_columns,
+                        data_headers,
+                        column_map,
+                        async_write=getattr(data_list, 'async_write', False),
+                        queue_size=getattr(data_list, 'queue_size', 5000),
+                    )
+                    if is_artifact_result:
+                        data_list.set_row_count(inserted_count)
+                        lava_update_artifact_record_count(category, table_name, inserted_count)
+                        logfunc(f"Inserted {inserted_count:,} streamed records for {artifact_name}")
+                    if is_lava_only:
+                        lava_only_info(category, artifact_name, table_name, inserted_count)
 
-            if check_output_types('lava', output_types):
-                table_name, object_columns, column_map = lava_process_artifact(category,
-                                                                               module_name,
-                                                                               artifact_name,
-                                                                               data_headers,
-                                                                               len(data_list),
-                                                                               func_name=func_name,
-                                                                               data_views=artifact_info.get("data_views"),
-                                                                               artifact_icon=icon,
-                                                                               source_path=source_path)
-                if is_lava_only:
-                    lava_only_info(category, artifact_name, table_name, len(data_list))
-                lava_insert_sqlite_data(table_name, data_list, object_columns, data_headers, column_map)
+                def output_rows(html_output=False):
+                    rows = data_list
+                    if is_artifact_result:
+                        rows = lava_iter_artifact_rows(table_name, data_headers, object_columns, inserted_count)
+                    if media_header_info and needs_text_or_html_data:
+                        return iter_data_list_with_media(media_header_info, rows, html_output)
+                    return rows
 
-            if check_output_types('kml', output_types):
-                kmlgen(report_folder, safe_artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
+                if check_output_types('html', output_types):
+                    report = artifact_report.ArtifactHtmlReport(artifact_name)
+                    report.start_artifact_report(report_folder, safe_artifact_name, description)
+                    report.add_script()
+                    report.write_artifact_data_table(
+                        stripped_headers,
+                        output_rows(html_output=True) if is_artifact_result else html_data_list,
+                        source_path,
+                        html_no_escape=html_columns,
+                        row_count=inserted_count if is_artifact_result else None)
+                    report.end_artifact_report()
 
-        else:
-            if output_types != 'none':
+                if check_output_types('tsv', output_types):
+                    tsv_rows = output_rows() if is_artifact_result else txt_data_list if media_header_info else data_list
+                    tsv(report_folder, stripped_headers, tsv_rows, safe_artifact_name)
+
+                if check_output_types('timeline', output_types):
+                    timeline_rows = output_rows() if is_artifact_result else txt_data_list if media_header_info else data_list
+                    timeline(report_folder, artifact_name, timeline_rows, stripped_headers)
+
+                if check_output_types('kml', output_types):
+                    kml_rows = output_rows() if is_artifact_result else txt_data_list if media_header_info else data_list
+                    kmlgen(report_folder, safe_artifact_name, kml_rows, stripped_headers)
+
+            elif output_types != 'none':
                 logfunc(f"No data found for {artifact_name}")
                 if is_lava_only:
                     lava_only_info(category, artifact_name, artifact_name, 0)
+        finally:
+            if is_artifact_result:
+                data_list.cleanup()
 
         return data_headers, data_list, source_path
     return wrapper
@@ -906,10 +1028,8 @@ def kmlgen(report_folder, kmlactivity, data_list, data_headers):
 
     data = []
     kml = simplekml.Kml(open=1)    
-    a = 0
-    length = len(data_list)
-    while a < length:
-        modifiedDict = dict(zip(data_headers, data_list[a]))
+    for row in data_list:
+        modifiedDict = dict(zip(data_headers, row))
         lon = modifiedDict['Longitude']
         lat = modifiedDict['Latitude']
         times_header = "Timestamp"
@@ -926,7 +1046,6 @@ def kmlgen(report_folder, kmlactivity, data_list, data_headers):
             pnt.description = f"{times_header}: {times} - {kmlactivity}"
             pnt.coords = [(lon, lat)]
             data.append((times, lat, lon, kmlactivity))
-        a += 1
 
     if len(data) > 0:
         report_folder = report_folder.rstrip('/')

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -18,6 +18,7 @@ Functions:
     lava_add_module: Adds module information to the LAVA data.
     lava_create_sqlite_table: Creates a SQLite table for artifact data.
     lava_insert_sqlite_data: Inserts data rows into a SQLite table.
+    lava_iter_artifact_rows: Streams stored artifact rows back from LAVA.
     lava_get_media_item: Retrieves media item information from database.
     lava_insert_sqlite_media_item: Inserts media item metadata into database.
     lava_get_media_references: Retrieves media reference information.
@@ -34,6 +35,8 @@ from platform import platform
 from collections import OrderedDict
 import re
 import datetime
+import queue
+import threading
 
 from scripts.version_info import leapp_name, leapp_version
 from scripts.context import Context
@@ -43,6 +46,8 @@ lava_data = None
 lava_db = None
 lava_db_name = '_lava_artifacts.db'
 lava_json_name = '_lava_data.lava'
+lava_db_path = None
+_QUEUE_STOP = object()
 
 
 def sanitize_sql_name(name):
@@ -102,6 +107,82 @@ def get_sql_type(python_type):
     return type_map.get(python_type, 'TEXT')
 
 
+def _prepare_datetime_value(value):
+    """Convert supported datetime values to UTC Unix timestamps for LAVA storage."""
+
+    if isinstance(value, str):
+        try:
+            value = datetime.datetime.fromisoformat(value)
+        except ValueError:
+            return value
+
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        # Use subtraction instead of timestamp() so pre-epoch dates work consistently.
+        epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+        return (value - epoch).total_seconds()
+
+    return value
+
+
+def _prepare_date_value(value):
+    """Convert supported date values to UTC midnight Unix timestamps for LAVA storage."""
+
+    if isinstance(value, str):
+        try:
+            value = datetime.date.fromisoformat(value)
+        except ValueError:
+            return _prepare_datetime_value(value)
+
+    if isinstance(value, datetime.datetime):
+        return _prepare_datetime_value(value)
+
+    if isinstance(value, datetime.date):
+        value = datetime.datetime(value.year, value.month, value.day, tzinfo=datetime.timezone.utc)
+        return _prepare_datetime_value(value)
+
+    return value
+
+
+def _prepare_lava_value(value, column_type=None):
+    """
+    Convert a Python value into the representation stored in the LAVA SQLite table.
+
+    Only column types that need storage conversion get handlers here. Other object
+    column types, such as phonenumber, remain normal SQLite TEXT values while their
+    type metadata stays available in the LAVA artifact metadata.
+    """
+
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+
+    type_handlers = {
+        'datetime': _prepare_datetime_value,
+        'date': _prepare_date_value,
+    }
+    handler = type_handlers.get(column_type)
+    if handler:
+        return handler(value)
+
+    return value
+
+
+def _restore_lava_value(value, column_type=None):
+    """Restore a value streamed back from the LAVA SQLite table for secondary outputs."""
+
+    if value is None:
+        return value
+
+    if column_type == 'datetime' and isinstance(value, (int, float)):
+        return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
+
+    if column_type == 'date' and isinstance(value, (int, float)):
+        return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc).date()
+
+    return value
+
+
 def initialize_lava(input_path, output_path, input_type):
     '''
     Initialize the LAVA data.
@@ -114,7 +195,7 @@ def initialize_lava(input_path, output_path, input_type):
 
     # lava_data and lava_db are module level singletons for the run; this is the one
     # function that creates them, so the global statement is deliberate.
-    global lava_data, lava_db  # pylint: disable=global-statement
+    global lava_data, lava_db, lava_db_path  # pylint: disable=global-statement
 
     lava_data = {
         "parser_info": {
@@ -137,8 +218,8 @@ def initialize_lava(input_path, output_path, input_type):
         }
     }
 
-    db_path = os.path.join(output_path, lava_db_name)
-    lava_db = sqlite3.connect(db_path)
+    lava_db_path = os.path.join(output_path, lava_db_name)
+    lava_db = sqlite3.connect(lava_db_path)
 
     cursor = lava_db.cursor()
     cursor.execute('''CREATE TABLE _artifact_search_patterns (
@@ -307,6 +388,68 @@ def lava_process_artifact(
     return sanitized_table_name, object_columns, column_map
 
 
+def lava_update_artifact_record_count(category, table_name, record_count):
+    """Update LAVA metadata after a streamed insert discovers the exact count."""
+    global lava_data
+
+    if category not in lava_data["artifacts"]:
+        return
+
+    for artifact in lava_data["artifacts"][category]:
+        if artifact.get("tablename") == table_name:
+            artifact["record_count"] = record_count
+            return
+
+
+class _LavaArtifactRows:
+    """Reusable iterable for reading artifact rows back from the LAVA database."""
+
+    def __init__(self, table_name, headers, object_columns=None, row_count=None):
+        self.table_name = table_name
+        self.headers = headers
+        self.object_columns = object_columns or {}
+        self.row_count = row_count
+        self.sanitized_columns = [
+            sanitize_sql_name(header[0] if isinstance(header, tuple) else header)
+            for header in headers
+        ]
+        quoted_columns = ', '.join(quote_sql_name(column) for column in self.sanitized_columns)
+        self.query = f"SELECT {quoted_columns} FROM {quote_sql_name(table_name)} ORDER BY rowid"
+
+    def __len__(self):
+        if self.row_count is not None:
+            return self.row_count
+
+        cursor = lava_db.cursor()
+        cursor.execute(f"SELECT COUNT(*) FROM {quote_sql_name(self.table_name)}")
+        self.row_count = cursor.fetchone()[0]
+        return self.row_count
+
+    def __iter__(self):
+        cursor = lava_db.cursor()
+        for row in cursor.execute(self.query):
+            yield self._restore_row(row)
+
+    def _restore_row(self, row):
+        restored_row = []
+        for index, value in enumerate(row):
+            column = self.sanitized_columns[index]
+            value = _restore_lava_value(value, self.object_columns.get(column))
+            restored_row.append(value)
+        return tuple(restored_row)
+
+
+def lava_iter_artifact_rows(table_name, headers, object_columns=None, row_count=None):
+    """
+    Return a reusable iterable that streams artifact rows from the LAVA table.
+
+    ArtifactResult rows are consumed once while inserting into LAVA. Secondary
+    outputs can call this helper to replay the stored rows without materializing
+    the original module result in memory.
+    """
+    return _LavaArtifactRows(table_name, headers, object_columns, row_count)
+
+
 def lava_add_module(module_name, module_status, file_count=None):
     """
     Adds a module to the global lava_data structure.
@@ -381,29 +524,38 @@ def lava_create_sqlite_table(table_name, data):
 # column_map is unused here but is part of the established call signature: every caller
 # receives it from lava_create_sqlite_table and passes it straight through, so dropping
 # the parameter would mean touching every artifact that writes to LAVA.
-def lava_insert_sqlite_data(table_name, data, object_columns, headers, column_map):  # pylint: disable=unused-argument
+def lava_insert_sqlite_data(
+        table_name,
+        data,
+        object_columns,
+        headers,
+        column_map,
+        batch_size=10000,
+        async_write=False,
+        queue_size=5000):  # pylint: disable=unused-argument
     """
     Insert data into a SQLite database table with automatic column sanitization and type conversion.
     This function handles the insertion of multiple rows of data into a specified SQLite table,
-    with special handling for complex data types (dict, list) and datetime conversions.
+    with special handling for complex data types (dict, list) and object-column type conversions.
     Args:
         table_name (str): The name of the SQLite table to insert data into.
-        data (list): A list of rows to insert, where each row is a sequence of values
-                     corresponding to the headers.
+        data (iterable): Rows to insert, where each row is a sequence of values
+                         corresponding to the headers.
         object_columns (dict): A dictionary mapping column names to their data types.
-                              Supports 'datetime' type for automatic timestamp conversion.
+                              Type-specific storage handlers are applied when needed.
         headers (list): A list of column headers. Each header can be a string or a tuple
                        where the first element is the column name.
         column_map (dict): Column mapping configuration (currently unused in the function).
+        batch_size (int): Maximum rows to insert per SQLite executemany call.
+        async_write (bool): If True, prepare and insert rows on a writer thread.
+        queue_size (int): Maximum rows waiting for the async writer.
     Returns:
-        None
+        int: Number of rows inserted.
     """
 
 
     if not data:
-        return
-
-    cursor = lava_db.cursor()
+        return 0
 
     # Use the sanitized column names directly
     sanitized_columns = [sanitize_sql_name(h[0] if isinstance(h, tuple) else h) for h in headers]
@@ -413,40 +565,109 @@ def lava_insert_sqlite_data(table_name, data, object_columns, headers, column_ma
     quoted_columns = ', '.join(quote_sql_name(column) for column in sanitized_columns)
     query = f"INSERT INTO {quote_sql_name(table_name)} ({quoted_columns}) VALUES ({placeholders})"
 
-    # Prepare the data for insertion
-    rows_to_insert = []
-    for row in data:
-        processed_row = []
-        for sanitized_column, value in zip(sanitized_columns, row):
-            if isinstance(value, dict) or isinstance(value, list):
-                value = json.dumps(value)
-            if sanitized_column in object_columns and object_columns[sanitized_column] == 'datetime':
-                # Convert datetime to integer (Unix timestamp)
-                if isinstance(value, str):
-                    try:
-                        dt = datetime.datetime.fromisoformat(value)
-                        # Treat naive datetimes as UTC; otherwise int(dt.timestamp()) interprets the
-                        # value in the examiner machine's local tz, producing a wrong epoch off-UTC.
-                        if dt.tzinfo is None:
-                            dt = dt.replace(tzinfo=datetime.timezone.utc)
-                        value = int(dt.timestamp())
-                    except ValueError:
-                        # If conversion fails, keep the original value
-                        pass
-                elif isinstance(value, datetime.datetime):
-                    # Treat naive datetimes as UTC (the project convention is to store UTC) so the
-                    # subtraction below doesn't raise "can't subtract offset-naive and offset-aware".
-                    if value.tzinfo is None:
-                        value = value.replace(tzinfo=datetime.timezone.utc)
-                    # Need to do it this way due to dates that could be before Epoch
-                    epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
-                    value = (value - epoch).total_seconds()
-            processed_row.append(value)
-        rows_to_insert.append(tuple(processed_row))
+    column_types = [object_columns.get(column) for column in sanitized_columns]
 
-    # Execute the insert
-    cursor.executemany(query, rows_to_insert)
+    def prepare_row(row):
+        if isinstance(row, sqlite3.Row):
+            row = tuple(row)
+        processed_row = []
+        for index, value in enumerate(row):
+            processed_row.append(_prepare_lava_value(value, column_types[index]))
+        return tuple(processed_row)
+
+    if async_write:
+        return _lava_insert_sqlite_data_async(
+            query,
+            data,
+            prepare_row,
+            batch_size,
+            queue_size,
+        )
+
+    cursor = lava_db.cursor()
+    rows_to_insert = []
+    inserted_count = 0
+    for row in data:
+        rows_to_insert.append(prepare_row(row))
+        if len(rows_to_insert) >= batch_size:
+            cursor.executemany(query, rows_to_insert)
+            inserted_count += len(rows_to_insert)
+            rows_to_insert.clear()
+
+    if rows_to_insert:
+        cursor.executemany(query, rows_to_insert)
+        inserted_count += len(rows_to_insert)
+
     lava_db.commit()
+    return inserted_count
+
+
+def _lava_insert_sqlite_data_async(query, data, prepare_row, batch_size, queue_size):
+    """
+    Insert rows on a writer thread using a separate SQLite connection.
+    """
+    if not lava_db_path:
+        raise RuntimeError("LAVA database has not been initialized")
+
+    batch_queue = queue.Queue(maxsize=queue_size)
+    state = {
+        "error": None,
+        "inserted_count": 0,
+    }
+
+    def writer():
+        db = sqlite3.connect(lava_db_path)
+        cursor = db.cursor()
+        try:
+            while True:
+                batch = batch_queue.get()
+                if batch is _QUEUE_STOP:
+                    break
+                prepared_batch = [prepare_row(row) for row in batch]
+                cursor.executemany(query, prepared_batch)
+                state["inserted_count"] += len(prepared_batch)
+
+            db.commit()
+        except (sqlite3.Error, TypeError, ValueError) as ex:
+            state["error"] = ex
+            db.rollback()
+        finally:
+            db.close()
+
+    thread = threading.Thread(target=writer, name="LEAPPLavaArtifactWriter", daemon=True)
+    thread.start()
+
+    def put_or_raise(item):
+        while True:
+            if state["error"]:
+                raise state["error"]
+            try:
+                batch_queue.put(item, timeout=0.1)
+                return
+            except queue.Full:
+                continue
+
+    try:
+        batch = []
+        for row in data:
+            batch.append(row)
+            if len(batch) >= batch_size:
+                put_or_raise(batch)
+                batch = []
+        if batch:
+            put_or_raise(batch)
+        put_or_raise(_QUEUE_STOP)
+        thread.join()
+        if state["error"]:
+            raise state["error"]
+        return state["inserted_count"]
+    finally:
+        if thread.is_alive():
+            try:
+                batch_queue.put(_QUEUE_STOP, timeout=0.1)
+            except queue.Full:
+                pass
+            thread.join()
 
 
 def lava_get_media_item(media_id):


### PR DESCRIPTION
Adds ArtifactResult, a streaming result path for large artifacts.

Modules can still return the existing (headers, data_list, source_path) tuple, so current artifacts continue working unchanged. Larger artifacts can now create a result object with context.create_artifact_result(), set headers/source metadata, add rows one at a time with results.add_row(...), and return the result.

Rows added through ArtifactResult are written into the LAVA SQLite database in batches, then replayed from LAVA for HTML, TSV, timeline, and KML output. This avoids requiring modules to build one large in-memory data_list before handing results back to the core.

This PR also converts a small set of higher-volume artifacts to the new writer-style API for testing and comparison. Legacy, generator, and writer-style test runs produced matching LAVA record counts.

Intentionally including some extra test scripts to make it easier to do profiling and testing. Planning to remove before final merge.