### PR TITLE
Fix biomeStreams dual-case path tuples that double-count rows on Windows

### DIFF
--- a/scripts/artifacts/biomeStreams.py
+++ b/scripts/artifacts/biomeStreams.py
@@ -5,13 +5,12 @@ __artifacts_v2__ = {
                        "(harvest time, the message date, subject, sender and recipient).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "The message date comes from an embedded CFAbsoluteTime value; the harvest time is the SEGB "
                  "record timestamp.",
-        "paths": ('*/Biome/streams/restricted/ProactiveHarvesting.Mail/local/*',
-                  '*/biome/streams/restricted/ProactiveHarvesting.Mail/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/ProactiveHarvesting.Mail/local/*',),
         "output_types": "standard",
         "artifact_icon": "mail",
         "sample_data": {
@@ -31,12 +30,11 @@ __artifacts_v2__ = {
                        "stream (service and handle, message text, sender).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
-        "paths": ('*/Biome/streams/restricted/ProactiveHarvesting.Messages/local/*',
-                  '*/biome/streams/restricted/ProactiveHarvesting.Messages/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/ProactiveHarvesting.Messages/local/*',),
         "output_types": "standard",
         "artifact_icon": "message-circle",
         "sample_data": {
@@ -61,8 +59,7 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "Reference: Mattia Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
                  "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
-        "paths": ('*/Biome/streams/restricted/Messages.Read/local/*',
-                  '*/biome/streams/restricted/Messages.Read/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/Messages.Read/local/*',),
         "output_types": "standard",
         "artifact_icon": "check",
         "sample_data": {
@@ -87,8 +84,7 @@ __artifacts_v2__ = {
         "category": "Biome",
         "notes": "The SEGB record timestamp is used; an embedded timestamp field in this stream is unreliable. "
                  "The event code's meaning is not documented; its value is reported as stored.",
-        "paths": ('*/Biome/streams/restricted/ScreenTime.AppUsage/local/*',
-                  '*/biome/streams/restricted/ScreenTime.AppUsage/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/ScreenTime.AppUsage/local/*',),
         "output_types": "standard",
         "artifact_icon": "clock",
         "sample_data": {
@@ -112,8 +108,7 @@ __artifacts_v2__ = {
         "notes": "Some tokens are stored in a non-text form and appear blank. Reference: Mattia Epifani, "
                  "'84 Streams Later, Part 2: Inside Apple Biome', "
                  "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
-        "paths": ('*/Biome/streams/restricted/Keyboard.TokenFrequency/local/*',
-                  '*/biome/streams/restricted/Keyboard.TokenFrequency/local/*'),
+        "paths": ('*/[Bb]iome/streams/restricted/Keyboard.TokenFrequency/local/*',),
         "output_types": "standard",
         "artifact_icon": "keyboard",
         "sample_data": {


### PR DESCRIPTION
## Summary

Audit follow-up to #1845/#1847: every artifact path glob on main that names a case-specific `biome`/`Biome` segment was checked against where its data actually lives in the 11 registered sample corpora (46 patterns across the Biome family plus `privacyAccounting`, matched with exact `FileSeekerZip.search` semantics) and against the `admin/data/filepath-lists` CSVs.

Result: the capital-B-pinned artifacts are all genuinely correct — their streams (user-domain `mobile/Library/Biome` databases, sets, sync, and streams such as `App.WebUsage`, `Device.Wireless.*`, `NotesContent`, `Notification.Usage`) appear **only** under the capital root in every corpus and every CSV, and `privacyAccounting`'s `PrivacyAccounting/Biome/` casing is confirmed in the HC image. One file has a real defect:

**`biomeStreams.py` declared each of its five streams twice** — a `*/Biome/...` plus `*/biome/...` pattern pair (present since the file was added in e2a09d2e). That covers both roots on case-sensitive platforms, but it is exactly the tuple form rejected in #1845/#1847: on Windows `os.path.normcase` folds both patterns into the same lowercase string, `ileapp.py` extends `files_found` once per pattern without dedup, and the shared `_records()` generator has no dedup either — so **every SEGB file is parsed twice and all five artifacts report doubled rows on Windows**. Each pair is now a single `*/[Bb]iome/...` pattern.

## Verification

Ran each artifact's processor over the corpora registered in its `sample_data` (39 artifact/corpus pairs), with found-file lists produced by replicating `FileSeekerZip.search` semantics:

- **All 39 recorded counts reproduce exactly** with the collapsed `[Bb]iome` globs. (On these images the five streams live only under the capital root, so the lowercase half of the old tuple contributed nothing on macOS/Linux — the recorded counts were single-counted and stay unchanged.)
- **The Windows defect is reproducible**: re-running each artifact with its found-file list duplicated — what the folded tuple produces on Windows — yields exactly 2× rows in all 39 cases.

| corpus | ProactiveMail | ProactiveMessages | MessagesRead | ScreenTimeAppUsage | KeyboardTokens |
|---|---|---|---|---|---|
| dexter_ios18 | 295 ✓ | 383 ✓ | 280 ✓ | 3678 ✓ | 167 ✓ |
| felix_ios17 | 25 ✓ | 39 ✓ | 53 ✓ | 361 ✓ | 11 ✓ |
| fsfull002_ios17 | 0 ✓ | 0 ✓ | 14 ✓ | — | — |
| hc_ios18_7 | 275 ✓ | 118 ✓ | 136 ✓ | 3723 ✓ | 143 ✓ |
| iphone11_ios17 | 299 ✓ | 27 ✓ | 57 ✓ | — | 379 ✓ |
| iphone12_ios18 | 60 ✓ | 30 ✓ | 74 ✓ | 1152 ✓ | 180 ✓ |
| iphone14plus_ios18 | 62 ✓ | 13 ✓ | 16 ✓ | 317 ✓ | 58 ✓ |
| otto_ios17 | 193 ✓ | 170 ✓ | 168 ✓ | 2783 ✓ | 187 ✓ |
| abe_ios16 | — | — | — | — | 290 ✓ |
| felix23_ios16 | — | — | — | — | 3 ✓ |

(— = corpus not asserted in that artifact's sample_data; ✓ also means the duplicated-list run produced exactly double. This table was generated programmatically from the verification run output.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
