### PR TITLE
build: bundle the Unified Log parser in the PyInstaller builds

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -8,3 +8,8 @@
 
 - Apple ATX container and decode details adapted from `atx_reader` by galba-arueira.
   Licensed under [MIT or Apache-2.0](https://github.com/galba-arueira/atx_reader).
+
+- Apple Unified Log `.tracev3` parsing provided by the `unifiedlog_iterator` binary from
+  [`macos-UnifiedLogs`](https://github.com/mandiant/macos-UnifiedLogs) by Mandiant.
+  Licensed under [Apache-2.0](https://github.com/mandiant/macos-UnifiedLogs/blob/main/LICENSE).
+  Redistributed unmodified in builds that include it; see `bin/PROVENANCE.md`.

--- a/admin/scripts/fetch_unifiedlog_iterator.py
+++ b/admin/scripts/fetch_unifiedlog_iterator.py
@@ -1,0 +1,159 @@
+"""Download the pinned unifiedlog_iterator release into bin/ for packaging.
+
+The binary reads Apple Unified Log .tracev3 data directly, which is what lets iLEAPP
+import Unified Logs without a Mac and without Apple's `log show`. It is not committed to
+this repository: it is a third-party compiled artifact, it exists per platform, and an
+examiner should be able to see exactly which build went into a release.
+
+Run before building a release, on the machine doing the build:
+
+    python admin/scripts/fetch_unifiedlog_iterator.py
+    python admin/scripts/fetch_unifiedlog_iterator.py --platform linux-x86_64
+
+There is one bin/unifiedlog_iterator, holding the build for the platform being packaged,
+so fetching several in a row would just overwrite it. Each release build fetches its own.
+
+Every download is checked against the digest pinned below and the run refuses to write
+anything that does not match. Update PINNED_VERSION and the digests together, and record
+what changed; a release should be reproducible from the version in bin/PROVENANCE.md.
+"""
+import argparse
+import hashlib
+import io
+import os
+import pathlib
+import platform
+import ssl
+import sys
+import tarfile
+import urllib.request
+import zipfile
+
+PINNED_VERSION = 'v0.6.0'
+REPO = 'mandiant/macos-UnifiedLogs'
+BASE_URL = f'https://github.com/{REPO}/releases/download/{PINNED_VERSION}'
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BIN_DIR = REPO_ROOT / 'bin'
+
+# sha256 of each release archive, read from the .sha256 files published with v0.6.0.
+# Note: upstream's .sha256 files print the digest twice on one line; these are the single
+# correct value.
+ASSETS = {
+    'macos-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-apple-darwin.tar.gz',
+                    'd3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63'),
+    'macos-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-apple-darwin.tar.gz', None),
+    'linux-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-unknown-linux-gnu.tar.gz', None),
+    'linux-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-gnu.tar.gz', None),
+    'windows-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-pc-windows-msvc.zip', None),
+}
+
+
+def current_platform():
+    machine = platform.machine().lower()
+    arch = 'arm64' if machine in ('arm64', 'aarch64') else 'x86_64'
+    if sys.platform == 'darwin':
+        return f'macos-{arch}'
+    if sys.platform.startswith('linux'):
+        return f'linux-{arch}'
+    if sys.platform.startswith('win'):
+        return 'windows-x86_64'
+    raise SystemExit(f'no published build for {sys.platform}')
+
+
+def _ssl_context():
+    """Build a verifying SSL context that also works on a bare python.org install.
+
+    Those ship without a CA store until 'Install Certificates.command' is run, so an
+    otherwise fine build machine fails with CERTIFICATE_VERIFY_FAILED. certifi's bundle is
+    used when it happens to be installed. Verification is never disabled: this downloads an
+    executable that goes into a forensic tool.
+    """
+    try:
+        import certifi  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        return ssl.create_default_context()
+    return ssl.create_default_context(cafile=certifi.where())
+
+
+def _download(url):
+    print(f'  fetching {url}')
+    with urllib.request.urlopen(  # nosec B310 - fixed https GitHub URL
+            url, context=_ssl_context()) as response:
+        return response.read()
+
+
+def _expected_digest(asset, pinned):
+    """Use the pinned digest, or fall back to the published .sha256 for platforms we
+    have not pinned yet, reporting the value so it can be added above."""
+    if pinned:
+        return pinned
+    published = _download(f'{BASE_URL}/{asset}.sha256').decode().split()[0]
+    # Upstream concatenates the digest with itself; take one copy.
+    if len(published) == 128 and published[:64] == published[64:]:
+        published = published[:64]
+    print(f'  no pinned digest for {asset}; published value is {published}')
+    return published
+
+
+def _extract(archive_bytes, asset, destination_name):
+    """Pull the executable and the LICENSE out of the release archive."""
+    binary = license_text = None
+    if asset.endswith('.zip'):
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+            for name in archive.namelist():
+                base = os.path.basename(name)
+                if base in ('unifiedlog_iterator', 'unifiedlog_iterator.exe'):
+                    binary = archive.read(name)
+                elif base == 'LICENSE':
+                    license_text = archive.read(name)
+    else:
+        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode='r:gz') as archive:
+            for member in archive.getmembers():
+                base = os.path.basename(member.name)
+                if base in ('unifiedlog_iterator', 'unifiedlog_iterator.exe'):
+                    binary = archive.extractfile(member).read()
+                elif base == 'LICENSE':
+                    license_text = archive.extractfile(member).read()
+
+    if binary is None:
+        raise SystemExit(f'{asset} does not contain unifiedlog_iterator')
+    if license_text is None:
+        raise SystemExit(f'{asset} does not contain its LICENSE; Apache-2.0 redistribution '
+                         f'requires it')
+
+    BIN_DIR.mkdir(exist_ok=True)
+    target = BIN_DIR / destination_name
+    target.write_bytes(binary)
+    target.chmod(0o755)
+    (BIN_DIR / 'LICENSE-unifiedlog_iterator').write_bytes(license_text)
+    print(f'  wrote {target} ({len(binary):,} bytes) and its LICENSE')
+
+
+def fetch(key):
+    asset, pinned = ASSETS[key]
+    print(f'{key}:')
+    expected = _expected_digest(asset, pinned)
+    archive_bytes = _download(f'{BASE_URL}/{asset}')
+    actual = hashlib.sha256(archive_bytes).hexdigest()
+    if actual != expected:
+        raise SystemExit(f'  DIGEST MISMATCH for {asset}\n'
+                         f'    expected {expected}\n    got      {actual}\n'
+                         f'  Nothing was written.')
+    print(f'  sha256 verified: {actual}')
+    name = 'unifiedlog_iterator.exe' if key.startswith('windows') else 'unifiedlog_iterator'
+    _extract(archive_bytes, asset, name)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--platform', choices=sorted(ASSETS), default=None,
+                        help='build to fetch; defaults to the platform this is run on')
+    args = parser.parse_args()
+
+    fetch(args.platform or current_platform())
+    print(f'\nDone. {PINNED_VERSION} from https://github.com/{REPO}')
+
+
+if __name__ == '__main__':
+    main()

--- a/admin/test/scripts/test_pyinstaller_unifiedlog_bundle.py
+++ b/admin/test/scripts/test_pyinstaller_unifiedlog_bundle.py
@@ -1,0 +1,165 @@
+"""Every PyInstaller spec must bundle the Unified Log parser, and its license with it.
+
+There are six spec files, one per (CLI, GUI) x (Windows, macOS, Linux). A new spec, or a
+spec someone regenerates with `pyi-makespec`, silently goes back to `binaries=[]`, and the
+only symptom is that native Apple Unified Log support quietly disappears from that one
+platform's release. Nothing else in the test suite would notice.
+
+The specs are plain Python evaluated by PyInstaller, so they are exec'd here with stubbed
+PyInstaller globals and the resulting Analysis arguments inspected.
+
+The license check is not decoration. unifiedlog_iterator is Apache-2.0 and this project is
+MIT; section 4(a) requires that anyone receiving a redistribution also receives the
+license. A build that ships the binary without it is a licensing defect, so the helper
+raises rather than quietly omitting it.
+"""
+import pathlib
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / 'scripts' / 'pyinstaller'))
+
+import unifiedlog_binary  # pylint: disable=wrong-import-position
+
+SPEC_DIR = REPO_ROOT / 'scripts' / 'pyinstaller'
+EXPECTED_SPECS = {
+    'ileapp.spec', 'ileappGUI.spec',
+    'ileapp_Linux.spec', 'ileappGUI_Linux.spec',
+    'ileapp_macOS.spec', 'ileappGUI_macOS.spec',
+}
+
+
+class _Inert:
+    """Stands in for PYZ/EXE/COLLECT/BUNDLE, which the specs only pass around."""
+
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        pass
+
+
+class _CapturedAnalysis:
+    """Stands in for PyInstaller's Analysis, recording what the spec asked for.
+
+    Only Analysis records itself. The other stubs must not, or the last thing the spec
+    constructs (EXE, or COLLECT/BUNDLE in the macOS specs) would be what gets inspected.
+    """
+
+    last = None
+
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        # Positional args are the scripts list; only the keywords matter here.
+        self.kwargs = kwargs
+        self.pure = self.zipped_data = self.scripts = []
+        self.binaries = self.zipfiles = self.datas = []
+        _CapturedAnalysis.last = self
+
+
+def _run_spec(path):
+    """Execute one spec with PyInstaller's globals stubbed out, returning Analysis kwargs."""
+    _CapturedAnalysis.last = None
+    namespace = {
+        'Analysis': _CapturedAnalysis, 'PYZ': _Inert, 'EXE': _Inert,
+        'COLLECT': _Inert, 'BUNDLE': _Inert,
+        'SPECPATH': str(SPEC_DIR), '__file__': str(path),
+    }
+    # Spec files are Python that PyInstaller exec's; running them is the only way to
+    # see what they actually pass to Analysis.
+    exec(compile(path.read_text(encoding='utf-8'), str(path), 'exec'),  # pylint: disable=exec-used
+         namespace)  # nosec B102
+    if _CapturedAnalysis.last is None:
+        raise AssertionError(f'{path.name} never called Analysis()')
+    return _CapturedAnalysis.last.kwargs
+
+
+class TestSpecsBundleTheParser(unittest.TestCase):
+    """All six specs must pick up the binary and its license when both are present."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Point the helper at a throwaway bin/ so the result does not depend on whether
+        # the developer has run the fetch script.
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.original_bin_dir = unifiedlog_binary.BIN_DIR
+        unifiedlog_binary.BIN_DIR = cls.tmpdir
+        for name in ('unifiedlog_iterator', 'unifiedlog_iterator.exe'):
+            path = pathlib.Path(cls.tmpdir) / name
+            path.write_bytes(b'not a real binary')
+            path.chmod(0o755)
+        (pathlib.Path(cls.tmpdir) / unifiedlog_binary.LICENSE_NAME).write_text('Apache-2.0')
+
+    @classmethod
+    def tearDownClass(cls):
+        unifiedlog_binary.BIN_DIR = cls.original_bin_dir
+
+    def test_the_expected_specs_exist(self):
+        # A spec added without being added here would not be covered by the checks below.
+        self.assertEqual({p.name for p in SPEC_DIR.glob('*.spec')}, EXPECTED_SPECS)
+
+    def test_every_spec_bundles_binary_and_license(self):
+        for name in sorted(EXPECTED_SPECS):
+            with self.subTest(spec=name):
+                kwargs = _run_spec(SPEC_DIR / name)
+                binaries = kwargs['binaries']
+                datas = kwargs['datas']
+                self.assertTrue(
+                    any(dest == 'bin' and 'unifiedlog_iterator' in src for src, dest in binaries),
+                    f'{name} does not bundle the parser: {binaries}')
+                self.assertTrue(
+                    any(dest == 'bin' and unifiedlog_binary.LICENSE_NAME in src
+                        for src, dest in datas),
+                    f'{name} bundles the parser without its Apache-2.0 license')
+
+    def test_specs_keep_their_own_datas(self):
+        # The license is appended to each spec's existing datas; dropping the originals
+        # would ship a build with no scripts or assets.
+        for name in sorted(EXPECTED_SPECS):
+            with self.subTest(spec=name):
+                datas = _run_spec(SPEC_DIR / name)['datas']
+                self.assertTrue(any('scripts' in str(dest) for _, dest in datas),
+                                f'{name} lost its scripts data entry: {datas}')
+
+
+class TestBuildsWithoutTheBinary(unittest.TestCase):
+    """A checkout that has not run the fetch script must still build."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.original_bin_dir = unifiedlog_binary.BIN_DIR
+        unifiedlog_binary.BIN_DIR = self.tmpdir
+        self.addCleanup(setattr, unifiedlog_binary, 'BIN_DIR', self.original_bin_dir)
+
+    def test_absent_binary_yields_empty_lists(self):
+        self.assertEqual(unifiedlog_binary.unifiedlog_binaries(), [])
+        self.assertEqual(unifiedlog_binary.unifiedlog_datas(), [])
+
+    def test_every_spec_still_evaluates(self):
+        for name in sorted(EXPECTED_SPECS):
+            with self.subTest(spec=name):
+                self.assertEqual(_run_spec(SPEC_DIR / name)['binaries'], [])
+
+    def test_binary_without_license_is_refused(self):
+        path = pathlib.Path(self.tmpdir) / 'unifiedlog_iterator'
+        path.write_bytes(b'x')
+        path.chmod(0o755)
+        with self.assertRaises(SystemExit):
+            unifiedlog_binary.unifiedlog_datas()
+
+
+class TestRuntimeAndBuildAgreeOnLocation(unittest.TestCase):
+    """The specs put the binary in 'bin'; scripts/unifiedlogs.py has to look there."""
+
+    def test_bundle_destination_matches_runtime_search_path(self):
+        from scripts import unifiedlogs  # pylint: disable=import-outside-toplevel
+        searched = [pathlib.Path(d).name for d in unifiedlogs._bundled_binary_dirs()]  # pylint: disable=protected-access
+        self.assertIn('bin', searched)
+
+    def test_repo_bin_directory_is_searched_in_a_source_checkout(self):
+        from scripts import unifiedlogs  # pylint: disable=import-outside-toplevel
+        searched = [pathlib.Path(d) for d in unifiedlogs._bundled_binary_dirs()]  # pylint: disable=protected-access
+        self.assertIn(REPO_ROOT / 'bin', searched)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,5 @@
+# The parser executable and its license are fetched per build, not committed.
+# See PROVENANCE.md and admin/scripts/fetch_unifiedlog_iterator.py
+unifiedlog_iterator
+unifiedlog_iterator.exe
+LICENSE-unifiedlog_iterator

--- a/bin/PROVENANCE.md
+++ b/bin/PROVENANCE.md
@@ -1,0 +1,49 @@
+# bin/
+
+Holds the third-party `unifiedlog_iterator` executable used to read Apple Unified Log
+`.tracev3` data directly, so Unified Logs can be imported without a Mac and without
+Apple's `log show`. See `scripts/unifiedlogs.py` for how iLEAPP calls it.
+
+The executable is **not committed**. It is fetched per build:
+
+```
+python admin/scripts/fetch_unifiedlog_iterator.py
+```
+
+That verifies a pinned SHA-256 before writing anything, and also writes
+`LICENSE-unifiedlog_iterator` next to the binary. Builds without it still succeed; they
+just ship without native Unified Log support, and the artifact reports that at runtime.
+
+## What is pinned
+
+| | |
+|---|---|
+| Project | [mandiant/macos-UnifiedLogs](https://github.com/mandiant/macos-UnifiedLogs) |
+| Version | v0.6.0 (released 2026-05-07) |
+| License | Apache-2.0 (`LICENSE-unifiedlog_iterator`) |
+| macOS arm64 archive sha256 | `d3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63` |
+
+Digests for the other platforms are read from the `.sha256` files published with the
+release and printed by the fetch script; pin them in `ASSETS` as each is first used for a
+build. Upstream's `.sha256` files repeat the digest twice on one line, which is a quirk of
+their release workflow, not a corrupted file.
+
+## Why the version is pinned
+
+An examiner needs to be able to say which parser produced a set of records. Pin the
+version, record it here, and change both together. When a release is built, the version
+above is the one that shipped.
+
+## License obligations
+
+Apache-2.0 permits redistribution inside this MIT-licensed project. Two things must hold
+for any build that includes the binary:
+
+- `LICENSE-unifiedlog_iterator` ships alongside it. The PyInstaller specs refuse to build
+  if the binary is present and the license is not.
+- Attribution stays in `ATTRIBUTIONS.md`.
+
+The published binary statically links its Rust dependencies, which carry their own
+(predominantly MIT and Apache-2.0) licenses. Upstream ships only its own LICENSE in the
+release archive, and that is what is redistributed here. A build that wants a complete
+third-party notice file would need to generate one from the upstream crate graph.

--- a/scripts/pyinstaller/ileapp.spec
+++ b/scripts/pyinstaller/ileapp.spec
@@ -1,11 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import sys
+
+sys.path.insert(0, SPECPATH)
+from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+
 block_cipher = None
 
 a = Analysis(['..\\..\\ileapp.py'],
              pathex=['..\\scripts\\artifacts'],
-             binaries=[],
-             datas=[('..\\', '.\\scripts')],
+             binaries=unifiedlog_binaries(windows=True),
+             datas=[('..\\', '.\\scripts')] + unifiedlog_datas(windows=True),
              hiddenimports=[
                 'astc_decomp_faster',
                 'bencoding',

--- a/scripts/pyinstaller/ileappGUI.spec
+++ b/scripts/pyinstaller/ileappGUI.spec
@@ -1,11 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import sys
+
+sys.path.insert(0, SPECPATH)
+from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+
 block_cipher = None
 
 a = Analysis(['..\\..\\ileappGUI.py'],
              pathex=['..\\scripts\\artifacts'],
-             binaries=[],
-             datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets'), ('..\\..\\leapp_functions', '.\\leapp_functions')],
+             binaries=unifiedlog_binaries(windows=True),
+             datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets'), ('..\\..\\leapp_functions', '.\\leapp_functions')] + unifiedlog_datas(windows=True),
              hiddenimports=[
                 'astc_decomp_faster',
                 'bencoding',

--- a/scripts/pyinstaller/ileappGUI_Linux.spec
+++ b/scripts/pyinstaller/ileappGUI_Linux.spec
@@ -1,11 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
+import sys
+
+sys.path.insert(0, SPECPATH)
+from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+
 a = Analysis(
     ['../../ileappGUI.py'],
     pathex=['../scripts/artifacts'],
-    binaries=[],
-    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')],
+    binaries=unifiedlog_binaries(),
+    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')] + unifiedlog_datas(),
     hiddenimports=[
         'astc_decomp_faster',
         'bencoding',

--- a/scripts/pyinstaller/ileappGUI_macOS.spec
+++ b/scripts/pyinstaller/ileappGUI_macOS.spec
@@ -1,11 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
+import sys
+
+sys.path.insert(0, SPECPATH)
+from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+
 a = Analysis(
     ['../../ileappGUI.py'],
     pathex=['../scripts/artifacts'],
-    binaries=[],
-    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')],
+    binaries=unifiedlog_binaries(),
+    datas=[('../', 'scripts'), ('../../assets', 'assets'), ('../../leapp_functions', 'leapp_functions')] + unifiedlog_datas(),
     hiddenimports=[
         'astc_decomp_faster',
         'bencoding',

--- a/scripts/pyinstaller/ileapp_Linux.spec
+++ b/scripts/pyinstaller/ileapp_Linux.spec
@@ -1,11 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
+import sys
+
+sys.path.insert(0, SPECPATH)
+from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+
 a = Analysis(
     ['../../ileapp.py'],
     pathex=['../scripts/artifacts'],
-    binaries=[],
-    datas=[('../', 'scripts')],
+    binaries=unifiedlog_binaries(),
+    datas=[('../', 'scripts')] + unifiedlog_datas(),
     hiddenimports=[
         'astc_decomp_faster',
         'bencoding',

--- a/scripts/pyinstaller/ileapp_macOS.spec
+++ b/scripts/pyinstaller/ileapp_macOS.spec
@@ -1,11 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
+import sys
+
+sys.path.insert(0, SPECPATH)
+from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+
 a = Analysis(
     ['../../ileapp.py'],
     pathex=['../scripts/artifacts'],
-    binaries=[],
-    datas=[('../', 'scripts')],
+    binaries=unifiedlog_binaries(),
+    datas=[('../', 'scripts')] + unifiedlog_datas(),
     hiddenimports=[
         'astc_decomp_faster',
         'bencoding',

--- a/scripts/pyinstaller/unifiedlog_binary.py
+++ b/scripts/pyinstaller/unifiedlog_binary.py
@@ -1,0 +1,48 @@
+"""Locate the unifiedlog_iterator binary for the PyInstaller specs.
+
+Shared by all six spec files so the bundling rule lives in one place.
+
+The binary is not committed to this repository. Run
+`python admin/scripts/fetch_unifiedlog_iterator.py` before building to place a verified
+copy in bin/. When it is absent the build still succeeds and simply ships without native
+Apple Unified Log support, which is what happens today.
+
+It is added as a *binary* rather than as data because PyInstaller preserves the execute
+permission for binaries; a data file arrives without it on macOS and Linux, and
+scripts/unifiedlogs.py would then skip it as not executable.
+"""
+import os
+
+# Directory holding the binaries, relative to this file: <repo root>/bin
+BIN_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))), 'bin')
+
+LICENSE_NAME = 'LICENSE-unifiedlog_iterator'
+
+
+def unifiedlog_binaries(windows=False):
+    """Return the PyInstaller `binaries` entries for the parser, or [] when it is absent."""
+    name = 'unifiedlog_iterator.exe' if windows else 'unifiedlog_iterator'
+    path = os.path.join(BIN_DIR, name)
+    if not os.path.isfile(path):
+        print(f'unifiedlog_iterator not found at {path}; '
+              f'building without native Unified Log support')
+        return []
+    return [(path, 'bin')]
+
+
+def unifiedlog_datas(windows=False):
+    """Return the `datas` entries carrying the parser's Apache-2.0 license text.
+
+    Apache-2.0 section 4(a) requires that recipients of a redistribution get a copy of the
+    license, so it ships next to the binary and only when the binary ships.
+    """
+    if not unifiedlog_binaries(windows):
+        return []
+    license_path = os.path.join(BIN_DIR, LICENSE_NAME)
+    if not os.path.isfile(license_path):
+        raise SystemExit(
+            f'{license_path} is missing. The unifiedlog_iterator binary is Apache-2.0 '
+            f'licensed and may not be redistributed without it. Re-run '
+            f'admin/scripts/fetch_unifiedlog_iterator.py.')
+    return [(license_path, 'bin')]

--- a/scripts/unifiedlogs.py
+++ b/scripts/unifiedlogs.py
@@ -19,10 +19,11 @@ format directly. Three properties make it a fit:
 On a 1.16 GB / 29.3M event store it parsed in 250s against 355s for `log show` on the
 same data, so this path is not a speed trade-off.
 
-The binary is not vendored in this repository. `find_iterator()` looks for it in an
-explicit environment variable, then alongside the packaged application, then on PATH;
-when it is absent the artifact reports that and does nothing, leaving the existing JSON
-workflow as the supported route.
+The binary is not committed to this repository; release builds fetch a digest-verified
+copy into bin/ (see bin/PROVENANCE.md). `find_iterator()` looks for it in an explicit
+environment variable, then alongside the packaged application, then on PATH; when it is
+absent the artifact reports that and does nothing, leaving the existing JSON workflow as
+the supported route.
 """
 import json
 import os
@@ -55,13 +56,19 @@ MAX_DIAGNOSTIC_LINE_LENGTH = 300
 
 
 def _bundled_binary_dirs():
-    """Directories to search for a binary shipped with iLEAPP, frozen or from source."""
+    """Directories to search for a binary shipped with iLEAPP, frozen or from source.
+
+    Both point at 'bin': the PyInstaller specs place the executable there inside the
+    bundle, and admin/scripts/fetch_unifiedlog_iterator.py places it in the repository's
+    bin/ for a source checkout. Keep the two in step; a mismatch means a build that
+    bundles the parser cannot find it at runtime.
+    """
     dirs = []
     meipass = getattr(sys, '_MEIPASS', None)
     if meipass:
         dirs.append(os.path.join(meipass, 'bin'))
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    dirs.append(os.path.join(repo_root, 'scripts', 'bin'))
+    dirs.append(os.path.join(repo_root, 'bin'))
     return dirs
 
 


### PR DESCRIPTION
## Why

Native Apple Unified Log support (commit 10eb49fd / `scripts/unifiedlogs.py`, already on main) only works if `unifiedlog_iterator` is on the machine. That meant it worked from a source checkout and **not** from a release — the examiners most likely to need it are the ones least likely to have a Rust binary lying around.

All six specs now ship it, so a packaged iLEAPP reads `.tracev3` data with nothing else installed and no Mac involved.

## Platform coverage

Every iLEAPP release target has a matching published binary:

| iLEAPP release | `unifiedlog_iterator` v0.6.0 asset |
|---|---|
| Windows x64 | `x86_64-pc-windows-msvc` |
| macOS Apple Silicon | `aarch64-apple-darwin` |
| macOS Intel | `x86_64-apple-darwin` |
| Linux x86_64 | `x86_64-unknown-linux-gnu` |

## How

The binary is **not committed**. `admin/scripts/fetch_unifiedlog_iterator.py` pulls the pinned v0.6.0 release into `bin/`, verifies a SHA-256 before writing anything, and refuses to write on a mismatch.

Pinning is not ceremony: an examiner has to be able to say which parser produced a set of records, so the version and digest live in `bin/PROVENANCE.md` and change together.

It goes in `binaries=` rather than `datas=` because PyInstaller preserves the execute permission for binaries; as data it arrives without it on macOS and Linux and `find_iterator()` would skip it as not executable. The bundle destination and the runtime search path are both `bin`, and a test asserts they stay in step.

Builds without the binary still succeed and ship without native support, which is the behaviour today.

## Licensing

`unifiedlog_iterator` is **Apache-2.0**, this project is **MIT**. Permissive and compatible, no copyleft, nothing to relicense.

Section 4(a) does require that recipients get the license, so the fetch script extracts it alongside the binary and **the specs refuse to build if the binary is present without it** — a licensing defect should break the build, not ship quietly. Attribution added to `ATTRIBUTIONS.md`.

One caveat, recorded in `bin/PROVENANCE.md`: the published binary statically links its Rust dependencies, whose own notices are not reproduced beyond upstream's LICENSE (that is what upstream ships). A complete third-party notice file would have to be generated from the upstream crate graph.

## Verification

Real PyInstaller build on macOS:

```
frozen: True            bundled at bin/: True    executable: True
license shipped: True   runs: unifiedlog_iterator 0.6.0
```

A source-checkout run with no environment variable set imported 1,103,360 records using the copy in `bin/`.

8 tests / 18 subtests added. They exec each spec with stubbed PyInstaller globals and assert the binary and license are bundled, that existing `datas` survive, that a checkout without the binary still evaluates, and that build and runtime agree on the location. A spec regenerated with `pyi-makespec` silently reverts to `binaries=[]`, and nothing else in the suite would catch that.

## Notes for review

- Only the macOS arm64 build has been executed by me; the other five are confirmed as published assets only. Each release build fetches and verifies its own.
- Only the macOS arm64 digest is pinned. The rest fall back to upstream's published `.sha256`, which the script prints so it can be pinned the first time each is used.
- **Worth deciding:** the Linux entry maps to the *gnu* build, which dynamically links host glibc and can fail on distros older than the build machine — defeating the point of an AppImage. Upstream also publishes a statically linked *musl* build that is likely the better default here. Happy to switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
