### PR TITLE
Add parsers for requested iOS forensic artifacts

### DIFF
--- a/admin/test/scripts/test_requested_ios_databases.py
+++ b/admin/test/scripts/test_requested_ios_databases.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Focused parser tests for the iOS databases requested in July 2026."""
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.artifacts.keyboard import keyboardVulgarWordUsage
+from scripts.artifacts.personalizationPortrait import personalizationPortraitLocations
+from scripts.artifacts.powerlog import powerlogApplicationRuntime
+from scripts.artifacts.recents import appleRecents
+from scripts.artifacts.safariTabs import safariTabsDatabase
+from scripts.artifacts.wifiAnalytics import wifiAnalyticsGeotags
+
+
+class _Context:
+    def __init__(self, path):
+        self.path = str(path)
+
+    def get_files_found(self):
+        return [self.path]
+
+    def get_relative_path(self, path):
+        return Path(path).name
+
+
+class RequestedIOSDatabasesTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _database(self, relative_path, statements):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(path) as db:
+            for statement, values in statements:
+                db.execute(statement, values)
+        return path
+
+    def test_recents(self):
+        path = self._database("mobile/Library/Recents/Recents", [
+            ("CREATE TABLE recents (sending_address, original_source, dates, last_date, "
+             "weight, record_hash, count, group_kind)", ()),
+            ("CREATE TABLE contacts (recent_id, kind, address, display_name)", ()),
+            ("CREATE TABLE metadata (recent_id, key, value)", ()),
+            ("INSERT INTO recents VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             ("me@example.com", "com.apple.mobilemail", "1000,2000", 2000, 1, "hash", 2, 3)),
+            ("INSERT INTO contacts VALUES (?, ?, ?, ?)", (1, 1, "you@example.com", "You")),
+            ("INSERT INTO metadata VALUES (?, ?, ?)", (1, "key", b"\x01\x02")),
+        ])
+        headers, rows, _ = appleRecents.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][9], "0102")
+        self.assertIn("1970-01-01T00:00:01", rows[0][1])
+
+    def test_safari_tabs(self):
+        path = self._database("mobile/Library/Safari/SafariTabs.db", [
+            ("CREATE TABLE bookmarks (id, title, url, parent, last_modified, date_closed, "
+             "deleted, order_index)", ()),
+            ("INSERT INTO bookmarks VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             (1, "Private", None, None, None, None, 0, 0)),
+            ("INSERT INTO bookmarks VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             (2, "Example", "https://example.com", 1, 100, None, 0, 1)),
+        ])
+        headers, rows, _ = safariTabsDatabase.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][6], "Private")
+        self.assertEqual(rows[0][7], "Private")
+
+    def test_vulgar_words(self):
+        path = self._database("mobile/Library/Keyboard/VulgarWordUsage.db", [
+            ("CREATE TABLE vword_usage (ROWID INTEGER PRIMARY KEY, app TEXT, recipient TEXT, "
+             "vword TEXT, word_reading TEXT, usage_count INTEGER, "
+             "last_use_timestamp REAL, journaled)", ()),
+            ("INSERT INTO vword_usage VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             (1, "com.example", "recipient", "example", "", 4, 100, 1)),
+        ])
+        headers, rows, _ = keyboardVulgarWordUsage.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][6], 4)
+
+    def test_wifi_analytics(self):
+        path = self._database(
+            "root/Library/Application Support/com.apple.wifianalyticsd/"
+            "DeviceAnalyticsModel.sqlite",
+            [
+                ("CREATE TABLE ZGEOTAG (Z_PK, Z_ENT, ZDATE, ZLATITUDE, ZLONGITUDE, ZBSS)", ()),
+                ("CREATE TABLE ZBSS (Z_PK, ZLASTSEEN, ZBSSID, ZNETWORK)", ()),
+                ("CREATE TABLE ZNETWORK (Z_PK, ZSSID)", ()),
+                ("INSERT INTO ZGEOTAG VALUES (?, ?, ?, ?, ?, ?)", (1, 2, 100, 41.0, -87.0, 3)),
+                ("INSERT INTO ZBSS VALUES (?, ?, ?, ?)", (3, 200, "aa:bb", 4)),
+                ("INSERT INTO ZNETWORK VALUES (?, ?)", (4, "Network")),
+            ],
+        )
+        headers, rows, _ = wifiAnalyticsGeotags.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][-1], "Network")
+
+    def test_personalization_portrait(self):
+        path = self._database("mobile/Library/PersonalizationPortrait/PPSQLDatabase.db", [
+            ("CREATE TABLE sources (id, bundle_id, group_id, seconds_from_1970)", ()),
+            ("CREATE TABLE loc_records (id, source_id, cll_latitude_degrees, "
+             "cll_longitude_degrees, clp_name, clp_thoroughfare, clp_subThoroughfare, "
+             "clp_locality, clp_subLocality, clp_administrativeArea, "
+             "clp_subAdministrativeArea, clp_postalCode, clp_ISOcountryCode, clp_country, "
+             "extraction_os_build, category, algorithm, initial_score, is_sync_eligible)", ()),
+            ("INSERT INTO sources VALUES (?, ?, ?, ?)", (1, "com.apple.mobilemail", "group", 100)),
+            ("INSERT INTO loc_records VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+             "?, ?, ?, ?)", (1, 1, 41.0, -87.0, "Place", "Road", "1", "City", "", "IL", "",
+                             "12345", "US", "United States", "23A", "cat", "alg", 0.5, 1)),
+        ])
+        headers, rows, _ = personalizationPortraitLocations.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][-1], "Yes")
+
+    def test_powerlog_runtime(self):
+        path = self._database("PowerLog/CurrentPowerlog.PLSQL", [
+            ("CREATE TABLE PLAppTimeService_Aggregate_AppRunTime "
+             "(timestamp, BundleID, BackgroundTime, ScreenOnTime)", ()),
+            ("INSERT INTO PLAppTimeService_Aggregate_AppRunTime VALUES (?, ?, ?, ?)",
+             (1635847545, "com.apple.mobilesafari", 2.0, 30.0)),
+        ])
+        headers, rows, _ = powerlogApplicationRuntime.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][1], "com.apple.mobilesafari")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/artifacts/keyboard.py
+++ b/scripts/artifacts/keyboard.py
@@ -72,6 +72,24 @@ __artifacts_v2__ = {
             "jess_ios15": "iOS 15.0.2 | 3 rows",
             "magnet_ios16": "iOS 16.1.1 | 4 rows",
         }
+    },
+    "keyboardVulgarWordUsage": {
+        "name": "Keyboard Vulgar Word Usage",
+        "description": "Words and usage values stored in VulgarWordUsage.db",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "User Activity",
+        "notes": "The last-use timestamp uses the Apple Cocoa epoch.",
+        "paths": ("*/mobile/Library/Keyboard/VulgarWordUsage.db*",),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "message-2",
+        "sample_data": {
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows",
+        },
     }
 }
 
@@ -80,7 +98,10 @@ import string
 from os.path import dirname
 from datetime import datetime
 
-from scripts.ilapfuncs import open_sqlite_db_readonly, convert_ts_human_to_utc, artifact_processor
+from scripts.ilapfuncs import (
+    open_sqlite_db_readonly, convert_ts_human_to_utc, artifact_processor,
+    does_table_exist_in_db, get_sqlite_db_records,
+)
 
 @artifact_processor
 def keyboardLexicon(context):
@@ -155,3 +176,30 @@ def keyboardUsageStats(context):
     
     data_headers = (('Creation Date', 'datetime'), ('Last Update Date', 'datetime'), 'Key', 'Data Value', 'Source File')
     return data_headers, data_list, 'See source paths in data'
+
+
+@artifact_processor
+def keyboardVulgarWordUsage(context):
+    data_headers = (
+        ("Last Used", "datetime"), "Record ID", "Application", "Recipient", "Vulgar Word",
+        "Word Reading", "Usage Count", "Journaled",
+    )
+    data_list = []
+    source_path = next(
+        (str(path) for path in context.get_files_found()
+         if str(path).endswith("VulgarWordUsage.db")),
+        "",
+    )
+    if not source_path or not does_table_exist_in_db(source_path, "vword_usage"):
+        return data_headers, data_list, ""
+
+    query = """
+        SELECT CASE WHEN last_use_timestamp > 0
+                    THEN datetime(last_use_timestamp + 978307200, 'unixepoch') END,
+               ROWID, app, recipient, vword, word_reading, usage_count,
+               journaled
+        FROM vword_usage
+        ORDER BY last_use_timestamp
+    """
+    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/personalizationPortrait.py
+++ b/scripts/artifacts/personalizationPortrait.py
@@ -1,0 +1,70 @@
+__artifacts_v2__ = {
+    "personalizationPortraitLocations": {
+        "name": "Personalization Portrait - Locations",
+        "description": "Locations aggregated for Apple's personalization features",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Locations",
+        "notes": (
+            "Aggregated locations are not proof that the device visited a place; the source "
+            "bundle and group provide essential attribution context. Based on research by "
+            "Sarah Edwards: https://www.mac4n6.com/blog/2020/6/2/guest-post-by-bizzybarney-"
+            "a-peek-inside-the-ppsqldatabasedb-personalization-portrait-database"
+        ),
+        "paths": (
+            "*/mobile/Library/PersonalizationPortrait/PPSQLDatabase.db*",
+        ),
+        "output_types": ["html", "tsv", "lava", "timeline", "kml"],
+        "artifact_icon": "map",
+        "sample_data": {
+            "hickman_ios15": "iOS 15 | 169 rows",
+            "jess_ios15": "iOS 15.0.2 | 16 rows",
+            "magnet_ios16": "iOS 16.1.1 | 20 rows",
+            "felix_ios17": "iOS 17.6.1 | 76 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 664 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 726 rows",
+        },
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def personalizationPortraitLocations(context):
+    data_headers = (
+        ("Source Time", "datetime"), "Location ID", "Bundle ID", "Group ID",
+        ("Latitude", "latitude"), ("Longitude", "longitude"), "Name", "Road", "Street Number",
+        "City", "Sub-locality", "Administrative Area", "Sub-administrative Area", "Postal Code",
+        "Country Code", "Country", "iOS Build", "Category", "Algorithm", "Initial Score",
+        "Sync Eligible",
+    )
+    data_list = []
+    source_path = next(
+        (str(path) for path in context.get_files_found()
+         if str(path).endswith("PPSQLDatabase.db")),
+        "",
+    )
+    if not source_path:
+        return data_headers, data_list, ""
+
+    query = """
+        SELECT datetime(sources.seconds_from_1970, 'unixepoch'),
+               loc_records.id, sources.bundle_id, sources.group_id,
+               loc_records.cll_latitude_degrees, loc_records.cll_longitude_degrees,
+               loc_records.clp_name, loc_records.clp_thoroughfare,
+               loc_records.clp_subThoroughfare, loc_records.clp_locality,
+               loc_records.clp_subLocality, loc_records.clp_administrativeArea,
+               loc_records.clp_subAdministrativeArea, loc_records.clp_postalCode,
+               loc_records.clp_ISOcountryCode, loc_records.clp_country,
+               loc_records.extraction_os_build, loc_records.category, loc_records.algorithm,
+               loc_records.initial_score,
+               CASE loc_records.is_sync_eligible WHEN 1 THEN 'Yes' WHEN 0 THEN 'No' END
+        FROM loc_records
+        LEFT JOIN sources ON loc_records.source_id = sources.id
+        ORDER BY sources.seconds_from_1970
+    """
+    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/powerlog.py
+++ b/scripts/artifacts/powerlog.py
@@ -1,0 +1,66 @@
+__artifacts_v2__ = {
+    "powerlogApplicationRuntime": {
+        "name": "PowerLog - Application Runtime",
+        "description": "Application foreground and background runtime recorded by PowerLog",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "PowerLog",
+        "notes": (
+            "Parses PLAppTimeService_Aggregate_AppRunTime. PowerLog contains many additional "
+            "version-specific tables that require separate validation."
+        ),
+        "paths": (
+            "*/BatteryLife/*.PLSQL*",
+            "*/BatteryLife/Archives/*.PLSQL*",
+            "*/Powerlog/*.PLSQL*",
+            "*/PowerLog/*.PLSQL*",
+            "*/powerlog/*.PLSQL*",
+        ),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "battery",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 1256 rows",
+            "hickman_ios15": "iOS 15 | 3322 rows",
+            "jess_ios15": "iOS 15.0.2 | 723 rows",
+            "magnet_ios16": "iOS 16.1.1 | 933 rows",
+            "felix_ios17": "iOS 17.6.1 | 5662 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 4127 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 4244 rows",
+        },
+    }
+}
+
+from scripts.ilapfuncs import (
+    artifact_processor,
+    does_table_exist_in_db,
+    get_sqlite_db_records,
+)
+
+
+@artifact_processor
+def powerlogApplicationRuntime(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Bundle ID", "Background Time (seconds)",
+        "Screen-on Time (seconds)", "Source File",
+    )
+    data_list = []
+    source_paths = [
+        str(path) for path in context.get_files_found()
+        if str(path).endswith(".PLSQL")
+    ]
+    for source_path in source_paths:
+        if not does_table_exist_in_db(source_path, "PLAppTimeService_Aggregate_AppRunTime"):
+            continue
+        query = """
+            SELECT datetime(timestamp, 'unixepoch'), BundleID, BackgroundTime, ScreenOnTime
+            FROM PLAppTimeService_Aggregate_AppRunTime
+            ORDER BY timestamp
+        """
+        relative_path = context.get_relative_path(source_path)
+        data_list.extend(tuple(row) + (relative_path,)
+                         for row in get_sqlite_db_records(source_path, query))
+
+    source = "See source paths in data" if source_paths else ""
+    return data_headers, data_list, source

--- a/scripts/artifacts/recents.py
+++ b/scripts/artifacts/recents.py
@@ -1,0 +1,82 @@
+__artifacts_v2__ = {
+    "appleRecents": {
+        "name": "Apple Recents",
+        "description": "Recent interactions with Apple apps, contacts and addresses",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "User Activity",
+        "notes": (
+            "The Dates field may contain multiple comma-separated Unix timestamps in "
+            "milliseconds. Parsed Dates preserves all valid values. Query adapted from "
+            "https://github.com/kacos2000/Queries/blob/master/recents.sql"
+        ),
+        "paths": ("*/mobile/Library/Recents/Recents*",),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "history",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 19 rows",
+            "hickman_ios15": "iOS 15 | 39 rows",
+            "jess_ios15": "iOS 15.0.2 | 17 rows",
+            "magnet_ios16": "iOS 16.1.1 | 5 rows",
+            "felix_ios17": "iOS 17.6.1 | 56 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 14 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 53 rows",
+        },
+    }
+}
+
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+def _parse_dates(value):
+    parsed = []
+    for item in str(value or "").split(","):
+        try:
+            parsed.append(datetime.fromtimestamp(float(item.strip()) / 1000, timezone.utc))
+        except (ValueError, TypeError, OverflowError, OSError):
+            continue
+    return ", ".join(value.isoformat() for value in parsed)
+
+
+@artifact_processor
+def appleRecents(context):
+    data_headers = (
+        ("Last Date", "datetime"), "Parsed Dates (UTC)", "Dates (Raw)", "Recent ID",
+        "Contact Kind", "Sending Address", "Contact Address", "Display Name",
+        "Metadata Key", "Metadata Value", "Original Source", "Weight", "Record Hash",
+        "Count", "Group Kind",
+    )
+    data_list = []
+    source_path = next(
+        (str(path) for path in context.get_files_found()
+         if str(path).replace("\\", "/").endswith("/Recents/Recents")),
+        "",
+    )
+    if not source_path:
+        return data_headers, data_list, ""
+
+    query = """
+        SELECT datetime(recents.last_date / 1000, 'unixepoch'),
+               recents.ROWID, contacts.kind, recents.sending_address, contacts.address,
+               contacts.display_name, metadata.key, metadata.value, recents.original_source,
+               recents.dates, recents.weight, recents.record_hash, recents.count,
+               recents.group_kind
+        FROM recents
+        LEFT JOIN contacts ON recents.ROWID = contacts.recent_id
+        LEFT JOIN metadata ON metadata.recent_id = recents.ROWID
+        ORDER BY recents.last_date DESC
+    """
+    for row in get_sqlite_db_records(source_path, query):
+        metadata_value = row[7]
+        if isinstance(metadata_value, bytes):
+            metadata_value = metadata_value.hex()
+        data_list.append(
+            (row[0], _parse_dates(row[9]), row[9]) + tuple(row[1:7])
+            + (metadata_value, row[8]) + tuple(row[10:])
+        )
+
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -48,6 +48,27 @@ __artifacts_v2__ = {
             "jess_ios15": "iOS 15.0.2 | 2 rows",
             "magnet_ios16": "iOS 16.1.1 | 1 row",
         }
+    },
+    "safariTabsDatabase": {
+        "name": "Safari Browser - Tabs (SafariTabs)",
+        "description": "Open normal and private Safari tabs from SafariTabs.db",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Safari Browser",
+        "notes": "Public and LocalProfile are normal browsing; private is private browsing.",
+        "paths": ("**/Safari/SafariTabs.db*",),
+        "output_types": "standard",
+        "artifact_icon": "layout",
+        "sample_data": {
+            "hickman_ios15": "iOS 15 | 4 rows",
+            "jess_ios15": "iOS 15.0.2 | 2 rows",
+            "magnet_ios16": "iOS 16.1.1 | 1 row",
+            "felix_ios17": "iOS 17.6.1 | 4 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 11 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 4 rows",
+        },
     }
 }
 
@@ -57,7 +78,9 @@ from datetime import datetime, timezone
 
 import nska_deserialize as nd
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+from scripts.ilapfuncs import (
+    artifact_processor, does_table_exist_in_db, get_sqlite_db_records, logfunc,
+)
 
 _PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
                  nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
@@ -158,4 +181,60 @@ def safariTabsiCloud(context):
         data_list.append((_aware_utc(created), _aware_utc(modified), row[1], row[2], row[3],
                           row[4], row[5], mod_dev))
 
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def safariTabsDatabase(context):
+    data_headers = (
+        ("Last Modified", "datetime"), ("Date Closed", "datetime"), "Tab ID", "Title",
+        "URL", "Parent ID", "Parent / Tab Group", "Browsing Mode",
+    )
+    data_list = []
+    source_path = _find(context, "SafariTabs.db")
+    if not source_path or not does_table_exist_in_db(source_path, "bookmarks"):
+        return data_headers, data_list, ""
+
+    query = """
+        WITH RECURSIVE ancestry(tab_id, ancestor_id, parent_id, ancestor_title, depth) AS (
+            SELECT id, id, parent, title, 0
+            FROM bookmarks
+            WHERE url IS NOT NULL AND trim(url) != '' AND COALESCE(deleted, 0) = 0
+            UNION ALL
+            SELECT ancestry.tab_id, parent.id, parent.parent, parent.title, ancestry.depth + 1
+            FROM ancestry
+            JOIN bookmarks AS parent ON parent.id = ancestry.parent_id
+            WHERE ancestry.depth < 20
+        ),
+        tab_context AS (
+            SELECT tab_id,
+                   MAX(CASE WHEN lower(ancestor_title) IN ('private', 'privatepinned')
+                            THEN 1 ELSE 0 END) AS is_private
+            FROM ancestry
+            GROUP BY tab_id
+        )
+        SELECT CASE WHEN tab.last_modified IS NULL THEN NULL
+                    WHEN tab.last_modified > 978307200
+                        THEN datetime(tab.last_modified, 'unixepoch')
+                    ELSE datetime(tab.last_modified + 978307200, 'unixepoch') END,
+               CASE WHEN tab.date_closed IS NULL THEN NULL
+                    WHEN tab.date_closed > 978307200
+                        THEN datetime(tab.date_closed, 'unixepoch')
+                    ELSE datetime(tab.date_closed + 978307200, 'unixepoch') END,
+               tab.id, tab.title, tab.url, tab.parent,
+               COALESCE(parent.title, CAST(tab.parent AS TEXT)),
+               CASE
+                   WHEN lower(CAST(tab.parent AS TEXT)) = 'private'
+                        OR tab_context.is_private = 1 THEN 'Private'
+                   WHEN lower(CAST(tab.parent AS TEXT)) IN ('public', 'localprofile', 'local')
+                        THEN 'Normal'
+                   ELSE 'Normal'
+               END
+        FROM bookmarks AS tab
+        LEFT JOIN bookmarks AS parent ON parent.id = tab.parent
+        LEFT JOIN tab_context ON tab_context.tab_id = tab.id
+        WHERE tab.url IS NOT NULL AND trim(tab.url) != '' AND COALESCE(tab.deleted, 0) = 0
+        ORDER BY tab.order_index
+    """
+    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/wifiAnalytics.py
+++ b/scripts/artifacts/wifiAnalytics.py
@@ -1,0 +1,57 @@
+__artifacts_v2__ = {
+    "wifiAnalyticsGeotags": {
+        "name": "Wi-Fi Analytics - Geotags",
+        "description": "Geotagged Wi-Fi networks recorded by wifianalyticsd",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Wi-Fi",
+        "notes": "Dates use the Apple Cocoa epoch. Locations should be corroborated.",
+        "paths": (
+            "*/root/Library/Application Support/com.apple.wifianalyticsd/"
+            "DeviceAnalyticsModel.sqlite*",
+        ),
+        "output_types": ["html", "tsv", "lava", "timeline", "kml"],
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "hickman_ios15": "iOS 15 | 9 rows",
+            "jess_ios15": "iOS 15.0.2 | 17 rows",
+            "magnet_ios16": "iOS 16.1.1 | 14 rows",
+            "felix_ios17": "iOS 17.6.1 | 15 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 4 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 4 rows",
+        },
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+@artifact_processor
+def wifiAnalyticsGeotags(context):
+    data_headers = (
+        ("Date", "datetime"), ("Last Seen", "datetime"), "Geotag ID", "Entity ID",
+        ("Latitude", "latitude"), ("Longitude", "longitude"), "BSSID", "SSID",
+    )
+    data_list = []
+    source_path = next(
+        (str(path) for path in context.get_files_found()
+         if str(path).endswith("DeviceAnalyticsModel.sqlite")),
+        "",
+    )
+    if not source_path:
+        return data_headers, data_list, ""
+
+    query = """
+        SELECT datetime(ZGEOTAG.ZDATE + 978307200, 'unixepoch'),
+               datetime(ZBSS.ZLASTSEEN + 978307200, 'unixepoch'),
+               ZGEOTAG.Z_PK, ZGEOTAG.Z_ENT,
+               ZGEOTAG.ZLATITUDE, ZGEOTAG.ZLONGITUDE, ZBSS.ZBSSID, ZNETWORK.ZSSID
+        FROM ZGEOTAG
+        LEFT JOIN ZBSS ON ZBSS.Z_PK = ZGEOTAG.ZBSS
+        LEFT JOIN ZNETWORK ON ZNETWORK.Z_PK = ZBSS.ZNETWORK
+        ORDER BY ZGEOTAG.ZDATE
+    """
+    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/zProfileIOSArtifactGapReview.ilprofile
+++ b/zProfileIOSArtifactGapReview.ilprofile
@@ -1,0 +1,1 @@
+{"leapp": "ileapp", "format_version": 1, "plugins": ["appleRecents", "safariTabsDatabase", "keyboardVulgarWordUsage", "wifiAnalyticsGeotags", "personalizationPortraitLocations", "powerlogApplicationRuntime"]}


### PR DESCRIPTION
## Summary

- add Apple Recents parsing with multi-date handling
- add SafariTabs.db parsing with normal/private hierarchy detection
- add VulgarWordUsage.db parsing
- add Wi-Fi analytics geotag parsing
- add Personalization Portrait location parsing
- add PowerLog application runtime parsing
- add a focused review profile and schema regression tests
- order primary and secondary timestamps first in reports

## Validation

- 10 unit, import, and entry-point tests pass
- changed-file lint and whitespace checks pass
- profile resolves all six plugins
- corpus-tested across iOS 12, 15, 16, 17, 18.0, and 18.7
- end-to-end profile run produced HTML, TSV, LAVA, timeline, and KML output

Corpus report row counts: Recents 56; Safari Tabs 4; Vulgar Word Usage 1; Wi-Fi Analytics 15; Personalization Portrait 76; PowerLog 5,662.