### PR TITLE
fix: six code bugs found in the 2026-07-31 artifact doc audit

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1644,7 +1644,6 @@ def chromeMediaHistoryPlaybacks(context):
 
     lava_data_headers = data_headers.copy()
     lava_data_headers[0] = (lava_data_headers[0], 'datetime')
-    lava_data_headers[4] = (lava_data_headers[4], 'datetime')
 
     all_data_headers = lava_data_headers + ['Browser Name', 'Source']
 
@@ -1693,8 +1692,7 @@ def chromeMediaHistoryPlaybacks(context):
             data_list = []
             for row in all_rows:
                 last_update_dt = convert_ts_human_to_utc(row[0])
-                watch_dt = convert_ts_human_to_utc(row[4])
-                data_list.append((last_update_dt, row[1], row[2], row[3], watch_dt, row[5], row[6]))
+                data_list.append((last_update_dt, row[1], row[2], row[3], row[4], row[5], row[6]))
 
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()

--- a/scripts/artifacts/keychain.py
+++ b/scripts/artifacts/keychain.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses keychain to extract stored Wi-Fi credentials",
         "author": "@kobo220",
         "creation_date": "2026-06-18",
-        "last_update_date": "2027-07-22",
+        "last_update_date": "2026-07-22",
         "requirements": "none",
         "category": "Keychain",
         "notes": "",

--- a/scripts/artifacts/messageRetention.py
+++ b/scripts/artifacts/messageRetention.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0601,W0611,W0613
+# pylint: disable=W0611,W0613
 __artifacts_v2__ = {
     "messageRetention": {
         "name": "iOS Message Retention",
@@ -55,6 +55,8 @@ def messageRetention(context):
                     keep_val = '1 Year'
                 elif val == 30:
                     keep_val = '30 Days'
+                else:
+                    keep_val = f'Unrecognized value: {val}'
                 
                 data_list.append(('com.apple.MobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_one))
                 device_info('Messages Settings', 'com.apple.MobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_one)
@@ -67,6 +69,8 @@ def messageRetention(context):
                     keep_val = '1 Year'
                 elif val == 30:
                     keep_val = '30 Days'
+                else:
+                    keep_val = f'Unrecognized value: {val}'
                 
                 data_list.append(('com.apple.MobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_one))
                 device_info('Messages Settings', 'com.apple.MobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_one)
@@ -89,7 +93,9 @@ def messageRetention(context):
                 elif val == 365:
                     keep_val = '1 Year'
                 elif val == 30:
-                    keep_val = '30 Days'                            
+                    keep_val = '30 Days'
+                else:
+                    keep_val = f'Unrecognized value: {val}'
                 
                 data_list.append(('com.apple.mobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_two))
                 device_info('Messages Settings', 'com.apple.mobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_two)
@@ -102,6 +108,8 @@ def messageRetention(context):
                     keep_val = '1 Year'
                 elif val == 30:
                     keep_val = '30 Days'
+                else:
+                    keep_val = f'Unrecognized value: {val}'
                     
                 data_list.append(('com.apple.mobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_two))
                 device_info('Messages Settings', 'com.apple.mobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_two)

--- a/scripts/artifacts/voiceRecordings.py
+++ b/scripts/artifacts/voiceRecordings.py
@@ -61,7 +61,7 @@ def voice_memos(context):
         SELECT
             ZDATE,
             time(ZDURATION, 'unixepoch') as ZDURATION,
-            ZCUSTOMLABEL,
+            ZCUSTOMLABEL AS ZCUSTOMLABELFORSORTING,
             ZPATH
         FROM ZRECORDING
         """

--- a/scripts/artifacts/widgets.py
+++ b/scripts/artifacts/widgets.py
@@ -73,7 +73,6 @@ def widgets(context):
         png_path = media_path.with_suffix((".png"))
         if save_ktx_to_png_if_valid(media_path, png_path):
             media_item = check_in_media(file_found, app_name, png_path)
-            print(f"file_found = [{file_found}], media_item = [{media_item}]")
         else:
             continue
 

--- a/scripts/artifacts/wire.py
+++ b/scripts/artifacts/wire.py
@@ -60,8 +60,8 @@ def wireAccount(context):
 
     has_location_data = does_column_exist_in_db(
         source_path,
-        'ZUSER',
-        'ZUSERCLIENT.ZACTIVATIONLOCATIONLATITUDE'
+        'ZUSERCLIENT',
+        'ZACTIVATIONLOCATIONLATITUDE'
         )
 
     if has_location_data:


### PR DESCRIPTION
Fixes six small code bugs in `scripts/artifacts/` surfaced by the 2026-07-31 documentation audit, each verified against the code before fixing.

- **messageRetention.py** — a retention value other than 0/30/365 left `keep_val` unbound and raised `NameError` at the following `data_list.append`. Each branch now has an `else` that reports the raw value (`Unrecognized value: <val>`), and the now-stale `E0601` pylint suppression is removed.
- **voiceRecordings.py** — the `Recordings.db` query selected `ZCUSTOMLABEL` unaliased while the row loop reads `record["ZCUSTOMLABELFORSORTING"]`, breaking Recordings.db-only extractions. The column is now aliased to match.
- **wire.py** — `does_column_exist_in_db(source_path, 'ZUSER', 'ZUSERCLIENT.ZACTIVATIONLOCATIONLATITUDE')` checked a table-qualified column name against the wrong table, so the activation-location branch could never fire. Now checks `ZACTIVATIONLOCATIONLATITUDE` in `ZUSERCLIENT`.
- **chrome.py** — the media playbacks "Watch Time" column is a duration (`strftime('%H:%M:%S', ...)`) but was typed `datetime` for LAVA and passed through `convert_ts_human_to_utc`, whose `strptime('%Y-%m-%d %H:%M:%S')` raises `ValueError` on a time-only string. It is now a plain column carrying the duration string as-is.
- **widgets.py** — removed a stray debug `print()` from the parser loop.
- **keychain.py** — `keychain_wifi` had `"last_update_date": "2027-07-22"`, a future-dated typo; corrected to `2026-07-22`.

Verified locally: `python3 -m py_compile` on all six files, and `admin/scripts/lint_changed.py --base-ref origin/main` passes with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)