### PR TITLE
docs: correct the \bhabit justification in the claim-language check

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -78,11 +78,16 @@ import sys
 # The stems below are left UNCLOSED on purpose so inflections still match:
 #   \bcomplete -> complete, completeness, completely
 #   \breliable -> reliable and its compounds
-#   \bhabit    -> habit, habits
-# The cost of the open \bhabit is that it also matches "habitat"; no artifact in
-# this repo uses that word today, and this spelling is kept deliberately in sync
-# with the ALEAPP implementation of the same check. If a habitat-related artifact
-# ever lands, close it to \bhabits?\b rather than allowlisting the artifact.
+#   \bhabit    -> habit, habits, habitual, habitually
+# The open \bhabit is kept for "habitual", the inference word most likely to turn
+# up in a description of app usage data; the closed spelling \bhabits?\b does not
+# catch it. The cost is that the open stem also matches "habitat", which no
+# artifact name or description in this repo uses today (verified by grep over
+# scripts/artifacts). ALEAPP's implementation of this check uses the closed
+# \bhabits?\b and has since it was written, so the two spellings differ on
+# purpose -- they are not, and have never been, kept in sync. If a
+# habitat-related artifact ever lands here, close the stem rather than
+# allowlisting the artifact.
 CLAIM_PATTERN = re.compile(
     r'\ball\b'
     r'|\bevery\b'


### PR DESCRIPTION
`admin/scripts/check_claim_language.py` justified its open `\bhabit` stem with this:

> this spelling is kept deliberately in sync with the ALEAPP implementation of the same check

That is not true, and never was. ALEAPP uses the closed `\bhabits?\b` in both revisions of its copy of the file, and its comment says the closed form is deliberate *because* the open stem also matches "habitat". So the comment asserted a cross-repo sync that does not exist -- an unsupported claim inside the comment block of the tool written to catch unsupported claims.

## What changed

Comment only. The pattern is untouched, so there is no behaviour change.

The open stem is **kept**, and the comment now gives the real reason: `\bhabit` also matches "habitual" and "habitually", which is the inference wording most likely to turn up in a description of app usage data, and which the closed `\bhabits?\b` misses. The cost is that it matches "habitat" too; no artifact name or description in this repo uses that word today (verified by grep over `scripts/artifacts`). The divergence from ALEAPP is now recorded as a divergence, with ALEAPP's opposite choice noted, rather than as a sync.

ALEAPP is not modified.

## Verification

- `py_compile` clean.
- `python admin/scripts/check_claim_language.py` exits 0: 363 artifact modules checked, 13 allowlisted exceptions, unchanged from before.
- `admin/scripts/lint_changed.py --base-ref origin/main` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)