### PR TITLE
fix: correct the Wickr message type list and describe what the logs add

### DIFF
--- a/scripts/artifacts/wickr.py
+++ b/scripts/artifacts/wickr.py
@@ -23,12 +23,14 @@ __artifacts_v2__ = {
                  "messages carrying a linked file and the set with ZFULLTYPE 6000 are identical "
                  "and no other value appears among file-linked messages, and the same value is "
                  "reported independently by Josh Hickman, 'Wickr - Alright, We'll Call It A "
-                 "Draw', thebinaryhick.blog, 2019-08-23. The other observed values (1000, 4001, "
-                 "4006, 4007, 7000, 8000, 9000) have no such support and are reported as stored. "
-                 "Timestamps are "
-                 "Cocoa Core Data epoch. On the tested image the ZMSGID values and Cocoa "
-                 "timestamps match the messageId and arrival time independently recorded in the "
-                 "app's own plaintext logs, which cross-validates both readings.",
+                 "Draw', thebinaryhick.blog, 2019-08-23. The other values present in this table "
+                 "on the tested image (1000, 4001, 4007, 7000, 8000) have no such support and "
+                 "are reported as stored. The app's logs carry two further type values, 4006 and "
+                 "9000, which do not appear in this table at all; see the Wickr - App Log "
+                 "Message Events artifact.\n"
+                 "Timestamps are Cocoa Core Data epoch. Where a ZMSGID here also appears in the "
+                 "app's own plaintext logs, the Cocoa timestamp and the independently logged "
+                 "arrival time agree to within a second, which cross-validates both readings.",
         "paths": ('*/wickrLocal.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "message-square",
@@ -231,9 +233,19 @@ __artifacts_v2__ = {
                  "'Payload: {\"messageId\"...}' and the 'Download Message with Type' lines, both "
                  "of which carry identifiers in the clear. These logs are rolling files, so the "
                  "events present depend on what had not yet been rotated away. Log line "
-                 "timestamps are recorded by the app without a zone and are reported as written. "
-                 "On the tested image these identifiers match rows in ZWICKR_MESSAGE, which is "
-                 "what cross-validates the database timestamp reading.",
+                 "timestamps are recorded by the app without a zone and are reported as written.\n"
+                 "Where an identifier here also appears in ZWICKR_MESSAGE, the log arrival time "
+                 "and the database timestamp agree to within a second, which is what "
+                 "cross-validates the database timestamp reading.\n"
+                 "Most of them do not appear there. On the tested image the logs name 69 distinct "
+                 "message identifiers and 48 of those have no row in ZWICKR_MESSAGE, so this "
+                 "artifact reports the arrival of messages the message store no longer holds, "
+                 "together with the conversation, the sending user hash and the stored type for "
+                 "each. Those 48 include the only occurrences of type values 4006 and 9000 "
+                 "anywhere in the data. Why a logged message has no row is not established here: "
+                 "a rolling log covering a longer period than the store retains would produce "
+                 "this, and so would removal of the rows, and the records do not distinguish "
+                 "them.",
         "paths": ('*/Logs/com.wickr*.log', '*/Logs/com.mywickr*.log'),
         "output_types": "standard",
         "artifact_icon": "file-text",


### PR DESCRIPTION
I re-checked the claims written in today's Wickr notes against the data. Two were wrong, and chasing the first one surfaced something the artifact should have said from the start.

## The error

The **Wickr - Messages** note listed the unlabelled `ZFULLTYPE` values as `1000, 4001, 4006, 4007, 7000, 8000, 9000`.

The values actually present in `ZWICKR_MESSAGE` are `1000, 4001, 4007, 6000, 7000, 8000`. **4006 and 9000 are not in that table at all** — they come from the app's logs. Listing them as values of that column was wrong.

## What chasing it found

The logs name **69 distinct message identifiers, and 48 of them have no row in `ZWICKR_MESSAGE`.**

| | count |
|---|---|
| message ids in `ZWICKR_MESSAGE` | 44 |
| message ids in the logs | 69 |
| in both | 21 |
| **in the logs only** | **48** |

So **Wickr - App Log Message Events** is not just a cross-check on the database timestamps, which is all my note claimed. It reports the arrival of messages the message store no longer holds, with the conversation, the sending user hash and the stored type for each. For an app whose whole design point is that messages do not persist, that is arguably the most useful thing in the module, and I had described it as a validation aid.

The two type values absent from the database occur only among those 48.

**Why** a logged message has no row is not established, and the note says so plainly: a rolling log covering a longer period than the store retains would produce this, and so would removal of the rows, and nothing in the records distinguishes the two. The artifact reports the observation, not a cause.

## Also narrowed

The timestamp cross-validation sentence implied every message id matched between the two sources. 21 of 44 do. Reworded to "where a ZMSGID here also appears in the logs", which is what was actually verified.

## Verified clean

Everything else in the Wickr notes checked out against the data: all row counts (44, 6, 4, 4, 1, 49, 0, 4, 120); `ZFULLTYPE` 6000 matching the file-linked set exactly, 4 of 4; the entity-number drift (`Wickr_Network` 17 on iOS 16, 18 on iOS 17); `Secex_Convo` = 5 and `Secex_Secure_Room` = 6; and the keychain access group and item list.

Notes only. No parser behaviour changes and no counts move. Claim-language and HTML-safety checks pass, lint clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>