### PR TITLE
Populate SafariTabs.db tab timestamps from the attribute plists

### DIFF
--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -54,10 +54,13 @@ __artifacts_v2__ = {
         "description": "Open normal and private Safari tabs from SafariTabs.db",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "Safari Browser",
-        "notes": "Public and LocalProfile are normal browsing; private is private browsing.",
+        "notes": "Public and LocalProfile are normal browsing; private is private browsing. "
+                 "The bookmarks.last_modified and date_closed columns are NULL on every image "
+                 "tested (iOS 18.7 and 26.5.2); the per-tab timestamps and state live in the "
+                 "extra_attributes / local_attributes binary plists instead.",
         "paths": ("**/Safari/SafariTabs.db*",),
         "output_types": "standard",
         "artifact_icon": "layout",
@@ -109,6 +112,13 @@ def _load_blob_plist(blob):
     except _PLIST_ERRORS as ex:
         logfunc(f'Safari iCloud Tabs: failed to read plist, error was: {ex}')
         return None
+
+
+def _yes_no(value):
+    """Render a plist boolean as Yes/No, leaving an absent key blank."""
+    if value is None:
+        return ''
+    return 'Yes' if value else 'No'
 
 
 def _find(context, filename):
@@ -187,8 +197,10 @@ def safariTabsiCloud(context):
 @artifact_processor
 def safariTabsDatabase(context):
     data_headers = (
+        ("Last Visit Time", "datetime"), ("Date Last Viewed", "datetime"),
         ("Last Modified", "datetime"), ("Date Closed", "datetime"), "Tab ID", "Title",
-        "URL", "Parent ID", "Parent / Tab Group", "Browsing Mode",
+        "URL", "Parent ID", "Parent / Tab Group", "Browsing Mode", "Opened from Link",
+        "Tab Index", "Muted", "Showing Reader", "Tab UUID",
     )
     data_list = []
     source_path = _find(context, "SafariTabs.db")
@@ -229,12 +241,31 @@ def safariTabsDatabase(context):
                    WHEN lower(CAST(tab.parent AS TEXT)) IN ('public', 'localprofile', 'local')
                         THEN 'Normal'
                    ELSE 'Normal'
-               END
+               END,
+               tab.extra_attributes, tab.local_attributes, tab.external_uuid
         FROM bookmarks AS tab
         LEFT JOIN bookmarks AS parent ON parent.id = tab.parent
         LEFT JOIN tab_context ON tab_context.tab_id = tab.id
         WHERE tab.url IS NOT NULL AND trim(tab.url) != '' AND COALESCE(tab.deleted, 0) = 0
         ORDER BY tab.order_index
     """
-    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    for row in get_sqlite_db_records(source_path, query):
+        # Safari keeps the per-tab timestamps and state in two binary plists rather
+        # than in table columns: LastVisitTime/OpenedFromLink/TabIndex/IsMuted/
+        # ShowingReader in local_attributes, DateLastViewed in extra_attributes.
+        extra = _load_blob_plist(row[8])
+        local = _load_blob_plist(row[9])
+        extra = extra if isinstance(extra, dict) else {}
+        local = local if isinstance(local, dict) else {}
+        data_list.append((
+            _aware_utc(local.get('LastVisitTime', '')),
+            _aware_utc(extra.get('DateLastViewed', '')),
+            row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
+            _yes_no(local.get('OpenedFromLink')),
+            local.get('TabIndex', ''),
+            _yes_no(local.get('IsMuted')),
+            _yes_no(local.get('ShowingReader')),
+            row[10] or '',
+        ))
+
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -82,7 +82,8 @@ from datetime import datetime, timezone
 import nska_deserialize as nd
 
 from scripts.ilapfuncs import (
-    artifact_processor, does_table_exist_in_db, get_sqlite_db_records, logfunc,
+    artifact_processor, does_column_exist_in_db, does_table_exist_in_db,
+    get_sqlite_db_records, logfunc,
 )
 
 _PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
@@ -197,17 +198,29 @@ def safariTabsiCloud(context):
 @artifact_processor
 def safariTabsDatabase(context):
     data_headers = (
-        ("Last Visit Time", "datetime"), ("Date Last Viewed", "datetime"),
         ("Last Modified", "datetime"), ("Date Closed", "datetime"), "Tab ID", "Title",
-        "URL", "Parent ID", "Parent / Tab Group", "Browsing Mode", "Opened from Link",
-        "Tab Index", "Muted", "Showing Reader", "Tab UUID",
+        "URL", "Parent ID", "Parent / Tab Group", "Browsing Mode",
+        ("Last Visit Time", "datetime"), ("Date Last Viewed", "datetime"),
+        "Opened from Link", "Tab Index", "Muted", "Showing Reader", "Tab UUID",
     )
     data_list = []
     source_path = _find(context, "SafariTabs.db")
     if not source_path or not does_table_exist_in_db(source_path, "bookmarks"):
         return data_headers, data_list, ""
 
-    query = """
+    # The attribute plists and external_uuid are absent from older/reduced
+    # bookmarks schemas, so select them only when the columns really exist.
+    extra_col = ('tab.extra_attributes'
+                 if does_column_exist_in_db(source_path, 'bookmarks', 'extra_attributes')
+                 else 'NULL')
+    local_col = ('tab.local_attributes'
+                 if does_column_exist_in_db(source_path, 'bookmarks', 'local_attributes')
+                 else 'NULL')
+    uuid_col = ('tab.external_uuid'
+                if does_column_exist_in_db(source_path, 'bookmarks', 'external_uuid')
+                else 'NULL')
+
+    query = f"""
         WITH RECURSIVE ancestry(tab_id, ancestor_id, parent_id, ancestor_title, depth) AS (
             SELECT id, id, parent, title, 0
             FROM bookmarks
@@ -242,7 +255,7 @@ def safariTabsDatabase(context):
                         THEN 'Normal'
                    ELSE 'Normal'
                END,
-               tab.extra_attributes, tab.local_attributes, tab.external_uuid
+               {extra_col}, {local_col}, {uuid_col}
         FROM bookmarks AS tab
         LEFT JOIN bookmarks AS parent ON parent.id = tab.parent
         LEFT JOIN tab_context ON tab_context.tab_id = tab.id
@@ -258,9 +271,9 @@ def safariTabsDatabase(context):
         extra = extra if isinstance(extra, dict) else {}
         local = local if isinstance(local, dict) else {}
         data_list.append((
+            row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             _aware_utc(local.get('LastVisitTime', '')),
             _aware_utc(extra.get('DateLastViewed', '')),
-            row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             _yes_no(local.get('OpenedFromLink')),
             local.get('TabIndex', ''),
             _yes_no(local.get('IsMuted')),


### PR DESCRIPTION
Follow-on from #1699 / #1700 / #1702, using a validated iOS 26.5.2 full filesystem extraction.

## Problem
The `Safari Browser - Tabs (SafariTabs)` artifact defines two datetime columns — **Last Modified** and **Date Closed** — and both come back **empty on every image tested**. `bookmarks.last_modified` and `bookmarks.date_closed` are NULL on **iOS 18.7 and iOS 26.5.2 alike** (0 of 4 rows populated on each). Open tabs were therefore reported with no time at all.

## Cause
Safari does not keep per-tab timestamps in table columns. They live in two binary plists on the `bookmarks` row:

| Blob column | Keys used |
|---|---|
| `local_attributes` | `LastVisitTime`, `OpenedFromLink`, `TabIndex`, `IsMuted`, `ShowingReader` |
| `extra_attributes` | `DateLastViewed` |

Both timestamps are native plist `NSDate` values, so no epoch conversion is involved.

## Change
Read both blobs and add **Last Visit Time** and **Date Last Viewed** as the leading datetime columns (tagged UTC through the file's existing `_aware_utc` helper), plus the tab state fields and `external_uuid` as **Tab UUID**. `Last Modified` / `Date Closed` are kept — `date_closed` is meaningful for closed tabs even though it is NULL in these images — and the artifact `notes` now records that they are unpopulated in practice.

Private/Normal detection is deliberately left alone.

## Verification
Two full filesystem extractions, timestamps now fully populated with no change to what rows are returned:

| Image | Rows | Last Visit Time | tz-aware UTC | Browsing mode split |
|---|---|---|---|---|
| iOS 26.5.2 | 4 | **4/4** (was 0/4) | yes | 2 Private / 2 Normal |
| iOS 18.7 | 4 | **4/4** (was 0/4) | yes | 2 Private / 2 Normal |

Row counts match the existing `sample_data` (`hc_ios18_7` = 4 rows), and the Private/Normal split matches the structural ground truth — on the iOS 26 image the private tabs' parent group is exactly `windows.private_tab_group_id`.

- `pylint --disable=C,R` → 10.00/10
- `PluginLoader` → 760 plugins, all three Safari tab artifacts registered
- Header/row widths asserted equal (15 columns)

## Notes for reviewers
- Contrary to what the iOS 26 timestamp reports might suggest, **`SafariTabs.db` is not new in iOS 26** — it is present at least as far back as iOS 18.7 (and `sample_data` cites iOS 15+). What *is* notable is that `BrowserState.db` is completely empty on iOS 26.5.2 (all of `tabs`, `tab_sessions`, `browser_windows` at 0 rows), consistent with the 0-row `sample_data` already recorded for several iOS 17/18 images. `SafariTabs.db` is the store that actually holds open tabs.
- Because that iOS 26 `BrowserState.db` is empty, it could **not** be used to confirm the Unix-epoch flip reported in #1699; #1700 still rests on the reporter's screenshots. The guard added there is harmless either way.
- Possible follow-up: private-tab detection currently matches the literal parent title `private`/`privatepinned`. `windows.private_tab_group_id` is the authoritative structural signal and would be more robust; it agreed with the title heuristic on both images tested, so this PR does not change it.