### PR TITLE
fix: match the spaced AVFlashlight form so flashlight use is not missed

### DIFF
--- a/admin/test/scripts/test_logarchive_native.py
+++ b/admin/test/scripts/test_logarchive_native.py
@@ -242,6 +242,49 @@ class TestStreamingWriter(unittest.TestCase):
         self.assertNotIn('streaming_probe', tables)
 
 
+class TestFlashlightPredicates(unittest.TestCase):
+    """The flashlight artifact has to match both spellings AVFoundation emits.
+
+    On iOS 17.1 the logging macro renders '<<<< AVFlashlight >>>> -[AVFlashlight
+    turnPowerOff]:' with spaces inside the brackets. The original predicate has no spaces,
+    so an image with 190 genuine flashlight records reported nothing at all, which reads
+    as "the flashlight was never used" rather than "the pattern did not match". Both
+    spellings are now matched and both must stay.
+
+    logarchive_flashlight selects from the table logarchive_artifacts builds, so a
+    predicate missing from the broad query cannot be recovered by the narrow one. That
+    coupling is the easy thing to get wrong, hence checking both.
+    """
+
+    SPACED = "'%<<<< AVFlashlight >>>>%'"
+    UNSPACED = "'%<<<<AVFlashlight>>>>-%'"
+
+    def _query_for(self, function_name):
+        source = pathlib.Path(logarchive.__file__).read_text(encoding='utf-8')
+        return source.split(f'def {function_name}', 1)[1].split("'''")[1]
+
+    def test_broad_query_matches_both_spellings(self):
+        query = self._query_for('logarchive_artifacts')
+        self.assertIn(self.UNSPACED, query)
+        self.assertIn(self.SPACED, query)
+
+    def test_flashlight_artifact_matches_both_spellings(self):
+        query = self._query_for('logarchive_flashlight')
+        self.assertIn(self.UNSPACED, query)
+        self.assertIn(self.SPACED, query)
+
+    def test_spaced_predicate_matches_real_message_text(self):
+        # Verbatim from an iOS 17.1 extraction.
+        message = ('<<<< AVFlashlight >>>> -[AVFlashlight setFlashlightLevel:withError:]: '
+                   'called (2800F8780) level 0')
+        with sqlite3.connect(':memory:') as connection:
+            connection.execute('CREATE TABLE t (event_message TEXT)')
+            connection.execute('INSERT INTO t VALUES (?)', (message,))
+            matched = connection.execute(
+                f'SELECT COUNT(*) FROM t WHERE event_message LIKE {self.SPACED}').fetchone()[0]
+        self.assertEqual(matched, 1)
+
+
 class TestColumnContract(unittest.TestCase):
     """Both sources must produce the eight columns the dependent artifacts query."""
 

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -452,6 +452,12 @@ def logarchive_artifacts(context):
         OR event_message LIKE '%transition source:%'
         OR event_message LIKE '%[Flashlight Controller]%'
         OR event_message LIKE '%<<<<AVFlashlight>>>>-%'
+        -- AVFoundation's logging macro renders as '<<<< AVFlashlight >>>> -[AVFlashlight
+        -- turnPowerOff]: ...' with spaces inside the brackets on iOS 17.1, which the
+        -- unspaced predicate above misses entirely. Both forms are kept because the
+        -- unspaced one was written from observed output on another release. The method
+        -- prefix is not matched, so class methods ('+[') are picked up too.
+        OR event_message LIKE '%<<<< AVFlashlight >>>>%'
         OR event_message LIKE '%Tethering is now enabled with%'
         OR event_message LIKE '%Received notification that wireless modem state changed%'
         OR event_message LIKE '%Previous tethering state was%'
@@ -501,8 +507,11 @@ def logarchive_flashlight(context):
     query = '''
     SELECT *
     FROM logarchive_artifacts
-    WHERE event_message LIKE '%[Flashlight Controller]%' 
+    WHERE event_message LIKE '%[Flashlight Controller]%'
     OR event_message LIKE '%<<<<AVFlashlight>>>>-%'
+    -- Spaced variant; see the note in logarchive_artifacts. Both queries need it, since
+    -- this artifact reads from the table that one builds.
+    OR event_message LIKE '%<<<< AVFlashlight >>>>%'
     '''
     
     data_list = list( get_sqlite_db_records(source_path, query) )


### PR DESCRIPTION
## The problem

An iOS 17.1 extraction with **190 genuine flashlight records** reported nothing at all.

AVFoundation's logging macro renders as:

```
<<<< AVFlashlight >>>> -[AVFlashlight turnPowerOff]: called (2800F8780)
```

with spaces inside the brackets. The predicate looked for `<<<<AVFlashlight>>>>-` with none, so it matched zero rows. The other flashlight predicate, `[Flashlight Controller]`, does not appear in that device's logs in any form.

An empty artifact reads as *"the flashlight was never used"*, which is the worst possible way for a pattern to fail — it looks like evidence of absence.

## The fix

Both spellings are now matched. The unspaced one is kept: it was written from observed output on another release and nothing here shows it to be wrong.

The new pattern stops at the closing brackets rather than requiring the `-` method prefix, so class methods (`+[`) are picked up too. Over-specificity is what caused the original miss.

**Added to both queries, not just the flashlight one.** `logarchive_flashlight` selects from the table `logarchive_artifacts` builds, so a predicate missing from the broad query cannot be recovered by the narrow one.

## Verification

Against the same iOS 17.1 image (build 21B74, 30,362,747 records imported from tracev3):

| | before | after |
|---|---|---|
| `logarchive flashlight` | 0 | **190** |
| `logarchive artifacts` | 92,579 | 92,769 (exactly the 190) |
| every other artifact | — | unchanged |

No collateral matches. Three regression tests added covering both queries and the real message text.

## Open question

I could not confirm whether Apple's own renderer emits the spaced form too, because `log show` on macOS 26.5 cannot read a reconstructed archive without the metadata `logarchive_info.py` generates. The AVFoundation `<<<< %s >>>>` convention suggests it does, which would mean this predicate never matched on the JSON path either — but that is inference, not measurement. Worth confirming against an Apple JSON export from a device with flashlight activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)