### PR TITLE
PowerLog time-offset correction and three new artifacts

### DIFF
--- a/admin/test/scripts/test_local_corpus_artifacts.py
+++ b/admin/test/scripts/test_local_corpus_artifacts.py
@@ -32,6 +32,8 @@ from scripts.artifacts.appleAccountDeviceList import appleAccountDeletedDeviceLi
     appleAccountDeviceList
 from scripts.artifacts.locationdCacheEncryptedB import locationdCellLocations, \
     locationdWifiHarvest, locationdWifiLocations, locationdWifiTiles
+from scripts.artifacts.powerlog import powerlogApplicationRuntime, powerlogAppState, \
+    powerlogBatteryLevel, powerlogDevicePowerState
 from scripts.artifacts.safariCache import safariCache
 from scripts.artifacts.storeSystem import storeSystemAppInstalls, storeSystemAppPackages, \
     storeSystemAppUpdates
@@ -383,6 +385,49 @@ class LocationdCacheLocalTest(LocalCorpusTestCase):
         for row in rows:
             self.assert_plausible_timestamp(row[0])
             self.assert_plausible_timestamp(row[1])
+
+
+@unittest.skipUnless(LOCAL_IMAGE, 'set ILEAPP_LOCAL_IMAGE to run local corpus tests')
+class PowerlogLocalTest(LocalCorpusTestCase):
+    SUFFIX = 'Library/BatteryLife/CurrentPowerlog.PLSQL'
+
+    def setUp(self):
+        super().setUp()
+        self.path = self.fetch(self.SUFFIX)
+        if not self.path:
+            self.skipTest(f'{self.SUFFIX} not present in {LOCAL_IMAGE}')
+
+    def run_artifact(self, func):
+        headers, rows, _ = func.__wrapped__(_Context(self.path))
+        self.assert_row_shape(headers, rows)
+        for row in rows:
+            # Corrected timestamp first, applied offset second-to-last.
+            self.assert_plausible_timestamp(row[0])
+            if row[-2] is not None:
+                self.assertIsInstance(row[-2], int)
+        return rows
+
+    def test_application_runtime_structure(self):
+        for row in self.run_artifact(powerlogApplicationRuntime):
+            if row[2] is not None:
+                self.assertGreaterEqual(row[2], 0)   # Background Time
+            if row[3] is not None:
+                self.assertGreaterEqual(row[3], 0)   # Screen-on Time
+
+    def test_battery_level_structure(self):
+        for row in self.run_artifact(powerlogBatteryLevel):
+            if row[1] is not None:
+                self.assertTrue(0 <= row[1] <= 100,
+                                f'battery level shape {_redact(row[1])}')
+            self.assert_matches(row[2], r'^(Yes|No|\d+)$', 'Is Charging')
+
+    def test_device_power_state_structure(self):
+        self.run_artifact(powerlogDevicePowerState)
+
+    def test_app_state_structure(self):
+        for row in self.run_artifact(powerlogAppState):
+            if row[3] is not None:
+                self.assertIsInstance(row[3], int)   # State code as stored
 
 
 if __name__ == '__main__':

--- a/scripts/artifacts/powerlog.py
+++ b/scripts/artifacts/powerlog.py
@@ -1,69 +1,325 @@
 __artifacts_v2__ = {
     "powerlogApplicationRuntime": {
         "name": "PowerLog - Application Runtime",
-        "description": "Application foreground and background runtime recorded by PowerLog",
+        "description": "Application foreground and background runtime recorded by PowerLog "
+                       "(PLAppTimeService_Aggregate_AppRunTime table)",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-03",
         "requirements": "none",
         "category": "PowerLog",
         "notes": (
-            "Parses PLAppTimeService_Aggregate_AppRunTime. PowerLog contains many additional "
-            "version-specific tables that require separate validation. "
-            "Reference: Sarah Edwards, APOLLO powerlog_app_usage_by_hour module, "
-            "https://github.com/mac4n6/APOLLO/blob/master/modules/powerlog_app_usage_by_hour.txt "
-            "(SCREENONTIME/BACKGROUNDTIME in seconds)."
+            "Raw PowerLog 'timestamp' values run on the log's internal clock, which can "
+            "diverge from wall-clock time. The PLStorageOperator_EventForward_TimeOffset "
+            "table records the correction in effect across the span of the log ('system' "
+            "column, in seconds). Each row here is adjusted by the offset entry at or "
+            "before its raw timestamp (rows older than the oldest retained entry use that "
+            "oldest entry) and the applied offset is reported in its own column. Checked "
+            "against test images: raw values lagged an iOS 18.7 acquisition date by ~32 "
+            "days and led an iOS 12.4 acquisition by 69 seconds; corrected values align "
+            "with the acquisition dates. ScreenOnTime/BackgroundTime read as seconds are "
+            "consistent with the sampling-window durations in test data. PowerLog holds "
+            "many additional version-specific tables that require separate validation; "
+            "gzipped archive logs (*.PLSQL.gz) are not parsed."
         ),
         "paths": (
             "*/BatteryLife/*.PLSQL*",
-            "*/BatteryLife/Archives/*.PLSQL*",
-            "*/Powerlog/*.PLSQL*",
-            "*/PowerLog/*.PLSQL*",
-            "*/powerlog/*.PLSQL*",
+            "*/[Pp]ower[Ll]og/*.PLSQL*",
         ),
         "output_types": ["html", "tsv", "lava", "timeline"],
         "artifact_icon": "battery",
         "sample_data": {
-            "ctf2020_ios12": "iOS 12.4 | 1256 rows",
-            "hickman_ios15": "iOS 15 | 3322 rows",
+            "ctf2020_ios12": "iOS 12.4 | 4317 rows",
+            "hickman_ios13": "iOS 13.3.1 | 2723 rows",
+            "hickman_ios14": "iOS 14.3 | 4040 rows",
             "jess_ios15": "iOS 15.0.2 | 723 rows",
+            "hickman_ios15": "iOS 15 | 3322 rows",
             "magnet_ios16": "iOS 16.1.1 | 933 rows",
+            "abe_ios16": "iOS 16.5 | 7211 rows",
+            "felix23_ios16": "iOS 16.5 | 2170 rows",
+            "fsfull002_ios17": "iOS 17.1 | 1717 rows",
+            "iphone11_ios17": "iOS 17.3 | 6235 rows",
+            "otto_ios17": "iOS 17.5.1 | 2364 rows",
             "felix_ios17": "iOS 17.6.1 | 5662 rows",
             "iphone14plus_ios18": "iOS 18.0 | 4127 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "iphone12_ios18": "iOS 18.7 | 2425 rows",
             "hc_ios18_7": "iOS 18.7.8 | 4244 rows",
+            "hc_ios26": "iOS 26 | 3550 rows",
         },
-    }
+    },
+    "powerlogBatteryLevel": {
+        "name": "PowerLog - Battery Level",
+        "description": "Battery level and charging state samples recorded by PowerLog "
+                       "(PLBatteryAgent_EventBackward_BatteryUI table)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-08-03",
+        "last_update_date": "2026-08-03",
+        "requirements": "none",
+        "category": "PowerLog",
+        "notes": (
+            "Level values ranged 1-100 across test images (iOS 12.4-26), consistent "
+            "with a percentage. IsCharging holds 0/1, reported as No/Yes with other "
+            "values passed through as stored. Timestamps are adjusted using PowerLog's "
+            "time-offset table and the applied offset is reported per row; see the "
+            "PowerLog - Application Runtime notes for the mechanism."
+        ),
+        "paths": (
+            "*/BatteryLife/*.PLSQL*",
+            "*/[Pp]ower[Ll]og/*.PLSQL*",
+        ),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "battery-charging",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 3994 rows",
+            "hickman_ios13": "iOS 13.3.1 | 1743 rows",
+            "hickman_ios14": "iOS 14.3 | 1470 rows",
+            "jess_ios15": "iOS 15.0.2 | 507 rows",
+            "hickman_ios15": "iOS 15 | 1584 rows",
+            "magnet_ios16": "iOS 16.1.1 | 210 rows",
+            "abe_ios16": "iOS 16.5 | 1652 rows",
+            "felix23_ios16": "iOS 16.5 | 530 rows",
+            "fsfull002_ios17": "iOS 17.1 | 671 rows",
+            "iphone11_ios17": "iOS 17.3 | 1585 rows",
+            "otto_ios17": "iOS 17.5.1 | 5229 rows",
+            "felix_ios17": "iOS 17.6.1 | 7115 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 3165 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "iphone12_ios18": "iOS 18.7 | 2117 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 1527 rows",
+            "hc_ios26": "iOS 26 | 810 rows",
+        },
+    },
+    "powerlogDevicePowerState": {
+        "name": "PowerLog - Device Power State",
+        "description": "Device sleep and wake power state events recorded by PowerLog "
+                       "(PLSleepWakeAgent_EventForward_PowerState table)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-08-03",
+        "last_update_date": "2026-08-03",
+        "requirements": "none",
+        "category": "PowerLog",
+        "notes": (
+            "Event, State, and Reason are integer codes reported as stored; their "
+            "meanings are not decoded here. Observed in test images (iOS 12.4-26): "
+            "State 0-2, Event 0-5, Reason 1 or null. Timestamps are adjusted using "
+            "PowerLog's time-offset table and the applied offset is reported per row; "
+            "see the PowerLog - Application Runtime notes for the mechanism."
+        ),
+        "paths": (
+            "*/BatteryLife/*.PLSQL*",
+            "*/[Pp]ower[Ll]og/*.PLSQL*",
+        ),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "power",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 14721 rows",
+            "hickman_ios13": "iOS 13.3.1 | 5893 rows",
+            "hickman_ios14": "iOS 14.3 | 2762 rows",
+            "jess_ios15": "iOS 15.0.2 | 75 rows",
+            "hickman_ios15": "iOS 15 | 6242 rows",
+            "magnet_ios16": "iOS 16.1.1 | 1472 rows",
+            "abe_ios16": "iOS 16.5 | 2686 rows",
+            "felix23_ios16": "iOS 16.5 | 1124 rows",
+            "fsfull002_ios17": "iOS 17.1 | 664 rows",
+            "iphone11_ios17": "iOS 17.3 | 2670 rows",
+            "otto_ios17": "iOS 17.5.1 | 5809 rows",
+            "felix_ios17": "iOS 17.6.1 | 509 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 832 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "iphone12_ios18": "iOS 18.7 | 1048 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 1334 rows",
+            "hc_ios26": "iOS 26 | 406 rows",
+        },
+    },
+    "powerlogAppState": {
+        "name": "PowerLog - Application State",
+        "description": "Application state transition events recorded by PowerLog "
+                       "(PLApplicationAgent_EventForward_Application table)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-08-03",
+        "last_update_date": "2026-08-03",
+        "requirements": "none",
+        "category": "PowerLog",
+        "notes": (
+            "State and Reason are integer codes reported as stored; their meanings are "
+            "not decoded here. Observed in test images (iOS 12.4-26): State 0, 1, 2, 4, "
+            "8, 32; Reason 0 or 1. Timestamps are adjusted using PowerLog's time-offset "
+            "table and the applied offset is reported per row; see the PowerLog - "
+            "Application Runtime notes for the mechanism."
+        ),
+        "paths": (
+            "*/BatteryLife/*.PLSQL*",
+            "*/[Pp]ower[Ll]og/*.PLSQL*",
+        ),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "activity",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 4292 rows",
+            "hickman_ios13": "iOS 13.3.1 | 4743 rows",
+            "hickman_ios14": "iOS 14.3 | 4590 rows",
+            "jess_ios15": "iOS 15.0.2 | 324 rows",
+            "hickman_ios15": "iOS 15 | 2916 rows",
+            "magnet_ios16": "iOS 16.1.1 | 360 rows",
+            "abe_ios16": "iOS 16.5 | 1775 rows",
+            "felix23_ios16": "iOS 16.5 | 901 rows",
+            "fsfull002_ios17": "iOS 17.1 | 550 rows",
+            "iphone11_ios17": "iOS 17.3 | 5189 rows",
+            "otto_ios17": "iOS 17.5.1 | 5404 rows",
+            "felix_ios17": "iOS 17.6.1 | 2577 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 799 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "iphone12_ios18": "iOS 18.7 | 9604 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 2023 rows",
+            "hc_ios26": "iOS 26 | 1307 rows",
+        },
+    },
 }
+
+from bisect import bisect_right
 
 from scripts.ilapfuncs import (
     artifact_processor,
+    convert_unix_ts_to_utc,
     does_table_exist_in_db,
     get_sqlite_db_records,
 )
+
+TIME_OFFSET_TABLE = "PLStorageOperator_EventForward_TimeOffset"
+
+
+def _powerlog_sources(context):
+    """Plain .PLSQL files among the found paths, deduplicated.
+
+    The path globs also surface -wal/-shm sidecars and gzipped archives; the
+    sidecars ride along for SQLite to read, the .gz archives are not parsed.
+    A file matched by more than one glob is returned once.
+    """
+    return list(dict.fromkeys(
+        str(path) for path in context.get_files_found()
+        if str(path).endswith(".PLSQL")
+    ))
+
+
+def _load_time_offsets(source_path):
+    """Read the log's clock corrections as parallel timestamp-sorted lists.
+
+    Returns ([raw timestamp], [offset seconds]); empty lists when the table
+    is missing or holds no usable rows.
+    """
+    if not does_table_exist_in_db(source_path, TIME_OFFSET_TABLE):
+        return [], []
+    stamps = []
+    offsets = []
+    for row in get_sqlite_db_records(source_path, f'''
+            SELECT timestamp, system
+            FROM "{TIME_OFFSET_TABLE}"
+            WHERE timestamp IS NOT NULL AND system IS NOT NULL
+            ORDER BY timestamp
+        '''):
+        stamps.append(row[0])
+        offsets.append(row[1])
+    return stamps, offsets
+
+
+def _corrected_utc(raw_ts, stamps, offsets):
+    """Apply the clock correction in effect at raw_ts.
+
+    Returns (aware datetime, applied offset in whole seconds). Rows older
+    than the oldest retained offset entry use that oldest entry; a log with
+    no offset entries gets the raw value back and no offset reported.
+    """
+    if raw_ts is None:
+        return None, None
+    if not stamps:
+        return convert_unix_ts_to_utc(raw_ts), None
+    idx = bisect_right(stamps, raw_ts) - 1
+    if idx < 0:
+        idx = 0
+    offset = offsets[idx]
+    return convert_unix_ts_to_utc(raw_ts + offset), int(round(offset))
+
+
+def _parse_powerlog_table(context, table, columns, row_builder):
+    """Run one query shape over every PowerLog db found.
+
+    row_builder(corrected_ts, offset, row, relative_path) -> output tuple.
+    """
+    data_list = []
+    source_paths = _powerlog_sources(context)
+    for source_path in source_paths:
+        if not does_table_exist_in_db(source_path, table):
+            continue
+        stamps, offsets = _load_time_offsets(source_path)
+        relative_path = context.get_relative_path(source_path)
+        for row in get_sqlite_db_records(source_path, f'''
+                SELECT {", ".join(columns)}
+                FROM "{table}"
+                ORDER BY timestamp
+            '''):
+            ts, offset = _corrected_utc(row[0], stamps, offsets)
+            data_list.append(row_builder(ts, offset, row, relative_path))
+    source = "See source paths in data" if source_paths else ""
+    return data_list, source
 
 
 @artifact_processor
 def powerlogApplicationRuntime(context):
     data_headers = (
         ("Timestamp", "datetime"), "Bundle ID", "Background Time (seconds)",
-        "Screen-on Time (seconds)", "Source File",
+        "Screen-on Time (seconds)", "Time Offset (seconds)", "Source File",
     )
-    data_list = []
-    source_paths = [
-        str(path) for path in context.get_files_found()
-        if str(path).endswith(".PLSQL")
-    ]
-    for source_path in source_paths:
-        if not does_table_exist_in_db(source_path, "PLAppTimeService_Aggregate_AppRunTime"):
-            continue
-        query = """
-            SELECT datetime(timestamp, 'unixepoch'), BundleID, BackgroundTime, ScreenOnTime
-            FROM PLAppTimeService_Aggregate_AppRunTime
-            ORDER BY timestamp
-        """
-        relative_path = context.get_relative_path(source_path)
-        data_list.extend(tuple(row) + (relative_path,)
-                         for row in get_sqlite_db_records(source_path, query))
+    data_list, source = _parse_powerlog_table(
+        context, "PLAppTimeService_Aggregate_AppRunTime",
+        ("timestamp", "BundleID", "BackgroundTime", "ScreenOnTime"),
+        lambda ts, offset, row, rel: (ts, row[1], row[2], row[3], offset, rel),
+    )
+    return data_headers, data_list, source
 
-    source = "See source paths in data" if source_paths else ""
+
+@artifact_processor
+def powerlogBatteryLevel(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Battery Level (%)", "Is Charging",
+        "Time Offset (seconds)", "Source File",
+    )
+
+    def build(ts, offset, row, rel):
+        charging = {0: "No", 1: "Yes"}.get(row[2], row[2])
+        return (ts, row[1], charging, offset, rel)
+
+    data_list, source = _parse_powerlog_table(
+        context, "PLBatteryAgent_EventBackward_BatteryUI",
+        ("timestamp", "Level", "IsCharging"), build,
+    )
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def powerlogDevicePowerState(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Event (as stored)", "State (as stored)",
+        "Reason (as stored)", "UUID", "Time Offset (seconds)", "Source File",
+    )
+    data_list, source = _parse_powerlog_table(
+        context, "PLSleepWakeAgent_EventForward_PowerState",
+        ("timestamp", "Event", "State", "Reason", "UUID"),
+        lambda ts, offset, row, rel: (
+            ts, row[1], row[2], row[3], row[4], offset, rel),
+    )
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def powerlogAppState(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Identifier", "PID", "State (as stored)",
+        "Reason (as stored)", "Time Offset (seconds)", "Source File",
+    )
+    data_list, source = _parse_powerlog_table(
+        context, "PLApplicationAgent_EventForward_Application",
+        ("timestamp", "Identifier", "pid", "State", "Reason"),
+        lambda ts, offset, row, rel: (
+            ts, row[1], row[2], row[3], row[4], offset, rel),
+    )
     return data_headers, data_list, source


### PR DESCRIPTION
## Summary

Addresses part of #1864 (PowerLog artifact coverage) with independently developed parsers — no APOLLO code or queries were used or consulted for these implementations. Schema facts come from the databases themselves; every behavioral claim was validated against 16 local test images spanning iOS 12.4 through iOS 26.

### Bug fix: time-offset correction

PowerLog's raw `timestamp` values run on the log's internal clock, which diverges from wall-clock time. `PLStorageOperator_EventForward_TimeOffset` records the correction in effect ('system' column, seconds) across the span of the log. The shipped **PowerLog - Application Runtime** artifact reported raw values: on one iOS 18.7 test image they lagged the acquisition date by **~32 days** (on an iOS 12.4 image the skew was only -69 seconds, which is why this went unnoticed).

Every PowerLog artifact now applies the offset entry at or before each row's raw timestamp and reports the applied offset in a dedicated column. Corrected timestamp spans align with each image's known acquisition window on all 16 corpora.

### New artifacts

| Artifact | Table |
|---|---|
| PowerLog - Battery Level | `PLBatteryAgent_EventBackward_BatteryUI` |
| PowerLog - Device Power State | `PLSleepWakeAgent_EventForward_PowerState` |
| PowerLog - Application State | `PLApplicationAgent_EventForward_Application` |

Integer state codes are reported as stored with observed value ranges noted in the artifact notes; no decode is claimed.

### Path glob cleanup

The previous five-glob tuple double-counted: `*/BatteryLife/*.PLSQL*` already matches the `Archives/` subdirectory, and the three case-variants of `Powerlog/` would multiply-match on case-insensitive filesystems (the Biome glob failure mode). Collapsed to two globs plus in-code dedup of found sources. Plain-`.PLSQL` rotated archives now contribute rows where present (e.g. the 2020 CTF image gains ~3,000 Application Runtime rows).

### Testing

- `sample_data` regenerated for all four artifacts from real runs over 16 registered corpora (iOS 12.4, 13.3.1, 14.3, 15.x, 16.x, 17.x, 18.x, 26)
- New `PowerlogLocalTest` structural tests in the opt-in `ILEAPP_LOCAL_IMAGE` harness; 4/4 pass against a non-public iOS 18.7 image
- Full suite: 156 tests OK
- Claim-language check: clean

### Not in this PR (follow-ups)

- Gzipped archive logs (`*.PLSQL.gz`) are not parsed yet — would extend timelines by weeks on some images
- iOS 18 `InCall*` AppRunTime columns
- Additional PowerLog tables (adapter telemetry, lock state, display, audio routing, camera/torch, `GenerativeFunctionMetrics_*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)