### PR TITLE
ci: add a Windows arm64 test build

### DIFF
--- a/.github/workflows/build_windows_test.yml
+++ b/.github/workflows/build_windows_test.yml
@@ -20,7 +20,15 @@ permissions:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            arch: x64
+          - runner: windows-11-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +52,9 @@ jobs:
         # First time the Mandiant Windows build is executed anywhere in this
         # project's pipeline. --help is used because unifiedlog_iterator exits
         # non-zero on --version alone in some releases; either proves it runs.
+        # On the arm64 runner this is the x64 build under Windows 11's x64
+        # emulation - Mandiant publishes no windows-arm64 parser - so passing
+        # here also proves the emulation path an ARM examiner would rely on.
         run: |
           bin\unifiedlog_iterator.exe --help
           if ($LASTEXITCODE -ne 0) { exit 1 }
@@ -85,6 +96,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ileapp-windows-x64-test
+          name: ileapp-windows-${{ matrix.arch }}-test
           path: artifact/
           retention-days: 14

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,12 +29,14 @@ protobuf==5.29.6
 pycryptodome
 pyinstaller
 
-# pyliblzfse for Windows
-whl_files/pyliblzfse-0.4.1-cp310-cp310-win_amd64.whl; python_version == "3.10" and platform_system == "Windows"
-whl_files/pyliblzfse-0.4.1-cp311-cp311-win_amd64.whl; python_version == "3.11" and platform_system == "Windows"
-whl_files/pyliblzfse-0.4.1-cp312-cp312-win_amd64.whl; python_version == "3.12" and platform_system == "Windows"
-whl_files/pyliblzfse-0.4.1-cp313-cp313-win_amd64.whl; python_version == "3.13" and platform_system == "Windows"
-whl_files/pyliblzfse-0.4.1-cp314-cp314-win_amd64.whl; python_version == "3.14" and platform_system == "Windows"
+# pyliblzfse for Windows on x64. The markers pin the machine as well as the OS:
+# these wheels are win_amd64, and on Windows-on-ARM pip would otherwise try to
+# install them and fail. ARM builds compile pyliblzfse from the sdist below.
+whl_files/pyliblzfse-0.4.1-cp310-cp310-win_amd64.whl; python_version == "3.10" and platform_system == "Windows" and platform_machine == "AMD64"
+whl_files/pyliblzfse-0.4.1-cp311-cp311-win_amd64.whl; python_version == "3.11" and platform_system == "Windows" and platform_machine == "AMD64"
+whl_files/pyliblzfse-0.4.1-cp312-cp312-win_amd64.whl; python_version == "3.12" and platform_system == "Windows" and platform_machine == "AMD64"
+whl_files/pyliblzfse-0.4.1-cp313-cp313-win_amd64.whl; python_version == "3.13" and platform_system == "Windows" and platform_machine == "AMD64"
+whl_files/pyliblzfse-0.4.1-cp314-cp314-win_amd64.whl; python_version == "3.14" and platform_system == "Windows" and platform_machine == "AMD64"
 
 pyliblzfse
 


### PR DESCRIPTION
Adds `windows-11-arm` to the test-build matrix, producing an `ileapp-windows-arm64-test` artifact alongside the x64 one.

Two things make ARM different, both handled:

- **The `whl_files` pyliblzfse wheels are `win_amd64`.** Their requirement markers only checked OS, so pip on Windows-on-ARM would try to install an x64 wheel and fail before anything built. The markers now pin `platform_machine == "AMD64"`; ARM builds compile pyliblzfse from the sdist (MSVC is on the runner).
- **Mandiant publishes no windows-arm64 parser.** The fetch script pulls the x64 `unifiedlog_iterator.exe`, which runs under Windows 11's built-in x64 emulation. The on-runner smoke test executes it on the ARM runner, so the artifact only ships if the exact emulation path an ARM examiner would use actually works.

`fail-fast: false` so an ARM-specific failure never blocks the x64 artifact.

Known unknown, surfaced by the run itself: `astc-decomp-faster` has no `win_arm64` wheel on PyPI, so ARM installs build it from source on the runner — if that fails, the ARM job fails visibly and the dependency needs an upstream wheel or a committed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)