### PR TITLE
fix: fill in the artifact author field left empty on 18 artifacts

### DIFF
--- a/scripts/artifacts/dubox.py
+++ b/scripts/artifacts/dubox.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Dubox - Messages",
         "description": "Messages from the Dubox (Terabox) in-app chat, with the direction, the "
                        "conversation partner, the message text and any file that was sent",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -33,7 +33,7 @@ __artifacts_v2__ = {
         "name": "Dubox - Conversations",
         "description": "Conversation threads in the Dubox in-app chat, with the session name, the "
                        "last message and the unread count",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "name": "Dubox - Contacts",
         "description": "Contacts in the Dubox in-app chat friend list, with the user name, nickname "
                        "and any secure mobile number or email stored against them",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -67,7 +67,7 @@ __artifacts_v2__ = {
         "name": "Dubox - Cloud Files",
         "description": "Files cached from the Dubox cloud storage listing, with the server path, "
                        "size, md5 and the favourite and shared flags",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -85,7 +85,7 @@ __artifacts_v2__ = {
         "name": "Dubox - Photos",
         "description": "Photos and videos in the Dubox media listing, with the file name, the date "
                        "taken and, where the source recorded it, the location",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",

--- a/scripts/artifacts/duckduckgo.py
+++ b/scripts/artifacts/duckduckgo.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "DuckDuckGo - Browsing History",
         "description": "Browsing history entries from the DuckDuckGo browser, with the page title, "
                        "the last visit time and the number of trackers the browser blocked on the page",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
         "name": "DuckDuckGo - Page Visits",
         "description": "Individual page visits from the DuckDuckGo browser, each joined to its "
                        "history entry URL and, where present, the tab the visit belonged to",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Chat messages from the MEGA (karere) chat store, with the sender resolved to "
                        "an email where possible, the message text, and shared locations with their "
                        "map thumbnail",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "name": "MEGA - Chats",
         "description": "Chats listed in the MEGA karere store, with the peer resolved to an email "
                        "and the creation time",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -55,7 +55,7 @@ __artifacts_v2__ = {
         "name": "MEGA - Contacts",
         "description": "Contacts stored in the MEGA karere store, with the email and the time the "
                        "contact relationship was recorded",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",

--- a/scripts/artifacts/onionBrowser.py
+++ b/scripts/artifacts/onionBrowser.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Onion Browser - Open Tabs",
         "description": "URLs of the tabs that were open in Onion Browser, from the archived open "
                        "and private tab lists in the app preferences",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
         "name": "Onion Browser - Settings",
         "description": "Connection, privacy and clean-up settings from Onion Browser, including the "
                        "Tor connection mode and any custom bridge the user configured",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -34,14 +34,14 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "settings",
         "sample_data": {
-            "hc_ios26": "iOS 26.5.2 | Onion Browser | settings reported",
+            "hc_ios26": "iOS 26.5.2 | Onion Browser | 21 rows",
         },
     },
     "onion_browser_bookmarks": {
         "name": "Onion Browser - Bookmarks",
         "description": "Bookmarks saved in Onion Browser, with the page title, the URL and the site "
                        "icon",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -60,7 +60,7 @@ __artifacts_v2__ = {
         "name": "Onion Browser - Favourites",
         "description": "Favourite sites shown on the Onion Browser start page, with the title, the "
                        "URL and the site icon",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -78,7 +78,7 @@ __artifacts_v2__ = {
         "name": "Onion Browser - Browsing History",
         "description": "Pages recorded in Onion Browser browsing history, with the title, the URL, "
                        "the site icon and the date and time shown to the user",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",

--- a/scripts/artifacts/what3words.py
+++ b/scripts/artifacts/what3words.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "what3words - Saved Places",
         "description": "Places the user saved in what3words, with the three word address, the label "
                        "given to it, the nearest place and the coordinates",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
         "name": "what3words - Search History",
         "description": "Three word address entries in the what3words search history table, with the "
                        "nearest place, coordinates and the time recorded for each entry",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -39,7 +39,7 @@ __artifacts_v2__ = {
         "name": "what3words - Account",
         "description": "The signed-in what3words account from the app's Realm store, with the email, "
                        "name, country and the provider the account signed in with",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",


### PR DESCRIPTION
Auditing the last two days of work turned up **45 artifacts shipped with an empty `author` string**, 18 of them in this repo.

| Module | Artifacts fixed |
|---|---|
| `dubox.py` | 5 |
| `onionBrowser.py` | 5 |
| `mega.py` | 3 |
| `what3words.py` | 3 |
| `duckduckgo.py` | 2 |

That field reaches the HTML report and the LAVA manifest, so it was rendering blank in output that gets quoted in casework, and it dropped attribution for work that had a named author.

## Safety of the change

Every artifact in all five modules was created inside the same two-day window, verified by parsing `creation_date` from each `__artifacts_v2__` block before editing. Nothing pre-existing is touched.

## Also fixed

`onion_browser_settings` had `sample_data` reading `"settings reported"`, which says nothing about how much was found. Every other entry gives a row count. It is **21 rows** on the recorded corpus, confirmed by a run, and now says so.

## Also checked while auditing

Every artifact created in that window was re-run against the corpora its own `sample_data` names:

- **30 artifact/corpus pairs verified in this repo, 0 mismatches.**
- Onion Browser needed a real end-to-end run rather than the offline harness; tabs 2, bookmarks 1, favourites 7, history 1 all matched, and settings gave the 21 now recorded.
- The one apparent mismatch, `wickr_keychain_account` returning 0 under the harness, is the artifact behaving correctly: with no `Context` it cannot auto-discover the extraction's keychain, and it logs exactly that. The real run produces its recorded 4 rows.

No behaviour changes, no row counts move, claim-language and HTML-safety checks pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>