### PR TITLE
fix: harden extraction and three artifacts against iOS 26 case-run errors

### DIFF
--- a/admin/test/scripts/test_extraction_illegal_filenames.py
+++ b/admin/test/scripts/test_extraction_illegal_filenames.py
@@ -1,0 +1,135 @@
+"""Guard extraction against archive members whose names Windows cannot write.
+
+Real iOS extractions carry files with ASCII control characters in their names:
+/private/var/mobile/Library/chronod/icons/ holds entries like
+'╞¼\\x01\\x0e::com.apple.siri.heic'. ZipFile.extract() only replaces a fixed
+set of printable characters (:<>|"?*) and only on Windows, so the control
+bytes reach the OS untouched and open() fails with [Errno 22] Invalid
+argument. In a case run this produced 81 'Could not write file to filesystem'
+lines and the matched files were silently absent from the extraction; worse,
+the failing member appended the *previous* member's path to the seeker's
+result list because `extracted_path` still held its stale value.
+
+These tests pin the fix: sanitize_file_path()/sanitize_file_name() treat
+control characters as illegal, and FileSeekerZip writes such members manually
+to a sanitized path inside the data folder on every platform.
+"""
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from leapp_functions.app.platform import (  # pylint: disable=wrong-import-position
+    sanitize_file_name, sanitize_file_path, validate_filename)
+from scripts.search_files import FileSeekerZip  # pylint: disable=wrong-import-position
+
+# The real member name observed in an iOS 26 full file system extraction.
+ICON_MEMBER = ('/private/var/mobile/Library/chronod/icons/'
+               '╖¬\x01\x0e::com.apple.siri.heic')
+ICON_CONTENT = b'not really a heic'
+
+
+def _has_control_chars(text):
+    return any(ord(c) < 0x20 or ord(c) == 0x7f for c in text)
+
+
+class TestSanitizeControlChars(unittest.TestCase):
+    """The sanitize helpers must replace what Windows rejects with EINVAL."""
+
+    def test_file_path_replaces_control_chars_but_keeps_separators(self):
+        cleaned = sanitize_file_path('icons/\x01\x0e::a.heic')
+        self.assertEqual(cleaned, 'icons/__::a.heic'.replace(':', '_'))
+        self.assertIn('/', cleaned)
+        self.assertFalse(_has_control_chars(cleaned))
+
+    def test_file_name_replaces_control_chars(self):
+        self.assertEqual(sanitize_file_name('a\x00b\x1fc\x7fd'), 'a_b_c_d')
+
+    def test_printable_illegal_chars_still_replaced(self):
+        self.assertEqual(sanitize_file_name('a:b*c?d'), 'a_b_c_d')
+
+    def test_unicode_stays_untouched(self):
+        self.assertEqual(sanitize_file_name('╖¬ café'),
+                         '╖¬ café')
+
+    def test_validate_filename_rejects_control_chars_without_crashing(self):
+        is_valid, message = validate_filename('output\x01folder')
+        self.assertFalse(is_valid)
+        self.assertTrue(message)
+
+
+class TestFileSeekerZipIllegalNames(unittest.TestCase):
+    """A zip member with control characters in its name must still extract."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.data_folder = os.path.join(self.tmpdir, 'data')
+        os.makedirs(self.data_folder)
+        self.zip_path = os.path.join(self.tmpdir, 'fs-full.zip')
+        with zipfile.ZipFile(self.zip_path, 'w') as z:
+            z.writestr(ICON_MEMBER, ICON_CONTENT)
+            z.writestr('/private/var/mobile/Library/chronod/icons/plain.heic',
+                       b'plain content')
+        self.seeker = FileSeekerZip(self.zip_path, self.data_folder)
+
+    def tearDown(self):
+        self.seeker.cleanup()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_both_members_are_extracted(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        self.assertEqual(len(paths), 2)
+        for path in paths:
+            self.assertTrue(os.path.isfile(path), path)
+
+    def test_extracted_path_carries_no_illegal_characters(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')]
+        self.assertEqual(len(sanitized), 1)
+        relative = os.path.relpath(sanitized[0], self.data_folder)
+        self.assertFalse(_has_control_chars(relative))
+        self.assertNotIn(':', relative)
+
+    def test_extracted_content_is_intact(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')][0]
+        with open(sanitized, 'rb') as f:
+            self.assertEqual(f.read(), ICON_CONTENT)
+
+    def test_extraction_stays_inside_the_data_folder(self):
+        """Member names lead with '/'; a naive join would escape data_folder."""
+        for path in self.seeker.search('*/chronod/icons/*'):
+            self.assertTrue(
+                os.path.realpath(path).startswith(
+                    os.path.realpath(self.data_folder) + os.sep), path)
+
+    def test_file_info_is_recorded_for_sanitized_members(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')][0]
+        self.assertIn(sanitized, self.seeker.file_infos)
+        self.assertEqual(self.seeker.file_infos[sanitized].source_path, ICON_MEMBER)
+
+    def test_dot_dot_segments_cannot_escape_the_data_folder(self):
+        traversal_zip = os.path.join(self.tmpdir, 'traversal.zip')
+        with zipfile.ZipFile(traversal_zip, 'w') as z:
+            z.writestr('icons/../../../evil\x01.txt', b'x')
+        seeker = FileSeekerZip(traversal_zip, self.data_folder)
+        try:
+            paths = seeker.search('**')
+            self.assertTrue(paths)
+            for path in paths:
+                self.assertTrue(
+                    os.path.realpath(path).startswith(
+                        os.path.realpath(self.data_folder) + os.sep), path)
+        finally:
+            seeker.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_swissmeteo_missing_files.py
+++ b/admin/test/scripts/test_swissmeteo_missing_files.py
@@ -1,0 +1,110 @@
+"""Swissmeteo artifacts must return a result tuple even when files are absent.
+
+When the app is not on the device, plz_interaction and swissmeteo_plz logged
+'No Swissmeteo'/'No app_open' and then fell off the end of the function,
+returning None. The artifact_processor wrapper unpacks three values, so every
+extraction without Swissmeteo reported
+
+    TypeError: cannot unpack non-iterable NoneType object
+
+as a parsing error. A second latent crash sat in plz_interaction: with the
+favorites database present but localdata.sqlite absent, the localdata cursor
+stayed None and get_location_infos(None, ...) would raise AttributeError.
+
+These tests run both artifacts through the missing-file and partial-file
+shapes and require a well-formed (headers, rows, source) result each time.
+"""
+import pathlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.artifacts.swissmeteo import plz_interaction, swissmeteo_plz  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+
+TS_MS = 1756684800000  # 2025-09-01 00:00:00 UTC in milliseconds
+
+
+class TestSwissmeteoMissingFiles(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        Context.clear()
+        Context.set_report_folder(self.tmpdir)
+
+    def tearDown(self):
+        Context.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_prediction_db(self):
+        db_path = pathlib.Path(self.tmpdir) / 'favorites_prediction_db.sqlite'
+        db = sqlite3.connect(db_path)
+        db.execute('CREATE TABLE plz_interaction '
+                   '(timestamp INTEGER, plz INTEGER, lat REAL, lon REAL)')
+        db.execute('INSERT INTO plz_interaction VALUES (?, 1000, 46.5, 6.6)',
+                   (TS_MS,))
+        db.execute('CREATE TABLE app_open (timestamp INTEGER, lat REAL, lon REAL)')
+        db.execute('INSERT INTO app_open VALUES (?, 46.5, 6.6)', (TS_MS,))
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def _make_localdata_db(self):
+        db_path = pathlib.Path(self.tmpdir) / 'localdata.sqlite'
+        db = sqlite3.connect(db_path)
+        db.execute('CREATE TABLE plz (plz_pk INTEGER, x REAL, y REAL, '
+                   'altitude REAL, primary_name TEXT)')
+        db.execute("INSERT INTO plz VALUES (1000, 538000, 152000, 500, 'Lausanne')")
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def test_plz_interaction_returns_tuple_when_app_absent(self):
+        # The real-world trigger: the path globs matched only a stray
+        # localdata.sqlite (another app's file), never the favorites database.
+        Context.set_files_found([self._make_localdata_db()])
+        result = plz_interaction.__wrapped__(Context)
+        self.assertIsNotNone(result)
+        data_headers, data_list, _source = result
+        self.assertEqual(len(data_headers), 4)
+        self.assertEqual(data_list, [])
+
+    def test_swissmeteo_plz_returns_tuple_when_app_absent(self):
+        Context.set_files_found([self._make_localdata_db()])
+        result = swissmeteo_plz.__wrapped__(Context)
+        self.assertIsNotNone(result)
+        data_headers, data_list, _source = result
+        self.assertEqual(len(data_headers), 4)
+        self.assertEqual(data_list, [])
+
+    def test_plz_interaction_without_localdata_keeps_raw_rows(self):
+        """favorites db present, localdata.sqlite absent: no cursor, no crash."""
+        Context.set_files_found([self._make_prediction_db()])
+        _headers, data_list, source = plz_interaction.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][1], 1000)
+        self.assertTrue(str(source).endswith('favorites_prediction_db.sqlite'))
+
+    def test_plz_interaction_with_localdata_enriches_rows(self):
+        Context.set_files_found([self._make_prediction_db(),
+                                 self._make_localdata_db()])
+        _headers, data_list, _source = plz_interaction.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][1], 'Lausanne')
+        self.assertIn('openstreetmap.org', data_list[0][2])
+
+    def test_swissmeteo_plz_parses_app_open_rows(self):
+        Context.set_files_found([self._make_prediction_db()])
+        _headers, data_list, _source = swissmeteo_plz.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][1], 46.5)
+        self.assertIn('openstreetmap.org', data_list[0][3])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_timestamp_range_and_type_guards.py
+++ b/admin/test/scripts/test_timestamp_range_and_type_guards.py
@@ -1,0 +1,128 @@
+"""Guard artifacts against timestamp values that crash the whole module.
+
+Two failure shapes observed in a single iOS 26 case run:
+
+* webkit_cache_records: a cache record carried a double far outside the
+  platform's time_t range; datetime.fromtimestamp() raised OverflowError on
+  Windows and one bad record aborted the artifact, losing every webkit cache
+  record in the case.
+
+* health_achievements: ACHAchievementsPlugin_earned_instances stores
+  created_date as REAL (Core Data seconds) in older schemas but as TEXT in the
+  iOS 26 schema. convert_cocoa_core_data_ts_to_utc() did str + int and the
+  TypeError aborted the artifact.
+
+These tests pin the guards: out-of-range cache timestamps become None instead
+of an exception, and health_achievements handles both schema generations.
+"""
+import pathlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.artifacts.webkit import cache_record_timestamp  # pylint: disable=wrong-import-position
+from scripts.artifacts.health import health_achievements  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+
+# 2025-09-01 00:00:00 UTC expressed as Core Data seconds (Cocoa epoch 2001-01-01).
+COCOA_2025_09_01 = 1756684800 - 978307200
+
+
+class TestCacheRecordTimestamp(unittest.TestCase):
+    """One corrupt double must not cost the examiner every cache record."""
+
+    def test_valid_timestamp_converts(self):
+        self.assertEqual(cache_record_timestamp(1756684800.0),
+                         datetime(2025, 9, 1, tzinfo=timezone.utc))
+
+    def test_post_2038_timestamp_still_converts(self):
+        """64-bit time_t values beyond 2038 are valid on every current platform."""
+        self.assertEqual(cache_record_timestamp(2 ** 33).year, 2242)
+
+    def test_absurdly_large_double_returns_none(self):
+        self.assertIsNone(cache_record_timestamp(1e300))
+
+    def test_absurdly_negative_double_returns_none(self):
+        self.assertIsNone(cache_record_timestamp(-1e18))
+
+
+class TestHealthAchievementsSchemas(unittest.TestCase):
+    """created_date must parse whether the column is REAL or TEXT."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        Context.clear()
+        Context.set_report_folder(self.tmpdir)
+
+    def tearDown(self):
+        Context.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_db(self, created_date_type, rows):
+        db_path = pathlib.Path(self.tmpdir) / 'healthdb_secure.sqlite'
+        db = sqlite3.connect(db_path)
+        db.execute(f'''CREATE TABLE ACHAchievementsPlugin_earned_instances
+                       (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+                        template_unique_name TEXT, earned_date REAL,
+                        created_date {created_date_type},
+                        value_in_canonical_unit REAL,
+                        value_canonical_unit TEXT, external_identifier TEXT,
+                        creator_device INTEGER, sync_provenance INTEGER,
+                        sync_identity INTEGER NOT NULL)''')
+        db.executemany(
+            '''INSERT INTO ACHAchievementsPlugin_earned_instances
+               (template_unique_name, earned_date, created_date,
+                value_in_canonical_unit, value_canonical_unit, creator_device,
+                sync_identity)
+               VALUES (?, ?, ?, ?, ?, ?, 1)''', rows)
+        db.commit()
+        db.close()
+        Context.set_files_found([str(db_path)])
+        return db_path
+
+    def test_real_created_date_converts_to_datetime(self):
+        """The pre-iOS-26 schema: created_date is Core Data seconds (REAL)."""
+        self._make_db('REAL', [('FirstWorkout', 730.0, float(COCOA_2025_09_01),
+                                1.0, 'count', 1)])
+        _headers, data_list, _source = health_achievements.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][0],
+                         datetime(2025, 9, 1, tzinfo=timezone.utc))
+
+    def test_text_numeric_created_date_converts_to_datetime(self):
+        """A numeric string is still a Core Data timestamp."""
+        self._make_db('TEXT', [('FirstWorkout', 730.0, str(COCOA_2025_09_01),
+                                1.0, 'count', 1)])
+        _headers, data_list, _source = health_achievements.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][0],
+                         datetime(2025, 9, 1, tzinfo=timezone.utc))
+
+    def test_text_non_numeric_created_date_passes_through(self):
+        """The iOS 26 shape that crashed the artifact: text that is not a number.
+
+        The value must survive to the report untouched rather than abort the
+        module; asserting pass-through also documents that we have not seen the
+        real text format and are not guessing a parse for it.
+        """
+        self._make_db('TEXT', [('FirstWorkout', 730.0, '2025-10-13 06:53:59',
+                                1.0, 'count', 1)])
+        _headers, data_list, _source = health_achievements.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][0], '2025-10-13 06:53:59')
+
+    def test_null_created_date_does_not_crash(self):
+        self._make_db('TEXT', [('FirstWorkout', 730.0, None, 1.0, 'count', 1)])
+        _headers, data_list, _source = health_achievements.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertIsNone(data_list[0][0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/leapp_functions/app/platform.py
+++ b/leapp_functions/app/platform.py
@@ -17,14 +17,24 @@ ILLEGAL_FILENAME_CHARS = {
     '\n': '\\n newline',
 }
 
+# ASCII control characters (0x00-0x1F, 0x7F): Windows rejects them in paths
+# with EINVAL, so they must be sanitized alongside the printable illegal set.
+# iOS extractions really do contain them, e.g. chronod icon files named
+# '╞¼\x01\x0e::com.apple.siri.heic'.
+_CONTROL_CHARS_PATTERN = '\\x00-\\x1f\\x7f'
+
+
+def _is_control_char(char):
+    return ord(char) < 0x20 or ord(char) == 0x7f
+
 
 def _illegal_filename_char_pattern():
-    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + ']'
+    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + _CONTROL_CHARS_PATTERN + ']'
 
 
 def _illegal_filepath_char_pattern():
     chars = ''.join(c for c in ILLEGAL_FILENAME_CHARS if c not in '\\/')
-    return '[' + re.escape(chars) + ']'
+    return '[' + re.escape(chars) + _CONTROL_CHARS_PATTERN + ']'
 
 
 def format_illegal_filename_chars(chars):
@@ -36,8 +46,10 @@ def format_illegal_filename_chars(chars):
 
 def illegal_chars_in_filename(filename):
     '''Return sorted illegal characters present in filename.'''
-    return sorted({c for c in filename if c in ILLEGAL_FILENAME_CHARS},
-                  key=lambda c: list(ILLEGAL_FILENAME_CHARS).index(c))
+    order = {char: index for index, char in enumerate(ILLEGAL_FILENAME_CHARS)}
+    return sorted({c for c in filename
+                   if c in ILLEGAL_FILENAME_CHARS or _is_control_char(c)},
+                  key=lambda c: order.get(c, len(order)))
 
 
 def sanitize_file_path(filename, replacement_char='_'):

--- a/scripts/artifacts/health.py
+++ b/scripts/artifacts/health.py
@@ -194,7 +194,7 @@ __artifacts_v2__ = {
                        "https://github.com/mac4n6/APOLLO",
         "author": "@KevinPagano3",
         "creation_date": "2022-08-24",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "Health",
         "notes": "",
@@ -1066,7 +1066,15 @@ def health_achievements(context):
     db_records = get_sqlite_db_records(data_source, query)
 
     for record in db_records:
-        created_timestamp = convert_cocoa_core_data_ts_to_utc(record[0])
+        # created_date is REAL (Core Data seconds) in older schemas but TEXT in
+        # newer ones (seen on iOS 26); a str value made the converter's
+        # arithmetic raise and abort the artifact. Convert numeric values
+        # (including numeric strings) and pass other text through as-is.
+        created_date = record[0]
+        try:
+            created_timestamp = convert_cocoa_core_data_ts_to_utc(float(created_date))
+        except (TypeError, ValueError):
+            created_timestamp = created_date
         data_list.append((created_timestamp, record[1], record[2], record[3],
                           record[4], record[5]))
 

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parse the interaction with meteo prevision of particular places",
         "author": "jonah.osterwalder@vd.ch",
         "creation_date": "2026-03-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "Meteo",
         "notes": "",
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
         "description": "Parse the app opening time and location",
         "author": "jonah.osterwalder@vd.ch",
         "creation_date": "2026-03-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "Meteo",
         "notes": "",
@@ -35,6 +35,7 @@ from scripts.ilapfuncs import artifact_processor, get_file_path, \
 @artifact_processor
 def plz_interaction(context):
     source_path = get_file_path(context.get_files_found(), "favorites_prediction_db.sqlite")
+    data_headers = (('Interaction Timestamp','datetime'), "Meteo of the city", "Meteo of the city (link)", "Coordinates (lat/lon)")
     data_list = []
     cursor = None
     prediction_db = ""
@@ -50,7 +51,7 @@ def plz_interaction(context):
 
     if prediction_db != "":
         query = '''
-        SELECT 
+        SELECT
             datetime(timestamp/1000, 'unixepoch') AS created_date,
             plz,
             lat,
@@ -58,7 +59,6 @@ def plz_interaction(context):
         FROM plz_interaction
         '''
 
-        data_headers = (('Interaction Timestamp','datetime'), "Meteo of the city", "Meteo of the city (link)", "Coordinates (lat/lon)")
         db_records = get_sqlite_db_records(prediction_db, query)
 
         local_data = []
@@ -67,7 +67,7 @@ def plz_interaction(context):
             cursor = db.cursor()
 
         for record in db_records:
-            local_data = get_location_infos(cursor, record[1])
+            local_data = get_location_infos(cursor, record[1]) if cursor else []
             # test for 1111 postal code case
             if len(local_data) > 0:
                 meteo_link = lv03_to_osm(local_data[0][1], local_data[0][2])
@@ -78,14 +78,15 @@ def plz_interaction(context):
                 data_list.append((record[0], local_data[0][4], meteo_link, cons_link))
             else:
                 data_list.append(record)
-
-        return data_headers, data_list, source_path
     else:
         logfunc('No Swissmeteo')
+
+    return data_headers, data_list, source_path
 
 @artifact_processor
 def swissmeteo_plz(context):
     source_path = get_file_path(context.get_files_found(), "favorites_prediction_db.sqlite")
+    data_headers = (('Opened Timestamp','datetime'), 'Latitude', 'Longitude', "Map link")
     data_list = []
     prediction_db = ""
 
@@ -96,21 +97,20 @@ def swissmeteo_plz(context):
 
     if prediction_db != "":
         query = '''
-        SELECT 
+        SELECT
             datetime(timestamp/1000, 'unixepoch') AS created_date,
             lat,
             lon
         FROM app_open
         '''
 
-        data_headers = (('Opened Timestamp','datetime'), 'Latitude', 'Longitude', "Map link")
         db_records = get_sqlite_db_records(prediction_db, query)
         for record in db_records:
             data_list.append((record[0], record[1], record[2], coordinate_to_osm(record[1], record[2])))
-
-        return data_headers, data_list, source_path
     else:
         logfunc('No app_open')
+
+    return data_headers, data_list, source_path
 
 def coordinate_to_osm(lat, lon): 
     return f"https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=15"

--- a/scripts/artifacts/webkit.py
+++ b/scripts/artifacts/webkit.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Extracts detailed information from WebKit Network Cache record files",
         "author": "@JamesHabben",
         "creation_date": "2024-10-24",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "Browser",
         "notes": "The cache record layout (timestamp, hash, response-code positions) was established through reverse engineering and is unverified against WebKit source; undeciphered fields are reported as U1-U8.",
@@ -41,6 +41,20 @@ import json
 from datetime import datetime, timezone
 from collections import OrderedDict
 from scripts.ilapfuncs import logfunc, artifact_processor, check_in_media, check_in_embedded_media
+
+def cache_record_timestamp(timestamp):
+    """Convert a cache record's double timestamp, tolerating garbage values.
+
+    Corrupt or overwritten records carry doubles far outside the platform's
+    time_t range; fromtimestamp() then raises (OverflowError/OSError/ValueError
+    depending on platform) and a single bad record used to abort the whole
+    artifact. Out-of-range values are reported as no timestamp instead.
+    """
+    try:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
 
 def read_vf(file):
     """Read a variable-length field from a file"""
@@ -134,7 +148,7 @@ def webkit_cache_records(context):
                 file_data['Filename'] = f.read(20).hex()
                 file_data['Foldername'] = f.read(20).hex()
                 timestamp = struct.unpack('<d', f.read(8))[0]
-                file_data['Timestamp'] = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+                file_data['Timestamp'] = cache_record_timestamp(timestamp)
                 file_data['Meta SHA1'] = f.read(20).hex()
                 file_data['Meta Size'] = struct.unpack('<Q', f.read(8))[0]
                 file_data['Body SHA1'] = f.read(20).hex()

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -774,8 +774,7 @@ class FileSeekerZip(FileSeekerBase):
             if pat(root + normcase(member)) is not None:
                 if member not in self.copied or force:
                     try:
-                        # already replaces illegal chars with _ when exporting
-                        extracted_path = self.zip_file.extract(member, path=self.data_folder)
+                        extracted_path = self._extract_member(member)
                         f = self.zip_file.getinfo(member)
                         creation_date, modification_date = self.decode_extended_timestamp(f.extra)
                         file_info = FileInfo(member, creation_date, modification_date)
@@ -786,6 +785,7 @@ class FileSeekerZip(FileSeekerBase):
                         self.copied[member] = extracted_path
                     except OSError as ex:
                         logfunc(f'Could not write file to filesystem, path was {member} ' + str(ex))
+                        continue
                 else:
                     extracted_path = self.copied[member]
                 pathlist.append(extracted_path)
@@ -794,6 +794,29 @@ class FileSeekerZip(FileSeekerBase):
                     return extracted_path
         self.searched[filepattern] = pathlist
         return pathlist
+
+    def _extract_member(self, member):
+        """Extract one member, sanitizing names ZipFile.extract() cannot write.
+
+        ZipFile.extract() only replaces a fixed set of printable characters
+        (:<>|"?*) and only on Windows; ASCII control characters in the stored
+        name (present in real iOS extractions, e.g. chronod icon files) reach
+        the OS untouched and Windows rejects them with EINVAL. Members whose
+        names need sanitizing are written out manually to a cleaned path.
+        """
+        clean_member = sanitize_file_path(member)
+        if clean_member == member:
+            return self.zip_file.extract(member, path=self.data_folder)
+        parts = [part for part in clean_member.split('/')
+                 if part not in ('', '.', '..')]
+        extracted_path = os.path.join(self.data_folder, *parts)
+        if member.endswith('/'):
+            os.makedirs(extracted_path, exist_ok=True)
+        else:
+            os.makedirs(os.path.dirname(extracted_path), exist_ok=True)
+            with self.zip_file.open(member) as fin, open(extracted_path, 'wb') as fout:
+                fout.write(fin.read())
+        return extracted_path
 
     def cleanup(self):
         self.zip_file.close()


### PR DESCRIPTION
## Summary

A Windows iLEAPP v2026.2.1 run over an iOS 26 full file system extraction surfaced four recurring error patterns in the process log. This PR fixes all four.

- **FileSeekerZip / filename sanitization**: zip members with ASCII control characters in their names (e.g. `chronod/icons/╞¼\x01\x0e::com.apple.siri.heic`, 81 occurrences in the case log) failed to write on Windows with `[Errno 22] Invalid argument` — `ZipFile.extract()` only sanitizes `:<>|"?*` and only on Windows. A failing member also appended the *previous* member's stale path to the seeker results. Members whose names need cleaning are now written manually to a sanitized path inside the data folder on every platform, `sanitize_file_path`/`sanitize_file_name` treat control characters (0x00-0x1F, 0x7F) as illegal, and a failed write no longer appends a stale path.
- **webkit_cache_records**: one record carrying a double outside the platform's `time_t` range raised `OverflowError` on Windows and aborted the artifact, losing every cache record in the case. Out-of-range timestamps now become `None`.
- **health_achievements**: the iOS 26 schema stores `created_date` as TEXT where older schemas used REAL Core Data seconds; `str + int` in the converter aborted the artifact. Numeric values (including numeric strings) convert; other text passes through unchanged.
- **swissmeteo (plz_interaction, swissmeteo_plz)**: when the favorites database was absent both functions returned `None` after logging, so every extraction without Swissmeteo reported `cannot unpack non-iterable NoneType object`. Both now always return `(headers, rows, source)`. Also fixed the latent None-cursor crash when `localdata.sqlite` is missing but the favorites db is present.

## Testing

- 24 new tests in three files (`test_extraction_illegal_filenames.py`, `test_timestamp_range_and_type_guards.py`, `test_swissmeteo_missing_files.py`) — synthetic zips and databases only, no image data.
- Full local suite: 161 passed, 29 skipped.
- Real-corpus verification (local, non-public images): the 69 control-char chronod icons extract cleanly with sanitized names from an iOS 26 image; `webkit_cache_records` reproduces its recorded `hc_ios18_7` baseline of 3286 rows exactly; `health_achievements` runs clean on both corpora.
- `lint_changed.py` (CI-equivalent): 0 new warnings. `check_claim_language.py`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)