### PR TITLE
Update apple_build_id_to_os_version.json

### DIFF
--- a/scripts/data/apple_build_id_to_os_version.json
+++ b/scripts/data/apple_build_id_to_os_version.json
@@ -3617,6 +3617,6 @@
     "26100": "Windows 11 version 24H2",
     "26200": "Windows 11 version 25H2",
     "28000": "Windows 11 version 26H1",
-	"26300": "Windows 11 version 26H2",
+	"26300": "Windows 11 version 26H2"
   }
 }


### PR DESCRIPTION
Character remove - was causing errors for App Conduit, Biome - Device Syncs, Connected Device Information, Files App - Operating System Updates, Health - Provenances, OS Updates - Migrations, Sysdiagnose - Account Devices.