### PR TITLE
Cover current paths for WiFi network store, Safari profiles, and user-space FSEvents

### DIFF
--- a/scripts/artifacts/fileSystemEvents.py
+++ b/scripts/artifacts/fileSystemEvents.py
@@ -4,24 +4,29 @@ __artifacts_v2__ = {
         "description": "Path-level file-system event records from the fseventsd disk log stream",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
             "FSEvents records do not contain per-event timestamps. Event IDs provide sequence, "
             "not time. Notifications can be coalesced, paths can be truncated, and a record "
             "does not establish which process or user caused an event. Interpret flags as file-"
-            "system notifications and correlate them with other evidence. Supports gzip-wrapped "
+            "system notifications and correlate them with other evidence. Covers the data "
+            "volume stream at /private/var/.fseventsd and the user-space stream at "
+            "/private/var/mobile/.fseventsd. Supports gzip-wrapped "
             "1SLD, 2SLD, and 3SLD streams. Format and flag research: Joachim Metz/libyal and "
             "Yogesh Khatri/mac_apt. References: https://github.com/libyal/dtformats/blob/main/"
             "documentation/MacOS%20File%20System%20Events%20Disk%20Log%20Stream%20format."
             "asciidoc and https://github.com/ydkhatri/mac_apt/blob/master/plugins/fsevents.py"
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "file-search",
         "sample_data": {
-            "hc_ios18_7": "iOS 18.7.8 | 11939 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 26957 rows (11939 data volume, 15018 user space)",
         },
     },
     "iosFileSystemEventsCommunications": {
@@ -29,7 +34,7 @@ __artifacts_v2__ = {
         "description": "FSEvents paths associated with communications, contacts, calls, and accounts",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -37,7 +42,10 @@ __artifacts_v2__ = {
             "file-system notification, not message content or proof of a user communication. "
             "Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "messages",
         "sample_data": {},
@@ -49,7 +57,7 @@ __artifacts_v2__ = {
         ),
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -58,7 +66,10 @@ __artifacts_v2__ = {
             "do not, alone, prove completion or identify an actor. Rows can overlap other Items of "
             "Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "device-mobile-up",
         "sample_data": {},
@@ -68,7 +79,7 @@ __artifacts_v2__ = {
         "description": "FSEvents paths within application and shared application containers",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -76,7 +87,10 @@ __artifacts_v2__ = {
             "A container-path notification does not establish application execution or user "
             "interaction. Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "apps",
         "sample_data": {},
@@ -86,7 +100,7 @@ __artifacts_v2__ = {
         "description": "FSEvents paths associated with location and routing services",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -94,7 +108,10 @@ __artifacts_v2__ = {
             "does not establish the device's location. Rows can overlap other Items of Interest "
             "reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "map-pin",
         "sample_data": {},
@@ -104,7 +121,7 @@ __artifacts_v2__ = {
         "description": "FSEvents paths associated with keychains, keybags, trust, and access control",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -112,7 +129,10 @@ __artifacts_v2__ = {
             "an actor. Interpret notifications with the underlying artifacts and system logs. "
             "Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "shield-lock",
         "sample_data": {},
@@ -122,7 +142,7 @@ __artifacts_v2__ = {
         "description": "FSEvents paths specifically associated with restore, erase, and backup services",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -130,7 +150,10 @@ __artifacts_v2__ = {
             "A matching notification is not, by itself, proof that a restore, erase, or backup "
             "completed. Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "restore",
         "sample_data": {},
@@ -140,14 +163,17 @@ __artifacts_v2__ = {
         "description": "FSEvents paths associated with Safari, WebKit, and browser storage",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
             "This is a path-based subset and does not contain browsing content or prove a website "
             "visit. Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "world",
         "sample_data": {},
@@ -157,7 +183,7 @@ __artifacts_v2__ = {
         "description": "FSEvents paths associated with APT, dpkg, Cydia, Sileo, and Zebra",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -165,7 +191,10 @@ __artifacts_v2__ = {
             "They are not labeled as proof of jailbreak status and should be correlated with "
             "other device evidence. Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "package",
         "sample_data": {},
@@ -175,7 +204,7 @@ __artifacts_v2__ = {
         "description": "FSEvents records carrying the Removed event flag",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "File System",
         "notes": (
@@ -183,7 +212,10 @@ __artifacts_v2__ = {
             "deletion. Events can be coalesced and can carry Created and Removed together. "
             "Rows can overlap other Items of Interest reports."
         ),
-        "paths": ("*/private/var/.fseventsd/*",),
+        "paths": (
+            "*/private/var/.fseventsd/*",
+            "*/private/var/mobile/.fseventsd/*",
+        ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "trash",
         "sample_data": {},

--- a/scripts/artifacts/safariHistory.py
+++ b/scripts/artifacts/safariHistory.py
@@ -4,11 +4,18 @@ __artifacts_v2__ = {
         "description": "Safari web history visits",
         "author": "@KevinPagano3",
         "creation_date": "2023-02-14",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "Safari Browser",
-        "notes": "",
-        "paths": ('**/Safari/History.db*',),
+        "notes": (
+            "Starting with iOS 17 Safari supports multiple profiles, each with its own "
+            "History.db under Safari/Profiles/. The Profile column carries the profile "
+            "directory name for those records and Default for the main history database."
+        ),
+        "paths": (
+            '**/Safari/History.db*',
+            '**/Safari/Profiles/*/History.db*',
+        ),
         "output_types": "standard",
         "artifact_icon": "globe",
         "sample_data": {
@@ -31,31 +38,32 @@ __artifacts_v2__ = {
     }
 }
 
+from pathlib import PurePath
+
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+def _profile_name(source_path):
+    parts = PurePath(source_path).parts
+    if len(parts) >= 3 and parts[-3] == 'Profiles':
+        return parts[-2]
+    return 'Default'
 
 
 @artifact_processor
 def safariHistory(context):
     data_headers = (('Visit Timestamp', 'datetime'), 'Title', 'URL', 'Visit Count',
-                    'Redirect Source', 'Redirect Destination', 'Visit ID', 'Origin')
+                    'Redirect Source', 'Redirect Destination', 'Visit ID', 'Origin',
+                    'Profile')
     data_list = []
 
-    source_path = ''
+    source_paths = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if file_found.endswith('History.db'):
-            source_path = file_found
-            break
-    if not source_path:
+            source_paths.append(file_found)
+    if not source_paths:
         return data_headers, data_list, ''
-
-    # Map visit id -> url so redirect source/destination ids can be resolved to URLs
-    id_url = {}
-    for row in get_sqlite_db_records(source_path, '''
-        SELECT history_visits.id, history_items.url
-        FROM history_visits
-        LEFT JOIN history_items ON history_items.id = history_visits.history_item'''):
-        id_url[str(row[0])] = row[1]
 
     # visit_time is Apple absolute (Cocoa) time on iOS <= 18, but iOS 26+ may
     # store a Unix timestamp instead. Cocoa values for realistic dates stay well
@@ -78,10 +86,23 @@ def safariHistory(context):
     FROM history_visits
     LEFT JOIN history_items ON history_visits.history_item = history_items.id
     '''
-    for row in get_sqlite_db_records(source_path, query):
-        redirect_source = id_url.get(str(row[4]), '') if row[4] is not None else ''
-        redirect_destination = id_url.get(str(row[5]), '') if row[5] is not None else ''
-        data_list.append((row[0], row[1], row[2], row[3], redirect_source, redirect_destination,
-                          row[6], row[7]))
+    for source_path in source_paths:
+        profile = _profile_name(source_path)
 
-    return data_headers, data_list, context.get_relative_path(source_path)
+        # Map visit id -> url so redirect source/destination ids can be resolved to
+        # URLs. Visit ids are only unique within one database, so the map is per file.
+        id_url = {}
+        for row in get_sqlite_db_records(source_path, '''
+            SELECT history_visits.id, history_items.url
+            FROM history_visits
+            LEFT JOIN history_items ON history_items.id = history_visits.history_item'''):
+            id_url[str(row[0])] = row[1]
+
+        for row in get_sqlite_db_records(source_path, query):
+            redirect_source = id_url.get(str(row[4]), '') if row[4] is not None else ''
+            redirect_destination = id_url.get(str(row[5]), '') if row[5] is not None else ''
+            data_list.append((row[0], row[1], row[2], row[3], redirect_source,
+                              redirect_destination, row[6], row[7], profile))
+
+    sources = '\n'.join(context.get_relative_path(path) for path in source_paths)
+    return data_headers, data_list, sources

--- a/scripts/artifacts/wifiNetworkStoreModel.py
+++ b/scripts/artifacts/wifiNetworkStoreModel.py
@@ -6,11 +6,14 @@ __artifacts_v2__ = {
         "description": "Parses Wifi details found in WiFiNetworkStoreModel database",
         "author": "@KevinPagano",
         "creation_date": "2022-08-23",
-        "last_update_date": "2026-03-20",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "Network",
         "notes": "",
-        "paths": ('*/Library/Application Support/WiFiNetworkStoreModel.sqlite*'),
+        "paths": (
+            '*/Library/Application Support/WiFiNetworkStoreModel.sqlite*',
+            '*/Library/Application Support/com.apple.wifianalyticsd/WiFiNetworkStoreModel.sqlite*',
+        ),
         "output_types": "all",
         "artifact_icon": "wifi",
         "sample_data": {


### PR DESCRIPTION
Reported by Mattia Epifani while cross-checking iLEAPP coverage against the FOR585 poster.

## WiFi Known Networks (`wifiNetworkStoreModel.py`)
Recent iOS versions store the database at `/root/Library/Application Support/com.apple.wifianalyticsd/WiFiNetworkStoreModel.sqlite`; the module only searched the older `/Library/Application Support/` location. Both globs are now searched. Verified with `fnmatchcase` that the new glob matches the reported path and the old glob still matches the recorded sample images. No local image carries the database at the new location, so the schema could not be re-verified against the new path; the query is unchanged.

## Safari History (`safariHistory.py`)
Since iOS 17, Safari profiles keep separate `History.db` files under `Safari/Profiles/<UUID>/`, which the old glob missed — and the module only parsed the first database found. Now all matched databases are parsed, with a new **Profile** column (profile directory name, or `Default` for the main database). The visit-id → URL redirect map is built per database since visit ids are only unique within one file.

Verified against the iPhone 12 iOS 18.7 image: the main database still yields the recorded 151 rows, and a staged profile database aggregates correctly with its profile name.

## FSEvents (`fileSystemEvents.py`)
All ten FSEvents artifacts only searched the data volume stream at `/private/var/.fseventsd/`. The user-space stream at `/private/var/mobile/.fseventsd/` is now searched too — it is where references to app containers (including removed apps and their original paths) live.

Verified on the HC iOS 18.7 image: the data volume stream reproduces the recorded 11,939 rows exactly, and the user-space stream adds 15,018 rows including 664 app-container rows from the sampled files. The Hickman iOS 17 filepath list shows 1,989 user-space files the old glob missed.

Tests: artifact imports and LAVA SQL identifier suites pass; pylint (`--disable=C,R`) is clean at 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)