### PR TITLE
build: fetch the musl parser build for Linux x86_64

### DIFF
--- a/admin/scripts/fetch_unifiedlog_iterator.py
+++ b/admin/scripts/fetch_unifiedlog_iterator.py
@@ -37,14 +37,22 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 BIN_DIR = REPO_ROOT / 'bin'
 
 # sha256 of each release archive, read from the .sha256 files published with v0.6.0.
-# Note: upstream's .sha256 files print the digest twice on one line; these are the single
-# correct value.
+# Note: some of upstream's .sha256 files print the digest twice on one line; these are
+# the single correct value.
 ASSETS = {
     'macos-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-apple-darwin.tar.gz',
                     'd3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63'),
     'macos-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-apple-darwin.tar.gz', None),
+    # No musl build is published for aarch64; gnu is the only option there.
     'linux-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-unknown-linux-gnu.tar.gz', None),
-    'linux-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-gnu.tar.gz', None),
+    # Linux x86_64 deliberately takes the musl build (verified static-pie linked, no
+    # dynamic libc). The gnu build links whatever glibc the release runner carries, and a
+    # binary built against a newer glibc refuses to start on older distros - the exact
+    # machines an AppImage exists to support, and forensic workstations skew old. The gnu
+    # build stays reachable below for anyone who wants it.
+    'linux-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-musl.tar.gz',
+                     '43fb304af5b3cc19ce15490f6e0ff4255e7707b69c51fc67e279677ea9784adb'),
+    'linux-x86_64-gnu': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-gnu.tar.gz', None),
     'windows-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-pc-windows-msvc.zip', None),
 }
 

--- a/bin/PROVENANCE.md
+++ b/bin/PROVENANCE.md
@@ -22,11 +22,21 @@ just ship without native Unified Log support, and the artifact reports that at r
 | Version | v0.6.0 (released 2026-05-07) |
 | License | Apache-2.0 (`LICENSE-unifiedlog_iterator`) |
 | macOS arm64 archive sha256 | `d3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63` |
+| Linux x86_64 (musl) archive sha256 | `43fb304af5b3cc19ce15490f6e0ff4255e7707b69c51fc67e279677ea9784adb` |
 
 Digests for the other platforms are read from the `.sha256` files published with the
 release and printed by the fetch script; pin them in `ASSETS` as each is first used for a
-build. Upstream's `.sha256` files repeat the digest twice on one line, which is a quirk of
-their release workflow, not a corrupted file.
+build. Some of upstream's `.sha256` files repeat the digest twice on one line, which is a
+quirk of their release workflow, not a corrupted file.
+
+## Linux: musl, not gnu
+
+`linux-x86_64` fetches the **musl** build, verified `static-pie linked` - it carries no
+dynamic libc dependency at all. The gnu build links the glibc of whatever machine built
+it, and a binary built against a newer glibc refuses to start on older distros with
+`version 'GLIBC_x.yy' not found`. iLEAPP ships Linux as an AppImage, whose whole premise
+is one file that runs anywhere; forensic workstations also skew old and locked down.
+`--platform linux-x86_64-gnu` remains available. No musl build is published for aarch64.
 
 ## Why the version is pinned
 


### PR DESCRIPTION
## Why

The gnu build of `unifiedlog_iterator` dynamically links the glibc of whatever machine built it. A binary built against a newer glibc refuses to start on older distros with `version 'GLIBC_x.yy' not found` — and iLEAPP ships Linux as an **AppImage**, whose whole premise is one file that runs on any distro. Forensic workstations also skew old and locked down, which is exactly the direction glibc compatibility breaks in.

## What

`linux-x86_64` now fetches upstream's **musl** build:

- digest pinned: `43fb304af5b3cc19ce15490f6e0ff4255e7707b69c51fc67e279677ea9784adb`
- verified `static-pie linked` with `file` — no dynamic libc dependency at all
- archive confirmed to carry the binary and its Apache-2.0 LICENSE

musl's known trade-offs (allocator throughput under heavy multithreaded allocation, DNS and locale behaviour differences) touch nothing this binary does — it is single-threaded file parsing.

The gnu build stays reachable as `--platform linux-x86_64-gnu`. aarch64 keeps gnu because upstream publishes no musl build for it. `bin/PROVENANCE.md` records the digest and the reasoning.

## Verified

Ran the fetch for real: digest check passes, extraction works, `file` confirms static-pie. **Not executed on a Linux host** — that remains the standing gap for the Linux and Windows builds generally (#1824 notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)