### PR TITLE
Correct misleading swissmeteo_plz log message

### DIFF
--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -108,7 +108,7 @@ def swissmeteo_plz(context):
         for record in db_records:
             data_list.append((record[0], record[1], record[2], coordinate_to_osm(record[1], record[2])))
     else:
-        logfunc('No app_open')
+        logfunc('Swissmeteo favorites_prediction_db.sqlite not found')
 
     return data_headers, data_list, source_path
 


### PR DESCRIPTION
`swissmeteo_plz` logged `No app_open` when `favorites_prediction_db.sqlite` was absent — but the condition is a missing database, not a missing table. The message now names the actual missing file: `Swissmeteo favorites_prediction_db.sqlite not found`.

Same fix applied to ALEAPP's sibling artifact, which logged `No plz_interaction` under the same condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)