### PR TITLE
fix: find Unified Log data in UFED-layout extractions

### DIFF
--- a/admin/test/scripts/test_logarchive_native.py
+++ b/admin/test/scripts/test_logarchive_native.py
@@ -59,6 +59,69 @@ class TestIteratorTimestamp(unittest.TestCase):
         self.assertEqual(logarchive.parse_iterator_timestamp(''), '')
 
 
+class TestSearchPatternsMatchRealLayouts(unittest.TestCase):
+    """The declared globs must match every extraction layout the data arrives in.
+
+    This failed in the field before it failed in a test: the globs were anchored at
+    private/var/db/, Cellebrite UFED zips store the data partition as filesystem2/db/
+    with no private/var prefix, and an 18 GB image with 616 MB of tracev3 data produced
+    'No data found for logarchive' in three seconds. The corpus CSVs in
+    admin/data/filepath-lists use the same filesystem2/db/ layout.
+
+    Matching is checked with the seeker's own machinery (fnmatch against 'root/' + path),
+    not a reimplementation, so these stay honest if the seeker changes.
+    """
+
+    # Verbatim shapes from, respectively: a UFED FFS zip (CTF23 Felix), an Apple-native
+    # full file system extraction, and a collected/reconstructed logarchive package.
+    UFED = [
+        'filesystem2/db/diagnostics/Persist/000000000000034f.tracev3',
+        'filesystem2/db/diagnostics/timesync/0000000000000002.timesync',
+        'filesystem2/db/uuidtext/03/1122334455667788',
+        'filesystem2/db/uuidtext/dsc/ABCDEF0011',
+    ]
+    NATIVE = [
+        'private/var/db/diagnostics/Persist/0000000000000001.tracev3',
+        'private/var/db/uuidtext/00/AABBCCDD',
+    ]
+    LOGARCHIVE = [
+        'case/device.logarchive/Persist/0000000000000001.tracev3',
+        'case/device.logarchive/dsc/ABCDEF',
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        from fnmatch import _compile_pattern  # what search_files.py matches with
+        patterns = logarchive.__artifacts_v2__['logarchive']['paths']
+        compiled = [_compile_pattern(os.path.normcase(p)) for p in patterns]
+        cls.matches = staticmethod(
+            lambda path: any(pat(os.path.normcase('root/' + path)) for pat in compiled))
+
+    def test_ufed_layout_matches(self):
+        for path in self.UFED:
+            with self.subTest(path=path):
+                self.assertTrue(self.matches(path), f'globs miss UFED path {path}')
+
+    def test_apple_native_layout_matches(self):
+        for path in self.NATIVE:
+            with self.subTest(path=path):
+                self.assertTrue(self.matches(path), f'globs miss native path {path}')
+
+    def test_logarchive_package_matches(self):
+        for path in self.LOGARCHIVE:
+            with self.subTest(path=path):
+                self.assertTrue(self.matches(path), f'globs miss logarchive path {path}')
+
+    def test_globs_do_not_swallow_unrelated_databases(self):
+        # 'db' appears all over an iOS filesystem; the diagnostics/uuidtext anchors are
+        # what keep this artifact from claiming files that belong to other modules.
+        for path in ('private/var/db/CoreDuet/Knowledge/knowledgeC.db',
+                     'private/var/mobile/Library/CallHistoryDB/CallHistory.storedata',
+                     'filesystem2/db/timezone/localtime'):
+            with self.subTest(path=path):
+                self.assertFalse(self.matches(path), f'globs wrongly claim {path}')
+
+
 class TestArchiveRootDiscovery(unittest.TestCase):
     """The parser needs directory roots, but the seeker hands back individual file paths."""
 
@@ -82,6 +145,29 @@ class TestArchiveRootDiscovery(unittest.TestCase):
         self.assertEqual(archive, '/case/device.logarchive')
         self.assertIsNone(diagnostics)
         self.assertIsNone(uuidtext)
+
+    def test_populated_partition_beats_empty_system_partition(self):
+        """The UFED two-partition trap: CTF23 Felix reported zero records because
+        filesystem1's empty diagnostics directory was found first and won on order.
+        The root with the files under it has to win regardless of position."""
+        found = [
+            # The system partition's directory arrives first and is empty (the seeker
+            # extracts the bare directory entry from the zip).
+            '/out/data/filesystem1/private/var/db/diagnostics/',
+            '/out/data/filesystem2/db/diagnostics/Persist/000000000000034f.tracev3',
+            '/out/data/filesystem2/db/diagnostics/timesync/0000000000000002.timesync',
+            '/out/data/filesystem2/db/uuidtext/03/1122334455667788',
+        ]
+        _, diagnostics, uuidtext = unifiedlogs.find_archive_roots(found)
+        self.assertEqual(diagnostics, '/out/data/filesystem2/db/diagnostics')
+        self.assertEqual(uuidtext, '/out/data/filesystem2/db/uuidtext')
+
+    def test_lone_empty_directory_still_resolves(self):
+        # With nothing better on offer, an empty directory is still the right answer;
+        # the artifact reports the absence of tracev3 data rather than "no files found".
+        found = ['/out/data/private/var/db/diagnostics/']
+        _, diagnostics, _ = unifiedlogs.find_archive_roots(found)
+        self.assertEqual(diagnostics, '/out/data/private/var/db/diagnostics')
 
 
 class TestArchiveAssembly(unittest.TestCase):

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -10,9 +10,14 @@ __artifacts_v2__ = {
                         "binary; see scripts/unifiedlogs.py",
         "category": "Unified Logs",
         "notes": "",
+        # The tracev3 globs are anchored at db/, not private/var/db/: Cellebrite UFED
+        # zips (and the corpus CSVs in admin/data/filepath-lists) store the data
+        # partition as filesystem2/db/diagnostics with no private/var prefix, and the
+        # anchored form never matched them. fnmatch's '*' crosses path separators, so
+        # these cover the Apple-native layout too.
         "paths": ('*/logarchive*.json',
-                  '*/private/var/db/diagnostics/*',
-                  '*/private/var/db/uuidtext/*',
+                  '*/db/diagnostics/*',
+                  '*/db/uuidtext/*',
                   '*.logarchive/*'),
         "output_types": "lava_only",
         "artifact_icon": "database",

--- a/scripts/unifiedlogs.py
+++ b/scripts/unifiedlogs.py
@@ -100,22 +100,44 @@ def find_archive_roots(files_found):
 
     Returns (logarchive_dir, diagnostics_dir, uuidtext_dir), where either the first item
     is set (the examiner supplied a ready-made .logarchive) or the other two are.
+
+    An extraction can hold the same directory name on more than one partition. A UFED
+    zip of an iPhone carries filesystem1 (system) and filesystem2 (data), and
+    filesystem1 has an *empty* private/var/db/diagnostics; the populated one lives at
+    filesystem2/db/diagnostics. Taking the first name match handed the parser the empty
+    directory and a real image reported zero records with no error anywhere. So roots
+    are chosen by how many found files sit beneath them, judged from the seeker's list
+    alone - the paths may describe files that only exist inside an archive.
     """
     logarchive = None
-    diagnostics = None
-    uuidtext = None
+    diagnostics_candidates = {}
+    uuidtext_candidates = {}
 
     for path in files_found:
         components = _path_components(path)
+        is_file = bool(components) and not str(path).replace('\\', '/').endswith('/')
         for index, component in enumerate(components):
             if component.lower().endswith('.logarchive'):
                 logarchive = logarchive or '/'.join(components[:index + 1])
-            elif component == DIAGNOSTICS_DIR:
-                diagnostics = diagnostics or '/'.join(components[:index + 1])
+                continue
+            if component == DIAGNOSTICS_DIR:
+                candidates = diagnostics_candidates
             elif component == UUIDTEXT_DIR:
-                uuidtext = uuidtext or '/'.join(components[:index + 1])
+                candidates = uuidtext_candidates
+            else:
+                continue
+            root = '/'.join(components[:index + 1])
+            below = index + 1 < len(components) and is_file
+            candidates[root] = candidates.get(root, 0) + (1 if below else 0)
 
-    return logarchive, diagnostics, uuidtext
+    def best(candidates):
+        if not candidates:
+            return None
+        # Most files underneath wins; insertion order breaks ties, so a lone empty
+        # directory still resolves when it is all there is.
+        return max(candidates, key=lambda root: candidates[root])
+
+    return logarchive, best(diagnostics_candidates), best(uuidtext_candidates)
 
 
 def _link_file(source, destination):


### PR DESCRIPTION
## The problem

Testing the packaged build against a real Cellebrite image (CTF23 Felix, iOS 16.5, 18.8 GB, 616 MB of tracev3 data) took **three seconds** and reported `No data found for logarchive` — exit 0, report generated, nothing wrong anywhere. That reads as *"this phone has no Unified Logs"*, which is the worst way to fail.

Two stacked causes:

1. **The search globs never matched.** They were anchored at `private/var/db/`. UFED zips store the data partition as `filesystem2/db/diagnostics` with **no `private/var` prefix** — as do all the corpus CSVs in `admin/data/filepath-lists`. So native-layout extractions worked and Cellebrite extractions silently produced nothing.
2. **With that fixed, the parser ran against an empty directory.** The same image also carries `filesystem1` (system partition) with an *empty* `private/var/db/diagnostics`, and `find_archive_roots` took the first name match. The populated directory on `filesystem2` lost on ordering.

## The fix

- Globs now anchor at `db/`: `*/db/diagnostics/*`, `*/db/uuidtext/*`. fnmatch's `*` crosses path separators, so the Apple-native layout still matches.
- Roots are chosen by **how many found files sit beneath them**, judged from the seeker's path list alone (the paths may describe files that only exist inside an archive). The populated partition wins regardless of ordering; a lone empty directory still resolves so the artifact reports absence of data rather than absence of files.

## Tests

New cases pin the UFED layout, the Apple-native layout, the reconstructed-`.logarchive` layout, the two-partition trap, and a guard that the looser globs don't claim unrelated `db/` paths (`knowledgeC.db`, `db/timezone`, …). Matching is checked with the seeker's own `fnmatch` machinery rather than a reimplementation.

## Verified

Same Felix image, source run from this branch:

| | before | after |
|---|---|---|
| wall time | 3 s | 9 m 34 s |
| logarchive records | 0 | **19,419,414** |
| dependent artifacts populated | 0 of 12 | **9 of 12** |
| peak RSS | — | 688 MB |

Flashlight among them: 70 records, the spaced-form predicate from #1823 earning its keep on a second device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)