### PR TITLE
feat: make Apple Unified Logs opt-in in the GUI

### DIFF
--- a/admin/test/scripts/test_modules_to_exclude.py
+++ b/admin/test/scripts/test_modules_to_exclude.py
@@ -1,0 +1,70 @@
+"""The default-deselected module list has to name real modules, and cover the expensive ones.
+
+`scripts/modules_to_exclude.py` is matched against `plugin.module_name`, which is the
+artifact script's filename stem. An entry that names an artifact instead of its module, or
+that survives a module being renamed or deleted, silently does nothing: the checkbox goes
+back to selected and nobody notices until a run takes far longer than expected. Nothing
+else in the suite reads this file.
+
+The logarchive entry matters most. It is the largest job in iLEAPP by a wide margin, it
+now triggers on every full file system extraction because the artifact declares
+diagnostics/ and uuidtext/ paths, and its cost is paid during file extraction before any
+parsing starts. It has to stay opt-in.
+"""
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.modules_to_exclude import modules_to_exclude  # pylint: disable=wrong-import-position
+from scripts.plugin_loader import PluginLoader  # pylint: disable=wrong-import-position
+
+ARTIFACTS_DIR = REPO_ROOT / 'scripts' / 'artifacts'
+
+
+class TestExcludedModulesAreReal(unittest.TestCase):
+    """Every entry must correspond to a module that exists and is actually loaded."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.loaded_module_names = {plugin.module_name for plugin in PluginLoader().plugins}
+
+    def test_no_duplicate_entries(self):
+        self.assertEqual(sorted(modules_to_exclude), sorted(set(modules_to_exclude)),
+                         'modules_to_exclude contains duplicates')
+
+    def test_each_entry_names_an_existing_artifact_script(self):
+        for name in modules_to_exclude:
+            with self.subTest(module=name):
+                self.assertTrue((ARTIFACTS_DIR / f'{name}.py').is_file(),
+                                f'{name} is listed but scripts/artifacts/{name}.py does not exist')
+
+    def test_each_entry_matches_a_loaded_module_name(self):
+        # module_name is what the GUI compares against; an entry that never matches is dead.
+        for name in modules_to_exclude:
+            with self.subTest(module=name):
+                self.assertIn(name, self.loaded_module_names,
+                              f'{name} never appears as a plugin module_name')
+
+
+class TestLogarchiveIsOptIn(unittest.TestCase):
+    """Unified Logs must not run unless the examiner asks for them."""
+
+    def test_logarchive_is_deselected_by_default(self):
+        self.assertIn('logarchive', modules_to_exclude)
+
+    def test_the_entry_covers_every_logarchive_artifact(self):
+        # One module supplies the raw import plus twelve dependent artifacts. They all
+        # share module_name 'logarchive', so the single entry has to cover the whole set;
+        # if any of them ever moved to its own file, this would catch it.
+        plugins = [p for p in PluginLoader().plugins if p.name.startswith('logarchive')]
+        self.assertGreater(len(plugins), 1, 'expected the logarchive artifact family')
+        for plugin in plugins:
+            with self.subTest(artifact=plugin.name):
+                self.assertEqual(plugin.module_name, 'logarchive')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/modules_to_exclude.py
+++ b/scripts/modules_to_exclude.py
@@ -1,7 +1,17 @@
 # This list contains the filenames of artifact scripts that take a long time to run.
 # These modules are deselected by default in the GUI.
+#
+# Entries are module filenames (the .py stem), not artifact names, so one entry covers
+# every artifact a module declares.
 
 modules_to_exclude = [
+    # Apple Unified Logs. Reading the .tracev3 data in a full file system extraction is
+    # the largest single job in iLEAPP: an iOS 17.1 image produced 30.4 million records in
+    # 16 minutes and a 6.4 GB LAVA database, and getting there means extracting the whole
+    # of uuidtext (hundreds of megabytes) before parsing starts. Worth every second when
+    # Unified Logs are what the case turns on, and worth nothing at all otherwise, so the
+    # examiner opts in rather than paying for it on every run.
+    'logarchive',
     'photosDbexif',
     'photosMetadata',
     'walStrings',


### PR DESCRIPTION
## Why

The logarchive artifact used to need a `logarchive*.json` file the examiner had deliberately produced on a Mac, so it only ran when someone had gone out of their way to make it run.

Reading `.tracev3` data natively (commit 10eb49fd) changed that. The artifact now declares `diagnostics/` and `uuidtext/` paths, which **every full file system extraction has**, so it fires on every run whether or not the case has anything to do with Unified Logs.

That is the largest single job in iLEAPP. An iOS 17.1 image produced **30.4 million records in 16 minutes** and a 6.4 GB LAVA database — and most of the cost lands *before parsing even starts*, while the seeker extracts the whole of `uuidtext` (hundreds of megabytes).

Worth every second when Unified Logs are what the case turns on. Worth nothing at all otherwise.

## The change

One entry in `scripts/modules_to_exclude.py`, the mechanism that already exists for this and is currently used for the slow Photos artifacts. The checkbox comes up unselected and the examiner opts in.

Nothing else changes. The module is still available, still runs normally once ticked, and **Select All still picks it up** — this is a default, not a lockout.

The twelve dependent artifacts share `module_name='logarchive'` and are hidden from the list anyway (chained off the parent), so the single entry covers the whole family.

Simulating the GUI's list construction:

```
checkboxes shown           : 745
unchecked by default       : 53   (was 52)
logarchive shown?          : True
logarchive unchecked?      : True
dependents hidden & chained: 12
```

## Scope

The CLI does not consult `modules_to_exclude` and is unchanged. Running iLEAPP from the command line is already an explicit act, and profiles name their modules. Happy to add CLI parity if you'd rather have it.

## Tests

Adds the first test for this list — nothing covered it before, and its failure mode is silent. An entry that names an artifact instead of a module, or that outlives a renamed file, simply stops matching and the checkbox quietly comes back on. The test asserts every entry names a real, loaded module, and that logarchive specifically stays opt-in with its family intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)