### PR TITLE
docs: drop residual unsupported claims and add a CI tripwire for them

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -39,6 +39,13 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/test/scripts/test_no_pypi_blackboxprotobuf.py
 
+      # Artifact name/description fields ship to the HTML report and the LAVA manifest
+      # and get quoted in casework, so they must not assert what the data means in the
+      # real world. See the script's docstring for the allowlist workflow.
+      - name: Guard against unsupported claim language
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_claim_language.py
+
       # Fails only on warnings this pull request introduces. Long-lived modules carry
       # deliberate pre-existing warnings (ileapp.py's wildcard imports, ilapfuncs.py's
       # backward-compat re-exports), and failing on those pushed contributors toward

--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -1,0 +1,279 @@
+"""Guard the examiner-facing artifact metadata against unsupported claims.
+
+Every artifact module declares an `__artifacts_v2__` dict. Its `name` and
+`description` fields are not developer notes: they are rendered into the HTML
+report, written into the LAVA manifest, and from there they get pasted into
+examination notes and quoted in court. A description that says an artifact holds
+"every site the user visited" is a statement about a person's conduct that the
+underlying database does not make. The standard for these fields is therefore:
+
+    Say what the data is and where it came from. Do not say what it means about
+    the world, or who did it, unless the data itself establishes that or the
+    description cites a source that documents it.
+
+The failure mode this check exists to stop is a partial fix. In PR #1852 a Waze
+artifact's docstring was corrected to drop an unsupported claim, but the
+`description` field a few lines above it kept the original wording, so the claim
+kept shipping to reports until PR #1854 caught it. Prose fixes go stale exactly
+where nothing is watching them.
+
+The check parses each artifact module with `ast`, evaluates its `__artifacts_v2__`
+literal, and matches the `name` and `description` of every entry against a
+vocabulary of phrasing that has historically signalled an unsupported claim
+(completeness words, attributions of an act to "the user", certainty words).
+
+Two ways a match gets resolved:
+
+* The wording overstates what the parser can show. Reword it to what the data
+  shows -- name the table, file, or stream, and drop the actor and the
+  completeness word. This is the common case.
+* The match is a false positive: a product feature literally named "All Files",
+  a verbatim database enum value, a UI path reproduced from the app, or a
+  cautionary sentence whose matched word is part of the hedge. Add a
+  `(filename, artifact_key, field)` tuple to ALLOWLIST **with an inline comment
+  saying why**. The allowlist is a record of decisions someone made on purpose;
+  it is not a place to park a description nobody wanted to rewrite.
+
+Usage:
+    python admin/scripts/check_claim_language.py           # CI mode, exits 1 on a violation
+    python admin/scripts/check_claim_language.py --list    # every match, allowlisted included
+    python admin/scripts/check_claim_language.py --verbose # also report unparsed modules
+"""
+
+import argparse
+import ast
+import glob
+import os
+import re
+import sys
+
+# The claim vocabulary. Each alternative is a phrasing that has, in past audits,
+# turned out to be an assertion the parsed data does not support:
+#   - completeness claims over a source that is rotated, cached, or truncated
+#     ("all", "every", "complete", "full list", "entire")
+#   - attributing an act to a person when the record only shows a stored value
+#     ("the user viewed", "user-created", "searched by", "manually")
+#   - certainty and inference-about-conduct words ("proves", "definitively",
+#     "always", "reliable", "visited", "habits")
+# Matching is case-insensitive and boundary-aware, so "install" does not trip
+# "all" and "unreliable" does not trip "reliable".
+CLAIM_PATTERN = re.compile(
+    r'\ball\b'
+    r'|\bevery\b'
+    r'|\bcomplete\w*'
+    r'|\bfull list\b'
+    r'|\bentire\b'
+    r'|\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent'
+    r'|created|hid|chose)\b'
+    r'|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b'
+    r'|\bsearched by\b'
+    r'|\btyped by\b'
+    r'|\bviewed by\b'
+    r'|\bread by\b'
+    r'|\bmanually\b'
+    r'|\bproves?\b'
+    r'|\bdefinitively\b'
+    r'|\balways\b'
+    r'|\breliable\b'
+    r'|\bvisited\b'
+    r'|\bhabits?\b',
+    re.IGNORECASE)
+
+# Fields that reach the examiner through the report and the LAVA manifest.
+CHECKED_FIELDS = ('name', 'description')
+
+# Reviewed exceptions, keyed by (filename, artifact_key, field). Every entry
+# needs a comment justifying it. See the module docstring before adding one.
+ALLOWLIST = {
+    # "All Files" is Box's own name for the product feature; renaming it would
+    # make the artifact harder to match to what the examiner sees in the app.
+    ('box.py', 'box_all_files', 'name'),
+    ('box.py', 'box_all_files', 'description'),
+
+    # The match is inside the cautionary note itself -- "these timestamps do not
+    # always indicate application usage" is the hedge, not a claim.
+    ('applicationStateDB.py', 'get_snapshot_creationDate', 'description'),
+    ('applicationStateDB.py', 'get_snapshot_lastUsedDate', 'description'),
+
+    # "may be user-entered or written by apps and connected devices" is an
+    # explicit statement that authorship is unknown, which is the point.
+    ('health.py', 'health_height', 'description'),
+    ('health.py', 'health_weight', 'description'),
+
+    # Both reproduce a path through the Apple Health UI ("Show All Health Data",
+    # "All Recorded Data", "All Watch Sleep Data"), so the word is a label the
+    # examiner can navigate to, not a completeness claim by us.
+    ('health.py', 'health_all_watch_sleep_data', 'name'),
+    ('health.py', 'health_wrist_temperature', 'description'),
+
+    # The match is inside verbatim ZSYNDICATIONSTATE enum labels quoted from the
+    # schema (e.g. "2-SyndPs-Manually-Saved_SWY_Synd_Asset-2"), not prose.
+    ('Ph026SyndicationPLAssets.py', 'Ph026_1SyndicationIDAssetsPhDaPsql', 'description'),
+    ('Ph026SyndicationPLAssets.py', 'Ph026_2SyndicationPLAssetsSyndPL', 'description'),
+
+    # "visited places" restates the name of the Location.Visit stream being
+    # parsed, and the description goes on to caution against relying on its
+    # timestamps.
+    ('biomeLocationVisit.py', 'get_biomeLocationVisit', 'description'),
+
+    # "all interfaces listed in NetworkInterfaces.plist" is scoped to the file
+    # being parsed, not a claim about the interfaces the device ever had.
+    ('wifiIdentifiers.py', 'wifiIdentifiers', 'description'),
+
+    # A Foursquare list is user-created by the definition of the feature, and
+    # the artifact reads the account holder's own list table.
+    ('foursquareSwarm.py', 'foursquare_swarm_saved_lists', 'description'),
+}
+
+STANDARD_NOTE = (
+    'Artifact name/description reach the examiner through the HTML report and the LAVA\n'
+    'manifest and get quoted in casework. State what the data is and where it came from;\n'
+    'do not state what it means in the real world, or who performed an act, unless the\n'
+    'data establishes it or a cited source documents it.\n'
+    'Reword to what the data shows, or -- if the match is a product name, a verbatim\n'
+    'schema value, a UI path, or part of a hedge -- add it to ALLOWLIST in\n'
+    'admin/scripts/check_claim_language.py with a comment saying why.'
+)
+
+
+def find_artifacts_dict(tree):
+    """Return the AST node assigned to `__artifacts_v2__`, or None."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == '__artifacts_v2__':
+                return node.value
+    return None
+
+
+def load_artifacts(path):
+    """Return (artifacts_dict, skip_reason). Exactly one of the two is None."""
+    try:
+        with open(path, 'r', encoding='utf-8') as handle:
+            source = handle.read()
+    except OSError as ex:
+        return None, f'could not read file: {ex}'
+
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError as ex:
+        return None, f'could not parse module: {ex}'
+
+    node = find_artifacts_dict(tree)
+    if node is None:
+        return None, 'no __artifacts_v2__ assignment'
+
+    # Modules that build the dict dynamically cannot be evaluated statically.
+    try:
+        artifacts = ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError) as ex:
+        return None, f'__artifacts_v2__ is not a literal: {ex}'
+
+    if not isinstance(artifacts, dict):
+        return None, '__artifacts_v2__ is not a dict'
+    return artifacts, None
+
+
+def scan_file(path):
+    """Return (matches, skip_reason) for one artifact module.
+
+    Each match is a (rel_path, artifact_key, field, text, matched_terms,
+    allowlisted) tuple.
+    """
+    artifacts, skip_reason = load_artifacts(path)
+    if artifacts is None:
+        return [], skip_reason
+
+    filename = os.path.basename(path)
+    matches = []
+    for artifact_key, entry in artifacts.items():
+        if not isinstance(entry, dict):
+            continue
+        for field in CHECKED_FIELDS:
+            text = entry.get(field)
+            if not isinstance(text, str):
+                continue
+            terms = CLAIM_PATTERN.findall(text)
+            if not terms:
+                continue
+            allowlisted = (filename, str(artifact_key), field) in ALLOWLIST
+            matches.append((path, str(artifact_key), field, text, terms, allowlisted))
+    return matches, None
+
+
+def repo_root():
+    """Return the repository root, derived from this script's location."""
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def format_match(match):
+    """Render one match as `path:artifact_key:field: <text>`."""
+    path, artifact_key, field, text, terms, _ = match
+    collapsed = ' '.join(text.split())
+    if len(collapsed) > 300:
+        collapsed = collapsed[:297] + '...'
+    quoted = ', '.join(sorted({term.lower() for term in terms}))
+    return f'{path}:{artifact_key}:{field}: {collapsed}\n    matched: {quoted}'
+
+
+def main():
+    """Scan the artifact modules and report unallowlisted claim language."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--list', action='store_true', dest='list_all',
+                        help='print every match, including allowlisted ones')
+    parser.add_argument('--verbose', action='store_true',
+                        help='also report modules whose __artifacts_v2__ could not be read')
+    args = parser.parse_args()
+
+    root = repo_root()
+    pattern = os.path.join(root, 'scripts', 'artifacts', '*.py')
+    paths = sorted(glob.glob(pattern))
+    if not paths:
+        print(f'No artifact modules found under {pattern}', file=sys.stderr)
+        return 2
+
+    violations = []
+    allowlisted = []
+    skipped = []
+    for path in paths:
+        rel_path = os.path.relpath(path, root)
+        matches, skip_reason = scan_file(path)
+        if skip_reason:
+            skipped.append((rel_path, skip_reason))
+            continue
+        for match in matches:
+            entry = (rel_path,) + match[1:]
+            if match[5]:
+                allowlisted.append(entry)
+            else:
+                violations.append(entry)
+
+    if args.verbose and skipped:
+        print(f'Skipped {len(skipped)} module(s):')
+        for rel_path, reason in skipped:
+            print(f'  {rel_path}: {reason}')
+        print()
+
+    if args.list_all and allowlisted:
+        print(f'Allowlisted matches ({len(allowlisted)}):')
+        for match in allowlisted:
+            print(f'  {format_match(match)}')
+        print()
+
+    if violations:
+        print(f'Unsupported claim language in examiner-facing artifact fields '
+              f'({len(violations)}):')
+        for match in violations:
+            print(f'  {format_match(match)}')
+        print()
+        print(STANDARD_NOTE)
+        return 1
+
+    print(f'Checked {len(paths)} artifact module(s): no unsupported claim language '
+          f'({len(allowlisted)} reviewed exception(s) allowlisted).')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/artifacts/appStoreSearches.py
+++ b/scripts/artifacts/appStoreSearches.py
@@ -18,10 +18,10 @@ __artifacts_v2__ = {
     },
     'appStoreCachedRequests': {
         'name': 'App Store - Cached Requests',
-        'description': 'All App Store API requests held in the application URL cache',
+        'description': 'App Store API requests held in the application URL cache',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-25',
-        'last_update_date': '2026-07-25',
+        'last_update_date': '2026-08-01',
         'requirements': 'none',
         'category': 'App Store',
         'notes': '',

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -2,12 +2,12 @@ __artifacts_v2__ = {
     "get_biomeShareSheetFeedback": {
         "name": "Biome - Share Sheet Feedback",
         "description": "Parses share sheet activity from the ShareSheet.Feedback biome stream: "
-                       "the app the content was shared from, the activity the user chose (for "
-                       "example copy to pasteboard, save photo, open in Safari) and the list "
-                       "of share targets that were offered.",
+                       "the app the content was shared from, the activity recorded as chosen "
+                       "(for example copy to pasteboard, save photo, open in Safari) and the "
+                       "list of share targets that were offered.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Biome",
         "notes": "In tested data the candidate list contained bundle IDs of apps installed on "

--- a/scripts/artifacts/foursquareSwarm.py
+++ b/scripts/artifacts/foursquareSwarm.py
@@ -148,10 +148,10 @@ __artifacts_v2__ = {
     },
     "foursquare_swarm_photos": {
         "name": "Foursquare Swarm - Photos",
-        "description": "Parses and extracts Foursquare Swarm photos from all artifacts",
+        "description": "Parses and extracts Foursquare Swarm photos",
         "author": "@djangofaiola",
         "creation_date": "2024-11-10",
-        "last_update_date": "2026-06-01",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Foursquare Swarm",
         "notes": "https://djangofaiola.blogspot.com",
@@ -169,11 +169,11 @@ __artifacts_v2__ = {
     },
     "foursquare_swarm_comments": {
         "name": "Foursquare Swarm - Comments",
-        "description": "Parses and extracts all Foursquare Swarm comments from "
+        "description": "Parses and extracts Foursquare Swarm comments from "
                        "check-ins, plans, tips, lists, and stickers",
         "author": "@djangofaiola",
         "creation_date": "2024-11-10",
-        "last_update_date": "2026-06-01",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Foursquare Swarm",
         "notes": "https://djangofaiola.blogspot.com",

--- a/scripts/artifacts/hikvision.py
+++ b/scripts/artifacts/hikvision.py
@@ -10,7 +10,7 @@ following information can be interpreted:
 - Hikvision - CCTV Info: information about the CCTV system.
 - Hikvision - CCTV Activity: user interaction with the app. User actions are not easy
   to attribute but can indirectly indicate remote live view/play back of CCTV footage.
-- Hikvision - User Created Media: media files the user created while viewing CCTV footage.
+- Hikvision - CCTV Media: media files stored under Documents/YYYY/MM/DD in the app container.
 """
 __artifacts_v2__ = {
     "hikvisionChannels": {
@@ -53,11 +53,11 @@ __artifacts_v2__ = {
         "artifact_icon": "activity"
     },
     "hikvisionMedia": {
-        "name": "Hikvision - User Created Media",
-        "description": "Media files the user created while viewing CCTV footage",
+        "name": "Hikvision - CCTV Media",
+        "description": "Media files stored under Documents/YYYY/MM/DD in the Hikvision app container",
         "author": "Evangelos D. (@theAtropos4n6)",
         "creation_date": "2023-03-27",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Hikvision",
         "notes": "Media are stored under Documents/YYYY/MM/DD within the app container.",

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -61,10 +61,10 @@ __artifacts_v2__ = {
     },
     "mobileInstall_historical": {
         "name": "Apps - Historical Combined",
-        "description": "All app install/update/uninstall/container/reboot events from mobile_installation.log",
+        "description": "App install/update/uninstall/container/reboot events from mobile_installation.log",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Mobile Installation Logs",
         "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time.",


### PR DESCRIPTION
Two halves: the last few unsupported claims in examiner-facing artifact fields, and a check that stops the class from coming back.

## Why these fields matter

`__artifacts_v2__` `name` and `description` are not developer notes. They render into the HTML report, get written into the LAVA manifest, and from there they are pasted into examination notes and quoted in court. The standard is: say what the data is and where it came from; do not say what it means about the world, or who did it, unless the data establishes that or a cited source documents it.

## Half 1 - the residuals

A vocabulary scan over all 363 artifact modules found six the recent audit missed:

| File | Artifact | Before | After |
|---|---|---|---|
| `hikvision.py` | `hikvisionMedia` | name "Hikvision - User Created Media", desc "Media files the user created while viewing CCTV footage" | name "Hikvision - CCTV Media", desc "Media files stored under Documents/YYYY/MM/DD in the Hikvision app container" |
| `appStoreSearches.py` | `appStoreCachedRequests` | "**All** App Store API requests held in the application URL cache" | "App Store API requests held in the application URL cache" |
| `foursquareSwarm.py` | `foursquare_swarm_photos` | "...Foursquare Swarm photos **from all artifacts**" | "Parses and extracts Foursquare Swarm photos" |
| `foursquareSwarm.py` | `foursquare_swarm_comments` | "...**all** Foursquare Swarm comments from check-ins, plans, tips, lists, and stickers" | same minus "all" (the enumeration is accurate about where it looks, so it stays) |
| `mobileInstall.py` | `mobileInstall_historical` | "**All** app install/update/uninstall/container/reboot events..." | "App install/update/uninstall/container/reboot events..." |
| `biomeShareSheetFeedback.py` | `get_biomeShareSheetFeedback` | "the activity **the user chose**" | "the activity recorded as chosen" |

Notes on the two judgement calls:

- **hikvision** asserted both authorship and circumstance. The parser enumerates `.jpg`/`.mov`/`.mp4` files under `Documents/YYYY/MM/DD` in the app container; it establishes neither who created them nor that anyone was viewing footage at the time. The ALEAPP twin was already corrected to "Hikvision - CCTV Media"; the description here names what this copy actually reads (this iLEAPP version walks the container, it does not read `image.db` like the Android one).
- **biomeShareSheetFeedback** was not on the original list - the new check found it. The `ShareSheet.Feedback` stream stores a chosen activity; it does not record who chose it. Reworded rather than allowlisted.

`wifiIdentifiers.py` was reviewed and deliberately left alone: "all interfaces listed in NetworkInterfaces.plist" is scoped to the file being parsed, not a claim about the device.

## Half 2 - the tripwire

The motivating case: PR #1852 corrected a Waze docstring but left the matching `description` field a few lines above it, so the claim kept shipping to reports until PR #1854 caught it. Prose fixes go stale exactly where nothing is watching them.

`admin/scripts/check_claim_language.py` parses each artifact module with `ast`, `literal_eval`s its `__artifacts_v2__`, and matches every `name` and `description` against a claim vocabulary kept in one commented constant - completeness words, attributions of an act to "the user", and certainty words. Matching is case-insensitive and boundary-aware, so `install` does not trip `all` and `unreliable` does not trip `reliable`.

- Violations print as `path:artifact_key:field: <text>` with the matched terms and a restatement of the standard; exit 1 if any remain, 0 otherwise.
- `--list` prints every match including allowlisted ones, for maintenance. `--verbose` reports modules whose `__artifacts_v2__` could not be read statically (currently none - all 363 parse).
- `ALLOWLIST` holds 13 reviewed exceptions, each with an inline comment saying why: Box's own "All Files" product feature, Apple Health UI paths, verbatim `ZSYNDICATIONSTATE` enum labels, and cautionary sentences whose matched word is part of the hedge ("do not always indicate", "may be user-entered"). The docstring is explicit that the allowlist is a deliberate act, not a dumping ground.

Wired in as a step on the existing `python_lint` job rather than a new workflow.

## Verification

- Checker exits 0 on the tree after the fixes: `Checked 363 artifact module(s): no unsupported claim language (13 reviewed exception(s) allowlisted).`
- Deliberate-break test: temporarily set the `appStoreCachedRequests` description to "all records the user viewed in the application URL cache". The checker exited 1 and named the file, artifact, field, and both matched terms (`all`, `the user viewed`). Reverted.
- `python3 -m py_compile` clean on all five edited artifacts and the new script.
- `admin/scripts/lint_changed.py --base-ref origin/main` on all six changed `.py` files: 0 pre-existing, 0 new. PASS.

Generated docs (`admin/docs/generated/module_info.md`) are not touched here - the `update_module_info` workflow regenerates them on push to main, which will pick up the hikvision rename.