### PR TITLE
Fix case-broken path globs in five sibling Biome artifacts

### DIFF
--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -4,11 +4,11 @@ __artifacts_v2__ = {
         "description": "Parses battery percentage entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/restricted/_DKEvent.Device.BatteryPercentage/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/_DKEvent.Device.BatteryPercentage/local/*',),
         "output_types": "standard",
         "artifact_icon": "battery",
         "sample_data": {

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -4,11 +4,11 @@ __artifacts_v2__ = {
         "description": "Parses DKEvent InFocus Events from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/restricted/_DKEvent.App.InFocus/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/_DKEvent.App.InFocus/local/*',),
         "output_types": "standard",
         "artifact_icon": "focus-2",
         "sample_data": {

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses device plugged in entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-27",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "A record is written whenever the device is charging, which includes wireless "
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
                  "state more accurately than plugged in (observation by Ian Whiffin). Reference: "
                  "Mattia Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
                  "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
-        "paths": ('*/Biome/streams/restricted/_DKEvent.Device.IsPluggedIn/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/_DKEvent.Device.IsPluggedIn/local/*',),
         "output_types": "standard",
         "artifact_icon": "battery-charging",
         "sample_data": {

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -8,9 +8,22 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "The Foreground/Background labels for values 1 and 0 are an interpretation of the App.InFocus stream name; other values are reported as stored.",
-        "paths": ('*/Biome/streams/restricted/App.InFocus/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/App.InFocus/local/*',),
         "output_types": "standard",
-        "artifact_icon": "focus-2"
+        "artifact_icon": "focus-2",
+        "sample_data": {
+            "dexter_ios18": "iOS 18.3.2 | 2439 rows",
+            "felix_ios17": "iOS 17.6.1 | 516 rows",
+            "fsfull002_ios17": "iOS 17.1 | 559 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 4031 rows",
+            "iphone11_ios17": "iOS 17.3 | 4943 rows",
+            "iphone12_ios18": "iOS 18.7 | 1868 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 262 rows",
+            "otto_ios17": "iOS 17.5.1 | 825 rows",
+            "abe_ios16": "iOS 16.5 | 0 rows",
+            "felix23_ios16": "iOS 16.5 | 0 rows",
+            "magnet_ios16": "iOS 16.1.1 | 0 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -4,11 +4,11 @@ __artifacts_v2__ = {
         "description": "Parses location activity entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/restricted/_DKEvent.App.LocationActivity/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/_DKEvent.App.LocationActivity/local/*',),
         "output_types": "standard",
         "artifact_icon": "map-pin",
         "sample_data": {
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
             "iphone14plus_ios18": "iOS 18.0 | 0 rows",
             "otto_ios17": "iOS 17.5.1 | 32 rows",
             "iphone12_ios18": "iOS 18.7 | 92 rows",
-            "abe_ios16": "iOS 16.5 | 73 rows",
+            "abe_ios16": "iOS 16.5 | 79 rows",
             "felix23_ios16": "iOS 16.5 | 44 rows",
             "magnet_ios16": "iOS 16.1.1 | 8 rows",
         }


### PR DESCRIPTION
## Summary

Follow-up to #1845, covering the five sibling Biome artifacts touched by bd70faee (`biomeBattperc`, `biomeDKInfocus`, `biomeDevplugin`, `biomeInfocus`, `biomeLocationactivity`). That commit changed their path globs from `*/biome/...` to `*/Biome/...`, but seeker matching is case-sensitive off Windows (`os.path.normcase` is the identity), and the two Biome locations on iOS use different cases:

- The four `_DKEvent.*` streams live under lowercase `/private/var/db/biome/` in **every** registered sample corpus and in the `admin/data/filepath-lists` CSVs — so since bd70faee those four artifacts have matched **no data files at all on macOS/Linux**.
- `App.InFocus` (**biomeInfocus**) is the mirror image: its data lives only under capital `/private/var/mobile/Library/Biome/` — so the *original* lowercase glob never matched anywhere, and this artifact has produced no rows on any case-sensitive platform (which is also why it was the one sibling with no `sample_data` block).

Each glob now uses a `[Bb]iome` character class so one pattern matches both spellings on every platform, same as biomeSafari in #1845. (A two-pattern tuple was rejected for the same reason as there: on Windows `normcase` folds both patterns into the same lowercase string, and `ileapp.py` extends `files_found` per pattern without dedup, so every file would be processed twice.)

Unlike biomeSafari, none of these five had the early-return-inside-the-loop defect — `data_headers`/`return` are already at function level in all of them.

## Verification

Ran each artifact's processor over all 11 zip corpora registered in `sample_data`, with found-file lists produced by replicating `FileSeekerZip.search` semantics exactly (same `_compile_pattern(normcase(...))` matching, namelist order, directory members included), under both the old lowercase glob and the new `[Bb]iome` glob:

- **All 44 recorded row counts reproduce exactly** (recorded pre-bd70faee under the lowercase glob; identical under `[Bb]iome` except the abe case below).
- **biomeLocationactivity / abe_ios16: 73 → 79 rows.** This corpus has non-tombstone SEGB data for the stream in *both* locations; the extra 6 rows come from the `Library/Biome` file the lowercase glob always missed. `sample_data` updated to 79.
- **biomeInfocus: new `sample_data` block.** Previously 0 rows on case-sensitive platforms in every corpus; with the fix it produces rows in 8 of 11 corpora (up to 4,943 on iphone11_ios17; the three iOS 16 corpora have empty `App.InFocus` stream dirs → 0 rows recorded for them).

| corpus | Battperc | DKInfocus | Devplugin | Locationactivity | Infocus (new) |
|---|---|---|---|---|---|
| dexter_ios18 | 4321 ✓ | 3838 ✓ | 1415 ✓ | 435 ✓ | 2439 |
| felix_ios17 | 1676 ✓ | 261 ✓ | 304 ✓ | 0 ✓ | 516 |
| fsfull002_ios17 | 1857 ✓ | 290 ✓ | 153 ✓ | 0 ✓ | 559 |
| hc_ios18_7 | 4021 ✓ | 2024 ✓ | 639 ✓ | 19 ✓ | 4031 |
| iphone11_ios17 | 6159 ✓ | 2476 ✓ | 476 ✓ | 93 ✓ | 4943 |
| iphone12_ios18 | 1146 ✓ | 936 ✓ | 455 ✓ | 92 ✓ | 1868 |
| iphone14plus_ios18 | 450 ✓ | 132 ✓ | 18 ✓ | 0 ✓ | 262 |
| otto_ios17 | 4307 ✓ | 1758 ✓ | 746 ✓ | 32 ✓ | 825 |
| abe_ios16 | 8138 ✓ | 2938 ✓ | 3619 ✓ | 73 → **79** | 0 |
| felix23_ios16 | 2945 ✓ | 753 ✓ | 170 ✓ | 44 ✓ | 0 |
| magnet_ios16 | 960 ✓ | 333 ✓ | 36 ✓ | 8 ✓ | 0 |

A final closed-loop pass on abe_ios16 and dexter_ios18 using the globs as declared in the edited files matches the committed `sample_data` on all 10 artifact/corpus pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
