### PR TITLE
fix: storeUser_ca column misalignment and fabricated system-app status

### DIFF
--- a/scripts/artifacts/storeUser.py
+++ b/scripts/artifacts/storeUser.py
@@ -76,7 +76,7 @@ def storeUser_ca(context):
     item_id,
     case is_system_app
         when 1 then 'Yes'
-        else 'No'
+        when 0 then 'No'
     end as "system_app",
     deletion_date
     from current_apps
@@ -107,7 +107,8 @@ def storeUser_ca(context):
         else:
             db_records = get_sqlite_db_records(source_path, current_app_prev_query)
             for record in db_records:
-                data_list.append((record[0], record[1], record[2], record[3], record[4], record[5], 'No', record[6], record[7]))
+                # schema has no is_system_app column, so System App is left blank
+                data_list.append((record[0], record[1], record[2], record[3], record[4], record[5], record[6], '', record[7]))
 
     return data_headers, data_list, source_path
 


### PR DESCRIPTION
## Summary
- In `storeUser_ca`'s fallback branch (for `current_apps` schemas lacking `is_system_app`), the hardcoded `'No'` was appended before `item_id`, so `'No'` was reported under **App Store ID** and the store item id under **System App**. The tuple now places `item_id` under App Store ID.
- The fabricated `'No'` is replaced with a blank: the old schema records no system-app status, so asserting "No" is not defensible in a forensic report.
- Same reasoning applied to the main query: `CASE is_system_app` no longer coerces NULL to `'No'` — only `1 → 'Yes'` and `0 → 'No'`, NULL stays blank (matches the `hidden_from_springboard` CASE style in `storeUser_pha`).

## Testing
- Synthetic fixture with the old schema (no `is_system_app`): App Store ID gets the item id, System App is blank, all other columns aligned.
- Synthetic fixture with the modern schema: `1 → Yes`, `0 → No`, `NULL →` blank, App Store ID correct.
- Real corpora re-verified against recorded `sample_data` counts: dexter_ios18 50 rows, jess_ios15 13 rows, magnet_ios16 75 rows — all unchanged (row counts are unaffected by this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)