### PR TITLE
Improve iOS app snapshot reporting and interpretation

### DIFF
--- a/admin/test/scripts/test_app_snapshots.py
+++ b/admin/test/scripts/test_app_snapshots.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Focused regression tests for App Snapshots path and manifest joins."""
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.artifacts.appSnapshots import (
+    _bundle_id_from_path,
+    _manifest_record,
+    _snapshot_group_from_path,
+)
+
+
+class AppSnapshotPathTest(unittest.TestCase):
+    def test_bundle_directory_wins_over_scene_directory(self):
+        path = Path(
+            '/private/var/mobile/Library/SplashBoard/Snapshots/com.apple.camera/'
+            'sceneID:com.apple.camera-default/ABC@3x.ktx')
+        self.assertEqual(_bundle_id_from_path(path), 'com.apple.camera')
+
+    def test_scene_only_layout_yields_bundle_identifier(self):
+        path = Path(
+            '/private/var/mobile/Containers/Data/Application/UUID/Library/SplashBoard/'
+            'Snapshots/sceneID:com.google.Keep-default/ABC@3x.ktx')
+        self.assertEqual(_bundle_id_from_path(path), 'com.google.Keep')
+
+    def test_scene_identifier_suffix_is_not_part_of_bundle(self):
+        path = Path(
+            '/private/var/mobile/Containers/Data/Application/UUID/Library/SplashBoard/'
+            'Snapshots/sceneID:com.example.app-19F2E62F-A756-4397-9E92-2DD765BDB306/'
+            'ABC@3x.ktx')
+        self.assertEqual(_bundle_id_from_path(path), 'com.example.app')
+
+    def test_downscaled_variant_keeps_owning_scene(self):
+        path = Path(
+            '/private/var/mobile/Library/SplashBoard/Snapshots/com.apple.camera/'
+            'sceneID:com.apple.camera-default/downscaled/ABC@3x.ktx')
+        self.assertEqual(
+            _snapshot_group_from_path(path),
+            'sceneID:com.apple.camera-default')
+
+
+class AppSnapshotManifestJoinTest(unittest.TestCase):
+    def test_duplicate_filename_prefers_matching_bundle_and_group(self):
+        wanted = SimpleNamespace(
+            bundleID='com.example.two', snapshot_group='sceneID:com.example.two-default')
+        other = SimpleNamespace(
+            bundleID='com.example.one', snapshot_group='sceneID:com.example.one-default')
+        index = {'ABC@3x.ktx': [other, wanted]}
+
+        result = _manifest_record(
+            index,
+            Path('/Snapshots/sceneID:com.example.two-default/ABC@3x.ktx'),
+            'com.example.two',
+            'sceneID:com.example.two-default')
+
+        self.assertIs(result, wanted)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/appSnapshots.py
+++ b/scripts/artifacts/appSnapshots.py
@@ -1,19 +1,28 @@
 __artifacts_v2__ = {
     "applicationSnapshots": {
         "name": "App Snapshots",
-        "description": "Snapshots saved by iOS for individual apps appear here. KTX files smaller than 2500 bytes are skipped. \
-            Dates and times shown are from file modified timestamps",
-        "author": "@ydkhatri",
+        "description": "Snapshots saved by iOS for individual apps. KTX images are converted to PNG for display, and \
+            XBApplicationSnapshotManifest metadata is joined when applicationState.db is available. KTX files smaller \
+            than 2500 bytes are skipped.",
+        "author": "@ydkhatri - @AlexisBrignoni",
         "creation_date": "2020-07-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-06",
         "requirements": "none",
         "category": "Installed Apps",
-        "notes": "",
+        "notes": "Apple explains that UIKit takes a scene snapshot after an app enters the background for display in "
+                 "the app switcher. Apps may deliberately hide or replace sensitive content before capture, so an "
+                 "image can be a launch/default screen or privacy overlay and should not by itself be treated as proof "
+                 "that the user viewed the depicted content. File Modified Date is source-file metadata; Manifest "
+                 "Creation Date and Manifest Last Used Date are separate fields stored by SplashBoard. Reference: "
+                 "https://developer.apple.com/documentation/uikit/preparing-your-ui-to-run-in-the-background ; "
+                 "foundational research: https://gforce4n6.blogspot.com/2019/09/a-quick-look-into-ios-snapshots.html "
+                 "and https://abrignoni.blogspot.com/2019/09/ios-snapshots-triage-parser-working.html",
         "paths": (
             '*/Library/Caches/Snapshots/*.ktx', 
             '*/Library/Caches/Snapshots/*.jpeg', 
             '*/SplashBoard/Snapshots/*.ktx', 
-            '*/SplashBoard/Snapshots/*.jpeg'),
+            '*/SplashBoard/Snapshots/*.jpeg',
+            '*/mobile/Library/FrontBoard/applicationState.db*'),
         "output_types": "standard",
         "artifact_icon": "package",
         "sample_data": {
@@ -36,15 +45,19 @@ __artifacts_v2__ = {
     },
 }
 
+from collections import defaultdict
 from pathlib import Path
+import re
+import sqlite3
 
 from PIL import Image
+from scripts.artifacts.applicationStateDB import _get_snapshots
 from scripts.ktx.ios_ktx2png import KTX_reader
 from scripts.ilapfuncs import artifact_processor, check_in_media, lava_get_full_media_info, logfunc, convert_unix_ts_to_utc
 
 
 def save_ktx_to_png_if_valid(ktx_path, save_to_path):
-    '''Excludes all white or all black blank images'''
+    '''Convert a valid iOS KTX image to PNG.'''
 
     with open(ktx_path, 'rb') as f:
         ktx = KTX_reader()
@@ -67,38 +80,145 @@ def save_ktx_to_png_if_valid(ktx_path, save_to_path):
     return False
 
 
+def _bundle_id_from_path(media_path):
+    """Return the bundle directory immediately below a Snapshots directory."""
+
+    parts = media_path.parts
+    for idx in range(len(parts) - 1, -1, -1):
+        if parts[idx] == 'Snapshots' and idx + 1 < len(parts):
+            bundle_id = parts[idx + 1]
+            bundle_id = bundle_id.split(' - {', 1)[0]
+            if bundle_id.startswith(('sceneID:', 'sceneID_')):
+                bundle_id = bundle_id[len('sceneID:'):]
+                bundle_id = re.sub(
+                    r'-(?:default|[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})$',
+                    '',
+                    bundle_id,
+                )
+            return bundle_id
+
+    # Fallback for an unexpected layout. The parent is normally either the
+    # snapshot group or its downscaled variant directory.
+    group_path = media_path.parent.parent if media_path.parent.name == 'downscaled' else media_path.parent
+    group_name = group_path.name.replace('sceneID:', '').replace('sceneID_', '')
+    return group_name.split(' - {', 1)[0].rsplit('-default', 1)[0]
+
+
+def _snapshot_group_from_path(media_path):
+    """Return the group or scene directory that contains a snapshot."""
+
+    group_path = media_path.parent.parent if media_path.parent.name == 'downscaled' else media_path.parent
+    return group_path.name.replace('sceneID_', 'sceneID:')
+
+
+def _manifest_index(files_found):
+    """Index XBApplicationSnapshotManifest rows by their relative filename."""
+
+    db_path = next((path for path in files_found if Path(path).name == 'applicationState.db'), None)
+    index = defaultdict(list)
+    if not db_path:
+        return index
+
+    try:
+        for snapshot in _get_snapshots(db_path):
+            if snapshot.relativePath:
+                index[Path(snapshot.relativePath).name].append(snapshot)
+    except (OSError, ValueError, sqlite3.Error) as ex:
+        logfunc(f'Unable to parse snapshot metadata from applicationState.db: {ex}')
+    return index
+
+
+def _manifest_record(index, media_path, bundle_id, snapshot_group):
+    """Find the manifest record for an image, tolerating sanitized ZIP paths."""
+
+    candidates = index.get(media_path.name, ())
+    if len(candidates) == 1:
+        return candidates[0]
+
+    for candidate in candidates:
+        if candidate.bundleID == bundle_id and candidate.snapshot_group == snapshot_group:
+            return candidate
+    for candidate in candidates:
+        if candidate.bundleID == bundle_id:
+            return candidate
+    return None
+
+
 @artifact_processor
 def applicationSnapshots(context): #files_found, report_folder, seeker, wrap_text, timezone_offset):
     # artifact_info = inspect.stack()[0]
     data_list = []
-    
-    for file_found in context.get_files_found():
+
+    files_found = context.get_files_found()
+    manifest_index = _manifest_index(files_found)
+
+    for file_found in files_found:
         media_path = Path(file_found)
-        parts = media_path.parts
-        if parts[-2] != 'downscaled':
-            app_name = parts[-2].split(' ')[0].replace("sceneID:", "")
-        else:
-            app_name = parts[-3].split(' ')[0].replace("sceneID:", "")
-        dash_pos = app_name.find('-') 
-        if dash_pos > 0:
-            app_name = app_name[0:dash_pos]
-        if file_found.lower().endswith('.ktx'):
-            if media_path.stat().st_size < 2500: # too small, they are blank
+        suffix = media_path.suffix.lower()
+        if suffix not in ('.ktx', '.jpeg'):
+            continue
+
+        bundle_id = _bundle_id_from_path(media_path)
+        snapshot_group = _snapshot_group_from_path(media_path)
+        variant = 'downscaled' if media_path.parent.name == 'downscaled' else 'default'
+        manifest = _manifest_record(manifest_index, media_path, bundle_id, snapshot_group)
+        if manifest and manifest.bundleID:
+            bundle_id = manifest.bundleID
+
+        if suffix == '.ktx':
+            # Preserve the artifact's established lower-size threshold. Some
+            # very small files are incomplete or do not contain a useful image.
+            if media_path.stat().st_size < 2500:
                 continue
             png_path = media_path.with_suffix((".png"))
             if save_ktx_to_png_if_valid(media_path, png_path):
-                media_item = check_in_media(file_found, app_name, png_path)
+                media_item = check_in_media(
+                    file_found,
+                    bundle_id,
+                    png_path,
+                    force_type='image/png',
+                    force_extension='png',
+                )
             else:
                 continue
         else:
-            media_item = check_in_media(file_found, app_name)
+            media_item = check_in_media(
+                file_found,
+                bundle_id,
+                force_type='image/jpeg',
+                force_extension='jpeg',
+            )
         
         if not media_item:
             continue
             
         last_modified_date = convert_unix_ts_to_utc(lava_get_full_media_info(media_item)['updated_at'])
-        data_list.append([last_modified_date, app_name, context.get_relative_path(file_found), media_item])
-    
-    data_headers = (('Date Modified', 'datetime'), 'App Name', 'Source Path', ('Snapshot', 'media'))
+        creation_date = manifest.creationDate if manifest else ''
+        last_used_date = manifest.lastUsedDate if manifest else ''
+        manifest_group = manifest.snapshot_group if manifest else snapshot_group
+        identifier = manifest.identifier if manifest else media_path.stem.split('@', 1)[0]
+        data_list.append([
+            last_modified_date,
+            creation_date,
+            last_used_date,
+            bundle_id,
+            manifest_group,
+            identifier,
+            variant,
+            context.get_relative_path(file_found),
+            media_item,
+        ])
+
+    data_headers = (
+        ('File Modified Date', 'datetime'),
+        ('Manifest Creation Date', 'datetime'),
+        ('Manifest Last Used Date', 'datetime'),
+        'Bundle ID',
+        'Snapshot Group',
+        'Snapshot Identifier',
+        'Variant',
+        'Source Path',
+        ('Snapshot', 'media'),
+    )
 
     return data_headers, data_list, 'see Source Path for more info'

--- a/scripts/artifacts/applicationStateDB.py
+++ b/scripts/artifacts/applicationStateDB.py
@@ -6,18 +6,15 @@ bundleIdentifier, bundlePath and sandboxPath. This new version includes a
 refactored version of the original plugin and adds support for
 XBApplicationSnapshotManifest BLOBs in applicationState.db records.
 
-Initial experiments on an iPhone 8 with iOS version 16.7.7 indicate that the
-timestamps in these BLOBs are only stored or updated at a moment when a user
-interacts with a device, for example when switching between apps using the app
-selector. Note that the timestamps do not necessarily reflect the moment at
-which the corresponding app was actively used in the foreground, so be careful
-with the interpretation of these records.
-
-When the device in our experiment was left untouched for a period of hours or
-days, the timestamps were not updated. This indicates that the timestamps can
-be used to investigate hypothesis concerning user-activity at the specific time
-periods. A write-up of our experiments will be published online at which point
-a link will be added to this plugin.
+SplashBoard names the two persisted timestamp properties creationDate and
+lastUsedDate. Runtime-derived SplashBoard headers expose both properties but do
+not document their forensic meaning. Where source file timestamps were available
+in the tested iOS 18 and iOS 26 extractions, creationDate agreed with the
+corresponding snapshot file's UTC modified time to the precision available in
+the extraction ZIP. In contrast, lastUsedDate is sparse and may be updated well
+after creationDate. Neither field by itself proves that the application was
+active in the foreground or that the user viewed the image contents at that
+time.
 
 The XBApplicationSnapshotManifest BLOBs in applicationState.db are
 related to .ktx files, for which support is also already available in iLEAPP in
@@ -29,6 +26,8 @@ Related work:
 
     https://abrignoni.blogspot.com/2019/09/ios-snapshots-triage-parser-working.html
     https://gforce4n6.blogspot.com/2019/09/a-quick-look-into-ios-snapshots.html
+    https://github.com/nst/iOS-Runtime-Headers/blob/master/PrivateFrameworks/SplashBoard.framework/XBApplicationSnapshot.h
+    https://developer.apple.com/documentation/uikit/preparing-your-ui-to-run-in-the-background
 '''
 
 
@@ -65,17 +64,19 @@ __artifacts_v2__ = {
     },
     "get_snapshot_creationDate": {
         "name": "Application Snapshot",
-        "description": "Extract XBApplicationSnapshotManifest records from applicationState.db. "
-                       "NOTE: these timestamps do not always indicate application usage "
-                       "but experiments on an iPhone 8 with iOS 16.7.7 suggest that these "
-                       "timestamps do indicate user-interaction with the "
-                       "device, such as switching between apps.",
-        "author": "@mxkrt",
+        "description": "Extract XBApplicationSnapshotManifest records from applicationState.db, using the stored "
+                       "creationDate as the primary timestamp. The value records snapshot-object creation; it does "
+                       "not by itself prove foreground application use or that the user viewed the image contents.",
+        "author": "@mxkrt - @AlexisBrignoni",
         "creation_date": "2025-08-04",
-        "last_update_date": "2025-10-24",
+        "last_update_date": "2026-08-06",
         "requirements": "none",
         "category": "Device Usage",
-        "notes": "",
+        "notes": "SplashBoard runtime headers expose creationDate and lastUsedDate properties on "
+                 "XBApplicationSnapshot. Apple documents that UIKit creates app-switcher snapshots after a scene "
+                 "enters the background and that applications may hide sensitive content before capture. Sources: "
+                 "https://github.com/nst/iOS-Runtime-Headers/blob/master/PrivateFrameworks/SplashBoard.framework/XBApplicationSnapshot.h ; "
+                 "https://developer.apple.com/documentation/uikit/preparing-your-ui-to-run-in-the-background",
         "paths": ('*/mobile/Library/FrontBoard/applicationState.db*'),
         "output_types": "standard",
         "artifact_icon": "device-mobile",
@@ -100,17 +101,18 @@ __artifacts_v2__ = {
     "get_snapshot_lastUsedDate": {
         "name": "Application Snapshot lastUsedDate",
         "description": "Extract XBApplicationSnapshotManifest records with a "
-                       "lastUsedDate from applicationState.db. "
-                       "NOTE: these timestamps do not always indicate application usage "
-                       "but experiments on an iPhone 8 with iOS 16.7.7 suggest that these "
-                       "timestamps do indicate user-interaction with the "
-                       "device, such as switching between apps.",
-        "author": "@mxkrt",
+                       "lastUsedDate from applicationState.db. The property belongs to SplashBoard's snapshot object, "
+                       "but its update event is not publicly documented. It is sparse and must not be treated as "
+                       "proof that the application was in the foreground or that the user viewed the image contents "
+                       "at that time.",
+        "author": "@mxkrt - @AlexisBrignoni",
         "creation_date": "2025-08-04",
-        "last_update_date": "2025-10-24",
+        "last_update_date": "2026-08-06",
         "requirements": "none",
         "category": "Device Usage",
-        "notes": "",
+        "notes": "The property name is sourced from the runtime-derived SplashBoard header. Its forensic meaning is "
+                 "not documented by Apple. Corroborate with independent device-usage artifacts and report the field "
+                 "as stored. Source: https://github.com/nst/iOS-Runtime-Headers/blob/master/PrivateFrameworks/SplashBoard.framework/XBApplicationSnapshot.h",
         "paths": ('*/mobile/Library/FrontBoard/applicationState.db*'),
         "output_types": "standard",
         "artifact_icon": "device-mobile",


### PR DESCRIPTION
## Summary
- joins KTX and JPEG snapshot images to XBApplicationSnapshotManifest metadata from applicationState.db
- preserves converted KTX images as real PNG media so they display in HTML and LAVA
- separates bundle identifiers, scene groups, snapshot identifiers, and default/downscaled variants
- requests applicationState.db sidecars so current WAL records are included
- documents conservative semantics for creationDate and lastUsedDate with Apple and SplashBoard sources
- adds focused regression tests for scene-based paths and manifest joins

## Real-data validation
Tested through complete iLEAPP runs against full-file-system images from:

| iOS | Displayable snapshots | Manifest joins |
|---|---:|---:|
| 12.4 | 68 | 68 / 68 |
| 18.7.8 | 207 | 207 / 207 |
| 26.5.2 | 283 | 283 / 283 |

All 558 converted snapshots rendered as PNG images. For the 490 iOS 18 and iOS 26 files with source modified timestamps, every value agreed with manifest creationDate within one second. Including the iOS 26 WAL and SHM increased current image-to-manifest matches from 279 to 283.

## Local checks
- 7 focused and artifact-import tests passed
- Python compilation passed
- git diff check passed

Companion blog post: https://github.com/abrignoni/leapps-website/pull/213