### PR TITLE
docs: hold Biome/SEGB artifact claims to the sourced-evidence standard

### DIFF
--- a/scripts/artifacts/biomeAppActivity.py
+++ b/scripts/artifacts/biomeAppActivity.py
@@ -6,12 +6,13 @@ __artifacts_v2__ = {
                        "such as note titles or map activity details.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The expiration timestamp was observed to be exactly 30 days after the record "
-                 "timestamp (the NSUserActivity default). Payload strings are URL-decoded for "
-                 "display.",
+                 "timestamp. Payload strings are URL-decoded for display. Reference: Mattia "
+                 "Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/streams/*/App.Activity/local/*',),
         "output_types": "standard",
         "artifact_icon": "activity",

--- a/scripts/artifacts/biomeAppInstallation.py
+++ b/scripts/artifacts/biomeAppInstallation.py
@@ -2,12 +2,12 @@ __artifacts_v2__ = {
     "get_biomeAppInstallation": {
         "name": "Biome - App Installation",
         "description": "Parses app installation events from the App.Installation biome stream: "
-                       "the bundle identifier, the app's install UUID, its short and build "
+                       "the bundle identifier, a per-app UUID, its short and build "
                        "version, and the time the event was recorded. Complements the older "
                        "App.Install and _DKEvent.App.Install streams.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The event type field takes values 1, 2 and 3 in the sample; which of install, "

--- a/scripts/artifacts/biomeAppIntentsTranscript.py
+++ b/scripts/artifacts/biomeAppIntentsTranscript.py
@@ -3,11 +3,11 @@ __artifacts_v2__ = {
         "name": "Biome - App Intents Transcript",
         "description": "Parses donated App Intents from the App.Intents.Transcript biome "
                        "stream: the donating app, the intent class, the intent parameter and "
-                       "the human readable entity title shown to the user (for example a "
-                       "Settings destination or a Focus filter target).",
+                       "the human readable entity title associated with the intent (for "
+                       "example a Settings destination or a Focus filter target).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Each record also embeds an NSKeyedArchiver plist holding the full entity "

--- a/scripts/artifacts/biomeAppLocationActivity.py
+++ b/scripts/artifacts/biomeAppLocationActivity.py
@@ -5,22 +5,25 @@ __artifacts_v2__ = {
                        "App.LocationActivity biome stream: the donating app, the activity type "
                        "and payload, the web page or item involved, and the associated street "
                        "address, city and postal code. TIMESTAMP CAUTION: the place details in "
-                       "this stream are reliable but the timestamps are not. Records are "
+                       "this stream parse consistently, but the timestamps require caution. "
+                       "Records are "
                        "written in batches, so the SEGB record time is a write time rather than "
                        "the moment of the activity, and the other timestamp on the record is an "
                        "expiry roughly 30 days ahead. Corroborate any time here against another "
                        "source before relying on it.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Same NSUserActivity record shape as the App.Activity stream, extended with "
                  "place fields. In the sample data the SEGB write times were identical across "
                  "records and fell on an exact minute boundary, which is a further sign they "
                  "are batch write times and not activity times. The expiration timestamp sits "
-                 "about 30 days after the SEGB write, matching the NSUserActivity default seen "
-                 "in App.Activity. Payload strings are URL-decoded for display.",
+                 "about 30 days after the SEGB write, matching the interval seen in "
+                 "App.Activity. Payload strings are URL-decoded for display. Reference: Mattia "
+                 "Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/streams/*/App.LocationActivity/local/*',),
         "output_types": "standard",
         "artifact_icon": "map-pin",

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -1,10 +1,10 @@
 __artifacts_v2__ = {
     "get_biomeAppinstall": {
         "name": "Biome - App Install",
-        "description": "Parses airplane mode entries from biomes",
+        "description": "Parses app install entries from biomes",
        "author": "@JohnHyla, @Gear-I",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",

--- a/scripts/artifacts/biomeAppleIntelligence.py
+++ b/scripts/artifacts/biomeAppleIntelligence.py
@@ -44,14 +44,15 @@ __artifacts_v2__ = {
                        "AppleIntelligence.Reporting.AssetDeliveryLog.ModelCatalog biome "
                        "stream. Each record names the Apple Intelligence feature whose model "
                        "was requested, for example a text composition or summarisation "
-                       "feature, and the language it was requested for, which evidences which "
-                       "AI features were exercised on the device and when.",
+                       "feature, and the language it was requested for, showing which "
+                       "features' models were requested on the device and when; user exercise "
+                       "of the feature is not established.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "This is the highest volume stream of the Apple Intelligence family.",
+        "notes": "In test data, this is the highest volume stream of the Apple Intelligence family.",
         "paths": ('*/streams/*/AppleIntelligence.Reporting.AssetDeliveryLog.ModelCatalog/local/*',),
         "output_types": "standard",
         "artifact_icon": "cpu",
@@ -79,7 +80,7 @@ __artifacts_v2__ = {
                        "even where the payload itself no longer survives.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The sample for this stream held only deleted records, so the written record "
@@ -89,7 +90,7 @@ __artifacts_v2__ = {
                  "sample shows a different layout the detail columns will be empty while the "
                  "timestamps stay correct. Deleted payloads in the sample were largely "
                  "overwritten and did not decode, but their SEGB timestamps are intact and "
-                 "still evidence that reporting occurred at those times.",
+                 "consistent with reporting having occurred at those times.",
         "paths": ('*/streams/*/AppleIntelligence.Reporting.SafetyOverrides/local/*',),
         "output_types": "standard",
         "artifact_icon": "shield",

--- a/scripts/artifacts/biomeApplePaySecurity.py
+++ b/scripts/artifacts/biomeApplePaySecurity.py
@@ -178,10 +178,11 @@ __artifacts_v2__ = {
                        "by Apple in the ApplePay.Security.Features Biome database.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Timestamps are normalized by Apple to the start of the day.",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
+                 "Timestamps are normalized by Apple to the start of the day.",
         "paths": ('*/Biome/databases/ApplePay.Security.Features/ApplePay.Security.Features.sqlite3*',),
         "output_types": "standard",
         "artifact_icon": "headphones",

--- a/scripts/artifacts/biomeAudioMediaRoutes.py
+++ b/scripts/artifacts/biomeAudioMediaRoutes.py
@@ -1,8 +1,8 @@
 """Biome audio and media route streams.
 
 Both streams record the route in use when audio or media plays. Bluetooth and
-CarPlay routes carry the accessory MAC address and name, which places a specific
-accessory with the device at a specific time.
+CarPlay routes carry an accessory identifier and name, which may associate an
+accessory with the device at the recorded time.
 """
 __artifacts_v2__ = {
     "get_biomeAudioRoute": {

--- a/scripts/artifacts/biomeAutonamingMessageIds.py
+++ b/scripts/artifacts/biomeAutonamingMessageIds.py
@@ -2,11 +2,11 @@ __artifacts_v2__ = {
     "get_biomeAutonamingMessageIds": {
         "name": "Biome - Autonaming Message IDs",
         "description": "Parses message references (message GUID, conversation identifier and message "
-                       "date) from the Autonaming.Messages.MessageIds biome stream, used by Messages "
-                       "conversation auto-naming.",
+                       "date) from the Autonaming.Messages.MessageIds biome stream, apparently "
+                       "related to Messages conversation auto-naming (per the stream name).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Message GUIDs and Unix epoch double dates validated against sms.db (guid, date) "

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -1,10 +1,10 @@
 __artifacts_v2__ = {
     "get_biomeBluetooth": {
         "name": "Biome - Bluetooth",
-        "description": "Parses bluetooth connection entries from biomes",
+        "description": "Parses Bluetooth device entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-27",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Use caution when interpreting this artifact. Lists of Bluetooth devices have been "

--- a/scripts/artifacts/biomeBootSession.py
+++ b/scripts/artifacts/biomeBootSession.py
@@ -4,18 +4,19 @@ __artifacts_v2__ = {
         "description": "Parses boot session records from the Device.BootSession biome stream. "
                        "Each boot closes the previous session identifier and opens a new one, "
                        "so the stream reconstructs when the device started and stopped running "
-                       "and, where a close and the following open are separated in time, how "
-                       "long the device was powered off.",
+                       "and, where a close and the following open are separated in time, a "
+                       "gap consistent with the device being powered off.",
         "author": "@abrignoni",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Session state 1 is the opening of a session and 0 its close, established by "
                  "the record pattern across four test images: a close and an open share a "
                  "timestamp at a reboot, and each session identifier appears exactly twice, "
                  "once opened and once closed. A close with no open at the same instant marks "
-                 "a shutdown, and the gap to the next open is the period the device was off. "
+                 "a shutdown, and the gap to the next open is consistent with the device "
+                 "being powered off during that period. "
                  "Sort by timestamp and pair on Session ID to measure uptime.",
         "paths": ('*/streams/*/Device.BootSession/local/*',),
         "output_types": "standard",

--- a/scripts/artifacts/biomeCameraAutoFocusROI.py
+++ b/scripts/artifacts/biomeCameraAutoFocusROI.py
@@ -2,12 +2,11 @@ __artifacts_v2__ = {
     "get_biomeCameraAutoFocusROI": {
         "name": "Biome - Camera Auto Focus ROI",
         "description": "Parses camera autofocus region of interest events from the "
-                       "CameraCapture.AutoFocusROI biome stream. Each record marks the camera "
-                       "being used and which lens it was using, so the stream evidences camera "
-                       "activity even where no resulting photo or video survives.",
+                       "CameraCapture.AutoFocusROI biome stream. Each record marks camera "
+                       "use and which camera port was in use.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Only the camera port (for example PortTypeBack) is self describing. The "

--- a/scripts/artifacts/biomeClockAlarm.py
+++ b/scripts/artifacts/biomeClockAlarm.py
@@ -2,16 +2,18 @@ __artifacts_v2__ = {
     "get_biomeClockAlarm": {
         "name": "Biome - Clock Alarm",
         "description": "Parses alarm state changes from the Clock.Alarm biome stream, including "
-                       "the alarm identifier, which can be correlated with the Clock app alarm "
-                       "list and with the _DKEvent.Clock.Alarm stream.",
+                       "the alarm identifier, which also appears in the _DKEvent.Clock.Alarm "
+                       "stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Raw state values observed: 0, 1, 2 and 4. Apple describes this stream as "
-                 "capturing alarm states such as firing and snoozed; exact value semantics are "
-                 "not confirmed, so the raw value is reported.",
+        "notes": "Raw state values observed: 0, 1, 2 and 4. Published research states this "
+                 "stream captures alarm states such as firing and snoozed; exact value "
+                 "semantics are not confirmed, so the raw value is reported. Reference: Mattia "
+                 "Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/streams/*/Clock.Alarm/local/*',),
         "output_types": "standard",
         "artifact_icon": "clock",

--- a/scripts/artifacts/biomeDKEventStreams.py
+++ b/scripts/artifacts/biomeDKEventStreams.py
@@ -48,16 +48,18 @@ __artifacts_v2__ = {
     "get_biomeDKClockAlarm": {
         "name": "Biome - Clock Alarm DKEvent",
         "description": "Parses alarm state changes from the _DKEvent.Clock.Alarm biome stream. "
-                       "Metadata carries the alarm identifier, which can be correlated with the "
-                       "Clock app alarm list.",
+                       "Metadata carries the alarm identifier, which also appears in the "
+                       "Clock.Alarm stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Raw state values observed: 0, 1, 2 and 4. Apple's plist describes this stream "
-                 "as capturing alarm states such as firing and snoozed; exact value semantics "
-                 "are not confirmed, so the raw value is reported.",
+        "notes": "Raw state values observed: 0, 1, 2 and 4. Published research states this "
+                 "stream captures alarm states such as firing and snoozed; exact value "
+                 "semantics are not confirmed, so the raw value is reported. Reference: Mattia "
+                 "Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/streams/*/_DKEvent.Clock.Alarm/local/*',),
         "output_types": "standard",
         "artifact_icon": "clock",
@@ -72,11 +74,12 @@ __artifacts_v2__ = {
                        "_DKEvent.Device.IsLockedImputed biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "This is the imputed variant of the screen lock stream: iOS fills in lock "
-                 "state transitions it did not observe directly.",
+        "notes": "This is the imputed variant of the screen lock stream: the stream name "
+                 "suggests iOS imputes (fills in) lock states rather than only recording "
+                 "observed transitions; the mechanism is not documented.",
         "paths": ('*/streams/*/_DKEvent.Device.IsLockedImputed/local/*',),
         "output_types": "standard",
         "artifact_icon": "lock",
@@ -135,12 +138,12 @@ __artifacts_v2__ = {
     "get_biomeDKSiriUi": {
         "name": "Biome - Siri UI DKEvent",
         "description": "Parses Siri interface events from the _DKEvent.Siri.Ui biome stream. "
-                       "Runs alongside the Siri.UI stream and carries the same activity in the "
-                       "DuetKnowledge wrapper, with start and end timestamps that bound each "
-                       "appearance of the Siri interface.",
+                       "In test data this stream carried activity matching the Siri.UI stream "
+                       "in the DuetKnowledge wrapper, with start and end timestamps recorded "
+                       "for each Siri interface session.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The event detail is carried in the metadata entries rather than the value "

--- a/scripts/artifacts/biomeDevTimeZone.py
+++ b/scripts/artifacts/biomeDevTimeZone.py
@@ -1,11 +1,11 @@
 __artifacts_v2__ = {
     "get_biomeDevTimeZone": {
         "name": "Biome - Device TimeZone",
-        "description": "Parses historical device time zone changes from the Device.TimeZone biome "
+        "description": "Parses historical device time zone records from the Device.TimeZone biome "
                        "stream",
         "author": "Cynthia van Dorp, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-09",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -66,11 +66,11 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Modern counterpart of the _DKEvent.System.AirplaneMode stream parsed by "
-                 "Biome - Airplane Mode DKEvent.",
+        "notes": "Appears to be the modern counterpart of the _DKEvent.System.AirplaneMode "
+                 "stream parsed by Biome - Airplane Mode DKEvent.",
         "paths": ('*/streams/*/Device.Wireless.AirplaneMode/local/*',),
         "output_types": "standard",
         "artifact_icon": "airplay",
@@ -103,11 +103,11 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Modern counterpart of the _DKEvent.Carplay.IsConnected stream parsed by "
-                 "Biome - Carplay.",
+        "notes": "Appears to be the modern counterpart of the _DKEvent.Carplay.IsConnected "
+                 "stream parsed by Biome - Carplay.",
         "paths": ('*/streams/*/CarPlay.Connected/local/*',),
         "output_types": "standard",
         "artifact_icon": "truck",
@@ -160,17 +160,18 @@ __artifacts_v2__ = {
     "get_biomeKeybagLocked": {
         "name": "Biome - Keybag Locked",
         "description": "Parses keybag lock state changes from the Device.KeybagLocked biome "
-                       "stream. The keybag holds the class keys that protect file data, so its "
-                       "state tracks whether the device was unlocked after first unlock.",
+                       "stream. The keybag holds the class keys that protect file data; the "
+                       "stream records its locked state over time.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Lock polarity validated against the _DKEvent.Keybag.IsLocked stream on the "
                  "same device: 124 of 128 overlapping records agree, the exceptions falling on "
                  "interval boundaries. Modern counterpart of that stream, parsed by "
-                 "Biome - Keybag.",
+                 "Biome - Keybag. Reference: Apple Platform Security, 'Keybags for Data "
+                 "Protection', https://support.apple.com/guide/security/sec6483d5760/web",
         "paths": ('*/streams/*/Device.KeybagLocked/local/*',),
         "output_types": "standard",
         "artifact_icon": "lock",
@@ -185,12 +186,12 @@ __artifacts_v2__ = {
                        "stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The level is a percentage stored as a double (observed range 1.0 to 100.0). "
-                 "Modern counterpart of the _DKEvent.Device.BatteryPercentage stream parsed by "
-                 "Biome - Battery Percentage.",
+                 "Appears to be the modern counterpart of the _DKEvent.Device.BatteryPercentage "
+                 "stream parsed by Biome - Battery Percentage.",
         "paths": ('*/streams/*/Device.Power.BatteryLevel/local/*',),
         "output_types": "standard",
         "artifact_icon": "battery",

--- a/scripts/artifacts/biomeEmergencyVoiceCall.py
+++ b/scripts/artifacts/biomeEmergencyVoiceCall.py
@@ -3,11 +3,11 @@ __artifacts_v2__ = {
         "name": "Biome - Emergency Voice Call",
         "description": "Parses emergency voice calls from the "
                        "CommCenter.Call.EmergencyVoiceCall biome stream: the emergency number "
-                       "that was dialled and the mobile country and network codes of the "
-                       "serving network at the time of the call.",
+                       "that was dialled and the apparent mobile country and network codes of "
+                       "the serving network at the time of the call.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field mapped from a small private sample, so read the columns with that in "

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -2,16 +2,18 @@ __artifacts_v2__ = {
     "get_biomeFrontBoardDisplayElement": {
         "name": "Biome - FrontBoard Display Element",
         "description": "Parses app scene display events from the FrontBoard.DisplayElement "
-                       "biome stream: which app scene was shown on which display and when. "
-                       "This is a high volume stream that can reconstruct fine grained app "
-                       "foreground activity.",
+                       "biome stream: which app scene was recorded against which display and "
+                       "when. This is a high volume stream that may assist in reconstructing "
+                       "app display activity; whether a record corresponds to on-screen "
+                       "presentation is not established.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Records with an empty bundle id are system or home screen scenes. Numeric "
-                 "state fields are reported raw as their semantics are not confirmed.",
+        "notes": "In sample data, records with an empty bundle id corresponded to system or "
+                 "home screen scenes. Numeric state fields are reported raw as their semantics "
+                 "are not confirmed.",
         "paths": ('*/streams/*/FrontBoard.DisplayElement/local/*',),
         "output_types": "standard",
         "artifact_icon": "layers",

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -4,10 +4,10 @@ __artifacts_v2__ = {
         "description": "Parses InFocus Events from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "",
+        "notes": "The Foreground/Background labels for values 1 and 0 are an interpretation of the App.InFocus stream name; other values are reported as stored.",
         "paths": ('*/Biome/streams/restricted/App.InFocus/local/*'),
         "output_types": "standard",
         "artifact_icon": "focus-2"
@@ -50,7 +50,8 @@ def get_biomeInfocus(context):
 
                 bundleid = (protostuff['6'])
                 timestart = (webkit_timestampsconv(protostuff['4']))
-                foreground = ('Foreground' if protostuff['3'] == 1 else 'Background')
+                state = protostuff['3']
+                foreground = {1: 'Foreground', 0: 'Background'}.get(state, str(state))
 
                 data_list.append((ts, timestart, record.state.name, bundleid, foreground, filename, record.data_start_offset))
 

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -4,14 +4,16 @@ __artifacts_v2__ = {
         "description": "Parses app intent entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Each record is parsed independently: a record that cannot be decoded is "
                  "logged with its file and offset and skipped, so one malformed entry no "
                  "longer discards the rest of the stream. Intent payloads are app-authored "
                  "and their inner shape varies by app and iOS version, so an app branch that "
-                 "cannot read its own payload still emits the record metadata.",
+                 "cannot read its own payload still emits the record metadata. Labels inside "
+                 "the Data column (thread, sender, number) are inferred from observed record "
+                 "content; the underlying protobuf fields are not documented.",
         "paths": (
             '*/AppIntent/local/*',
             '*/streams/*/App.Intent/local/*',

--- a/scripts/artifacts/biomeLocationVisit.py
+++ b/scripts/artifacts/biomeLocationVisit.py
@@ -4,8 +4,9 @@ __artifacts_v2__ = {
         "description": "Parses visited places from the Location.Visit biome stream: coordinates "
                        "with horizontal accuracy, arrival and departure times, and the matched "
                        "point of interest (name, address and category) when iOS identified one. "
-                       "TIMESTAMP CAUTION: the coordinates in this stream are reliable but the "
-                       "timestamps are not. Records are written to the stream in batches long "
+                       "TIMESTAMP CAUTION: in tested samples the coordinates, accuracy and "
+                       "point of interest details decoded consistently; the timestamps require "
+                       "caution. Records are written to the stream in batches long "
                        "after the visit, so the SEGB record time is a write time, not a visit "
                        "time, and the detection timestamp does not consistently line up with "
                        "the arrival and departure pair. Treat every time in this artifact as "
@@ -13,7 +14,7 @@ __artifacts_v2__ = {
                        "is relied on.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Timestamp reliability, observed in the sample data: every record in a stream "
@@ -23,9 +24,12 @@ __artifacts_v2__ = {
                  "up to 28 days before the SEGB write. Arrival and departure are internally "
                  "consistent (arrival always precedes departure, spans from about half an hour "
                  "to just over a day) and are the most usable pair, but they are still not "
-                 "independently verified. The coordinates, accuracy and point of interest "
-                 "details are reliable. Latitude, longitude, horizontal accuracy in metres and "
-                 "confidence are stored as doubles; vertical accuracy of -1 means unavailable.",
+                 "independently verified. In tested samples the coordinates, accuracy and "
+                 "point of interest details decoded consistently. Latitude, longitude, "
+                 "horizontal accuracy in metres and confidence are stored as doubles; vertical "
+                 "accuracy of -1 means unavailable. Reference: Mattia Epifani, '84 Streams "
+                 "Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/streams/*/Location.Visit/local/*',),
         "output_types": ["html", "tsv", "timeline", "lava", "kml"],
         "artifact_icon": "map-pin",

--- a/scripts/artifacts/biomeNetworkingEdgeSelection.py
+++ b/scripts/artifacts/biomeNetworkingEdgeSelection.py
@@ -1,19 +1,19 @@
 __artifacts_v2__ = {
     "get_biomeNetworkingEdgeSelection": {
         "name": "Biome - Networking Edge Selection",
-        "description": "Parses the public-facing network prefix (a truncated IP address), interface "
-                       "type, radio technology, country and device time zone recorded by the "
-                       "Device.Networking.EdgeSelection biome stream",
+        "description": "Parses the apparent public-facing network prefix (a truncated IP address), "
+                       "interface type, radio technology, country and device time zone recorded by "
+                       "the Device.Networking.EdgeSelection biome stream",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Each record is a network-edge observation: the address is the public endpoint the "
-                 "device saw for itself, so it places the device on a carrier or Wi-Fi network at "
-                 "that moment. IMPORTANT: the address is TRUNCATED to the accompanying prefix "
-                 "length, not the device's full public IP - every observed value has its host bits "
-                 "zeroed (an IPv4 seen as 69.143.130.0 is the /24 network, an IPv6 as "
+        "notes": "Each record is a network-edge observation: the values are consistent with a "
+                 "device-side public network prefix; this interpretation is inferred from observed "
+                 "values and is unverified. IMPORTANT: the address is TRUNCATED to the accompanying "
+                 "prefix length, not the device's full public IP - every observed value has its host "
+                 "bits zeroed (an IPv4 seen as 69.143.130.0 is the /24 network, an IPv6 as "
                  "2600:380:1871:6d00:: is the /56). Report it as a network, not as an endpoint "
                  "address. The stream is protobuf, which carries field numbers but no field names, "
                  "so the column names other than the timestamp are inferred from the observed "

--- a/scripts/artifacts/biomePhotosSearchInsights.py
+++ b/scripts/artifacts/biomePhotosSearchInsights.py
@@ -4,10 +4,10 @@ __artifacts_v2__ = {
         "description": "Parses Photos search terms from the "
                        "AeroML.Insights.PhotosSearchInsights biome stream, along with the "
                        "language and region the search was made in. The search term is text "
-                       "the user typed into the Photos app.",
+                       "entered in the Photos app search.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Remaining fields were constant across the sample and are reported raw.",

--- a/scripts/artifacts/biomeSafariNavigations.py
+++ b/scripts/artifacts/biomeSafariNavigations.py
@@ -2,13 +2,13 @@ __artifacts_v2__ = {
     "get_biomeSafariNavigations": {
         "name": "Biome - Safari Navigations",
         "description": "Parses Safari navigation events from the Safari.Navigations biome stream: "
-                       "host, full URL (observed on iOS 18+; earlier versions record the host only) "
-                       "and country code. Complements App.WebUsage and _DKEvent.Safari.History, and "
-                       "records were observed to remain after the matching History.db visits were "
-                       "gone.",
+                       "host, full URL (the URL was not present in the iOS 17 sample tested; "
+                       "observed on iOS 18+) and country code. Complements App.WebUsage and "
+                       "_DKEvent.Safari.History, and records were observed to remain after the "
+                       "matching History.db visits were gone.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The rounded timestamp is the record timestamp rounded up to the next 30 minute "

--- a/scripts/artifacts/biomeSafariWebPagePerformance.py
+++ b/scripts/artifacts/biomeSafariWebPagePerformance.py
@@ -2,17 +2,17 @@ __artifacts_v2__ = {
     "get_biomeSafariWebPagePerformance": {
         "name": "Biome - Safari Web Page Performance",
         "description": "Parses Safari page load performance events from the "
-                       "Safari.WebPagePerformance biome stream. Each record marks Safari web "
-                       "activity in a rounded time bucket and complements Safari.Navigations "
-                       "and App.WebUsage.",
+                       "Safari.WebPagePerformance biome stream. Each record appears to "
+                       "correspond to Safari web activity in a rounded time bucket and "
+                       "complements Safari.Navigations and App.WebUsage.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Like Safari.Navigations, the second timestamp is rounded up to the next 30 "
-                 "minute boundary. Remaining fields are performance counters and are reported "
-                 "raw as their units are not confirmed.",
+                 "minute boundary. The remaining integer fields are of unconfirmed meaning "
+                 "and are reported raw.",
         "paths": ('*/streams/*/Safari.WebPagePerformance/local/*',),
         "output_types": "standard",
         "artifact_icon": "compass",

--- a/scripts/artifacts/biomeShareSheetConversation.py
+++ b/scripts/artifacts/biomeShareSheetConversation.py
@@ -1,13 +1,13 @@
 __artifacts_v2__ = {
     "get_biomeShareSheetConversation": {
         "name": "Biome - Share Sheet Conversation",
-        "description": "Parses share sheet conversation targets from the "
-                       "MLSE.ShareSheet.ConversationUserInteraction biome stream: the app the "
-                       "share was directed to and the conversation identifier, which carries "
-                       "the recipient handle for Messages shares.",
+        "description": "Parses share sheet conversation records from the "
+                       "MLSE.ShareSheet.ConversationUserInteraction biome stream: the app "
+                       "associated with the share and the conversation identifier, which "
+                       "carries a contact handle for Messages shares.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The conversation identifier follows the service;-;handle form used elsewhere "
@@ -102,7 +102,7 @@ def get_biomeShareSheetConversation(context):
                                   filename, record.data_start_offset))
 
     data_headers = (('SEGB Timestamp', 'datetime'), ('Interaction Timestamp', 'datetime'),
-                    'SEGB State', 'Bundle ID', 'Recipient Handle', 'Conversation ID',
+                    'SEGB State', 'Bundle ID', 'Contact Handle', 'Conversation ID',
                     'Field 10 (raw)', 'Filename', 'Offset')
 
     return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -3,16 +3,17 @@ __artifacts_v2__ = {
         "name": "Biome - Share Sheet Feedback",
         "description": "Parses share sheet activity from the ShareSheet.Feedback biome stream: "
                        "the app the content was shared from, the activity the user chose (for "
-                       "example copy to pasteboard, save photo, open in Safari) and the full "
-                       "list of share targets that were offered.",
+                       "example copy to pasteboard, save photo, open in Safari) and the list "
+                       "of share targets that were offered.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "The offered candidates list names third party apps installed at the time of "
-                 "the share, which can evidence app presence even after removal. Field 4 holds "
-                 "an NSKeyedArchiver plist that is not currently parsed.",
+        "notes": "In tested data the candidate list contained bundle IDs of apps installed on "
+                 "the device; if that holds generally, entries can indicate an app's past "
+                 "presence. Field 4 holds an NSKeyedArchiver plist that is not currently "
+                 "parsed.",
         "paths": ('*/streams/*/ShareSheet.Feedback/local/*',),
         "output_types": "standard",
         "artifact_icon": "share-2",

--- a/scripts/artifacts/biomeSiriRemembersAssistantSuggestions.py
+++ b/scripts/artifacts/biomeSiriRemembersAssistantSuggestions.py
@@ -1,19 +1,20 @@
 __artifacts_v2__ = {
     "get_biomeSiriRemembersAssistantSuggestions": {
         "name": "Biome - Siri Remembers Assistant Suggestions",
-        "description": "Parses Siri suggestion events from the "
-                       "Siri.Remembers.AssistantSuggestions biome stream: when Siri offered "
-                       "suggestions and which suggestions were shown, for example reminders "
-                       "due today or unread mail.",
+        "description": "Parses suggestion events recorded in the "
+                       "Siri.Remembers.AssistantSuggestions biome stream, with the suggestion "
+                       "names carried in each record, for example reminders due today or "
+                       "unread mail.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Shares the intent record shape of the other Siri.Remembers streams, with the "
                  "suggestion names carried as a list of entities rather than a single value. "
-                 "The stream syncs between devices, so the Sync Origin column distinguishes "
-                 "records written locally from those received from another device.",
+                 "Records are read from both the local and remote subfolders; the Sync Origin "
+                 "column reports which one a record came from. The local/remote naming is the "
+                 "stream's own folder layout; cross-device sync semantics are not documented.",
         "paths": (
             '*/streams/*/Siri.Remembers.AssistantSuggestions/local/*',
             '*/streams/*/Siri.Remembers.AssistantSuggestions/remote/*',

--- a/scripts/artifacts/biomeSiriRemembersAudioHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersAudioHistory.py
@@ -3,19 +3,21 @@ __artifacts_v2__ = {
         "name": "Biome - Siri Remembers Audio History",
         "description": "Parses media playback intents from the Siri.Remembers.AudioHistory "
                        "biome stream: the app that played the media, the title, artist and "
-                       "media type of what was played, and the app's own identifier for it. "
-                       "Audiobook and music playback both appear.",
+                       "media type of what was played, and a media identifier. "
+                       "Audiobook and music playback were both observed in test data.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Shares the intent record shape of the other Siri.Remembers streams. The "
                  "media details come from a JSON attribute on the item entity; title, artist "
                  "and media type were present on every record in the sample, with mediaName "
-                 "appearing on some. The media identifier is the playing app's own catalogue "
-                 "id, so for Audible it is the ASIN. The stream syncs between devices, so the "
-                 "Sync Origin column separates local records from ones received elsewhere.",
+                 "appearing on some. In the sample data the media identifier matched the "
+                 "playing app's catalogue id; for Audible items it was the ASIN. Records are "
+                 "read from both the local and remote subfolders; the Sync Origin column "
+                 "reports which one a record came from. The local/remote naming is the "
+                 "stream's own folder layout; cross-device sync semantics are not documented.",
         "paths": (
             '*/streams/*/Siri.Remembers.AudioHistory/local/*',
             '*/streams/*/Siri.Remembers.AudioHistory/remote/*',

--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -3,11 +3,11 @@ __artifacts_v2__ = {
         "name": "Biome - Siri Remembers Message History",
         "description": "Parses message exchange records (timestamps, participants, chat and message "
                        "identifiers) from the Siri.Remembers.MessageHistory biome stream. The stream "
-                       "records message activity for Messages and third party messaging apps but does "
-                       "not store message body content.",
+                       "records message activity for Messages and third party messaging apps; no "
+                       "message body content was present in the records examined.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Direction values and message timestamps validated against sms.db (is_from_me, date) "

--- a/scripts/artifacts/biomeSiriUI.py
+++ b/scripts/artifacts/biomeSiriUI.py
@@ -1,13 +1,14 @@
 __artifacts_v2__ = {
     "get_biomeSiriUI": {
         "name": "Biome - Siri UI",
-        "description": "Parses Siri interface sessions from the Siri.UI biome stream. Records "
-                       "pair up: one marks the Siri interface appearing and the next marks it "
-                       "going away, carrying the reason it was dismissed, so the stream shows "
-                       "both that Siri was invoked and how each invocation ended.",
+        "description": "Parses Siri interface sessions from the Siri.UI biome stream. In test "
+                       "data records paired: one carrying state 1 with no dismissal reason, "
+                       "followed by one carrying state 0 and a dismissal reason (e.g. "
+                       "HardwareButton), consistent with the Siri interface appearing and "
+                       "being dismissed.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Dismissal reasons observed: HardwareButton, Punchout, Timeout and "

--- a/scripts/artifacts/biomeStreams.py
+++ b/scripts/artifacts/biomeStreams.py
@@ -56,10 +56,11 @@ __artifacts_v2__ = {
                        "time it was read).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "",
+        "notes": "Reference: Mattia Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/Biome/streams/restricted/Messages.Read/local/*',
                   '*/biome/streams/restricted/Messages.Read/local/*'),
         "output_types": "standard",
@@ -77,13 +78,15 @@ __artifacts_v2__ = {
     },
     "biomeScreenTimeAppUsage": {
         "name": "Biome - ScreenTime App Usage",
-        "description": "Per-app foreground start/end events from the ScreenTime.AppUsage biome stream.",
+        "description": "Per-app usage events from the ScreenTime.AppUsage biome stream; the event code's "
+                       "meaning is not documented and is reported as stored.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "The SEGB record timestamp is used; an embedded timestamp field in this stream is unreliable.",
+        "notes": "The SEGB record timestamp is used; an embedded timestamp field in this stream is unreliable. "
+                 "The event code's meaning is not documented; its value is reported as stored.",
         "paths": ('*/Biome/streams/restricted/ScreenTime.AppUsage/local/*',
                   '*/biome/streams/restricted/ScreenTime.AppUsage/local/*'),
         "output_types": "standard",
@@ -103,10 +106,12 @@ __artifacts_v2__ = {
                        "with their frequency.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Some tokens are stored in a non-text form and appear blank.",
+        "notes": "Some tokens are stored in a non-text form and appear blank. Reference: Mattia Epifani, "
+                 "'84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths": ('*/Biome/streams/restricted/Keyboard.TokenFrequency/local/*',
                   '*/biome/streams/restricted/Keyboard.TokenFrequency/local/*'),
         "output_types": "standard",
@@ -238,14 +243,14 @@ def biomeMessagesRead(context):
 
 @artifact_processor
 def biomeScreenTimeAppUsage(context):
-    data_headers = (('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Event', 'Filename', 'Offset')
+    data_headers = (('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Event (as stored)', 'Filename',
+                    'Offset')
     data_list = []
     for ts, state, message, filename, offset in _records(context):
         if message is None:
             data_list.append((ts, state, '', '', filename, offset))
             continue
-        event = message.get('1')
-        event = 'Start' if event == 1 else 'End' if event == 0 else _txt(event)
+        event = _txt(message.get('1'))
         data_list.append((ts, state, _txt(message.get('3')), event, filename, offset))
     return data_headers, data_list, 'see Filename for more info'
 

--- a/scripts/artifacts/biomeSystemSettingsSearchTerms.py
+++ b/scripts/artifacts/biomeSystemSettingsSearchTerms.py
@@ -2,11 +2,11 @@ __artifacts_v2__ = {
     "get_biomeSystemSettingsSearchTerms": {
         "name": "Biome - System Settings Search Terms",
         "description": "Parses searches typed in the Settings app from the "
-                       "SystemSettings.SearchTerms biome stream, including the settings pane the "
-                       "user selected from the results.",
+                       "SystemSettings.SearchTerms biome stream, including result URIs and "
+                       "labels recorded with the search.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -98,6 +98,6 @@ def get_biomeSystemSettingsSearchTerms(context):
                                   record.data_start_offset))
 
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Search Term',
-                    'Selected Result URI', 'Selected Result Label', 'Filename', 'Offset')
+                    'Result URI(s)', 'Result Label(s)', 'Filename', 'Offset')
 
     return data_headers, data_list, 'see Filename for more info'

--- a/scripts/artifacts/biomeTextinputses.py
+++ b/scripts/artifacts/biomeTextinputses.py
@@ -4,10 +4,12 @@ __artifacts_v2__ = {
         "description": "Parses Text Input Session entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
-        "notes": "",
+        "notes": "Field meanings follow published research. Reference: Mattia Epifani, "
+                 "'84 Streams Later, Part 2: Inside Apple Biome', "
+                 "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
         "paths":
             ('*/Biome/streams/public/TextInputSession/local/*',
              '*/Biome/streams/restricted/Text.InputSession/local/*'),

--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -1,12 +1,12 @@
 __artifacts_v2__ = {
     "get_biomeWalletTransaction": {
         "name": "Biome - Wallet Transactions",
-        "description": "Parses Apple Pay transaction events from the Wallet.Transaction biome "
-                       "stream: transaction time, the card used (name as shown in Wallet), the "
+        "description": "Parses Wallet transaction events from the Wallet.Transaction biome "
+                       "stream: record time, the card used (name as shown in Wallet), the "
                        "pass identifier and a per-transaction UUID.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field mapped from a private sample of this stream; the stream is absent from "


### PR DESCRIPTION
Applies the fixes from a full documentation audit of all 65 Biome/SEGB artifact files (105 artifact entries): four independent review passes over every name/description/notes field, judged against the parsing code as the evidence base, with every candidate citation fetched and verified before being added. 35 files changed; 51 findings resolved.

## Citations added (source fetched and verified to support the specific claim)

- **Mattia Epifani, "84 Streams Later, Part 2: Inside Apple Biome"** — Messages.Read read timestamps, Keyboard.TokenFrequency learned tokens, App.LocationActivity street/city/postal fields, Text.InputSession Time Start/Duration, App.Activity ↔ NSUserActivity, Clock.Alarm states (firing/snoozed), Location.Visit field mapping.
- **Apple Platform Security, "Keybags for Data Protection"** — the keybag-holds-class-keys statement in the KeybagLocked artifact.
- **North Loop Consulting** — citation line added to the one biomeApplePaySecurity entry missing what its seven siblings carry (URL verified live).

## Reworded (sources do not cover the claim)

- Blanket "reliable" assurances (LocationVisit, AppLocationActivity) → parse-consistency language with the timestamp cautions kept.
- Device-placement / physical-proximity conclusions (NetworkingEdgeSelection, AudioMediaRoutes docstring) → inference language.
- User-action and display attributions (SystemSettingsSearchTerms "selected", SiriRemembers "shown", PhotosSearchInsights "typed", AppIntentsTranscript "shown to the user", ShareSheetConversation direction) → recorded-data language.
- Unlabeled sample generalizations (SafariNavigations version claim, AudioHistory ASIN, SiriUI pairing, FrontBoard empty-bundle note, AppleIntelligence superlative, MessageHistory negative claim, BootSession power-off gap, ShareSheetFeedback installed-at-time) → labeled observations.
- Unsourced mechanism/purpose claims (DeviceIsLockedImputed, Autonaming purpose, DKEventStreams counterpart assertions, CameraAutoFocusROI "evidences camera activity even where no media survives", AIModelCatalog "features were exercised") → hedged or dropped.
- Copy-paste error: biomeAppinstall description said "Parses airplane mode entries"; it parses App.Install streams.

## Small behavior fixes in the same spirit

- biomeInfocus: unknown enum values no longer mislabeled "Background" (raw pass-through).
- ScreenTime.AppUsage: event code reported as stored; the 1=Start/0=End mapping had no evidence anywhere.
- SystemSettingsSearchTerms: headers renamed to "Result URI(s)/Label(s)" (code joins multiple results per record).

All 35 files compile; lint gate (lint_changed.py vs origin/main) passes with zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)