### PR TITLE
fix: stop duplicating rows in Ph087 UFED device values plist

### DIFF
--- a/scripts/artifacts/Ph087UFEDdevcievaluesplist.py
+++ b/scripts/artifacts/Ph087UFEDdevcievaluesplist.py
@@ -40,40 +40,37 @@ def Ph087UFEDdevcievaluesplist(context):
                 logfunc(f"iOS version: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Product Version", str(val), data_source)
 
-            if key == "BuildVersion":
+            elif key == "BuildVersion":
                 logfunc(f"Build Version: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Build Version", str(val), data_source)
 
-            if key == "ProductType":
+            elif key == "ProductType":
                 logfunc(f"Product Type: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Product Type", str(val), data_source)
 
-            if key == "HardwareModel":
+            elif key == "HardwareModel":
                 logfunc(f"Hardware Model: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Hardware Model", str(val), data_source)
 
-            if key == "InternationalMobileEquipmentIdentity":
+            elif key == "InternationalMobileEquipmentIdentity":
                 logfunc(f"IMEI: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "IMEI", str(val), data_source)
 
-            if key == "SerialNumber":
+            elif key == "SerialNumber":
                 logfunc(f"Serial Number: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Serial Number", str(val), data_source)
 
-            if key == "DeviceName":
+            elif key == "DeviceName":
                 logfunc(f"Device Name: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Device Name", str(val), data_source)
 
-            if key == "PasswordProtected":
+            elif key == "PasswordProtected":
                 logfunc(f"Password Protected: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "Password Protected", str(val), data_source)
 
-            if key == "TimeZone":
+            elif key == "TimeZone":
                 logfunc(f"TimeZone: {val}")
                 device_info("devicevaluesplist-ufedadvlog", "TimeZone", str(val), data_source)
-
-            else:
-                data_list.append((key, str(val)))
 
     data_headers = ("Property", "Property Value")
 


### PR DESCRIPTION
## Summary

The key checks in `Ph087UFEDdevcievaluesplist.py` were a series of independent `if` statements with a trailing `else` that bound only to the last check (`TimeZone`). Since every key is already appended to `data_list` unconditionally at the top of the loop, the `else` appended every non-TimeZone key a **second** time, doubling nearly every row in the report.

This converts the chain to `if/elif` and removes the stray `else`, so the unconditional append is the only one and each plist key produces exactly one row. The `device_info`/`logfunc` side effects for the special-cased keys are unchanged.

## Testing

Verified with a synthetic `device_values.plist` containing all 9 special-cased keys plus 3 generic ones, run through both the old and fixed versions of the artifact (via `__wrapped__`, with `logfunc`/`device_info` stubbed):

- Before: 23 rows (every key doubled except TimeZone)
- After: 12 rows, one per key, same key set, values intact

`admin/scripts/lint_changed.py --base-ref origin/main` passes with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)