### PR TITLE
ci: build the Windows test binaries on Python 3.14

### DIFF
--- a/.github/workflows/build_windows_test.yml
+++ b/.github/workflows/build_windows_test.yml
@@ -27,14 +27,14 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          # 3.12 matches the local astc_decomp_faster wheel committed at the repo
-          # root; other versions would try to build it from source on the runner.
-          python-version: '3.12'
+          # Latest supported Python. astc-decomp-faster >= 1.1.5 publishes cp314
+          # win_amd64 wheels on PyPI, so the old cp312 wheel committed at the repo
+          # root is no longer needed here; pyliblzfse cp314 wheels ship in whl_files.
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install astc_decomp_faster-1.1.0-cp312-cp312-win_amd64.whl
           pip install -r requirements.txt
 
       - name: Fetch the Unified Log parser (digest-verified)


### PR DESCRIPTION
The Windows test build pinned Python 3.12 for the sake of the old `astc_decomp_faster` cp312 wheel committed at the repo root. `astc-decomp-faster` ≥ 1.1.5 now publishes cp314 `win_amd64` wheels on PyPI, and the `pyliblzfse` cp314 Windows wheels already ship in `whl_files/`, so the pin can go. 3.14 matches the macOS test binaries and the top of the runtime-contract matrix.

The 3.12 run ([30558091045](https://github.com/abrignoni/iLEAPP/actions/runs/30558091045)) passed all smoke tests; this re-runs the identical build and smoke chain on 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)