### PR TITLE
fix: biomeAppWebUsage GUID column no longer duplicates Bundle ID

### DIFF
--- a/scripts/artifacts/biomeAppWebUsage.py
+++ b/scripts/artifacts/biomeAppWebUsage.py
@@ -83,7 +83,7 @@ def get_biomeAppWebUsage(context):
             if record.state == EntryState.Written:
                 protostuff, _types = blackboxprotobuf.decode_message(record.data, typess)
 
-                guid               = protostuff.get('bundle_id', '')
+                guid               = protostuff.get('guid', '')
                 timestamp          = webkit_timestampsconv(protostuff['timestamp'])
                 pb_int_3           = protostuff.get('pb_int_3', None)
                 url                = protostuff.get('url', '')


### PR DESCRIPTION
## Summary

In `get_biomeAppWebUsage`, the `typess` dict maps protobuf field `'1'` to the name `guid`, but the decoded value was read with `protostuff.get('bundle_id', '')`. As a result the report's GUID column always repeated the Bundle ID column, and field 1 (the actual GUID/UUID string) was never surfaced. This changes the read to `protostuff.get('guid', '')`.

## Verification

Ran the module function against all 8 extractions recorded in the module's `sample_data` block (dexter_ios18, felix_ios17, fsfull002_ios17, hc_ios18_7, iphone11_ios17, iphone12_ios18, iphone14plus_ios18, otto_ios17):

- Row counts match the recorded notes exactly: 29 / 30 / 12 / 26 / 3 / 110 / 46 / 371.
- Every `Written` row (285 total across the corpus) now has a UUID-shaped GUID.
- No GUID equals the Bundle ID anymore (previously all of them did, by construction).

Local checks: `admin/scripts/lint_changed.py` introduces no new warnings; `python -m unittest discover -s admin/test/scripts` passes (152 tests, 15 skipped); the PyPI blackboxprotobuf guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)