### PR TITLE
Fix MeWe account artifact on newer schema (dropped DSNP column)

### DIFF
--- a/scripts/artifacts/meWe.py
+++ b/scripts/artifacts/meWe.py
@@ -137,6 +137,15 @@ def _parse_shared_location(text):
     return match.group(1), match.group(2)
 
 
+def _column_exists(source_path, table, column):
+    """Whether a column is present, so the account query survives MeWe schema versions
+    that drop version-specific columns such as the DSNP (web3) fields."""
+    rows = get_sqlite_db_records(
+        source_path,
+        f"SELECT 1 FROM pragma_table_info('{table}') WHERE name = '{column}'")
+    return any(True for _ in rows)
+
+
 @artifact_processor
 def meWeMessages(context):
     source_path = get_file_path(context.get_files_found(), 'sgrouplesdb.sqlite')
@@ -498,6 +507,14 @@ def meWeAccount(context):
     source_path = get_file_path(context.get_files_found(), 'sgrouplesdb.sqlite')
     data_list = []
 
+    # The DSNP (web3) columns are not present in every MeWe version, so they are
+    # selected only when the schema still carries them.
+    dsnp_registered = ('cu.ZISDSNPREGISTERED'
+                       if _column_exists(source_path, 'ZCURRENTUSER', 'ZISDSNPREGISTERED')
+                       else 'NULL')
+    dsnp_handle = ('u.ZDSNPHANDLE'
+                   if _column_exists(source_path, 'ZUSER', 'ZDSNPHANDLE') else 'NULL')
+
     query = f'''
     SELECT
         {USER_NAME_SQL} AS name,
@@ -506,12 +523,12 @@ def meWeAccount(context):
         u.ZFIRSTNAME AS firstName,
         u.ZLASTNAME AS lastName,
         u.ZFINGERPRINT AS fingerprint,
-        u.ZDSNPHANDLE AS dsnpHandle,
+        {dsnp_handle} AS dsnpHandle,
         cu.ZPRIMARYEMAIL AS primaryEmail,
         cu.ZPRIMARYPHONE AS primaryPhone,
         cu.ZCONTACTINVITEID AS contactInviteId,
         cu.ZREGISTERED AS registered,
-        cu.ZISDSNPREGISTERED AS dsnpRegistered,
+        {dsnp_registered} AS dsnpRegistered,
         cu.ZJAILSENTENCE AS jailSentence,
         cu.ZJAILDATE AS jailDate
     FROM ZCURRENTUSER cu


### PR DESCRIPTION
`meWeAccount` selected `cu.ZISDSNPREGISTERED` unconditionally. Newer MeWe versions drop the DSNP (web3) columns from `ZCURRENTUSER`, so the query hit `no such column` and the **whole artifact returned nothing** — losing the account owner's name, handle, email and phone.

The two DSNP columns (`cu.ZISDSNPREGISTERED`, `u.ZDSNPHANDLE`) are now selected only when the schema still carries them, via a small `_column_exists` guard, so the artifact works across MeWe versions.

## Testing (hc_ios26, iOS 26.5.2)
- Before: `MeWe - Account Information` errored → 0 rows
- After: 1 row (the signed-in account)
- Other MeWe artifacts unchanged: 13 chats, 46 contacts, 93 posts, 13 groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)