### PR TITLE
Fix Wire account artifact on newer schema (dropped phone column)

### DIFF
--- a/scripts/artifacts/wire.py
+++ b/scripts/artifacts/wire.py
@@ -64,13 +64,19 @@ def wireAccount(context):
         'ZACTIVATIONLOCATIONLATITUDE'
         )
 
+    # Newer Wire versions drop ZUSER.ZPHONENUMBER, so it is selected only when present.
+    phone_column = (
+        'ZUSER.ZPHONENUMBER' if does_column_exist_in_db(source_path, 'ZUSER', 'ZPHONENUMBER')
+        else 'NULL'
+        )
+
     if has_location_data:
-        query = '''
+        query = f'''
         SELECT
             DISTINCT ZUSER.ZHANDLE AS 'User ID',
             ZUSER.ZNAME AS 'Display Name',
             ZUSERCLIENT.ZACTIVATIONDATE AS 'Activation Date',
-            ZUSER.ZPHONENUMBER AS 'Phone Number',
+            {phone_column} AS 'Phone Number',
             ZUSER.ZEMAILADDRESS AS 'Email Address',
             ZUSERCLIENT.ZACTIVATIONLOCATIONLATITUDE AS 'Activation Latitude',
             ZUSERCLIENT.ZACTIVATIONLOCATIONLONGITUDE AS 'Activation Longitude'
@@ -87,12 +93,12 @@ def wireAccount(context):
             'Longitude'
             )
     else:
-        query = '''
+        query = f'''
         SELECT
             DISTINCT ZUSER.ZHANDLE AS 'User ID',
             ZUSER.ZNAME AS 'Display Name',
             ZUSERCLIENT.ZACTIVATIONDATE AS 'Activation Date',
-            ZUSER.ZPHONENUMBER AS 'Phone Number',
+            {phone_column} AS 'Phone Number',
             ZUSER.ZEMAILADDRESS AS 'Email Address'
         FROM ZUSER
         LEFT JOIN ZUSERCLIENT ON ZUSER.Z_PK = ZUSERCLIENT.ZUSER;


### PR DESCRIPTION
`wireAccount` selected `ZUSER.ZPHONENUMBER` unconditionally. Newer Wire versions no longer carry that column, so the query hit `no such column` and the **whole artifact returned nothing** — losing the account handles, display names, activation dates and email addresses.

The column is now selected only when present, reusing the same `does_column_exist_in_db` guard this artifact already applies to the activation-location columns.

## How it was found
Not from a report — by running the supported-app artifacts against a current corpus. This is the second artifact found broken this way (after MeWe, #1899); both were silently returning zero rows on modern data.

## Testing (hc_ios26, iOS 26.5.2)
- Before: `Wire Secure Messenger Account` errored → 0 rows
- After: 4 accounts, with activation dates and email addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)