### PR TITLE
Parse Apple Account device list from akd devicelist.db

### DIFF
--- a/admin/docs/testing/local_corpus_tests.md
+++ b/admin/docs/testing/local_corpus_tests.md
@@ -1,0 +1,60 @@
+# Testing Against Non-Public Images
+
+The normal test-case route records image content in the repository. `make_test_data.py`
+copies every responsive file verbatim into `admin/test/cases/data/<module>/testdata.*.zip`,
+and those zips are committed on purpose (`.gitignore` ignores that directory but
+re-includes `testdata*.zip`). `test_module_output.py` then writes the parsed rows
+themselves into `admin/test/results/<module>/`. Every case in the repository today comes
+from one of the four publicly distributed images in
+[image_manifest.json](../../image_manifest.json), so their device identifiers are already
+public.
+
+Some artifacts only appear in images that cannot be published. `devicelist.db` is the
+first: it is absent from all four manifest images. For these,
+`admin/test/scripts/test_local_corpus_artifacts.py` gives a repeatable check that leaves
+no image content behind.
+
+## Running
+
+```
+ILEAPP_LOCAL_IMAGE=/path/to/extraction.zip \
+    python -m pytest admin/test/scripts/test_local_corpus_artifacts.py -v
+```
+
+A `.zip` extraction or a directory of extracted files both work. Without the variable the
+tests skip, which is what happens in CI and for anyone who does not hold the image. When
+the image simply lacks the file, the test skips rather than fails.
+
+## What these tests may assert
+
+Structure only. Column counts, value shapes, timestamp ranges, whether a column came back
+empty for every row. Never a value from the image, because an assertion failure prints
+what it compared, and that output ends up in terminals, CI logs and pasted bug reports.
+
+Use the helpers on `LocalCorpusTestCase` rather than the bare `unittest` ones where an
+image value is involved:
+
+- `assert_matches(value, pattern, label)` instead of `assertRegex`
+- `assert_plausible_timestamp(value)` instead of comparing datetimes directly
+- `assert_row_shape(headers, rows)` for the row-length check
+
+Both redact through `_redact()` before reporting, so a failure shows `####-##-##` rather
+than a real date.
+
+## What they catch
+
+Real regressions in the parts that synthetic fixtures cannot reach: a misread epoch, a
+query naming a column the real schema does not have, a decode step that quietly returns
+nothing, a value shape that only occurs in the wild. Injecting a wrong-epoch bug into
+`appleAccountDeviceList` fails `test_device_list_structure` with a redacted message.
+
+They are not a substitute for the synthetic unit tests in
+`test_requested_ios_databases.py`, which run everywhere and are what a reviewer without
+the image can execute. Write both: synthetic tests for the logic, a local corpus test for
+fidelity against the real file.
+
+## When an image becomes public
+
+Add it to [image_manifest.json](../../image_manifest.json) following
+[guide_adding_images.md](guide_adding_images.md) and generate normal test cases. The local
+corpus test can stay; it costs nothing and keeps working for whoever holds the image.

--- a/admin/docs/testing/readme.md
+++ b/admin/docs/testing/readme.md
@@ -29,7 +29,11 @@ This documentation provides an overview of the testing processes and components 
    - Step-by-step guide for adding new test images to the project
    - Best practices for maintaining the [image manifest](../../image_manifest.json)
 
-7. [File Path Analysis](filepath_analysis.md)
+7. [Testing Against Non-Public Images](local_corpus_tests.md)
+   - Using `test_local_corpus_artifacts.py` for artifacts absent from the manifest images
+   - Structure-only assertions that keep image content out of the repository and test logs
+
+8. [File Path Analysis](filepath_analysis.md)
    - Overview of the file path search process
    - Explanation of [filepath_results.csv](../filepath_results.csv) and [filepath_search_summary.md](../filepath_search_summary.md)
 

--- a/admin/test/scripts/test_local_corpus_artifacts.py
+++ b/admin/test/scripts/test_local_corpus_artifacts.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Opt-in structural checks against a local, non-public extraction.
+
+Some artifacts are only present in images that cannot be committed to this
+repository, so the usual route (`make_test_data.py` into
+`admin/test/cases/data/`, expected output into `admin/test/results/`) is not
+available: both of those record the parsed values themselves.
+
+These tests take the other route. Point ILEAPP_LOCAL_IMAGE at an extraction and
+they run the real artifact code over the real database, asserting only
+structural invariants: column counts, value shapes, timestamp sanity. No value
+from the image is written to disk or recorded in an assertion, so nothing about
+the device enters the repository or the test output. Without the variable set
+they skip, which is what happens in CI.
+
+    ILEAPP_LOCAL_IMAGE=/path/to/extraction.zip \
+        python -m pytest admin/test/scripts/test_local_corpus_artifacts.py -v
+
+Accepts a .zip extraction or a directory of extracted files.
+"""
+
+import os
+import re
+import shutil
+import tempfile
+import unittest
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.artifacts.appleAccountDeviceList import appleAccountDeletedDeviceList, \
+    appleAccountDeviceList
+
+LOCAL_IMAGE = os.environ.get('ILEAPP_LOCAL_IMAGE', '')
+
+# Timestamps outside this window mean the epoch was read wrong, whatever the
+# image is. Apple shipped no iOS device before 2007 and these are not future
+# dated fields.
+EARLIEST_PLAUSIBLE = datetime(2007, 1, 1, tzinfo=timezone.utc)
+LATEST_PLAUSIBLE = datetime(2100, 1, 1, tzinfo=timezone.utc)
+
+
+def _redact(value):
+    """Reduce a value to its shape so failures can be reported safely."""
+    return re.sub(r'\w', '#', str(value))
+
+
+class _Context:
+    def __init__(self, path):
+        self.path = str(path)
+
+    def get_files_found(self):
+        return [self.path]
+
+    def get_relative_path(self, path):
+        return Path(path).name
+
+
+class LocalCorpusTestCase(unittest.TestCase):
+    """Base class handling the lookup of a file inside the local image."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+    def fetch(self, suffix):
+        """Copy the first file whose path ends with suffix out of the image.
+
+        Returns None when the image does not carry the file, which is a skip
+        rather than a failure: these images are whatever the examiner had.
+        """
+        destination = Path(self.temp_dir.name) / Path(suffix).name
+        source = Path(LOCAL_IMAGE)
+
+        if source.is_dir():
+            for candidate in source.rglob(Path(suffix).name):
+                if str(candidate).replace(os.sep, '/').endswith(suffix):
+                    shutil.copy2(candidate, destination)
+                    return destination
+            return None
+
+        with zipfile.ZipFile(source) as archive:
+            for name in archive.namelist():
+                if name.endswith(suffix):
+                    with archive.open(name) as member, open(destination, 'wb') as out:
+                        shutil.copyfileobj(member, out)
+                    return destination
+        return None
+
+    def assert_row_shape(self, headers, rows):
+        """Every row matches the declared headers."""
+        for row in rows:
+            self.assertEqual(len(row), len(headers))
+
+    def assert_matches(self, value, pattern, label):
+        """Assert a value's shape, reporting only the shape when it fails.
+
+        unittest prints the compared values on failure, which would put image
+        content in the test log. Everything reported here is redacted first.
+        """
+        self.assertTrue(
+            re.match(pattern, str(value)),
+            f'{label} does not match {pattern}; value shape was {_redact(value)}')
+
+    def assert_plausible_timestamp(self, value):
+        """A parsed timestamp column holds a sane datetime, or nothing at all."""
+        if value in (None, ''):
+            return
+        self.assertIsInstance(value, datetime)
+        self.assertIsNotNone(value.tzinfo)
+        self.assertTrue(
+            EARLIEST_PLAUSIBLE < value < LATEST_PLAUSIBLE,
+            f'timestamp outside {EARLIEST_PLAUSIBLE.year}-{LATEST_PLAUSIBLE.year}; '
+            f'value shape was {_redact(value)}')
+
+
+@unittest.skipUnless(LOCAL_IMAGE, 'set ILEAPP_LOCAL_IMAGE to run local corpus tests')
+class AppleAccountDeviceListLocalTest(LocalCorpusTestCase):
+    SUFFIX = 'Library/Application Support/com.apple.akd/devicelist.db'
+
+    def setUp(self):
+        super().setUp()
+        self.path = self.fetch(self.SUFFIX)
+        if not self.path:
+            self.skipTest(f'{self.SUFFIX} not present in {LOCAL_IMAGE}')
+
+    def test_device_list_structure(self):
+        headers, rows, source = appleAccountDeviceList.__wrapped__(_Context(self.path))
+        self.assertEqual(source, str(self.path))
+        self.assertTrue(rows, 'device_list parsed no rows')
+        self.assert_row_shape(headers, rows)
+
+        for row in rows:
+            self.assert_plausible_timestamp(row[0])   # Last Updated
+            self.assert_plausible_timestamp(row[1])   # Last Cache Updated
+            self.assert_matches(row[9], r'^(Yes|No)$', 'Trusted')
+            if row[8]:                                # IMEI, when the blob held one
+                for imei in row[8].split(', '):
+                    self.assert_matches(imei, r'^\d{14,16}$', 'IMEI')
+            if row[5]:                                # OS Version
+                self.assert_matches(row[5], r'^\d+(\.\d+)*$', 'OS Version')
+
+    def test_deleted_device_list_structure(self):
+        headers, rows, _ = appleAccountDeletedDeviceList.__wrapped__(_Context(self.path))
+        self.assert_row_shape(headers, rows)
+        for row in rows:
+            self.assert_plausible_timestamp(row[0])
+            self.assert_plausible_timestamp(row[1])
+
+    def test_no_column_is_wholly_unparsed(self):
+        """Catch a column that silently yields nothing on every row.
+
+        A header that is empty in every row usually means the query names a
+        column the schema does not have, or a decode step failed. Columns that
+        are legitimately sparse are listed as exempt.
+        """
+        headers, rows, _ = appleAccountDeviceList.__wrapped__(_Context(self.path))
+        exempt = {'IMEI', 'Additional Info', 'Circle Status'}
+        for index, header in enumerate(headers):
+            label = header[0] if isinstance(header, tuple) else header
+            if label in exempt:
+                continue
+            populated = any(row[index] not in (None, '') for row in rows)
+            self.assertTrue(populated, f'every row is empty for column {label}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_requested_ios_databases.py
+++ b/admin/test/scripts/test_requested_ios_databases.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.artifacts.appleAccountDeviceList import appleAccountDeletedDeviceList, \
+    appleAccountDeviceList
 from scripts.artifacts.keyboard import keyboardVulgarWordUsage
 from scripts.artifacts.personalizationPortrait import personalizationPortraitLocations
 from scripts.artifacts.powerlog import powerlogApplicationRuntime
@@ -127,6 +129,68 @@ class RequestedIOSDatabasesTest(unittest.TestCase):
         headers, rows, _ = powerlogApplicationRuntime.__wrapped__(_Context(path))
         self.assertEqual(len(headers), len(rows[0]))
         self.assertEqual(rows[0][1], "com.apple.mobilesafari")
+
+    def _devicelist_database(self, statements):
+        return self._database(
+            "mobile/Library/Application Support/com.apple.akd/devicelist.db", statements)
+
+    DEVICE_LIST_SCHEMA = (
+        "CREATE TABLE device_list (mid TEXT PRIMARY KEY, name TEXT, serial_number TEXT, "
+        "model TEXT, os TEXT, os_version TEXT, dc TEXT, clcg TEXT, clbg TEXT, clhs TEXT, "
+        "dec TEXT, circle_status INTEGER, build_number TEXT, trusted INTEGER, "
+        "last_updated_date DOUBLE, additional_info BLOB, altDSID TEXT, services TEXT, "
+        "last_cache_updated_date DOUBLE)")
+    DELETED_DEVICE_LIST_SCHEMA = (
+        "CREATE TABLE deleted_device_list (mid TEXT PRIMARY KEY, reason INTEGER, "
+        "last_updated_date DOUBLE, altDSID TEXT, deleted_date DOUBLE)")
+
+    def test_apple_account_device_list(self):
+        path = self._devicelist_database([
+            (self.DEVICE_LIST_SCHEMA, ()),
+            ("INSERT INTO device_list VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+             "?, ?, ?)",
+             ("MID000", "Test iPhone", "SERIAL00", "iPhone11,2", "iOS", "18.7.8", "1", "1",
+              "0", "1", "1", 0, "22H352", 1, 1781275553.938,
+              b'{"phones":[{"imei":"000000000000000","slotID":1}]}', "ALTDSID00",
+              "itunesstore,icloud", 1781315778.68896)),
+        ])
+        headers, rows, _ = appleAccountDeviceList.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertIn("2026-06-12T14:45:53", rows[0][0].isoformat())
+        self.assertEqual(rows[0][2], "Test iPhone")
+        self.assertEqual(rows[0][8], "000000000000000")
+        self.assertEqual(rows[0][9], "Yes")
+
+    def test_apple_account_device_list_unparsable_additional_info(self):
+        path = self._devicelist_database([
+            (self.DEVICE_LIST_SCHEMA, ()),
+            ("INSERT INTO device_list (mid, name, additional_info, trusted) VALUES (?, ?, ?, ?)",
+             ("MID001", "Test iPad", b"\x00\x01not json", 2)),
+        ])
+        headers, rows, _ = appleAccountDeviceList.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][8], "")
+        self.assertEqual(rows[0][9], 2)
+        self.assertIn("not json", rows[0][-1])
+
+    def test_apple_account_deleted_device_list(self):
+        path = self._devicelist_database([
+            (self.DEVICE_LIST_SCHEMA, ()),
+            (self.DELETED_DEVICE_LIST_SCHEMA, ()),
+            ("INSERT INTO deleted_device_list VALUES (?, ?, ?, ?, ?)",
+             ("MID002", 3, 1781275553.938, "ALTDSID00", 1781315778.68896)),
+        ])
+        headers, rows, _ = appleAccountDeletedDeviceList.__wrapped__(_Context(path))
+        self.assertEqual(len(headers), len(rows[0]))
+        self.assertEqual(rows[0][2], 3)
+        self.assertEqual(rows[0][3], "MID002")
+
+    def test_apple_account_deleted_device_list_missing_table(self):
+        path = self._devicelist_database([(self.DEVICE_LIST_SCHEMA, ())])
+        headers, rows, source = appleAccountDeletedDeviceList.__wrapped__(_Context(path))
+        self.assertEqual(rows, [])
+        self.assertEqual(source, "")
+        self.assertTrue(headers)
 
 
 if __name__ == "__main__":

--- a/scripts/artifacts/appleAccountDeviceList.py
+++ b/scripts/artifacts/appleAccountDeviceList.py
@@ -1,0 +1,155 @@
+__artifacts_v2__ = {
+    'appleAccountDeviceList': {
+        'name': 'Apple Account - Device List',
+        'description': 'Devices cached by the Apple authentication daemon (akd) for the '
+                       'Apple Accounts signed in on this device',
+        'author': '@AlexisBrignoni',
+        'creation_date': '2026-07-29',
+        'last_update_date': '2026-07-29',
+        'requirements': 'none',
+        'category': 'Accounts',
+        'notes': ('The list is a cache maintained by akd, so it reflects the last successful '
+                  'refresh rather than the account state at extraction time. Columns dc, clcg, '
+                  'clbg, clhs and dec are reported with their database names because their '
+                  'meaning is not documented.'),
+        'paths': ('*/mobile/Library/Application Support/com.apple.akd/devicelist.db*',),
+        'output_types': 'standard',
+        'artifact_icon': 'devices',
+        'sample_data': {
+            'hc_ios18_ffs': 'iOS 18.7.8 | 1 row (the device itself); additional_info held an IMEI',
+        },
+    },
+    'appleAccountDeletedDeviceList': {
+        'name': 'Apple Account - Deleted Device List',
+        'description': 'Devices removed from the Apple Accounts signed in on this device, as '
+                       'recorded by the Apple authentication daemon (akd)',
+        'author': '@AlexisBrignoni',
+        'creation_date': '2026-07-29',
+        'last_update_date': '2026-07-29',
+        'requirements': 'none',
+        'category': 'Accounts',
+        'notes': ('The reason column is an integer code whose values are not documented, so it '
+                  'is reported as stored.'),
+        'paths': ('*/mobile/Library/Application Support/com.apple.akd/devicelist.db*',),
+        'output_types': 'standard',
+        'artifact_icon': 'device-mobile-off',
+        'sample_data': {
+            'hc_ios18_ffs': 'iOS 18.7.8 | 0 rows (table present but empty)',
+        },
+    },
+}
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, \
+    get_file_path, get_sqlite_db_records, does_table_exist_in_db, convert_unix_ts_to_utc
+
+
+def _decode_additional_info(blob):
+    """Return (imei list, raw text) for the additional_info column.
+
+    On the tested image the blob is UTF-8 JSON of the form
+    {"phones": [{"imei": "...", "slotID": 1}]}. Anything that does not decode
+    as JSON is passed through as text so nothing is silently dropped.
+    """
+    if not blob:
+        return '', ''
+    if isinstance(blob, bytes):
+        text = blob.decode('utf-8', 'replace')
+    else:
+        text = str(blob)
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return '', text
+    imeis = []
+    if isinstance(parsed, dict):
+        for phone in parsed.get('phones') or []:
+            if isinstance(phone, dict) and phone.get('imei'):
+                imeis.append(str(phone['imei']))
+    return ', '.join(imeis), text
+
+
+def _yes_no(value):
+    """Render the 0/1 flag columns, leaving anything unexpected as stored."""
+    if value == 1:
+        return 'Yes'
+    if value == 0:
+        return 'No'
+    return value
+
+
+@artifact_processor
+def appleAccountDeviceList(context):
+    source_path = get_file_path(context.get_files_found(), 'devicelist.db')
+    data_list = []
+    data_headers = (
+        ('Last Updated', 'datetime'), ('Last Cache Updated', 'datetime'), 'Device Name',
+        'Model', 'OS', 'OS Version', 'Build Number', 'Serial Number', 'IMEI', 'Trusted',
+        'Circle Status', 'Services', 'Machine ID (mid)', 'altDSID', 'dc', 'clcg', 'clbg',
+        'clhs', 'dec', 'Additional Info')
+    if not source_path:
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT last_updated_date, last_cache_updated_date, name, model, os, os_version,
+           build_number, serial_number, additional_info, trusted, circle_status, services,
+           mid, altDSID, dc, clcg, clbg, clhs, dec
+    FROM device_list
+    ORDER BY last_updated_date
+    '''
+
+    for record in get_sqlite_db_records(source_path, query):
+        imei, additional_info = _decode_additional_info(record['additional_info'])
+        data_list.append((
+            convert_unix_ts_to_utc(record['last_updated_date']),
+            convert_unix_ts_to_utc(record['last_cache_updated_date']),
+            record['name'],
+            record['model'],
+            record['os'],
+            record['os_version'],
+            record['build_number'],
+            record['serial_number'],
+            imei,
+            _yes_no(record['trusted']),
+            record['circle_status'],
+            record['services'],
+            record['mid'],
+            record['altDSID'],
+            record['dc'],
+            record['clcg'],
+            record['clbg'],
+            record['clhs'],
+            record['dec'],
+            additional_info,
+        ))
+
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def appleAccountDeletedDeviceList(context):
+    source_path = get_file_path(context.get_files_found(), 'devicelist.db')
+    data_list = []
+    data_headers = (
+        ('Deleted', 'datetime'), ('Last Updated', 'datetime'), 'Reason Code',
+        'Machine ID (mid)', 'altDSID')
+    if not source_path or not does_table_exist_in_db(source_path, 'deleted_device_list'):
+        return data_headers, data_list, ''
+
+    query = '''
+    SELECT deleted_date, last_updated_date, reason, mid, altDSID
+    FROM deleted_device_list
+    ORDER BY deleted_date
+    '''
+
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append((
+            convert_unix_ts_to_utc(record['deleted_date']),
+            convert_unix_ts_to_utc(record['last_updated_date']),
+            record['reason'],
+            record['mid'],
+            record['altDSID'],
+        ))
+
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Adds parsing for `/private/var/mobile/Library/Application Support/com.apple.akd/devicelist.db`, one of six iOS databases requested by Mattia. Nothing in the repo touched this file before.

## Artifacts

**Apple Account - Device List** (`device_list`) — devices cached by the Apple authentication daemon for the Apple Accounts signed in on this device: last-updated and last-cache-updated timestamps, device name, model, OS/version/build, serial number, IMEI, trusted flag, circle status, services, `mid`, `altDSID`.

**Apple Account - Deleted Device List** (`deleted_device_list`) — devices removed from those accounts: deleted and last-updated timestamps, reason code, `mid`, `altDSID`. Returns empty when the table is absent.

## Notes on the data

- `additional_info` is not a plist. On the tested image it is UTF-8 JSON of the form `{"phones":[{"imei":"...","slotID":1}]}`. The IMEI gets its own column and the raw decoded text is kept in a trailing column so nothing is lost if the shape differs on other versions.
- `dc`, `clcg`, `clbg`, `clhs`, `dec`, `circle_status` and `reason` have no documented meaning, so they are reported under their database names rather than given invented labels.
- The list is an akd cache, so it reflects the last successful refresh rather than account state at extraction time. That caveat is in the artifact `notes`.

## Testing

- Verified against an iOS 18.7.8 full filesystem extraction: 1 row in `device_list`, `deleted_device_list` present and empty, IMEI decoded from the blob.
- Verified end to end through a filesystem run, confirming the path pattern matches and both TSV outputs generate.
- Four unit tests added to `admin/test/scripts/test_requested_ios_databases.py` covering the populated table, a non-JSON `additional_info` blob, the deleted table, and a database where the deleted table is missing. All 10 tests in that file pass, along with `test_artifact_imports` and `test_lava_sql_identifiers`.
- `admin/scripts/lint_changed.py` reports no new warnings.

The tests use synthetic databases because `devicelist.db` is not present in any of the four images in `admin/image_manifest.json` — those carry only akd `authorization.db` and `privateEmails.db`. It appears to be a newer-iOS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)