### PR TITLE
Fix biomeSafari early return and case-broken path glob

### DIFF
--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -4,11 +4,11 @@ __artifacts_v2__ = {
         "description": "Parses safari entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/restricted/_DKEvent.Safari.History/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/_DKEvent.Safari.History/local/*',),
         "output_types": "standard",
         "artifact_icon": "compass",
         "sample_data": {
@@ -145,7 +145,7 @@ def get_biomeSafari(context):
                 data_list.append((ts, None, record.state.name, None, None, None, None, None, None, None, filename,
                                   record.data_start_offset))
 
-        data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Activity', 'Title',
-                        'URL', 'Detail', 'Detail 2', 'Detail 3', 'GUID', "Filename", "Offset")
+    data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Activity', 'Title',
+                    'URL', 'Detail', 'Detail 2', 'Detail 3', 'GUID', "Filename", "Offset")
 
-        return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, 'see Filename for more info'


### PR DESCRIPTION
## Summary

Two defects left **Biome - Safari** returning `None` on case-sensitive platforms and truncating multi-file streams everywhere:

- **Early return inside the file loop.** `data_headers` and the `return` were indented inside `for file_found in context.get_files_found():`, so the artifact returned after the first non-skipped SEGB file, silently dropping any remaining files. Worse, when every found path was filtered out (dotfiles, tombstones, directories), the function fell off the end and returned `None`, which breaks `artifact_processor`'s tuple unpacking (`data_headers, data_list, source_path = func(Context)` in `scripts/ilapfuncs.py:528`). Both statements are now dedented to function level, matching sibling parsers such as `biomeLocationactivity.py`.

- **Path glob unmatched on case-sensitive platforms.** bd70faee changed the glob from `*/biome/...` to `*/Biome/...`, but seeker matching is case-sensitive off Windows (`os.path.normcase` is the identity), and this stream's data lives under lowercase `/private/var/db/biome/` in every registered sample corpus and in all four `admin/data/filepath-lists` CSVs. Since that change the artifact finds **no data files at all on macOS/Linux** — only the empty capital-B `Library/Biome` directory entries — which triggers the `None` return above. The glob now uses a `[Bb]iome` character class so one pattern matches both spellings on every platform. (A two-pattern tuple was rejected: on Windows `normcase` folds both patterns into the same lowercase string, and `ileapp.py` extends `files_found` per pattern without dedup, so every file would be processed twice.)

## Verification

Ran the artifact over all 11 corpora registered in the `sample_data` block, with found-file lists produced by replicating `FileSeekerZip.search` semantics exactly (same `_compile_pattern(normcase(...))` matching, namelist order, directory members included):

| corpus | recorded rows | fixed branch | current main (macOS) |
|---|---|---|---|
| dexter_ios18 | 2 | 2 | None |
| felix_ios17 | 4 | 4 | None |
| fsfull002_ios17 | 4 | 4 | None |
| hc_ios18_7 | 8 | 8 | None |
| iphone11_ios17 | 12 | 12 | None |
| iphone12_ios18 | 18 | 18 | None |
| iphone14plus_ios18 | 17 | 17 | None |
| otto_ios17 | 108 | 108 | None |
| abe_ios16 | 100 | 100 | None |
| felix23_ios16 | 7 | 7 | None |
| magnet_ios16 | 2 | 2 | None |

All 11 recorded row counts reproduce exactly. Each of these corpora holds a single SEGB data file for this stream, which is why the recorded counts (captured before bd70faee, under the lowercase glob) were not themselves undercounts.

Note: the five sibling Biome artifacts touched by bd70faee (`biomeBattperc`, `biomeDKInfocus`, `biomeDevplugin`, `biomeInfocus`, `biomeLocationactivity`) have the same capital-B glob and likely the same silent no-match on macOS/Linux; left for a follow-up to keep this change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)