### PR TITLE
fix: compare parser digests case-insensitively, pin all six platforms

### DIFF
--- a/admin/scripts/fetch_unifiedlog_iterator.py
+++ b/admin/scripts/fetch_unifiedlog_iterator.py
@@ -36,15 +36,19 @@ BASE_URL = f'https://github.com/{REPO}/releases/download/{PINNED_VERSION}'
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 BIN_DIR = REPO_ROOT / 'bin'
 
-# sha256 of each release archive, read from the .sha256 files published with v0.6.0.
-# Note: some of upstream's .sha256 files print the digest twice on one line; these are
-# the single correct value.
+# sha256 of each release archive. Every digest below was verified by downloading the
+# archive and hashing it independently, not just read from the published .sha256 files.
+# All values are stored lowercase; comparisons are case-insensitive (see
+# _normalize_digest) because upstream's per-platform build runners disagree on case -
+# the Windows .sha256 is uppercase (PowerShell Get-FileHash style), the rest lowercase.
 ASSETS = {
     'macos-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-apple-darwin.tar.gz',
                     'd3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63'),
-    'macos-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-apple-darwin.tar.gz', None),
+    'macos-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-apple-darwin.tar.gz',
+                     '28f4a5641543559ef90472537950fafb344a13eb64c432d7929748b45007afe8'),
     # No musl build is published for aarch64; gnu is the only option there.
-    'linux-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-unknown-linux-gnu.tar.gz', None),
+    'linux-arm64': ('unifiedlog_iterator-v0.6.0-aarch64-unknown-linux-gnu.tar.gz',
+                    '1e519eef11e5763d44311600077318d9bdd2c8b1c806191b7c9b345e1c995c5f'),
     # Linux x86_64 deliberately takes the musl build (verified static-pie linked, no
     # dynamic libc). The gnu build links whatever glibc the release runner carries, and a
     # binary built against a newer glibc refuses to start on older distros - the exact
@@ -52,9 +56,25 @@ ASSETS = {
     # build stays reachable below for anyone who wants it.
     'linux-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-musl.tar.gz',
                      '43fb304af5b3cc19ce15490f6e0ff4255e7707b69c51fc67e279677ea9784adb'),
-    'linux-x86_64-gnu': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-gnu.tar.gz', None),
-    'windows-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-pc-windows-msvc.zip', None),
+    'linux-x86_64-gnu': ('unifiedlog_iterator-v0.6.0-x86_64-unknown-linux-gnu.tar.gz',
+                         'f5a17b056092be347e5d7f5051a6c3698e635bd7eeb22e595efbf13897e03419'),
+    'windows-x86_64': ('unifiedlog_iterator-v0.6.0-x86_64-pc-windows-msvc.zip',
+                       '749731fc09d0d107958d777188c99682db8f2d7810835d6afe46172e1d0d9d36'),
 }
+
+
+def _normalize_digest(value):
+    """Lowercase a hex digest and unfold upstream's doubled-digest quirk.
+
+    Two independent formatting differences in upstream's published .sha256 files have
+    produced false "mismatch" refusals for users: the Windows file is UPPERCASE
+    (PowerShell Get-FileHash), and some files print the digest twice on one line. The
+    hex value is what matters; its presentation is not evidence of tampering.
+    """
+    value = value.strip().split()[0].lower() if value.strip() else ''
+    if len(value) == 128 and value[:64] == value[64:]:
+        value = value[:64]
+    return value
 
 
 def current_platform():
@@ -93,13 +113,11 @@ def _download(url):
 
 def _expected_digest(asset, pinned):
     """Use the pinned digest, or fall back to the published .sha256 for platforms we
-    have not pinned yet, reporting the value so it can be added above."""
+    have not pinned yet (a new PINNED_VERSION), reporting the value so it can be
+    added above."""
     if pinned:
-        return pinned
-    published = _download(f'{BASE_URL}/{asset}.sha256').decode().split()[0]
-    # Upstream concatenates the digest with itself; take one copy.
-    if len(published) == 128 and published[:64] == published[64:]:
-        published = published[:64]
+        return _normalize_digest(pinned)
+    published = _normalize_digest(_download(f'{BASE_URL}/{asset}.sha256').decode())
     print(f'  no pinned digest for {asset}; published value is {published}')
     return published
 
@@ -144,7 +162,7 @@ def fetch(key):
     expected = _expected_digest(asset, pinned)
     archive_bytes = _download(f'{BASE_URL}/{asset}')
     actual = hashlib.sha256(archive_bytes).hexdigest()
-    if actual != expected:
+    if _normalize_digest(actual) != expected:
         raise SystemExit(f'  DIGEST MISMATCH for {asset}\n'
                          f'    expected {expected}\n    got      {actual}\n'
                          f'  Nothing was written.')

--- a/admin/test/scripts/test_fetch_unifiedlog_digest.py
+++ b/admin/test/scripts/test_fetch_unifiedlog_digest.py
@@ -1,0 +1,85 @@
+"""Digest handling in the unifiedlog_iterator fetch script must be case-insensitive.
+
+A Windows examiner following the run-from-source instructions got a hard DIGEST MISMATCH
+refusal on a byte-identical download: upstream's Windows .sha256 file is UPPERCASE
+(PowerShell Get-FileHash style) while Python's hexdigest() is lowercase, and the
+comparison was case-sensitive. The values were equal; only the presentation differed.
+Upstream's files also sometimes print the digest twice on one line. Neither quirk is
+evidence of tampering, and neither may block a verified download again.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+_SPEC = importlib.util.spec_from_file_location(
+    'fetch_unifiedlog_iterator',
+    REPO_ROOT / 'admin' / 'scripts' / 'fetch_unifiedlog_iterator.py')
+fetch = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(fetch)
+
+# The normalizer is module-private; the tests exist precisely to pin its behavior.
+normalize = fetch._normalize_digest  # pylint: disable=protected-access
+
+LOWER = '749731fc09d0d107958d777188c99682db8f2d7810835d6afe46172e1d0d9d36'
+UPPER = LOWER.upper()
+
+
+class TestNormalizeDigest(unittest.TestCase):
+    """Every formatting variant upstream has actually shipped must normalize equal."""
+
+    def test_uppercase_windows_style(self):
+        # The exact failure a Windows user reported: right value, wrong case.
+        self.assertEqual(normalize(UPPER), LOWER)
+
+    def test_lowercase_passes_through(self):
+        self.assertEqual(normalize(LOWER), LOWER)
+
+    def test_doubled_digest_folds(self):
+        # Some of upstream's .sha256 files print the digest twice on one line.
+        self.assertEqual(normalize(LOWER + LOWER), LOWER)
+
+    def test_doubled_uppercase_folds_and_lowers(self):
+        self.assertEqual(normalize(UPPER + UPPER), LOWER)
+
+    def test_filename_suffix_and_whitespace_stripped(self):
+        # shasum-style "digest  filename" lines and stray CR/LF.
+        self.assertEqual(normalize(f'{UPPER}  some-file.zip\r\n'), LOWER)
+
+    def test_empty_input_is_empty_not_crash(self):
+        self.assertEqual(normalize('  \n'), '')
+
+    def test_distinct_halves_are_not_folded(self):
+        # 128 hex chars whose halves differ is NOT the doubled-digest quirk; folding it
+        # would hide a genuinely malformed published file.
+        other = 'a' * 64 + 'b' * 64
+        self.assertEqual(normalize(other), other)
+
+
+class TestPinnedDigests(unittest.TestCase):
+    """The pin table is the trust anchor; keep it in a state comparisons can rely on."""
+
+    def test_every_platform_is_pinned(self):
+        # With every digest pinned, the published .sha256 fallback (and its formatting
+        # quirks) is out of the trust path entirely for the pinned version.
+        for key, (asset, digest) in fetch.ASSETS.items():
+            with self.subTest(platform=key):
+                self.assertIsNotNone(digest, f'{key} ({asset}) has no pinned digest')
+
+    def test_pins_are_normalized_lowercase_hex(self):
+        for key, (_, digest) in fetch.ASSETS.items():
+            with self.subTest(platform=key):
+                self.assertEqual(digest, digest.lower())
+                self.assertEqual(len(digest), 64)
+                int(digest, 16)  # raises if not hex
+
+    def test_windows_pin_matches_upstreams_uppercase_publication(self):
+        # Upstream publishes this one in uppercase; the pin must be its lowercase form.
+        self.assertEqual(fetch.ASSETS['windows-x86_64'][1], LOWER)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bin/PROVENANCE.md
+++ b/bin/PROVENANCE.md
@@ -16,18 +16,24 @@ just ship without native Unified Log support, and the artifact reports that at r
 
 ## What is pinned
 
-| | |
+| Platform | Archive sha256 |
 |---|---|
-| Project | [mandiant/macos-UnifiedLogs](https://github.com/mandiant/macos-UnifiedLogs) |
-| Version | v0.6.0 (released 2026-05-07) |
-| License | Apache-2.0 (`LICENSE-unifiedlog_iterator`) |
-| macOS arm64 archive sha256 | `d3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63` |
-| Linux x86_64 (musl) archive sha256 | `43fb304af5b3cc19ce15490f6e0ff4255e7707b69c51fc67e279677ea9784adb` |
+| macOS arm64 | `d3e0e620b51358dc3f4a7d376551a435153e9a4a7942cb52ddb7144a72bbdb63` |
+| macOS x86_64 | `28f4a5641543559ef90472537950fafb344a13eb64c432d7929748b45007afe8` |
+| Linux arm64 (gnu) | `1e519eef11e5763d44311600077318d9bdd2c8b1c806191b7c9b345e1c995c5f` |
+| Linux x86_64 (musl) | `43fb304af5b3cc19ce15490f6e0ff4255e7707b69c51fc67e279677ea9784adb` |
+| Linux x86_64 (gnu) | `f5a17b056092be347e5d7f5051a6c3698e635bd7eeb22e595efbf13897e03419` |
+| Windows x86_64 | `749731fc09d0d107958d777188c99682db8f2d7810835d6afe46172e1d0d9d36` |
 
-Digests for the other platforms are read from the `.sha256` files published with the
-release and printed by the fetch script; pin them in `ASSETS` as each is first used for a
-build. Some of upstream's `.sha256` files repeat the digest twice on one line, which is a
-quirk of their release workflow, not a corrupted file.
+Project: [mandiant/macos-UnifiedLogs](https://github.com/mandiant/macos-UnifiedLogs),
+version v0.6.0 (released 2026-05-07), Apache-2.0 (`LICENSE-unifiedlog_iterator`).
+
+Every digest above was verified by downloading the archive and hashing it independently,
+not by trusting the published `.sha256` files alone. Digest comparison in the fetch
+script is case-insensitive: upstream's Windows `.sha256` is published in UPPERCASE
+(PowerShell `Get-FileHash` style) while the others are lowercase, and some files print
+the digest twice on one line. Presentation quirks of the publication, not corruption.
+When bumping PINNED_VERSION, verify and pin all six the same way.
 
 ## Linux: musl, not gnu
 


### PR DESCRIPTION
## The report

A Windows examiner following the blog's run-from-source instructions got a hard refusal on a byte-identical download:

```
DIGEST MISMATCH for unifiedlog_iterator-v0.6.0-x86_64-pc-windows-msvc.zip
  expected 749731FC09D0D107958D777188C99682DB8F2D7810835D6AFE46172E1D0D9D36
  got      749731fc09d0d107958d777188c99682db8f2d7810835d6afe46172e1d0d9d36
```

Same value, different case. Upstream's **Windows** `.sha256` is published in UPPERCASE (PowerShell `Get-FileHash` style); the other five platforms are lowercase, and Python's `hexdigest()` is lowercase. The comparison was case-sensitive, and only the unpinned platforms fell back to the published files — which is why only Windows hit it. Reproduced verbatim before fixing.

## The fix

- **Digests normalize on both sides**: lowercased, whitespace/filename suffixes stripped, and upstream's doubled-digest quirk folded — but only when the two halves are identical, so a genuinely malformed 128-character value still fails. The hex value is the evidence; its presentation is not.
- **All six platform digests are now pinned**, each verified by downloading the archive and hashing it independently rather than trusting the published `.sha256` files. For v0.6.0 the published files are out of the trust path entirely. `bin/PROVENANCE.md` carries the full table.

## Verified

- The exact failing command (`--platform windows-x86_64`) now succeeds: downloads, verifies, extracts `unifiedlog_iterator.exe` + LICENSE.
- 10 new tests / 12 subtests pin every formatting variant upstream has actually shipped (uppercase, doubled, doubled-uppercase, filename-suffixed) plus pin-table completeness; the distinct-halves case asserts the folding never masks a malformed file.
- Full suite: 124 passed. Lint: no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)