### PR TITLE
fix: anchor claim-language regex on \b and surface allowlist/coverage gaps

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -34,10 +34,22 @@ Two ways a match gets resolved:
   saying why**. The allowlist is a record of decisions someone made on purpose;
   it is not a place to park a description nobody wanted to rewrite.
 
+Two things the check reports rather than hides, because both are ways it can
+quietly stop doing its job:
+
+* An ALLOWLIST entry that no longer matches anything. It means the description
+  was reworded or the artifact key changed, and the entry now shields nothing --
+  except the next claim that lands under the same key. Stale entries fail the
+  run and must be deleted.
+* A module whose `__artifacts_v2__` is not a static literal (built by a helper,
+  or absent). Its fields cannot be read without importing the module, so they
+  are never checked. Those modules are printed as NOT CHECKED on every run, so
+  the coverage hole stays visible.
+
 Usage:
     python admin/scripts/check_claim_language.py           # CI mode, exits 1 on a violation
     python admin/scripts/check_claim_language.py --list    # every match, allowlisted included
-    python admin/scripts/check_claim_language.py --verbose # also report unparsed modules
+    python admin/scripts/check_claim_language.py --verbose # coverage and allowlist counts
 """
 
 import argparse
@@ -55,12 +67,26 @@ import sys
 #     ("the user viewed", "user-created", "searched by", "manually")
 #   - certainty and inference-about-conduct words ("proves", "definitively",
 #     "always", "reliable", "visited", "habits")
-# Matching is case-insensitive and boundary-aware, so "install" does not trip
-# "all" and "unreliable" does not trip "reliable".
+#
+# Every alternative is anchored with an explicit \b. Do NOT express a boundary as
+# a trailing space ("all ", "every ", "always "): that spelling matches inside
+# "call log", "calllog.db" and similar, and in a sibling implementation it turned
+# 35 of 37 raw hits into call-log false positives, which is enough noise to make
+# the check worth ignoring. Word boundaries also keep the hedges quiet -- neither
+# "unreliable" nor "incomplete" trips, because there is no boundary mid-word.
+#
+# The stems below are left UNCLOSED on purpose so inflections still match:
+#   \bcomplete -> complete, completeness, completely
+#   \breliable -> reliable and its compounds
+#   \bhabit    -> habit, habits
+# The cost of the open \bhabit is that it also matches "habitat"; no artifact in
+# this repo uses that word today, and this spelling is kept deliberately in sync
+# with the ALEAPP implementation of the same check. If a habitat-related artifact
+# ever lands, close it to \bhabits?\b rather than allowlisting the artifact.
 CLAIM_PATTERN = re.compile(
     r'\ball\b'
     r'|\bevery\b'
-    r'|\bcomplete\w*'
+    r'|\bcomplete'
     r'|\bfull list\b'
     r'|\bentire\b'
     r'|\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent'
@@ -74,9 +100,9 @@ CLAIM_PATTERN = re.compile(
     r'|\bproves?\b'
     r'|\bdefinitively\b'
     r'|\balways\b'
-    r'|\breliable\b'
+    r'|\breliable'
     r'|\bvisited\b'
-    r'|\bhabits?\b',
+    r'|\bhabit',
     re.IGNORECASE)
 
 # Fields that reach the examiner through the report and the LAVA manifest.
@@ -236,6 +262,7 @@ def main():
     violations = []
     allowlisted = []
     skipped = []
+    fired = set()
     for path in paths:
         rel_path = os.path.relpath(path, root)
         matches, skip_reason = scan_file(path)
@@ -244,15 +271,38 @@ def main():
             continue
         for match in matches:
             entry = (rel_path,) + match[1:]
+            fired.add((os.path.basename(path), match[1], match[2]))
             if match[5]:
                 allowlisted.append(entry)
             else:
                 violations.append(entry)
 
-    if args.verbose and skipped:
-        print(f'Skipped {len(skipped)} module(s):')
+    # An allowlist entry that no longer matches anything is either a fixed
+    # description or a stale key, and it hides the next real claim behind a name
+    # nobody rechecks. Surface it so the allowlist stays a list of live decisions.
+    stale = sorted(ALLOWLIST - fired)
+
+    # A module whose __artifacts_v2__ cannot be evaluated statically is a real
+    # coverage hole: its fields are never checked. Report it rather than hide it.
+    if skipped:
+        print(f'NOT CHECKED -- {len(skipped)} module(s) have no statically readable '
+              f'__artifacts_v2__:')
         for rel_path, reason in skipped:
             print(f'  {rel_path}: {reason}')
+        print()
+
+    if args.verbose:
+        print(f'Scanned {len(paths)} module(s); {len(paths) - len(skipped)} checked, '
+              f'{len(skipped)} skipped.')
+        print(f'Allowlist holds {len(ALLOWLIST)} entr(ies); {len(allowlisted)} fired '
+              f'this run.')
+        print()
+
+    if stale:
+        print(f'Stale ALLOWLIST entr(ies) ({len(stale)}) -- these no longer match '
+              f'anything and should be deleted:')
+        for entry in stale:
+            print(f'  {entry[0]}:{entry[1]}:{entry[2]}')
         print()
 
     if args.list_all and allowlisted:
@@ -270,8 +320,16 @@ def main():
         print(STANDARD_NOTE)
         return 1
 
-    print(f'Checked {len(paths)} artifact module(s): no unsupported claim language '
-          f'({len(allowlisted)} reviewed exception(s) allowlisted).')
+    if stale:
+        print('Remove the stale entr(ies) above from ALLOWLIST in '
+              'admin/scripts/check_claim_language.py.')
+        return 1
+
+    summary = (f'Checked {len(paths) - len(skipped)} artifact module(s): no unsupported '
+               f'claim language ({len(allowlisted)} reviewed exception(s) allowlisted).')
+    if skipped:
+        summary += f' {len(skipped)} module(s) NOT checked, listed above.'
+    print(summary)
     return 0
 
 


### PR DESCRIPTION
Follow-up to #1855, keeping this check in sync with the ALEAPP implementation (ALEAPP #1016).

## The reported bug, and where iLEAPP actually stood

The pattern this check was specified from used trailing spaces as pseudo-boundaries (`all `, `every `, `always `). That spelling matches **inside** "call log" and "calllog.db", which on ALEAPP turned 35 of 37 raw hits into call-log false positives — enough noise to make the check worth ignoring.

The version merged here in #1855 was already anchored with explicit `\b` and never had that bug. Confirmed rather than assumed:

| text | seed pattern | as merged in #1855 | this PR |
|---|---|---|---|
| `Call logs from the calllog.db` | `['all ']` fires | no fire | no fire |
| `Installed applications on the device` | no fire | no fire | no fire |
| `unreliable` / `incomplete` | `['reliable']`, `['complete']` fire | no fire | no fire |

So **no false positives were being masked, and the hit set is unchanged at 13**. Three stems are still brought into line with ALEAPP so the two implementations read the same, left unclosed so inflections match: `\bcomplete` (completeness, completely), `\breliable`, `\bhabit`.

The constant now carries a comment explaining why a trailing space must not be used as a boundary, so the bug cannot be reintroduced by someone copying the original wording back in.

**Verification requested:** `"Call logs from the calllog.db"` and `"Call log entries and call duration"` do not fire; all six residual strings fixed in #1855 still do (`user created`, `the user created`, `all` x3, `the user chose`). Both checks run and pass.

One tradeoff recorded in the comment: open `\bhabit` also matches "habitat". No artifact in this repo uses that word (checked), and parity with ALEAPP is worth more than the theoretical hit; if a habitat artifact ever lands, the fix is to close the stem, not to allowlist the artifact.

## Allowlist: re-derived, not carried over

Re-ran the scan with `ALLOWLIST` emptied and the corrected pattern. All 13 entries fire on their own text; none is dead. **iLEAPP stays at 13 where ALEAPP landed at 2** — not because entries were carried over uncritically, but because the two corpora differ. ALEAPP's seed list was mostly call-log false positives from the bad regex; iLEAPP's 13 are distinct real matches on real text:

- Box's own "All Files" product feature (x2)
- Apple Health UI paths — "Show All Health Data", "All Recorded Data", "All Watch Sleep Data" (x2)
- verbatim `ZSYNDICATIONSTATE` enum labels containing "Manually-Saved" (x2)
- explicit hedges where the matched word *is* the hedge — "do not **always** indicate" (x2), "may be **user-entered** or written by apps" (x2)
- `visited places` restating the Location.Visit stream name, plus its own timestamp caution
- `wifiIdentifiers` and `foursquare_swarm_saved_lists`, both reviewed and deliberately unchanged

Each still carries its inline justification.

## Two ways the check could quietly stop working, now reported

- **Stale allowlist entry** — one that no longer matches anything because the description was reworded or the key renamed. It shields nothing *except the next claim that lands under the same key*. These now **fail the run** with the entry named. This is the mechanism that keeps the allowlist from becoming the dumping ground the docstring warns about.
- **Unreadable `__artifacts_v2__`** — a module that builds its dict through a helper, or has none. Its fields cannot be read without importing the module, so they are never checked. These now print as `NOT CHECKED` on **every** run, not just under `--verbose`, and the summary line repeats the count. iLEAPP currently has **zero**: all 363 modules parse to a static literal. ALEAPP has two, so the reporting matters there and guards against it silently appearing here.

`--verbose` now also prints scanned/checked/skipped counts and how many allowlist entries fired.

## Tests

- `check_claim_language.py` exits **0** on the tree: `Checked 363 artifact module(s): no unsupported claim language (13 reviewed exception(s) allowlisted).`
- Deliberate break, claim language: set the `appStoreCachedRequests` description to "all records the user viewed in the application URL cache" → **exit 1**, naming file, artifact, field and both matched terms. Reverted.
- Deliberate break, stale allowlist: added `('deleted_artifact.py', 'gone_key', 'description')` → **exit 1**, `Stale ALLOWLIST entr(ies) (1)`, naming it. Reverted.
- `py_compile` clean; `lint_changed.py --base-ref origin/main`: 0 pre-existing, 0 new. PASS.