### PR TITLE
Remove every remote destination from the HTML report

### DIFF
--- a/admin/test/scripts/test_swissmeteo_missing_files.py
+++ b/admin/test/scripts/test_swissmeteo_missing_files.py
@@ -96,14 +96,18 @@ class TestSwissmeteoMissingFiles(unittest.TestCase):
         _headers, data_list, _source = plz_interaction.__wrapped__(Context)
         self.assertEqual(len(data_list), 1)
         self.assertEqual(data_list[0][1], 'Lausanne')
-        self.assertIn('openstreetmap.org', data_list[0][2])
+        # Coordinates as text, not a map URL: a report links to nothing outside
+        # its own folder, so no openstreetmap.org destination is emitted.
+        self.assertNotIn('openstreetmap.org', data_list[0][2])
+        self.assertRegex(data_list[0][2], r'^-?\d+\.\d+, -?\d+\.\d+$')
 
     def test_swissmeteo_plz_parses_app_open_rows(self):
         Context.set_files_found([self._make_prediction_db()])
         _headers, data_list, _source = swissmeteo_plz.__wrapped__(Context)
         self.assertEqual(len(data_list), 1)
         self.assertEqual(data_list[0][1], 46.5)
-        self.assertIn('openstreetmap.org', data_list[0][3])
+        self.assertNotIn('openstreetmap.org', data_list[0][3])
+        self.assertEqual(data_list[0][3], '46.5, 6.6')
 
 
 if __name__ == '__main__':

--- a/scripts/artifacts/Oura.py
+++ b/scripts/artifacts/Oura.py
@@ -555,8 +555,9 @@ def oura_find_my_ring_location(context):
     if isinstance(loc, dict) and "latitude" in loc and "longitude" in loc:
         lat = loc.get("latitude", "")
         lon = loc.get("longitude", "")
-        map_link = (f'<a href="https://www.google.com/maps?q={esc(lat)},{esc(lon)}" '
-                    f'target="_blank">View on map</a>') if lat != "" and lon != "" else ""
+        # Coordinates as text, not a google.com/maps anchor: a report links to
+        # nothing outside its own folder.
+        map_link = f'{esc(lat)}, {esc(lon)}' if lat != "" and lon != "" else ""
         data_list.append((
             ts_cocoa(loc.get("timestamp")),
             lat,

--- a/scripts/artifacts/appleMapsTrips.py
+++ b/scripts/artifacts/appleMapsTrips.py
@@ -101,32 +101,37 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 from scripts.html_safe import esc
 
 def get_google_map_link(latitude_value, longitude_value):
+    """Return the coordinates as escaped text.
+
+    This was a live google.com/maps anchor. A report links to nothing outside its own
+    folder, so the coordinates are reported as the data they are; an examiner who
+    wants a map pastes them into one deliberately.
+    """
     if latitude_value is None or longitude_value is None:
         return ""
 
-    lat = esc(latitude_value)
-    lon = esc(longitude_value)
-    return f"<a href='https://www.google.com/maps?q={lat},{lon}' target='_blank'>https://www.google.com/maps?q={lat},{lon}</a>"
+    return f"{esc(latitude_value)}, {esc(longitude_value)}"
 
 def get_google_dir_link(o_latitude_value, o_longitude_value, d_latitude_value, d_longitude_value, mode):
+    """Return the origin, destination and travel mode as escaped text.
+
+    Formerly a google.com/maps directions anchor; see get_google_map_link().
+    """
     if o_latitude_value is None or o_longitude_value is None or d_latitude_value is None or d_longitude_value is None:
         return ""
 
-    base_url = "https://www.google.com/maps/dir/?api=1"
-    origin = f"&origin={esc(o_latitude_value)},{esc(o_longitude_value)}"
-    destination = f"&destination={esc(d_latitude_value)},{esc(d_longitude_value)}"
+    origin = f"{esc(o_latitude_value)}, {esc(o_longitude_value)}"
+    destination = f"{esc(d_latitude_value)}, {esc(d_longitude_value)}"
 
     # Travel mode
     if mode == 1:
-        travel_mode = "&travelmode=walking"
+        travel_mode = " (walking)"
     elif mode == 4:
-        travel_mode = "&travelmode=driving"
+        travel_mode = " (driving)"
     else:
         travel_mode = ""
 
-    url = base_url + origin + destination + travel_mode
-
-    return f"<a href='{url}' target='_blank'>{url}</a>"
+    return f"From {origin} to {destination}{travel_mode}"
 
 @artifact_processor
 def appleMapsTrips(context):

--- a/scripts/artifacts/booking.py
+++ b/scripts/artifacts/booking.py
@@ -383,14 +383,10 @@ def format_url(str_url : str | None, html_format : bool = False) -> str:
         return s
 
     if html_format:
-        # Escape both the href and the visible text to prevent XSS
-        safe_href = html.escape(normalized, quote=True)
-        safe_text = html.escape(normalized, quote=False)
-        # Add rel="noopener noreferrer" with target="_blank" to prevent tabnabbing
-        return (
-            f'<a href="{safe_href}" target="_blank" '
-            f'rel="noopener noreferrer">{safe_text}</a>'
-        )
+        # Escaped text, never an anchor: the host in a Booking URL comes from the
+        # evidence, and a report must not reach a destination outside its own
+        # folder. The URL is preserved verbatim for the examiner to read and copy.
+        return html.escape(normalized, quote=False)
 
     return normalized
 

--- a/scripts/artifacts/box.py
+++ b/scripts/artifacts/box.py
@@ -195,14 +195,10 @@ def format_url(str_url : str | None, html_format : bool = False) -> str:
         return s
 
     if html_format:
-        # Escape both the href and the visible text to prevent XSS
-        safe_href = html.escape(normalized, quote=True)
-        safe_text = html.escape(normalized, quote=False)
-        # Add rel="noopener noreferrer" with target="_blank" to prevent tabnabbing
-        return (
-            f'<a href="{safe_href}" target="_blank" '
-            f'rel="noopener noreferrer">{safe_text}</a>'
-        )
+        # Escaped text, never an anchor: the host in a Box URL comes from the
+        # evidence, and a report must not reach a destination outside its own
+        # folder. The URL is preserved verbatim for the examiner to read and copy.
+        return html.escape(normalized, quote=False)
 
     return normalized
 

--- a/scripts/artifacts/calendarAll.py
+++ b/scripts/artifacts/calendarAll.py
@@ -296,11 +296,9 @@ def calendarEvents(context):
                     location_coordinates = f'{latitude}, {longitude}' if latitude and longitude else ''
 
                     if latitude and longitude:
-                        location_coordinates_tag = f'''
-                        {esc(location_coordinates)} &nbsp;
-                        <a href="https://www.openstreetmap.org/?lat={esc(latitude)}&lon=%20{esc(longitude)}&zoom=17&layers=M" target="_blank">
-                        &#x1F5FA;</a>
-                        '''
+                        # Coordinates only. This carried an openstreetmap.org anchor;
+                        # a report links to nothing outside its own folder.
+                        location_coordinates_tag = esc(location_coordinates)
                     else:
                         location_coordinates_tag = ''
 

--- a/scripts/artifacts/foursquareSwarm.py
+++ b/scripts/artifacts/foursquareSwarm.py
@@ -464,19 +464,11 @@ def format_url(str_url: str | None, html_format: bool = False, label: str | None
     # Visible text: label or raw URL
     visible = label if label else s
 
-    # HTML rendering
+    # HTML rendering: escaped text, never an anchor. The host in a Foursquare URL
+    # comes from the evidence, and a report must not reach a destination outside its
+    # own folder. The URL is preserved verbatim for the examiner to read and copy.
     if html_format:
-        safe_text = html.escape(visible, quote=False)
-
-        if is_clickable:
-            safe_href = html.escape(s, quote=True)
-            return (
-                f'<a href="{safe_href}" target="_blank" '
-                f'rel="noopener noreferrer">{safe_text}</a>'
-            )
-
-        # Non-clickable: return escaped plain text — evidence preserved
-        return safe_text
+        return html.escape(visible, quote=False)
 
     # Plain text rendering
     if is_clickable and label:

--- a/scripts/artifacts/sbbmobile.py
+++ b/scripts/artifacts/sbbmobile.py
@@ -10,7 +10,6 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/ch.sbb.coredata.searchhistory.sqlite*'),
         "output_types": "standard",
-        "html_columns": ['Result Coordinates (link)'],
         "artifact_icon": "search"
     },
     "sbb_easyride_trips": {
@@ -74,16 +73,16 @@ def sbb_searchhistory(context):
         'Departure type', 
         'Target', 
         'Target type', 
-        'Result Coordinates (link)',
+        'Result Coordinates (lat/lon)',
     )
 
     db_records = get_sqlite_db_records(source_path, query)
 
     for record in db_records:
 
-        # Create map link
+        # Coordinates as text
         if record[5] and record[6]:
-            map_link = coordinate_to_osm(record[5]/1_000_000, record[6]/1_000_000)
+            map_link = coordinate_to_text(record[5]/1_000_000, record[6]/1_000_000)
         else:
             map_link = ""
 
@@ -244,5 +243,10 @@ def parse_ticket_html(html):
     return data
 
 
-def coordinate_to_osm(lat, lon): 
-    return f"https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=15"
+def coordinate_to_text(lat, lon):
+    """Return the coordinates as text.
+
+    This built an openstreetmap.org URL. A report links to nothing outside its own
+    folder, so the coordinates are reported as the data they are.
+    """
+    return f"{lat}, {lon}"

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -10,7 +10,6 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/databases/favorites_prediction_db.sqlite*', '*/mobile/Containers/Data/Application/*/Documents/localdata.sqlite*'),
         "output_types": "standard",
-        "html_columns": ['Meteo of the city (link)', 'Coordinates (lat/lon)'],
         "artifact_icon": "flag"
     },
     "swissmeteo_plz": {
@@ -24,7 +23,6 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/databases/favorites_prediction_db.sqlite*', '*/mobile/Containers/Data/Application/*/Documents/localdata.sqlite*'),
         "output_types": "all",
-        "html_columns": ['Map link'],
         "artifact_icon": "flag"
     }
 }
@@ -35,7 +33,7 @@ from scripts.ilapfuncs import artifact_processor, get_file_path, \
 @artifact_processor
 def plz_interaction(context):
     source_path = get_file_path(context.get_files_found(), "favorites_prediction_db.sqlite")
-    data_headers = (('Interaction Timestamp','datetime'), "Meteo of the city", "Meteo of the city (link)", "Coordinates (lat/lon)")
+    data_headers = (('Interaction Timestamp','datetime'), "Meteo of the city", "Meteo of the city (lat/lon)", "Coordinates (lat/lon)")
     data_list = []
     cursor = None
     prediction_db = ""
@@ -70,11 +68,11 @@ def plz_interaction(context):
             local_data = get_location_infos(cursor, record[1]) if cursor else []
             # test for 1111 postal code case
             if len(local_data) > 0:
-                meteo_link = lv03_to_osm(local_data[0][1], local_data[0][2])
+                meteo_link = lv03_to_text(local_data[0][1], local_data[0][2])
                 if not (record[2] and record[3]):
                     cons_link = ''
                 else:
-                    cons_link = coordinate_to_osm(record[2], record[3])
+                    cons_link = coordinate_to_text(record[2], record[3])
                 data_list.append((record[0], local_data[0][4], meteo_link, cons_link))
             else:
                 data_list.append(record)
@@ -86,7 +84,7 @@ def plz_interaction(context):
 @artifact_processor
 def swissmeteo_plz(context):
     source_path = get_file_path(context.get_files_found(), "favorites_prediction_db.sqlite")
-    data_headers = (('Opened Timestamp','datetime'), 'Latitude', 'Longitude', "Map link")
+    data_headers = (('Opened Timestamp','datetime'), 'Latitude', 'Longitude', "Coordinates (lat/lon)")
     data_list = []
     prediction_db = ""
 
@@ -106,16 +104,21 @@ def swissmeteo_plz(context):
 
         db_records = get_sqlite_db_records(prediction_db, query)
         for record in db_records:
-            data_list.append((record[0], record[1], record[2], coordinate_to_osm(record[1], record[2])))
+            data_list.append((record[0], record[1], record[2], coordinate_to_text(record[1], record[2])))
     else:
         logfunc('Swissmeteo favorites_prediction_db.sqlite not found')
 
     return data_headers, data_list, source_path
 
-def coordinate_to_osm(lat, lon): 
-    return f"https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=15"
+def coordinate_to_text(lat, lon):
+    """Return the coordinates as text.
 
-def lv03_to_osm(E, N): 
+    This built an openstreetmap.org URL. A report links to nothing outside its own
+    folder, so the coordinates are reported as the data they are.
+    """
+    return f"{lat}, {lon}"
+
+def lv03_to_text(E, N): 
     # based on https://github.com/ValentinMinder/Swisstopo-WGS84-LV03/blob/master/scripts/py/wgs84_ch1903.py
     y, x = (E-600000)/1e6, (N-200000)/1e6
     lat = (16.9023892 + (3.238272 * x)) + \
@@ -128,7 +131,7 @@ def lv03_to_osm(E, N):
                 + (0.1306 * y * pow(x, 2))) + \
                 - (0.0436 * pow(y, 3))
     lat, lon = lat*100/36, lon*100/36
-    return f"https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=15"
+    return f"{lat}, {lon}"
 
 def get_location_infos(cursor, NPA):
     query = '''

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -69,7 +69,7 @@ from scripts.ilapfuncs import (
     artifact_processor,
     logfunc
     )
-from scripts.html_safe import esc
+from scripts.html_safe import safe_local_link
 
 ASCII_STRINGS_RE = re.compile(rb'[\x20-\x7e]{4,}')
 _extraction_cache = {}
@@ -155,10 +155,10 @@ def process_journal_files(context):
         relative_output_path = (
             f'{os.path.basename(report_folder)}/{output_filename}'
         )
-        report_link = (
-            f'<a href="{esc(relative_output_path)}" target="_blank" '
-            f'style="color:blue">{esc(journal_name)}</a>'
-        )
+        # Report-relative: this points at a file written beside the report, so it
+        # stays clickable. safe_local_link() refuses anything that would leave the
+        # report folder.
+        report_link = safe_local_link(relative_output_path, journal_name)
         summary_row = (
             relative_output_path,
             journal_name,

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -445,19 +445,11 @@ def format_url(str_url: str | None, html_format: bool = False, label: str | None
     # Visible text: label or raw URL
     visible = label if label else s
 
-    # HTML rendering
+    # HTML rendering: escaped text, never an anchor. The host in a Waze URL comes
+    # from the evidence, and a report must not reach a destination outside its own
+    # folder. The URL is preserved verbatim for the examiner to read and copy.
     if html_format:
-        safe_text = html.escape(visible, quote=False)
-
-        if is_clickable:
-            safe_href = html.escape(s, quote=True)
-            return (
-                f'<a href="{safe_href}" target="_blank" '
-                f'rel="noopener noreferrer">{safe_text}</a>'
-            )
-
-        # Non-clickable: return escaped plain text — evidence preserved
-        return safe_text
+        return html.escape(visible, quote=False)
 
     # Plain text rendering
     if is_clickable and label:

--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -8,16 +8,26 @@ HTML/JavaScript injection sink: malicious content in a parsed return renders liv
 the examiner's report (stored XSS, CWE-79).
 
 Route every evidence-derived value in an ``html_columns`` cell through these helpers so
-the dynamic parts are escaped while the tool's own structural markup (``<a>``, ``<br>``,
+the dynamic parts are escaped while the tool's own structural markup (``<br>``,
 ``<table>``) is preserved.
+
+**A report links to nothing outside its own folder.** A remote destination in a
+report is a disclosure channel: an ``<img src="https://...">`` is fetched the moment
+the report is opened, with no click, which tells whoever controls that host that the
+account is under examination, when, and from which IP address. An ``<a href>`` needs a
+click but reaches the same place. Reports are read on analyst workstations and mailed
+to counsel, so no ``href`` or ``src`` may leave the report folder -- not ``http``,
+``https``, ``ftp``, and not ``mailto``/``tel``, which hand the subject's own address or
+number to a mail client or dialer.
+
+Evidence URLs are still *evidence*, so nothing is dropped: they are rendered as escaped
+text the examiner can read and copy. Only the anchor goes away. Report-relative
+destinations -- ``media/<file>`` thumbnails, files an artifact writes beside the report
+-- stay clickable through ``safe_local_link()``; they resolve offline and reach nothing.
 """
 
 import html
 from urllib.parse import urlparse
-
-# Schemes we are willing to turn into a live <a href>. Anything else (notably
-# javascript: and data:) is rendered as escaped text, never as a clickable link.
-ALLOWED_URL_SCHEMES = ('http', 'https', 'mailto', 'tel', 'ftp', 'ftps')
 
 
 def esc(value):
@@ -31,25 +41,42 @@ def esc(value):
     return html.escape(str(value), quote=True)
 
 
-def safe_url(url, text=None, target='_blank'):
-    """Build an ``<a href>`` anchor with an escaped, scheme-checked href.
+def safe_url(url, text=None, target=None):      # pylint: disable=unused-argument
+    """Render an evidence URL as escaped text. **Never returns a link.**
 
-    Returns the escaped visible text with **no** anchor when the URL is empty or its
-    scheme is not allowlisted, so ``javascript:``/``data:`` URLs never become live
-    links. ``text`` (the visible label) defaults to the URL itself.
+    A URL read out of an extraction names a host chosen by whoever wrote the data, so
+    it is exactly the destination a report must not reach; see the module docstring.
+    The URL itself is evidence and is preserved verbatim as escaped text, so an
+    examiner can read it, copy it, and open it deliberately elsewhere.
+
+    ``text`` overrides the visible string when the caller has a better label than the
+    raw URL. ``target`` is accepted and ignored: it exists so the call sites that
+    passed it before this became text-only keep working.
     """
     url = '' if url is None else str(url).strip()
-    label = esc(text if text is not None else url)
-    if not url:
+    return esc(text if text is not None else url)
+
+
+def safe_local_link(path, text=None):
+    """Build an ``<a href>`` to a file inside the report folder.
+
+    This is the only helper that still emits an anchor. The destination must be
+    report-relative -- no scheme, no protocol-relative ``//host``, no absolute path,
+    and no ``..`` escaping the folder -- so following it can never leave the report.
+    Anything else is returned as escaped text with no anchor.
+    """
+    path = '' if path is None else str(path).strip()
+    label = esc(text if text is not None else path)
+    if not path:
+        return label
+    if path.startswith(('/', '\\', '//')) or '..' in path.replace('\\', '/').split('/'):
         return label
     try:
-        scheme = urlparse(url).scheme.lower()
+        if urlparse(path).scheme:
+            return label
     except ValueError:
         return label
-    if scheme not in ALLOWED_URL_SCHEMES:
-        return label
-    rel = ' rel="noopener noreferrer"' if target == '_blank' else ''
-    return f'<a href="{esc(url)}" target="{esc(target)}"{rel}>{label}</a>'
+    return f'<a href="{esc(path)}" target="_blank">{label}</a>'
 
 
 def safe_join(values, sep='<br>'):


### PR DESCRIPTION
## Why

A remote `href` or `src` in a report is a disclosure channel. An `<img src="https://...">` is fetched the moment the report is opened, with no click, which tells whoever controls that host that the account is under examination, when, and from which IP address. An `<a href>` needs a click but reaches the same place.

Reports are read on analyst workstations and mailed to counsel, so a report should reach nothing outside its own folder.

## What changed

`safe_url()` no longer builds an anchor. It returns the URL as **escaped text**, so the evidence stays readable and copyable while the destination goes away. The scheme allowlist it used to gate anchors on goes with them. Callers that passed `target=` still work; the argument is ignored.

`safe_local_link()` is added for the destinations that stay: report-relative paths. It refuses a scheme, a protocol-relative `//host`, an absolute path, and any `..` segment, so following a report link can never leave the report folder.

Artifact changes are all in the `html_format` branch only. The plain `data_list` that feeds TSV, timeline and LAVA is untouched.

| Artifact | Before | After |
|---|---|---|
| `box`, `booking`, `foursquareSwarm`, `waze` | `format_url()` anchored a URL read from the app | escaped text |
| `BeReal`, `burnerCache` | delegate to `safe_url()` | fixed by the helper change |
| `appleMapsTrips`, `Oura`, `calendarAll` | google.com/maps and openstreetmap.org anchors | the coordinates themselves |
| `swissmeteo`, `sbbmobile` | bare openstreetmap.org URL in an `html_columns` cell | coordinates, and `html_columns` dropped |
| `walStrings` | hand-built anchor to a file beside the report | stays clickable via `safe_local_link()` |

`swissmeteo` and `sbbmobile` are worth a note: those cells were never anchors, because the report writer does no autolinking, so they already rendered as text. Dropping `html_columns` removes the no-escape sink entirely rather than guarding it. `coordinate_to_osm`/`lv03_to_osm` are renamed to `coordinate_to_text`/`lv03_to_text`, and the column headers no longer say "link".

`mailto:` and `tel:` are treated as remote too. They do not fetch, but they hand the subject's own address or number to a mail client or dialer, and a stray click in front of counsel is its own kind of incident.

## What examiners will notice

Map links become coordinates; evidence URLs become selectable text. No evidence is lost anywhere, only the anchors.

## Validation

- `py_compile` clean on all changed files
- `pylint --disable=C,R` introduces no new warnings (`E0401` import-error is pre-existing environment noise, 5 on an untouched file)
- `PluginLoader` loads 816 plugins, every changed module present
- `safe_url` returns no anchor for `https`/`http`/`mailto`/`tel`/`ftp`/`javascript:` payloads
- `safe_local_link` anchors only report-relative paths, rejecting scheme, `//host`, absolute and `..` targets
- Repo-wide AST scan reports 0 remaining remote destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)