### PR TITLE
feat: resolve AMDSQLiteDB app names offline, drop itunes.apple.com lookup

### DIFF
--- a/admin/test/scripts/test_amdsqlitedb_offline_lookup.py
+++ b/admin/test/scripts/test_amdsqlitedb_offline_lookup.py
@@ -1,0 +1,131 @@
+"""AMDSQLiteDB usage events must resolve app names offline, from the evidence.
+
+The artifact used to query http://itunes.apple.com/lookup per unique adamId to
+name apps missing from storeUser.db current_apps. On an offline forensic
+workstation every lookup failed (103 'ERROR fetching data' lines in one case
+run), and the design sent case-derived identifiers to an external service. The
+online lookup was removed: names now come from current_apps (installed apps)
+and purchase_history_apps (the account's purchase history, which retains
+uninstalled apps), both inside the extraction.
+
+These tests pin the offline resolution order, the guard for old storeUser.db
+schemas without purchase_history_apps, the no-storeUser.db fallback, and that
+the module performs no network I/O.
+"""
+import pathlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.artifacts.AMDSQLiteDB as amd_module  # pylint: disable=wrong-import-position
+from scripts.artifacts.AMDSQLiteDB import AMDSQLiteDB_UsageEvents  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+
+TS = 1756684800  # 2025-09-01 00:00:00 UTC
+
+INSTALLED = 111111111   # in current_apps
+UNINSTALLED = 222222222  # only in purchase_history_apps
+UNRESOLVED = 333333333   # in neither
+
+
+class TestAmdSqliteDbOfflineLookup(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        Context.clear()
+        Context.set_report_folder(self.tmpdir)
+
+    def tearDown(self):
+        Context.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_amd_db(self, adam_ids):
+        db_path = pathlib.Path(self.tmpdir) / 'AMDSQLite.db.0'
+        db = sqlite3.connect(db_path)
+        db.execute('CREATE TABLE AMDAppStoreUsageEvents '
+                   '(time INTEGER, type TEXT, adamId INTEGER, appVersion TEXT, '
+                   'foregroundDuration REAL, userId INTEGER)')
+        db.executemany('INSERT INTO AMDAppStoreUsageEvents VALUES (?, "2", ?, "1.0", 12.5, 42)',
+                       [(TS, adam_id) for adam_id in adam_ids])
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def _make_store_user_db(self, with_history_table=True):
+        db_path = pathlib.Path(self.tmpdir) / 'storeUser.db'
+        db = sqlite3.connect(db_path)
+        db.execute('CREATE TABLE current_apps (item_id INTEGER, item_name TEXT, '
+                   'bundle_id TEXT, vendor_name TEXT)')
+        db.execute('INSERT INTO current_apps VALUES (?, "Installed App", '
+                   '"com.example.installed", "Example Vendor")', (INSTALLED,))
+        db.execute('CREATE TABLE account_events (account_id INTEGER, apple_id TEXT)')
+        db.execute('INSERT INTO account_events VALUES (42, "user@example.com")')
+        if with_history_table:
+            db.execute('CREATE TABLE purchase_history_apps (store_item_id INTEGER, '
+                       'title TEXT, bundle_id TEXT, developer_name TEXT)')
+            db.execute('INSERT INTO purchase_history_apps VALUES (?, "Removed App", '
+                       '"com.example.removed", "Removed Vendor")', (UNINSTALLED,))
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def _run(self, adam_ids, store_user=True, with_history_table=True):
+        files = [self._make_amd_db(adam_ids)]
+        if store_user:
+            files.append(self._make_store_user_db(with_history_table))
+        Context.set_files_found(files)
+        headers, data_list, _source = AMDSQLiteDB_UsageEvents.__wrapped__(Context)
+        name_idx = [h[0] if isinstance(h, tuple) else h for h in headers].index('App Name')
+        return headers, data_list, name_idx
+
+    def test_installed_app_resolves_from_current_apps(self):
+        _headers, rows, name_idx = self._run([INSTALLED])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][name_idx], 'Installed App')
+        self.assertEqual(rows[0][0], datetime(2025, 9, 1, tzinfo=timezone.utc))
+
+    def test_uninstalled_app_resolves_from_purchase_history(self):
+        """The case the online lookup existed for: app gone from current_apps."""
+        _headers, rows, name_idx = self._run([UNINSTALLED])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][name_idx], 'Removed App')
+        self.assertEqual(rows[0][name_idx + 1], 'com.example.removed')
+
+    def test_unknown_adam_id_is_labeled_not_dropped(self):
+        _headers, rows, name_idx = self._run([UNRESOLVED])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][name_idx], f'Unknown ({UNRESOLVED})')
+
+    def test_old_store_user_schema_without_history_table_still_runs(self):
+        _headers, rows, name_idx = self._run([INSTALLED, UNINSTALLED],
+                                             with_history_table=False)
+        self.assertEqual(len(rows), 2)
+        names = {row[name_idx] for row in rows}
+        self.assertIn('Installed App', names)
+        self.assertIn(f'Unknown ({UNINSTALLED})', names)
+
+    def test_no_store_user_db_still_runs(self):
+        _headers, rows, name_idx = self._run([INSTALLED], store_user=False)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][name_idx], f'Unknown ({INSTALLED})')
+
+    def test_row_count_matches_events_exactly(self):
+        """Resolution must never multiply or drop event rows."""
+        _headers, rows, _ = self._run([INSTALLED, INSTALLED, UNINSTALLED, UNRESOLVED])
+        self.assertEqual(len(rows), 4)
+
+    def test_module_performs_no_network_io(self):
+        """The offline guarantee: no url-opening machinery in the module."""
+        source = pathlib.Path(amd_module.__file__).read_text(encoding='utf-8')
+        for marker in ('urlopen', 'urllib.request', 'requests.get', 'http.client'):
+            self.assertNotIn(marker, source)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/AMDSQLiteDB.py
+++ b/scripts/artifacts/AMDSQLiteDB.py
@@ -4,10 +4,16 @@ __artifacts_v2__ = {
         "description": "Apple App Store application foreground events",
         "author": "@stark4n6",
         "creation_date": "2025-07-21",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "App Usage",
-        "notes": "Reference: Kevin Pagano, 'iOS App Storage Usage via AMDSQLite.db', https://www.stark4n6.com/2025/07/ios-app-storage-usage-via-amdsqlite-db.html",
+        "notes": "App names, bundle IDs and vendors are resolved from the extraction itself: "
+                 "storeUser.db current_apps (installed apps) and purchase_history_apps (the "
+                 "account's purchase history, which retains uninstalled apps). Events whose "
+                 "adamId appears in neither table are labeled Unknown. Earlier versions queried "
+                 "itunes.apple.com per adamId; the online lookup was removed so processing stays "
+                 "offline. Reference: Kevin Pagano, 'iOS App Storage Usage via AMDSQLite.db', "
+                 "https://www.stark4n6.com/2025/07/ios-app-storage-usage-via-amdsqlite-db.html",
         "paths": (
             '*/mobile/Containers/Data/PluginKitPlugin/*/Documents/AMDSQLite.db.0*',
             '*/mobile/Library/Caches/com.apple.appstored/storeUser.db*'
@@ -61,60 +67,41 @@ __artifacts_v2__ = {
     }
 }
 
-import urllib.request
-import json
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, \
+    attach_sqlite_db_readonly, does_table_exist_in_db, logfunc, convert_unix_ts_to_utc
 
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, attach_sqlite_db_readonly, logfunc, convert_unix_ts_to_utc
+def get_purchase_history(store_user_db):
+    """Map adamId -> (title, bundle_id, developer_name) from purchase_history_apps.
 
-def get_data_from_itunes(lookup_value, lookup_type):
-    response_json_data = None
-    base_url = "http://itunes.apple.com/lookup?"
-    
-    if lookup_type == "adamId":
-        url = f"{base_url}id={lookup_value}"
-    elif lookup_type == "bundleId":
-        url = f"{base_url}bundleId={lookup_value}"
-    else:
-        return f"ERROR: Invalid lookup type '{lookup_type}'. Must be 'adamId' or 'bundleId'.", None
-
-    try:
-        with urllib.request.urlopen(url) as response:
-            response_data = response.read()
-            response_json_data = json.loads(response_data)
-    except Exception:  # pylint: disable=broad-exception-caught
-        return f"\nERROR fetching data for {lookup_value} ({lookup_type})", None
-    return None, response_json_data
-
-def process_ids(item_record, data_dictionary, lookup_type):
-    if item_record not in data_dictionary:
-        error, result = get_data_from_itunes(item_record, lookup_type)
-        if error:
-            logfunc(error)
-            data_dictionary[item_record] = ''
-        else:
-            data_dictionary[item_record] = result
-    return data_dictionary
-
-def results_for_id(item_record, data_dictionary):    
-    if item_record in data_dictionary:
-        app_name = bundle_name = ''
-        data = data_dictionary[item_record]
-        if data and data.get('resultCount', 0) > 0:
-            if 'trackName' in data['results'][0]:
-                app_name = data['results'][0].get('trackName','')
-                bundle_name = data['results'][0].get('bundleId','')
-                return app_name, bundle_name
-        else:
-            return app_name, bundle_name
+    The account's purchase history covers apps that were uninstalled and are no
+    longer in current_apps, so usage events for removed apps can still be named
+    from the extraction itself. The table is absent in some older storeUser.db
+    schemas, hence the existence check.
+    """
+    history = {}
+    if not store_user_db or not does_table_exist_in_db(store_user_db, 'purchase_history_apps'):
+        return history
+    query = '''
+    select
+    store_item_id,
+    title,
+    bundle_id,
+    developer_name
+    from purchase_history_apps
+    '''
+    for row in get_sqlite_db_records(store_user_db, query):
+        if row[0] is not None and row[0] not in history:
+            history[row[0]] = (row[1], row[2], row[3])
+    return history
 
 @artifact_processor
 def AMDSQLiteDB_UsageEvents(context):
     data_list = []
-    my_data_store = {}
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, "AMDSQLite.db.0")
-    
+
     storeUserDB = get_file_path(files_found, "storeUser.db")
+    purchase_history = get_purchase_history(storeUserDB)
     
     if storeUserDB:
         logfunc("storeUser.db found. Running combined database query.")
@@ -169,23 +156,28 @@ def AMDSQLiteDB_UsageEvents(context):
 
         local_bundle_id = record[2]
         adam_id = record[3]
-        local_item_name = record[8] # The new item_name column
-        
-        # Fetch from iTunes
-        app_name_api, bundle_name_api = results_for_id(adam_id, process_ids(adam_id, my_data_store, 'adamId'))
-        
-        # Resolve Bundle ID: Local DB first, then API
-        final_bundle_id = local_bundle_id if local_bundle_id else bundle_name_api
-        
-        # Resolve App Name: API first, then Local DB, then Bundle ID as last resort
-        if app_name_api:
-            final_app_name = app_name_api
-        elif local_item_name:
-            final_app_name = local_item_name
-        else:
-            final_app_name = f"Unknown ({final_bundle_id})"
+        local_item_name = record[8]
+        local_vendor_name = record[9]
 
-        data_list.append((time, record[1], final_app_name, final_bundle_id, record[3], record[4], record[9], record[5], record[6], record[7]))
+        # Resolve name/bundle/vendor from the extraction only: current_apps
+        # first (installed apps), then the account's purchase history
+        # (uninstalled apps). Values recorded on the device at the time of the
+        # events beat a live store lookup, whose listings can be renamed or
+        # delisted after the fact.
+        history_title, history_bundle_id, history_vendor = purchase_history.get(
+            adam_id, (None, None, None))
+
+        final_bundle_id = local_bundle_id or history_bundle_id or ''
+        final_vendor_name = local_vendor_name or history_vendor or ''
+
+        if local_item_name:
+            final_app_name = local_item_name
+        elif history_title:
+            final_app_name = history_title
+        else:
+            final_app_name = f"Unknown ({final_bundle_id or adam_id})"
+
+        data_list.append((time, record[1], final_app_name, final_bundle_id, record[3], record[4], final_vendor_name, record[5], record[6], record[7]))
                             
     data_headers = (('Timestamp', 'datetime'),'App Action','App Name','Bundle ID','AdamID','App Version','Vendor Name','Foreground Duration (as stored)','Apple ID','User ID')
     return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary

`AMDSQLiteDB_UsageEvents` queried `http://itunes.apple.com/lookup` for every unique adamId missing from `storeUser.db` `current_apps`. On offline forensic workstations every lookup failed (103 `ERROR fetching data` lines in one case run), and the design sent case-derived identifiers to an external service on every run with no opt-out.

The extraction itself already carries the mapping. `storeUser.db` `purchase_history_apps` holds the account's purchase history — **including uninstalled apps, exactly the gap the online lookup existed to fill** — with `store_item_id`, `title`, `bundle_id` and `developer_name`. Resolution is now:

1. `current_apps` (installed apps) — unchanged
2. `purchase_history_apps` (uninstalled apps) — new, guarded by a table-existence check for older schemas
3. `Unknown (<adamId>)` label preserving the id for manual lookup

Names recorded on the device at the time of the events are also forensically stronger than a live store lookup, whose listings can be renamed or delisted after the fact. This was the only network I/O under `scripts/artifacts/`; the artifact codebase is now fully offline, and a test pins that.

## Testing

- Measured adamId coverage on two local images before writing the change: 45/45 and 31/31 usage-event adamIds resolved from the evidence alone (`current_apps` + `purchase_history_apps`).
- Row counts reproduce the recorded `sample_data` baselines exactly: `hc_ios18_7` 484, `otto_ios17` 3064, `fsfull002_ios17` 294. Otto retains one adamId absent from both tables (an app opened and uninstalled, never in this account's purchase history), reported as `Unknown` with the id preserved.
- 7 new tests in `admin/test/scripts/test_amdsqlitedb_offline_lookup.py` (synthetic databases only): resolution order, old-schema guard, missing-storeUser fallback, exact row-count preservation, and a static no-network-IO check.
- Full local suite: 168 passed. `lint_changed.py`: 0 new warnings. `check_claim_language.py`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)