### PR TITLE
fix: stale sysdiagnose logarchives no longer outrank the device log store

### DIFF
--- a/admin/test/scripts/test_logarchive_native.py
+++ b/admin/test/scripts/test_logarchive_native.py
@@ -162,6 +162,33 @@ class TestArchiveRootDiscovery(unittest.TestCase):
         self.assertEqual(diagnostics, '/out/data/filesystem2/db/diagnostics')
         self.assertEqual(uuidtext, '/out/data/filesystem2/db/uuidtext')
 
+    def test_stale_sysdiagnose_logarchive_does_not_outrank_device_store(self):
+        """The Jess trap: iPhones carry their own .logarchive leftovers. An interrupted
+        sysdiagnose left IN_PROGRESS_.../system_logs.logarchive in the extraction, the
+        old absolute .logarchive priority handed the parser that stale 2022 snapshot,
+        and 556 MB of live tracev3 produced zero records with no error anywhere."""
+        found = [
+            '/o/data/private/var/mobile/Library/Logs/CrashReporter/DiagnosticLogs/'
+            'sysdiagnose/IN_PROGRESS_sysdiagnose_2022.02.14_12-57-34-0500/'
+            'system_logs.logarchive/Persist',
+            '/o/data/private/var/db/diagnostics/Persist/0000000000000001.tracev3',
+            '/o/data/private/var/db/diagnostics/timesync/0000000000000002.timesync',
+            '/o/data/private/var/db/uuidtext/00/AABBCCDD',
+        ]
+        archive, diagnostics, uuidtext = unifiedlogs.find_archive_roots(found)
+        self.assertIsNone(archive, 'stale sysdiagnose leftovers won over the device store')
+        self.assertEqual(diagnostics, '/o/data/private/var/db/diagnostics')
+        self.assertEqual(uuidtext, '/o/data/private/var/db/uuidtext')
+
+    def test_populated_logarchive_wins_when_no_device_store(self):
+        # A completed sysdiagnose (or examiner-collected archive) with real content is
+        # the right choice when there is no populated diagnostics directory at all.
+        found = ['/case/sysdiagnose/system_logs.logarchive/Persist/0000000000000001.tracev3',
+                 '/case/sysdiagnose/system_logs.logarchive/dsc/ABCDEF']
+        archive, diagnostics, _ = unifiedlogs.find_archive_roots(found)
+        self.assertEqual(archive, '/case/sysdiagnose/system_logs.logarchive')
+        self.assertIsNone(diagnostics)
+
     def test_lone_empty_directory_still_resolves(self):
         # With nothing better on offer, an empty directory is still the right answer;
         # the artifact reports the absence of tracev3 data rather than "no files found".

--- a/scripts/unifiedlogs.py
+++ b/scripts/unifiedlogs.py
@@ -100,17 +100,24 @@ def find_archive_roots(files_found):
     """Work out what to hand the parser from the paths the seeker returned.
 
     Returns (logarchive_dir, diagnostics_dir, uuidtext_dir), where either the first item
-    is set (the examiner supplied a ready-made .logarchive) or the other two are.
+    is set (a usable .logarchive package) or the other two are.
 
-    An extraction can hold the same directory name on more than one partition. A UFED
-    zip of an iPhone carries filesystem1 (system) and filesystem2 (data), and
-    filesystem1 has an *empty* private/var/db/diagnostics; the populated one lives at
-    filesystem2/db/diagnostics. Taking the first name match handed the parser the empty
-    directory and a real image reported zero records with no error anywhere. So roots
-    are chosen by how many found files sit beneath them, judged from the seeker's list
-    alone - the paths may describe files that only exist inside an archive.
+    Roots are chosen by how many found files sit beneath them, judged from the seeker's
+    list alone - the paths may describe files that only exist inside an archive. Two
+    real-world traps drove that:
+
+    - A UFED zip carries filesystem1 (system) with an *empty* private/var/db/diagnostics
+      next to the populated one on filesystem2; taking the first name match handed the
+      parser the empty directory.
+    - iPhones carry their own .logarchive leftovers: an interrupted sysdiagnose leaves
+      .../DiagnosticLogs/sysdiagnose/IN_PROGRESS_.../system_logs.logarchive in the
+      extraction. Giving any .logarchive absolute priority handed the parser a stale,
+      near-empty 2022 snapshot while 556 MB of live tracev3 sat in var/db - zero records,
+      no error. A .logarchive only wins when the device store has no tracev3 content;
+      when the examiner's input IS a .logarchive package, there is no diagnostics
+      directory in sight and it wins by default.
     """
-    logarchive = None
+    logarchive_candidates = {}
     diagnostics_candidates = {}
     uuidtext_candidates = {}
 
@@ -119,9 +126,8 @@ def find_archive_roots(files_found):
         is_file = bool(components) and not str(path).replace('\\', '/').endswith('/')
         for index, component in enumerate(components):
             if component.lower().endswith('.logarchive'):
-                logarchive = logarchive or '/'.join(components[:index + 1])
-                continue
-            if component == DIAGNOSTICS_DIR:
+                candidates = logarchive_candidates
+            elif component == DIAGNOSTICS_DIR:
                 candidates = diagnostics_candidates
             elif component == UUIDTEXT_DIR:
                 candidates = uuidtext_candidates
@@ -138,7 +144,18 @@ def find_archive_roots(files_found):
         # directory still resolves when it is all there is.
         return max(candidates, key=lambda root: candidates[root])
 
-    return logarchive, best(diagnostics_candidates), best(uuidtext_candidates)
+    best_diagnostics = best(diagnostics_candidates)
+    best_logarchive = best(logarchive_candidates)
+
+    if best_diagnostics and diagnostics_candidates[best_diagnostics] > 0:
+        return None, best_diagnostics, best(uuidtext_candidates)
+    if best_logarchive and logarchive_candidates[best_logarchive] > 0:
+        return best_logarchive, None, None
+    # Nothing populated: keep the old preference order so an empty input still
+    # resolves to something and the artifact reports absence of data honestly.
+    if best_logarchive:
+        return best_logarchive, None, None
+    return None, best_diagnostics, best(uuidtext_candidates)
 
 
 def _link_file(source, destination):


### PR DESCRIPTION
## The report

The Jess CTF image (iPhone 8, iOS 15.0.2, 556 MB of tracev3) produced `No data found for logarchive` in two seconds. Exit 0, report generated, nothing visibly wrong.

## The cause

The phone carries its own `.logarchive`: an **interrupted sysdiagnose from 2022** left `…/DiagnosticLogs/sysdiagnose/IN_PROGRESS_…/system_logs.logarchive` in the extraction. `find_archive_roots` gave any `.logarchive` absolute priority — a rule written for the examiner-supplied-archive case — so the parser ran against the stale, near-empty snapshot while the device's live store sat untouched. Third member of the wrong-root family, after the UFED empty-system-partition trap (#1827).

## The fix

Roots win by where the files actually are:

- a **populated** `diagnostics` + `uuidtext` store beats any `.logarchive` found inside an extraction
- a `.logarchive` wins only when it is the **only** populated source — exactly the examiner-supplied case, where no `diagnostics` directory exists at all
- nothing-populated inputs keep the old preference order, so the artifact still reports absence of data honestly

## Verified

Same image, same command: **16,558,937 records in 4:08** (67k records/s) where the old code produced zero in two seconds. The new progress reporting (#1834) tracked it live, first ETA landing within 13 seconds of actual.

Regression tests cover the stale IN_PROGRESS trap, a populated-sysdiagnose-only input, and the original examiner-supplied shape. Full suite 132 passed; lint clean.

Side note for the future: a *completed* sysdiagnose logarchive in an extraction is a second, older snapshot of the device's logs — potentially worth parsing as its own artifact someday. This PR just stops it from shadowing the live store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)