### PR TITLE
fix: declare the imports frozen builds crash without

### DIFF
--- a/admin/test/scripts/test_pyinstaller_unifiedlog_bundle.py
+++ b/admin/test/scripts/test_pyinstaller_unifiedlog_bundle.py
@@ -16,11 +16,28 @@ raises rather than quietly omitting it.
 import pathlib
 import sys
 import tempfile
+import types
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / 'scripts' / 'pyinstaller'))
+
+# The specs import collect_submodules from PyInstaller, which CI does not install (it
+# only installs requirements.txt). A stub is injected unconditionally - not just when the
+# real thing is absent - so the assertions below can look for deterministic sentinels
+# instead of whatever set of submodules the local PyInstaller happens to resolve. The
+# tests thereby verify that a spec ASKS for a package's submodules, which is the part a
+# regenerated spec loses; what PyInstaller does with the request is its own business.
+_hooks_stub = types.ModuleType('PyInstaller.utils.hooks')
+_hooks_stub.collect_submodules = lambda package: [f'<collect_submodules:{package}>']
+_pyinstaller_stub = types.ModuleType('PyInstaller')
+_pyinstaller_utils_stub = types.ModuleType('PyInstaller.utils')
+_pyinstaller_stub.utils = _pyinstaller_utils_stub
+_pyinstaller_utils_stub.hooks = _hooks_stub
+sys.modules['PyInstaller'] = _pyinstaller_stub
+sys.modules['PyInstaller.utils'] = _pyinstaller_utils_stub
+sys.modules['PyInstaller.utils.hooks'] = _hooks_stub
 
 import unifiedlog_binary  # pylint: disable=wrong-import-position
 
@@ -119,6 +136,46 @@ class TestSpecsBundleTheParser(unittest.TestCase):
                 datas = _run_spec(SPEC_DIR / name)['datas']
                 self.assertTrue(any('scripts' in str(dest) for _, dest in datas),
                                 f'{name} lost its scripts data entry: {datas}')
+
+
+class TestFrozenStartupDependencies(unittest.TestCase):
+    """Every spec must declare the imports a frozen build dies without.
+
+    These were found the expensive way: a build from the specs on main crashed on
+    startup, three times over, each failure hidden behind the previous one.
+
+    - Every spec listed the *vendored* blackboxprotobuf as a hidden import (PyInstaller
+      warns it is 'not found', which reads as noise), while nothing declared the real
+      google.protobuf package whose internals it imports. First run:
+      ModuleNotFoundError: google.protobuf.internal.
+    - PIL.ImageDraw was never collected. Second run: ImportError from PIL.
+    - The CLI specs bundled scripts/ but not leapp_functions/ or assets/, which the GUI
+      specs already carried. Third run: ModuleNotFoundError: leapp_functions.parsers.
+
+    The sentinels come from the stubbed collect_submodules above, so these assertions
+    check that each spec requests the collection - the exact thing lost when a spec is
+    regenerated or the entry is 'cleaned up' as unused.
+    """
+
+    def test_every_spec_collects_protobuf_and_pil(self):
+        for name in sorted(EXPECTED_SPECS):
+            with self.subTest(spec=name):
+                hidden = _run_spec(SPEC_DIR / name)['hiddenimports']
+                self.assertIn('<collect_submodules:google.protobuf>', hidden,
+                              f'{name} no longer collects google.protobuf; frozen builds '
+                              f'crash on startup without it')
+                self.assertIn('<collect_submodules:PIL>', hidden,
+                              f'{name} no longer collects PIL')
+
+    def test_every_spec_bundles_leapp_functions_and_assets(self):
+        for name in sorted(EXPECTED_SPECS):
+            with self.subTest(spec=name):
+                destinations = [str(dest).replace('.\\', '').replace('\\', '/')
+                                for _, dest in _run_spec(SPEC_DIR / name)['datas']]
+                self.assertIn('leapp_functions', destinations,
+                              f'{name} does not bundle leapp_functions')
+                self.assertIn('assets', destinations,
+                              f'{name} does not bundle assets')
 
 
 class TestBuildsWithoutTheBinary(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,11 @@ pytypedstream
 bencoding
 biplist
 bs4
+# admin/scripts/fetch_unifiedlog_iterator.py falls back to certifi's CA bundle on
+# python.org installs, which ship without a certificate store until the user runs
+# 'Install Certificates.command'. Without this, a fresh build venv cannot fetch the
+# Unified Log parser binary (CERTIFICATE_VERIFY_FAILED).
+certifi
 ijson
 mmh3
 mdplistlib

--- a/scripts/pyinstaller/ileapp.spec
+++ b/scripts/pyinstaller/ileapp.spec
@@ -4,17 +4,23 @@ import sys
 
 sys.path.insert(0, SPECPATH)
 from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
 
 a = Analysis(['..\\..\\ileapp.py'],
              pathex=['..\\scripts\\artifacts'],
              binaries=unifiedlog_binaries(windows=True),
-             datas=[('..\\', '.\\scripts')] + unifiedlog_datas(windows=True),
+             datas=[('..\\', '.\\scripts'), ('..\\..\\leapp_functions', '.\\leapp_functions'), ('..\\..\\assets', '.\\assets')] + unifiedlog_datas(windows=True),
              hiddenimports=[
                 'astc_decomp_faster',
                 'bencoding',
                 'blackboxprotobuf',
+                # blackboxprotobuf above is the vendored copy under scripts/ (PyInstaller
+                # reports it 'not found'); what actually has to be collected is the real
+                # google.protobuf package it imports internals from.
+                *collect_submodules('google.protobuf'),
+                *collect_submodules('PIL'),
                 'Crypto.Cipher.AES',
                 'ijson',
                 'lib2to3.refactor',

--- a/scripts/pyinstaller/ileappGUI.spec
+++ b/scripts/pyinstaller/ileappGUI.spec
@@ -4,6 +4,7 @@ import sys
 
 sys.path.insert(0, SPECPATH)
 from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
 
@@ -15,6 +16,11 @@ a = Analysis(['..\\..\\ileappGUI.py'],
                 'astc_decomp_faster',
                 'bencoding',
                 'blackboxprotobuf',
+                # blackboxprotobuf above is the vendored copy under scripts/ (PyInstaller
+                # reports it 'not found'); what actually has to be collected is the real
+                # google.protobuf package it imports internals from.
+                *collect_submodules('google.protobuf'),
+                *collect_submodules('PIL'),
                 'Crypto.Cipher.AES',
                 'ijson',
                 'lib2to3.refactor',

--- a/scripts/pyinstaller/ileappGUI_Linux.spec
+++ b/scripts/pyinstaller/ileappGUI_Linux.spec
@@ -5,6 +5,7 @@ import sys
 
 sys.path.insert(0, SPECPATH)
 from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+from PyInstaller.utils.hooks import collect_submodules
 
 a = Analysis(
     ['../../ileappGUI.py'],
@@ -15,6 +16,11 @@ a = Analysis(
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
+        # blackboxprotobuf above is the vendored copy under scripts/ (PyInstaller
+        # reports it 'not found'); what actually has to be collected is the real
+        # google.protobuf package it imports internals from.
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('PIL'),
         'Crypto.Cipher.AES',
         'ijson',
         'lib2to3.refactor',

--- a/scripts/pyinstaller/ileappGUI_macOS.spec
+++ b/scripts/pyinstaller/ileappGUI_macOS.spec
@@ -5,6 +5,7 @@ import sys
 
 sys.path.insert(0, SPECPATH)
 from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+from PyInstaller.utils.hooks import collect_submodules
 
 a = Analysis(
     ['../../ileappGUI.py'],
@@ -15,6 +16,11 @@ a = Analysis(
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
+        # blackboxprotobuf above is the vendored copy under scripts/ (PyInstaller
+        # reports it 'not found'); what actually has to be collected is the real
+        # google.protobuf package it imports internals from.
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('PIL'),
         'Crypto.Cipher.AES',
         'ijson',
         'lib2to3.refactor',

--- a/scripts/pyinstaller/ileapp_Linux.spec
+++ b/scripts/pyinstaller/ileapp_Linux.spec
@@ -5,16 +5,22 @@ import sys
 
 sys.path.insert(0, SPECPATH)
 from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+from PyInstaller.utils.hooks import collect_submodules
 
 a = Analysis(
     ['../../ileapp.py'],
     pathex=['../scripts/artifacts'],
     binaries=unifiedlog_binaries(),
-    datas=[('../', 'scripts')] + unifiedlog_datas(),
+    datas=[('../', 'scripts'), ('../../leapp_functions', 'leapp_functions'), ('../../assets', 'assets')] + unifiedlog_datas(),
     hiddenimports=[
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
+        # blackboxprotobuf above is the vendored copy under scripts/ (PyInstaller
+        # reports it 'not found'); what actually has to be collected is the real
+        # google.protobuf package it imports internals from.
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('PIL'),
         'Crypto.Cipher.AES',
         'ijson',
         'lib2to3.refactor',

--- a/scripts/pyinstaller/ileapp_macOS.spec
+++ b/scripts/pyinstaller/ileapp_macOS.spec
@@ -5,16 +5,22 @@ import sys
 
 sys.path.insert(0, SPECPATH)
 from unifiedlog_binary import unifiedlog_binaries, unifiedlog_datas
+from PyInstaller.utils.hooks import collect_submodules
 
 a = Analysis(
     ['../../ileapp.py'],
     pathex=['../scripts/artifacts'],
     binaries=unifiedlog_binaries(),
-    datas=[('../', 'scripts')] + unifiedlog_datas(),
+    datas=[('../', 'scripts'), ('../../leapp_functions', 'leapp_functions'), ('../../assets', 'assets')] + unifiedlog_datas(),
     hiddenimports=[
         'astc_decomp_faster',
         'bencoding',
         'blackboxprotobuf',
+        # blackboxprotobuf above is the vendored copy under scripts/ (PyInstaller
+        # reports it 'not found'); what actually has to be collected is the real
+        # google.protobuf package it imports internals from.
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('PIL'),
         'Crypto.Cipher.AES',
         'ijson',
         'lib2to3.refactor',


### PR DESCRIPTION
## The problem

A build from any of the six specs on main **crashes on startup**. Found while producing a macOS test build of the Unified Log work; all three causes are pre-existing and unrelated to it. They surface one at a time, each hidden behind the previous one:

1. `ModuleNotFoundError: No module named 'google.protobuf.internal'` — every spec lists the **vendored** `blackboxprotobuf` as a hidden import. PyInstaller warns `Hidden import 'blackboxprotobuf' not found`, which reads as noise and gets ignored — the vendored copy lives at `scripts/blackboxprotobuf/` and arrives via the `scripts` data entry. What nothing declared is the real `google.protobuf` package whose internals the vendored code imports.
2. `ImportError: cannot import name 'ImageDraw' from 'PIL'` — PIL's submodules were never collected.
3. `ModuleNotFoundError: No module named 'leapp_functions.parsers'` — the three **CLI** specs bundle `scripts/` but not `leapp_functions/` or `assets/`, both of which the GUI specs already carry.

## The fix

- All six specs: `*collect_submodules('google.protobuf')` and `*collect_submodules('PIL')` in `hiddenimports`.
- The three CLI specs: bundle `leapp_functions` and `assets`, matching their GUI counterparts.
- `certifi` added to requirements: `admin/scripts/fetch_unifiedlog_iterator.py` falls back to its CA bundle on python.org installs, which ship without a certificate store until `Install Certificates.command` is run. A fresh build venv could not fetch the parser binary at all (`CERTIFICATE_VERIFY_FAILED`).

## Tests

The spec test now injects a `collect_submodules` stub before exec'ing the specs, so assertions check that each spec *requests* the collection via deterministic sentinels — the exact thing lost when a spec is regenerated with `pyi-makespec` or an entry is removed as "unused". New assertions cover all three failure classes. The prior symptom was a binary that dies on launch, which no test ever ran.

## Verified

On macOS, built from this branch:

- `ileapp_macOS.spec` → frozen CLI runs a full case end to end: 1,103,360 Unified Log records via the bundled parser, **report generation completed**, exit 0.
- `ileappGUI_macOS.spec` → app launches and stays up.

**Not verified:** Windows and Linux builds — the specs receive identical changes, but there is no cross-build from macOS. Worth one smoke test on each before the next release.

## Relationship to `fix-pyinstaller-frozen-assets`

The unmerged local branch `fix-pyinstaller-frozen-assets` (786939cf) overlaps on bug 3 for the Windows specs and additionally changes `report.py` to resolve assets from `_MEIPASS`. This PR does not touch `report.py`. If that branch is still wanted, it will need a rebase over this; frozen report generation completed in my test without the `report.py` change, but I have not audited every asset reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)