### PR TITLE
fix: cast Cash App state/role extractions to text

### DIFF
--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses Cash App transactions and account data from the CCEntitySync SQLite stores.",
         "author": "@gforce4n6",
         "creation_date": "2021-10-06",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Banking",
         "notes": "",
@@ -34,9 +34,11 @@ def get_cashApp(context):
 
 -- Description of the role of the user account signed into the CashApp application of the device.
 -- Unrecognized role values are reported as stored in the record.
+-- ZSYNCPAYMENT is a BLOB, so SUBSTR over it also returns a BLOB. The result is CAST to TEXT so
+-- that extracted values render as text and an empty extraction renders as a blank cell.
 CASE WHEN ZPAYMENT.ZSYNCPAYMENT LIKE '%"RECIPIENT"%' THEN 'RECIPIENT'
-WHEN INSTR(ZPAYMENT.ZSYNCPAYMENT, '"role":"') > 0 THEN SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"role":"') + 8,
-INSTR(SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"role":"') + 8), '"') - 1) END AS "Account Owner Role",
+WHEN INSTR(ZPAYMENT.ZSYNCPAYMENT, '"role":"') > 0 THEN CAST(SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"role":"') + 8,
+INSTR(SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"role":"') + 8), '"') - 1) AS TEXT) END AS "Account Owner Role",
 
 --Full name from the name fields of the customer record.
 LTRIM(SUBSTR(CAST(ZCUSTOMER.ZSYNCCUSTOMER AS BLOB), INSTR(CAST(ZCUSTOMER.ZSYNCCUSTOMER AS BLOB), CAST(',"full_name":' AS BLOB)),
@@ -61,9 +63,11 @@ instr(CAST(ZPAYMENT.ZSYNCPAYMENT AS BLOB), CAST('"note":' AS BLOB))), ',"note":'
 
 --State of the transaction. Certain times the user may have to accept or decline a payment or payment request from the sender.
 -- Unrecognized state values are reported as stored in the record.
+-- ZSYNCPAYMENT is a BLOB, so SUBSTR over it also returns a BLOB. The result is CAST to TEXT so
+-- that extracted values render as text and an empty extraction renders as a blank cell.
 CASE WHEN ZPAYMENT.ZSYNCPAYMENT LIKE '%"COMPLETED"%' THEN 'COMPLETED' WHEN ZPAYMENT.ZSYNCPAYMENT LIKE '%"CANCELED"%' THEN 'CANCELED'
-WHEN INSTR(ZPAYMENT.ZSYNCPAYMENT, '"state":"') > 0 THEN SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"state":"') + 9,
-INSTR(SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"state":"') + 9), '"') - 1) END AS 'Transaction State',
+WHEN INSTR(ZPAYMENT.ZSYNCPAYMENT, '"state":"') > 0 THEN CAST(SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"state":"') + 9,
+INSTR(SUBSTR(ZPAYMENT.ZSYNCPAYMENT, INSTR(ZPAYMENT.ZSYNCPAYMENT, '"state":"') + 9), '"') - 1) AS TEXT) END AS 'Transaction State',
 
 --Unix Epoch timestamp for the transaction display time.
 ZPAYMENT.ZDISPLAYDATE as "TRANSACTION DISPLAY DATE"


### PR DESCRIPTION
Follow-up to the artifact-documentation audit fix in `scripts/artifacts/cashApp.py`.

## What the audit fix did (and got right)

The audit replaced two fabricated `ELSE` defaults that asserted a transaction state for any unrecognised value:

- Transaction State: `ELSE 'WAITING ON RECIPIENT'`
- Account Owner Role: `ELSE 'SENDER'`

Both were swapped for a `SUBSTR`/`INSTR` extraction of the real `"state":"..."` / `"role":"..."` value out of `ZPAYMENT.ZSYNCPAYMENT`. That was the correct change and it stays.

## The cosmetic regression

`ZSYNCPAYMENT` is a BLOB, and `SUBSTR` over a BLOB returns a BLOB. So every value produced by those two new branches came back to Python as `bytes` rather than `str`, and reached the report through `str()` with a `b'...'` wrapper. A zero-length extraction (a record holding `"state":""`) reached the report as the literal text `b''` instead of a blank cell.

Both the Transaction State and Account Owner Role columns had the identical problem.

## Fix

`CAST(... AS TEXT)` around each extraction. Nothing else changes: the same rows match the same branches, and the `db.text_factory` decoder then yields a clean string.

## Verified

Synthetic SQLite database reproducing the real `ZPAYMENT`/`ZCUSTOMER` schema shape, run through the artifact's own query (extracted from the file so the harness tests exactly what ships):

| case | before: Role | before: State | after: Role | after: State |
|---|---|---|---|---|
| `"state":"PENDING"`, `"role":"SENDER"` | `b'SENDER'` | `b'PENDING'` | `SENDER` | `PENDING` |
| `"state":"COMPLETED"`, `"role":"RECIPIENT"` (literal-match branches) | `RECIPIENT` | `COMPLETED` | `RECIPIENT` | `COMPLETED` |
| marker present, empty value `"state":""` | `b''` | `b''` | *(blank)* | *(blank)* |
| no `"state":"` / `"role":"` marker | NULL | NULL | NULL | NULL |
| NULL blob | NULL | NULL | NULL | NULL |

Row count is unchanged (5 in, 5 out) in both directions.

Note on scope: no Cash App `CCEntitySync` store exists in the extractions on the machine this was developed on, so the real-image row could not be re-run here. The synthetic case reproduces the reported `b''` exactly and identifies its producer as a record whose `"state"` value is an empty string.

## Deliberately not restored

The fabricated defaults are **not** reinstated. An unrecognised value still renders blank or as stored in the record; it is never reported as an asserted transaction state.

## Checks

- `py_compile` clean
- `admin/scripts/lint_changed.py --base-ref origin/main scripts/artifacts/cashApp.py` -> no new warnings, PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)