### PR TITLE
Add DuckDuckGo, MEGA and Onion Browser artifacts for iOS

### DIFF
--- a/scripts/artifacts/duckduckgo.py
+++ b/scripts/artifacts/duckduckgo.py
@@ -1,0 +1,114 @@
+__artifacts_v2__ = {
+    "duckduckgo_history": {
+        "name": "DuckDuckGo - Browsing History",
+        "description": "Browsing history entries from the DuckDuckGo browser, with the page title, "
+                       "the last visit time and the number of trackers the browser blocked on the page",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "DuckDuckGo",
+        "notes": "Read from the Core Data store History.sqlite. ZBROWSINGHISTORYENTRYMANAGEDOBJECT "
+                 "holds one row per visited page with an aggregate visit count and blocked-tracker "
+                 "count; the timestamps are Core Data (Cocoa) seconds.",
+        "paths": ('*/Library/Application Support/History.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | DuckDuckGo | 2 rows",
+        },
+    },
+    "duckduckgo_page_visits": {
+        "name": "DuckDuckGo - Page Visits",
+        "description": "Individual page visits from the DuckDuckGo browser, each joined to its "
+                       "history entry URL and, where present, the tab the visit belonged to",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "DuckDuckGo",
+        "notes": "ZPAGEVISITMANAGEDOBJECT records one row per visit and links to a history entry and "
+                 "to a tab history row, so a single page can appear several times with different "
+                 "visit times. Timestamps are Core Data (Cocoa) seconds.",
+        "paths": ('*/Library/Application Support/History.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "clock",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | DuckDuckGo | 3 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import (
+    artifact_processor,
+    convert_cocoa_core_data_ts_to_utc,
+    get_file_path,
+    get_sqlite_db_records,
+)
+
+
+@artifact_processor
+def duckduckgo_history(context):
+    source_path = get_file_path(context.get_files_found(), 'History.sqlite')
+    data_list = []
+
+    query = '''
+    SELECT ZLASTVISIT, ZURL, ZTITLE, ZNUMBEROFTOTALVISITS, ZNUMBEROFTRACKERSBLOCKED,
+           ZTRACKERSFOUND, ZBLOCKEDTRACKINGENTITIES, ZFAILEDTOLOAD, ZCOOKIEPOPUPBLOCKED
+    FROM ZBROWSINGHISTORYENTRYMANAGEDOBJECT
+    ORDER BY ZLASTVISIT
+    '''
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append((
+            convert_cocoa_core_data_ts_to_utc(record[0]),
+            record[1],
+            record[2],
+            record[3],
+            record[4],
+            record[5],
+            record[6],
+            'Yes' if record[7] else 'No',
+            'Yes' if record[8] else 'No',
+        ))
+
+    data_headers = (
+        ('Last Visit', 'datetime'),
+        ('URL', 'url'),
+        'Title',
+        'Total Visits',
+        'Trackers Blocked',
+        'Trackers Found',
+        'Blocked Tracking Entities',
+        'Failed To Load',
+        'Cookie Popup Blocked',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def duckduckgo_page_visits(context):
+    source_path = get_file_path(context.get_files_found(), 'History.sqlite')
+    data_list = []
+
+    query = '''
+    SELECT v.ZDATE, h.ZURL, h.ZTITLE, t.ZTABID
+    FROM ZPAGEVISITMANAGEDOBJECT v
+    LEFT JOIN ZBROWSINGHISTORYENTRYMANAGEDOBJECT h ON v.ZHISTORYENTRY = h.Z_PK
+    LEFT JOIN ZTABHISTORYMANAGEDOBJECT t ON v.ZTABHISTORY = t.Z_PK
+    ORDER BY v.ZDATE
+    '''
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append((
+            convert_cocoa_core_data_ts_to_utc(record[0]),
+            record[1],
+            record[2],
+            record[3],
+        ))
+
+    data_headers = (
+        ('Visit Time', 'datetime'),
+        ('URL', 'url'),
+        'Title',
+        'Tab ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -1,0 +1,271 @@
+__artifacts_v2__ = {
+    "mega_chat_messages": {
+        "name": "MEGA - Chat Messages",
+        "description": "Chat messages from the MEGA (karere) chat store, with the sender resolved to "
+                       "an email where possible, the message text, and shared locations with their "
+                       "map thumbnail",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "MEGA",
+        "notes": "Read from the karere-*.db history table. Direction is set by comparing the sender "
+                 "handle to the account's own handle, which the store keeps in vars as my_handle. "
+                 "Text messages (type 1) hold their content directly. Location shares (type 104) "
+                 "carry a JSON body with a maps URL, latitude and longitude and a base64 JPEG "
+                 "thumbnail, which is decoded and checked in. Other type values are management "
+                 "events and are reported with their stored type number and no body.",
+        "paths": ('*/karere-*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | MEGA | 10 rows",
+        },
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Chat ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Sender",
+                "mediaColumn": "Location Map",
+            }
+        },
+    },
+    "mega_chats": {
+        "name": "MEGA - Chats",
+        "description": "Chats listed in the MEGA karere store, with the peer resolved to an email "
+                       "and the creation time",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "MEGA",
+        "notes": "A peer handle of 0 is used by the store for group or self chats rather than a "
+                 "one-to-one contact.",
+        "paths": ('*/karere-*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | MEGA | 2 rows",
+        },
+    },
+    "mega_contacts": {
+        "name": "MEGA - Contacts",
+        "description": "Contacts stored in the MEGA karere store, with the email and the time the "
+                       "contact relationship was recorded",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "MEGA",
+        "notes": "",
+        "paths": ('*/karere-*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | MEGA | 1 row",
+        },
+    },
+}
+
+import base64
+import json
+
+from scripts.ilapfuncs import (
+    artifact_processor,
+    check_in_embedded_media,
+    convert_unix_ts_to_utc,
+    get_sqlite_db_records,
+)
+
+
+def _karere_db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if 'karere-' in file_found and file_found.endswith('.db'):
+            return file_found
+    return ''
+
+
+def _own_handle(source_path):
+    for record in get_sqlite_db_records(
+            source_path, "SELECT value FROM vars WHERE name = 'my_handle'"):
+        return str(record[0])
+    return None
+
+
+def _contact_emails(source_path):
+    emails = {}
+    for record in get_sqlite_db_records(source_path, 'SELECT userid, email FROM contacts'):
+        if record[1]:
+            emails[str(record[0])] = record[1]
+    return emails
+
+
+def _decode_text(blob):
+    if blob is None:
+        return ''
+    if isinstance(blob, (bytes, bytearray)):
+        try:
+            return blob.decode('utf-8')
+        except UnicodeDecodeError:
+            return ''
+    return str(blob)
+
+
+def _embedded_json(blob):
+    """Rich-message blobs (e.g. location shares) carry a short binary header before a
+    JSON body, so the object is located by its outermost braces rather than assumed at
+    the start."""
+    if not isinstance(blob, (bytes, bytearray)):
+        return None
+    start = blob.find(b'{')
+    end = blob.rfind(b'}')
+    if start < 0 or end <= start:
+        return None
+    try:
+        return json.loads(blob[start:end + 1].decode('utf-8', 'replace'))
+    except ValueError:
+        return None
+
+
+@artifact_processor
+def mega_chat_messages(context):
+    source_path = _karere_db(context.get_files_found())
+    data_list = []
+
+    own = _own_handle(source_path)
+    own_email = ''
+    emails = _contact_emails(source_path)
+    for record in get_sqlite_db_records(source_path, "SELECT value FROM vars WHERE name = 'my_email'"):
+        own_email = record[0]
+
+    query = '''
+    SELECT ts, chatid, userid, type, data, is_encrypted, msgid
+    FROM history
+    ORDER BY ts
+    '''
+    for record in get_sqlite_db_records(source_path, query):
+        sender_handle = str(record[2])
+        outgoing = own is not None and sender_handle == own
+        if outgoing:
+            sender = own_email or sender_handle
+        else:
+            sender = emails.get(sender_handle, sender_handle)
+
+        message = ''
+        latitude = ''
+        longitude = ''
+        maps_url = ''
+        media = ''
+        msg_type = record[3]
+
+        if record[5]:
+            message = '<encrypted>'
+        elif msg_type == 1:
+            message = _decode_text(record[4])
+        elif record[4]:
+            payload = _embedded_json(record[4])
+            if isinstance(payload, dict):
+                maps_url = payload.get('textMessage', '')
+                extra = payload.get('extra')
+                if isinstance(extra, list) and extra and isinstance(extra[0], dict):
+                    latitude = extra[0].get('la', '')
+                    longitude = extra[0].get('lng', '')
+                    thumb = extra[0].get('img')
+                    if thumb:
+                        try:
+                            raw = base64.b64decode(thumb)
+                            media = check_in_embedded_media(
+                                source_path, raw, f'mega_location_{record[6]}.jpg',
+                                force_type='image/jpeg', force_extension='jpg') or ''
+                        except (ValueError, TypeError):
+                            media = ''
+                message = maps_url
+
+        data_list.append((
+            convert_unix_ts_to_utc(record[0]),
+            'Outgoing' if outgoing else 'Incoming',
+            sender,
+            message,
+            media,
+            latitude,
+            longitude,
+            maps_url,
+            str(record[1]),
+            msg_type,
+            'Yes' if record[5] else 'No',
+        ))
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Direction',
+        'Sender',
+        'Message',
+        ('Location Map', 'media'),
+        'Latitude',
+        'Longitude',
+        ('Maps URL', 'url'),
+        'Chat ID',
+        'Message Type Value',
+        'Was Encrypted',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def mega_chats(context):
+    source_path = _karere_db(context.get_files_found())
+    data_list = []
+    emails = _contact_emails(source_path)
+
+    query = '''
+    SELECT ts_created, chatid, peer, title, shard, mode
+    FROM chats
+    ORDER BY ts_created
+    '''
+    for record in get_sqlite_db_records(source_path, query):
+        peer_handle = str(record[2])
+        data_list.append((
+            convert_unix_ts_to_utc(record[0]),
+            str(record[1]),
+            emails.get(peer_handle, peer_handle if record[2] else ''),
+            record[3],
+            record[4],
+            record[5],
+        ))
+
+    data_headers = (
+        ('Created', 'datetime'),
+        'Chat ID',
+        'Peer',
+        'Title',
+        'Shard',
+        'Mode',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def mega_contacts(context):
+    source_path = _karere_db(context.get_files_found())
+    data_list = []
+
+    query = 'SELECT since, userid, email, visibility FROM contacts ORDER BY since'
+    for record in get_sqlite_db_records(source_path, query):
+        data_list.append((
+            convert_unix_ts_to_utc(record[0]),
+            str(record[1]),
+            record[2],
+            record[3],
+        ))
+
+    data_headers = (
+        ('Since', 'datetime'),
+        'User ID',
+        'Email',
+        'Visibility Value',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/onionBrowser.py
+++ b/scripts/artifacts/onionBrowser.py
@@ -1,0 +1,148 @@
+__artifacts_v2__ = {
+    "onion_browser_tabs": {
+        "name": "Onion Browser - Open Tabs",
+        "description": "URLs of the tabs that were open in Onion Browser, from the archived open "
+                       "and private tab lists in the app preferences",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "Onion Browser",
+        "notes": "The open_tabs and privateTabs preference values are NSKeyedArchiver plists holding "
+                 "NSURL objects; each is decoded to its URL. Private tab URLs come from the "
+                 "privateTabs value and are labelled as such.",
+        "paths": ('*/Library/Preferences/ch.b-eng.tor.plist',),
+        "output_types": "standard",
+        "artifact_icon": "layers",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | Onion Browser | 2 rows",
+        },
+    },
+    "onion_browser_settings": {
+        "name": "Onion Browser - Settings",
+        "description": "Connection, privacy and clean-up settings from Onion Browser, including the "
+                       "Tor connection mode and any custom bridge the user configured",
+        "author": "",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "Onion Browser",
+        "notes": "Values are read directly from the app preferences plist. Each configured custom "
+                 "bridge is reported on its own row; a bridge line contains the transport, the "
+                 "relay address and its fingerprint as the user entered them.",
+        "paths": ('*/Library/Preferences/ch.b-eng.tor.plist',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | Onion Browser | settings reported",
+        },
+    },
+}
+
+import plistlib
+
+import nska_deserialize
+
+from scripts.ilapfuncs import artifact_processor, convert_plist_date_to_utc, get_file_path
+
+# Preference keys reported by the settings artifact, in the order shown, with readable labels.
+_SETTINGS = [
+    ('browser_connection_mode', 'Connection Mode'),
+    ('kSelectedVPNAddress', 'Selected VPN Address'),
+    ('kSelectedVPNCity', 'Selected VPN City'),
+    ('lastSelectedServer', 'Last Selected Server'),
+    ('kIsSearchHistory', 'Search History Enabled'),
+    ('isCookiesEnabled', 'Cookies Enabled'),
+    ('isPersistentCookiesSelected', 'Persistent Cookies'),
+    ('is_JavaScript_On', 'JavaScript Enabled'),
+    ('isFingerprintingEnabled', 'Fingerprinting Protection Off'),
+    ('isWebGLEnabled', 'WebGL Enabled'),
+    ('isDeleteBrowsingHistorySelected', 'Delete Browsing History On Exit'),
+    ('isDeleteCacheSelected', 'Delete Cache On Exit'),
+    ('isDeleteCookiesSelected', 'Delete Cookies On Exit'),
+    ('isDeleteSuggestionSelected', 'Delete Suggestions On Exit'),
+    ('isPrivacyBlurOn', 'Privacy Blur On'),
+    ('isBottomSearchBar', 'Bottom Search Bar'),
+    ('PremiumUser', 'Premium User'),
+    ('activatedSubscription', 'Activated Subscription'),
+]
+
+
+def _load_plist(path):
+    try:
+        with open(path, 'rb') as handle:
+            return plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException, ValueError):
+        return {}
+
+
+def _decode_tab_urls(value):
+    urls = []
+    if not isinstance(value, (bytes, bytearray)):
+        return urls
+    try:
+        import io
+        objects = nska_deserialize.deserialize_plist(io.BytesIO(value))
+    except Exception:  # pylint: disable=broad-except
+        return urls
+    if not isinstance(objects, list):
+        objects = [objects]
+    for obj in objects:
+        if isinstance(obj, dict):
+            url = obj.get('NS.relative') or obj.get('NS.base')
+            if url:
+                urls.append(url)
+        elif isinstance(obj, str):
+            urls.append(obj)
+    return urls
+
+
+@artifact_processor
+def onion_browser_tabs(context):
+    source_path = get_file_path(context.get_files_found(), 'ch.b-eng.tor.plist')
+    plist = _load_plist(source_path)
+    data_list = []
+
+    for url in _decode_tab_urls(plist.get('open_tabs')):
+        data_list.append(('Open', url))
+    for url in _decode_tab_urls(plist.get('privateTabs')):
+        data_list.append(('Private', url))
+
+    data_headers = (
+        'Tab Type',
+        ('URL', 'url'),
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def onion_browser_settings(context):
+    source_path = get_file_path(context.get_files_found(), 'ch.b-eng.tor.plist')
+    plist = _load_plist(source_path)
+    data_list = []
+
+    last_active = plist.get('lastActiveTime')
+    if last_active is not None:
+        try:
+            last_active = convert_plist_date_to_utc(last_active)
+        except (TypeError, ValueError):
+            pass
+        data_list.append(('Last Active Time', last_active))
+
+    for key, label in _SETTINGS:
+        if key in plist:
+            value = plist[key]
+            if isinstance(value, bool):
+                value = 'Yes' if value else 'No'
+            data_list.append((label, value))
+
+    bridges = plist.get('customBridges')
+    if isinstance(bridges, list):
+        for bridge in bridges:
+            data_list.append(('Custom Bridge', bridge))
+
+    data_headers = (
+        'Setting',
+        'Value',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Adds three iOS apps that had no dedicated iLEAPP parser, all validated against an iOS 26.5.2 full file system extraction.

## DuckDuckGo (`com.duckduckgo.mobile.ios`)
- **Browsing History** and **Page Visits** from the Core Data store `History.sqlite` (`ZBROWSINGHISTORYENTRYMANAGEDOBJECT` / `ZPAGEVISITMANAGEDOBJECT`), with page title, last-visit time (Cocoa timestamps) and the blocked-tracker counts the browser records.

## MEGA (`mega.ios`)
- **Chat Messages**, **Chats** and **Contacts** from the karere `karere-*.db` store. Direction is set from the account's own handle (`vars.my_handle`) and senders are resolved to their email via `contacts`. Text messages read directly; **location shares** carry a short binary header before a JSON body with a maps URL, latitude/longitude and a base64 JPEG map thumbnail — decoded, and the thumbnail checked in so it renders inline and in the conversation view.

## Onion Browser (`ch.b-eng.tor`)
- **Open Tabs**: the open and private tab URLs, decoded from the NSKeyedArchiver `open_tabs` / `privateTabs` preference values.
- **Settings**: Tor connection mode, any custom bridge the user configured (transport, relay address, fingerprint), the selected VPN, and the privacy and clean-up options.

## Testing (hc_ios26, iOS 26.5.2)
- DuckDuckGo: 2 history entries, 3 page visits
- MEGA: 10 messages including two location shares with recovered map thumbnails, 2 chats, 1 contact
- Onion Browser: 2 tabs (open + private), full configuration including two custom obfs4 bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)