### PR TITLE
ci: manual Windows test build with on-runner smoke tests

### DIFF
--- a/.github/workflows/build_windows_test.yml
+++ b/.github/workflows/build_windows_test.yml
@@ -1,0 +1,90 @@
+name: Windows test build
+
+# Build the Windows CLI and GUI binaries with PyInstaller and smoke-test them on a
+# real Windows machine, then upload them as a workflow artifact.
+#
+# Manual only. This is not the release pipeline; it exists so a Windows binary can be
+# produced and actually executed on Windows without anyone owning a Windows box.
+# PyInstaller cannot cross-build, so this cannot run on the macOS/Linux runners.
+#
+# The smoke tests are the point, not decoration: the frozen builds shipped a startup
+# crash for a long time (missing google.protobuf/PIL/leapp_functions) precisely
+# because nothing ever ran a built binary. Every step here that runs an .exe is a
+# regression test for that class of failure.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # 3.12 matches the local astc_decomp_faster wheel committed at the repo
+          # root; other versions would try to build it from source on the runner.
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install astc_decomp_faster-1.1.0-cp312-cp312-win_amd64.whl
+          pip install -r requirements.txt
+
+      - name: Fetch the Unified Log parser (digest-verified)
+        run: python admin/scripts/fetch_unifiedlog_iterator.py
+
+      - name: Smoke test the parser binary on Windows
+        # First time the Mandiant Windows build is executed anywhere in this
+        # project's pipeline. --help is used because unifiedlog_iterator exits
+        # non-zero on --version alone in some releases; either proves it runs.
+        run: |
+          bin\unifiedlog_iterator.exe --help
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Build CLI and GUI with PyInstaller
+        working-directory: scripts/pyinstaller
+        run: |
+          pyinstaller ileapp.spec --distpath ..\..\dist_build --workpath ..\..\build_tmp --noconfirm
+          pyinstaller ileappGUI.spec --distpath ..\..\dist_build --workpath ..\..\build_tmp --noconfirm
+
+      - name: Smoke test the frozen CLI
+        # --help proves the exe survives its imports (the historical crash class).
+        # The empty-input run proves module loading, report generation, and clean
+        # exit end to end; it must succeed with "no data found" everywhere.
+        run: |
+          dist_build\ileapp.exe --help
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          New-Item -ItemType Directory -Path smoke_in, smoke_out | Out-Null
+          "placeholder" | Out-File smoke_in\placeholder.txt
+          dist_build\ileapp.exe -t fs -i smoke_in -o smoke_out
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Verify the parser is bundled inside the frozen CLI
+        # The artifact must read tracev3 natively on the examiner's machine with
+        # nothing else installed. A onefile exe unpacks at runtime, so check the
+        # build manifest: Analysis-00.toc records everything PyInstaller packed.
+        run: |
+          if (-not (Select-String -Path build_tmp\ileapp\Analysis-00.toc -Pattern "unifiedlog_iterator.exe" -Quiet)) {
+            Write-Error "unifiedlog_iterator.exe was not bundled into the CLI build"
+            exit 1
+          }
+
+      - name: Package artifact
+        run: |
+          New-Item -ItemType Directory -Path artifact | Out-Null
+          Copy-Item dist_build\ileapp.exe artifact\
+          Copy-Item dist_build\ileappGUI.exe artifact\
+          Copy-Item bin\LICENSE-unifiedlog_iterator artifact\
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ileapp-windows-x64-test
+          path: artifact/
+          retention-days: 14


### PR DESCRIPTION
PyInstaller cannot cross-build, and the Windows frozen binaries have **never been executed** anywhere in this project's pipeline — which is exactly how the startup-crash class (#1826: missing `google.protobuf`/`PIL`/`leapp_functions`) shipped unnoticed for so long.

This adds a **manual** (`workflow_dispatch`) job on `windows-latest` that:

1. Installs deps on Python 3.12 (matches the committed `astc_decomp_faster` cp312 wheel)
2. Runs the digest-verified parser fetch on real Windows — live exercise of #1830's case-insensitive digest fix, in the exact environment that hit it
3. **Executes** the Mandiant `unifiedlog_iterator.exe` on Windows (a first)
4. Builds CLI + GUI from the real specs
5. **Executes** the frozen CLI: `--help` plus a full empty-input run through report generation (each step a regression test for the import-crash class)
6. Verifies `unifiedlog_iterator.exe` is inside the bundle via the build manifest
7. Uploads `ileapp.exe` + `ileappGUI.exe` (+ parser license) as a 14-day artifact

Not the release pipeline — just a repeatable way to get a testable Windows binary without anyone owning a Windows box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)