### PR TITLE
fix: do not mark URL columns as a link type

### DIFF
--- a/scripts/artifacts/dubox.py
+++ b/scripts/artifacts/dubox.py
@@ -159,7 +159,7 @@ def dubox_messages(context):
         'File Path',
         'File Size',
         'File MD5',
-        ('Link', 'url'),
+        'Link',
     )
     return data_headers, data_list, source_path
 

--- a/scripts/artifacts/duckduckgo.py
+++ b/scripts/artifacts/duckduckgo.py
@@ -73,7 +73,7 @@ def duckduckgo_history(context):
 
     data_headers = (
         ('Last Visit', 'datetime'),
-        ('URL', 'url'),
+        'URL',
         'Title',
         'Total Visits',
         'Trackers Blocked',
@@ -107,7 +107,7 @@ def duckduckgo_page_visits(context):
 
     data_headers = (
         ('Visit Time', 'datetime'),
-        ('URL', 'url'),
+        'URL',
         'Title',
         'Tab ID',
     )

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -207,7 +207,7 @@ def mega_chat_messages(context):
         ('Location Map', 'media'),
         'Latitude',
         'Longitude',
-        ('Maps URL', 'url'),
+        'Maps URL',
         'Chat ID',
         'Message Type Value',
         'Was Encrypted',

--- a/scripts/artifacts/onionBrowser.py
+++ b/scripts/artifacts/onionBrowser.py
@@ -173,7 +173,7 @@ def onion_browser_tabs(context):
 
     data_headers = (
         'Tab Type',
-        ('URL', 'url'),
+        'URL',
     )
     return data_headers, data_list, source_path
 
@@ -252,7 +252,7 @@ def onion_browser_bookmarks(context):
 
     data_headers = (
         'Title',
-        ('URL', 'url'),
+        'URL',
         ('Icon', 'media'),
     )
     return data_headers, data_list, source_path
@@ -269,7 +269,7 @@ def onion_browser_favourites(context):
 
     data_headers = (
         'Title',
-        ('URL', 'url'),
+        'URL',
         ('Icon', 'media'),
     )
     return data_headers, data_list, source_path
@@ -294,7 +294,7 @@ def onion_browser_history(context):
         'Date (device local)',
         'Time (device local)',
         'Title',
-        ('URL', 'url'),
+        'URL',
         ('Icon', 'media'),
     )
     return data_headers, data_list, source_path


### PR DESCRIPTION
Removes the `('...', 'url')` header type from four artifacts: `dubox.py`, `duckduckgo.py`, `mega.py`, `onionBrowser.py`. Eight columns.

## What it did

Nothing, today. No LEAPP core interprets a `url` header type. `strip_tuple_from_headers` takes `header[0]`, and the only types branched on are `media`, `html` and `datetime`. The generated HTML for these artifacts contains zero `<a href>` elements, which I verified against a real report.

But the type is still written into the LAVA manifest as an `object_columns` entry, and LAVA does not render it either. It branches on `datetime`, `date`, `separator`, `media`, `phonenumber` and `question`.

## Why remove it then

Two reasons.

It declares an intent that should not be there. A forensic report should not offer the examiner a click that reaches out to a remote server: following one is a live request to a third party from the examiner's machine, which should be a deliberate decision rather than a side effect of clicking a cell.

And because it is silently inert rather than rejected, it would become a live external link the moment either side grew a `url` renderer. That is a bad way to find out.

## Scope

Every use of this pseudo-type in the repo came from the same recent batch of work, so nothing long-standing is being changed. The equivalent ALEAPP change is a separate PR.

The values are still reported in full. They are just no longer presented as something to follow.

Claim-language and HTML-safety checks pass, lint clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>