### PR TITLE
docs: remove unsourced claims from artifact notes and descriptions

### DIFF
--- a/scripts/artifacts/locationdCacheEncryptedB.py
+++ b/scripts/artifacts/locationdCacheEncryptedB.py
@@ -4,11 +4,10 @@ __artifacts_v2__ = {
         'description': 'Access point positions cached by locationd, keyed by BSSID',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-29',
-        'last_update_date': '2026-07-29',
+        'last_update_date': '2026-07-30',
         'requirements': 'none',
         'category': 'Locations',
-        'notes': ('These are positions the location service reported for access points near '
-                  'the device, downloaded so the device can locate itself without GPS. A row '
+        'notes': ('These are positions the location service reported for access points. A row '
                   'is the position of the access point, not of the device, and does not mean '
                   'the device connected to it. Accuracy is coarse: treat the coordinates as '
                   'an area rather than a point. Speed and course of -1 mean no value was '
@@ -30,12 +29,13 @@ __artifacts_v2__ = {
                        'a position and signal strength at the time of the scan',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-29',
-        'last_update_date': '2026-07-29',
+        'last_update_date': '2026-07-30',
         'requirements': 'none',
         'category': 'Locations',
-        'notes': ('Unlike the Wi-Fi Locations table, these rows come from the device '
-                  'associating with an access point and recording where it was at the time, '
-                  'so the coordinates are a device position. Two timestamps are kept: the '
+        'notes': ('Unlike the Wi-Fi Locations table, these rows record access points the '
+                  'device associated with, per the name of the source table. Whether the '
+                  'coordinates are the position of the device at that time or of the access '
+                  'point is not documented. Two timestamps are kept: the '
                   'scan and the harvest record. A scan timestamp of -1 means locationd '
                   'recorded none, and is reported empty rather than converted to a real '
                   'looking date in 2000. The LoiType column is an integer code whose values '

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -154,10 +154,10 @@ __artifacts_v2__ = {
     },
     "logarchive_motionstate": {
         "name": "logarchive motion state transitions",
-        "description": "Navigation entries",
+        "description": "Motion state transition entries",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-04-30",
-        "last_update_date": "2025-04-30",
+        "last_update_date": "2026-07-30",
         "requirements": "logarchive module must be executed first",
         "category": "Unified Logs",
         "notes": "",

--- a/scripts/artifacts/storeSystem.py
+++ b/scripts/artifacts/storeSystem.py
@@ -1,11 +1,11 @@
 __artifacts_v2__ = {
     'storeSystemAppInstalls': {
         'name': 'Installed Apps - App Store Install Records',
-        'description': 'App Store install records held by appstored, including the purchasing '
+        'description': 'App Store install records from storeSystem.db, including the purchasing '
                        'Apple Account and the on-disk bundle path',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-29',
-        'last_update_date': '2026-07-29',
+        'last_update_date': '2026-07-30',
         'requirements': 'none',
         'category': 'Installed Apps',
         'notes': ('Store metadata is an NSKeyedArchiver payload recorded at install time, so the '
@@ -29,11 +29,11 @@ __artifacts_v2__ = {
     },
     'storeSystemAppUpdates': {
         'name': 'Installed Apps - App Store Update Records',
-        'description': 'Per-app update state tracked by appstored, with the App Store catalog '
+        'description': 'Per-app update state from storeSystem.db, with the App Store catalog '
                        'metadata cached alongside it',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-29',
-        'last_update_date': '2026-07-29',
+        'last_update_date': '2026-07-30',
         'requirements': 'none',
         'category': 'Installed Apps',
         'notes': ('The catalog metadata is a cached copy of the App Store listing, so the latest '
@@ -53,11 +53,11 @@ __artifacts_v2__ = {
     },
     'storeSystemAppPackages': {
         'name': 'Installed Apps - App Store Download Packages',
-        'description': 'Download packages recorded by appstored, with sizes and source URLs, '
-                       'joined to the install record they belong to',
+        'description': 'Download packages recorded in storeSystem.db, with sizes and source '
+                       'URLs, joined to the install record they belong to',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-29',
-        'last_update_date': '2026-07-29',
+        'last_update_date': '2026-07-30',
         'requirements': 'none',
         'category': 'Installed Apps',
         'notes': ('One install can own several packages, such as the app itself plus its '

--- a/scripts/artifacts/threeBars.py
+++ b/scripts/artifacts/threeBars.py
@@ -5,11 +5,11 @@ __artifacts_v2__ = {
                        'centroid coordinates the location service reported for each one',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-29',
-        'last_update_date': '2026-07-29',
+        'last_update_date': '2026-07-30',
         'requirements': 'none',
         'category': 'Locations',
-        'notes': ('ThreeBars caches tiles of Wi-Fi location data that the device downloaded '
-                  'for areas around it. A row records what the location service reported '
+        'notes': ('ThreeBars caches tiles of Wi-Fi location data that the device downloaded. '
+                  'A row records what the location service reported '
                   'about a network, not that this device connected to it or observed it, and '
                   'the coordinates are the network position rather than a device position. '
                   'The venue, type, authentication mask and score columns are integer codes '


### PR DESCRIPTION
Fixes from a documentation audit of artifacts touched 2026-07-29/30, applying the project standard that notes and descriptions must not state what data means in the real world unless the data (or a cited source) proves it. No parsing behavior changes.

- **locationdCacheEncryptedB**: the Wi-Fi Locations note claimed the positions were for access points "near the device, downloaded so the device can locate itself without GPS" — an unsourced purpose/proximity attribution. The Associated Wi-Fi Harvest note asserted the coordinates "are a device position"; nothing in the schema proves whose position the coordinates are, and that claim could be used to place a device at a location. Both now state only what the schema shows, with the device-vs-access-point question explicitly marked undocumented.
- **logarchive**: the motionstate artifact's description said "Navigation entries", copy-pasted from the navigation artifact; it filters Motion State Transition messages.
- **storeSystem**: descriptions attributed the records to the appstored daemon, which the wildcarded container path glob cannot establish; now attributed to storeSystem.db itself.
- **threeBars**: dropped "for areas around it" — the download is evidenced by the ETag column, device proximity to the tile areas is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)