### PR TITLE
fix: give every artifact an author, using the GitHub handle that sent it

### DIFF
--- a/scripts/artifacts/connectedDevices.py
+++ b/scripts/artifacts/connectedDevices.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "conDev": {
         "name": "Connected Devices",
         "description": "Extracts computer and user names recorded in iTunesPrefs (FRPD)",
-        "author": "",
+        "author": "@JamesHabben",
         "creation_date": "2024-10-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/deviceActivator.py
+++ b/scripts/artifacts/deviceActivator.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "deviceActivator": {
         "name": "iOS Device Activator Data",
         "description": "Extracts device information from activation data",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-10-29",
         "last_update_date": "2025-11-21",
         "requirements": "none",

--- a/scripts/artifacts/deviceDatam.py
+++ b/scripts/artifacts/deviceDatam.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "deviceDatam": {
         "name": "Device Data",
         "description": "Device identifiers and phone number information",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-10-29",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/dhcpl.py
+++ b/scripts/artifacts/dhcpl.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "dhcpLeases": {
         "name": "DHCP Received List",
         "description": "DHCP client lease information",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-10-29",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/discordAcct.py
+++ b/scripts/artifacts/discordAcct.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_discordAcct": {  # This should match the function name exactly
         "name": "Discord - Account",
         "description": "Parses Discord accounts",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "",
         "last_updated": "2025-11-25",
         "requirements": "none",

--- a/scripts/artifacts/duetLocations.py
+++ b/scripts/artifacts/duetLocations.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "duetlocations": {
         "name": "Duet Locations",
         "description": "Location records from the DuetExpertCenter location stream (SEGB)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/findMy.py
+++ b/scripts/artifacts/findMy.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "findMy": {
         "name": "Find My iPhone Settings",
         "description": "Find My iPhone account settings (FMIPAccounts.plist)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/geodApplications.py
+++ b/scripts/artifacts/geodApplications.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "geodapplications": {
         "name": "Geolocation - Applications",
         "description": "Per-application location count entries from the geod AP.db (mkcount/dailycounts)",
-        "author": "",
+        "author": "@flamusdiu",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-10",
         "requirements": "none",

--- a/scripts/artifacts/geodPDPlaceCache.py
+++ b/scripts/artifacts/geodPDPlaceCache.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "geodpdplacecache": {
         "name": "Geolocation - PD Place Cache",
         "description": "Cached place lookups from the geod PDPlaceCache.db",
-        "author": "",
+        "author": "@flamusdiu",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "googleDuoContacts": {
         "name": "Google Duo - Contacts",
         "description": "Google Duo contacts",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Google Duo", "notes": "",
         "paths": ('*/Application Support/DataStore*',),
         "output_types": "standard", "artifact_icon": "users",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "googleDuoCallHistory": {
         "name": "Google Duo - Call History",
         "description": "Google Duo call history",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Google Duo", "notes": "",
         "paths": ('*/Application Support/DataStore*',),
         "output_types": "standard", "artifact_icon": "phone",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     "googleDuoClips": {
         "name": "Google Duo - Clips",
         "description": "Google Duo media clips (with thumbnails from ClipsCache)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "Google Duo",
         "notes": "The media_clip_source value's direction semantics are not documented in published research; the value is reported as stored.",
         "paths": ('*/Application Support/DataStore*', '*/Application Support/ClipsCache/*.png'),

--- a/scripts/artifacts/iCloudWifi.py
+++ b/scripts/artifacts/iCloudWifi.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "iCloudWifi": {
         "name": "iCloud Wifi Networks",
         "description": "Wi-Fi networks synced via iCloud (com.apple.wifid.plist)",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/icloudMeta.py
+++ b/scripts/artifacts/icloudMeta.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "icloudmeta": {
         "name": "iCloud - File Metadata",
         "description": "iCloud Drive file metadata parsed from Metadata.txt (iCloud Returns)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/icloudPhotoMeta.py
+++ b/scripts/artifacts/icloudPhotoMeta.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "iCloud Photos Metadata",
         "description": "Parses photo metadata returned by iCloud (cloudphotolibrary Metadata.txt), "
                        "including decoded filenames, timestamps, GPS and embedded EXIF/TIFF.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/icloudSharedalbums.py
+++ b/scripts/artifacts/icloudSharedalbums.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "icloudSharedOwnerInfo": {
         "name": "iCloud Shared Albums - Owner Info",
         "description": "iCloud shared album owner info (Info.plist)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "iCloud Shared Albums", "notes": "",
         "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
         "output_types": "standard", "artifact_icon": "users",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     "icloudSharedAlbumData": {
         "name": "iCloud Shared Albums - Album Data",
         "description": "iCloud shared album DCIM counters (DCIM_CLOUD.plist)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "iCloud Shared Albums", "notes": "",
         "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
         "output_types": "standard", "artifact_icon": "photo",
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
     "icloudSharedPersonInfo": {
         "name": "iCloud Shared Albums - Person Info",
         "description": "iCloud shared album participants (cloudSharedPersonInfos.plist)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "iCloud Shared Albums", "notes": "",
         "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
         "output_types": "standard", "artifact_icon": "user",
@@ -77,7 +77,7 @@ __artifacts_v2__ = {
     "icloudSharedEmails": {
         "name": "iCloud Shared Albums - Emails",
         "description": "iCloud shared album emails (cloudSharedEmails.plist)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "iCloud Shared Albums", "notes": "",
         "paths": ('*/mobile/Media/PhotoData/PhotoCloudSharingData/*',),
         "output_types": "standard", "artifact_icon": "mail",

--- a/scripts/artifacts/imoHD_Chat.py
+++ b/scripts/artifacts/imoHD_Chat.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "imoHDChatMessages": {
         "name": "IMO HD Chat - Messages",
         "description": "IMO HD chat messages and attachments",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "IMO HD Chat", "notes": "URLs are constructed by the parser from object IDs using an observed IMO CDN pattern; they are not stored in the data.",
         "paths": ('*/IMODb2.sqlite*',
                   '*/mobile/Containers/Data/Application/*/Library/Caches/videos/*.webp'),
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
     "imoHDChatContacts": {
         "name": "IMO HD Chat - Contacts",
         "description": "IMO HD chat contacts",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "IMO HD Chat", "notes": "URLs are constructed by the parser from object IDs using an observed IMO CDN pattern; they are not stored in the data.",
         "paths": ('*/IMODb2.sqlite*',),
         "output_types": "standard", "artifact_icon": "users",

--- a/scripts/artifacts/interactionCcontacts.py
+++ b/scripts/artifacts/interactionCcontacts.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "interactionCContacts": {
         "name": "InteractionC - Contacts",
         "description": "Contact interactions recorded in interactionC.db",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
     "interactionCAttachments": {
         "name": "InteractionC - Attachments",
         "description": "Attachment interactions recorded in interactionC.db",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/locServicesconfig.py
+++ b/scripts/artifacts/locServicesconfig.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "locServicesConfigClients": {
         "name": "LSC - clients.plist",
         "description": "Location Services configuration for the Routine bundle from clients.plist",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
     "locServicesConfigLocationd": {
         "name": "LSC - com.apple.locationd.plist",
         "description": "Location Services configuration key/values from com.apple.locationd.plist",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-21",
         "requirements": "none",
@@ -62,7 +62,7 @@ __artifacts_v2__ = {
     "locServicesConfigRoutined": {
         "name": "LSC - com.apple.routined.plist",
         "description": "Location Services configuration key/values from com.apple.routined.plist",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-21",
         "requirements": "none",

--- a/scripts/artifacts/mapsSync.py
+++ b/scripts/artifacts/mapsSync.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Maps Sync",
         "description": "Apple Maps history — searches, displayed locations and navigation journeys "
                        "from MapsSync_0.0.1",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "mediaLibrary": {
         "name": "Media Library",
         "description": "Media items (music, video, podcasts, e-books) from Medialibrary.sqlitedb",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2023-11-21",
         "last_update_date": "2026-07-31",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "mediaLibraryInfo": {
         "name": "Media Library - Database Properties",
         "description": "iCloud/account properties from the Medialibrary.sqlitedb _MLDATABASEPROPERTIES table",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2023-11-21",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/metamask.py
+++ b/scripts/artifacts/metamask.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "metamaskWallets": {
         "name": "MetaMask - Wallets",
         "description": "MetaMask wallet accounts (import time, name, address, balance)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@ozaksen", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Metamask", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
         "output_types": "standard", "artifact_icon": "credit-card"
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
     "metamaskContacts": {
         "name": "MetaMask - Contacts",
         "description": "MetaMask address book contacts",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@ozaksen", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Metamask", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
         "output_types": "standard", "artifact_icon": "users"
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
     "metamaskTransactions": {
         "name": "MetaMask - Transactions",
         "description": "MetaMask transactions (time, from/to address, value, hash)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@ozaksen", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Metamask", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
         "output_types": "standard", "artifact_icon": "repeat"
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
     "metamaskBrowser": {
         "name": "MetaMask - Browser",
         "description": "MetaMask in-app browser history",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@ozaksen", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Metamask", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/persistStore/persist-root',),
         "output_types": "standard", "artifact_icon": "globe"

--- a/scripts/artifacts/notes.py
+++ b/scripts/artifacts/notes.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
     "notes": {
         "name": "Notes",
         "description": "Apple Notes including decoded note body text and embedded attachments",
-        "author": "",
+        "author": "@any333",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/notificationsXI.py
+++ b/scripts/artifacts/notificationsXI.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "notificationsXI": {
         "name": "Notifications (iOS 11 PushStore)",
         "description": "Delivered notifications parsed from iOS <= 11 SpringBoard PushStore files",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/notificationsXII.py
+++ b/scripts/artifacts/notificationsXII.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "notificationsXII": {
         "name": "Notifications",
         "description": "iOS 12+ delivered notifications (DeliveredNotifications.plist)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-26",
         "requirements": "none",

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "offlinePages": {
         "name": "Offline Pages (MHTML)",
         "description": "Saved offline web pages (MHTML/MHT) with their captured source URL and date",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/ooklaSpeedtestData.py
+++ b/scripts/artifacts/ooklaSpeedtestData.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "ooklaSpeedtestData": {
         "name": "Ookla Speedtest",
         "description": "Ookla Speedtest results including network details and test location",
-        "author": "",
+        "author": "@mastenp",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/photosDbexif.py
+++ b/scripts/artifacts/photosDbexif.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Correlates Photos.sqlite asset records with on-disk file EXIF to surface "
                        "timestamp and coordinate mismatches between the library database, cached EXIF, "
                        "and the media file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-08-06",
         "requirements": "none",

--- a/scripts/artifacts/photosMetadata.py
+++ b/scripts/artifacts/photosMetadata.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "timestamps, location/reverse-geocode, faces, moments, fingerprints and more. "
                        "Supported schemas: iOS 12-14 queries; on newer iOS versions this artifact "
                        "returns no rows (see the Ph* artifact series for current schemas).",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/protonMail.py
+++ b/scripts/artifacts/protonMail.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Proton Mail - Decrypted Emails",
         "description": "Decrypted Proton Mail emails and attachments (requires the device keychain "
                        "in scripts/keychain/)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "pgpy, pycryptodome, ccl_bplist; a keychain plist placed in scripts/keychain/",

--- a/scripts/artifacts/queryPredictions.py
+++ b/scripts/artifacts/queryPredictions.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "queryPredictions": {
         "name": "Query Predictions",
         "description": "Message query predictions from query_predictions.db",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-03",
         "requirements": "none",

--- a/scripts/artifacts/quickLook.py
+++ b/scripts/artifacts/quickLook.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "quickLook": {
         "name": "iCloud Quick Look",
         "description": "Entries from the Quick Look cloudthumbnails.db cache: paths of iCloud files with last-hit dates. A cache entry does not establish that a user viewed the file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/recentApphistory.py
+++ b/scripts/artifacts/recentApphistory.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "recentApphistory": {
         "name": "CarPlay Recent App History",
         "description": "CarPlay recent app history from com.apple.CarPlayApp.plist",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/reminders.py
+++ b/scripts/artifacts/reminders.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "reminders": {
         "name": "Reminders",
         "description": "iOS Reminders with creation and last-modified timestamps",
-        "author": "",
+        "author": "@any333",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/safariBookmarks.py
+++ b/scripts/artifacts/safariBookmarks.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "safariBookmarks": {
         "name": "Safari Browser - Bookmarks",
         "description": "Safari bookmarks",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-21",
         "requirements": "none",

--- a/scripts/artifacts/safariFavicons.py
+++ b/scripts/artifacts/safariFavicons.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "safariFavicons": {
         "name": "Safari Browser - Favicons",
         "description": "Safari favicon cache entries (page URL, icon URL, dimensions)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/safariRecentWebSearches.py
+++ b/scripts/artifacts/safariRecentWebSearches.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "safariRecentWebSearches": {
         "name": "Safari Browser - Recent Web Searches",
         "description": "Recent Safari web searches from com.apple.mobilesafari.plist",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/safariTabs.py
+++ b/scripts/artifacts/safariTabs.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "safariTabsBrowserState": {
         "name": "Safari Browser - Tabs (BrowserState)",
         "description": "Open Safari tabs from BrowserState.db",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Safari Browser", "notes": "",
         "paths": ('**/Safari/BrowserState.db*',),
         "output_types": "standard", "artifact_icon": "layout",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     "safariTabsiCloud": {
         "name": "Safari Browser - iCloud Tabs",
         "description": "Safari iCloud (cloud) tabs synced across devices",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Safari Browser", "notes": "",
         "paths": ('**/Safari/CloudTabs.db*',),
         "output_types": "standard", "artifact_icon": "cloud",

--- a/scripts/artifacts/safariWebsearch.py
+++ b/scripts/artifacts/safariWebsearch.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "safariWebsearch": {
         "name": "Safari Browser - Search Terms",
         "description": "Search-engine queries extracted from Safari History.db (search?q= URLs)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/simInfo.py
+++ b/scripts/artifacts/simInfo.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "simInfoUUID": {
         "name": "SIM - UUID",
         "description": "SIM personal wallet entries from com.apple.commcenter.data.plist",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "SIM Info", "notes": "Timestamps are Unix epoch seconds (UTC).",
         "paths": ('*/com.apple.commcenter.data.plist',),
         "output_types": "standard", "artifact_icon": "credit-card",
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
     "simInfoLabelStore": {
         "name": "SIM - Unique Label Store",
         "description": "SIM unique label store from com.apple.commcenter.data.plist",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "SIM Info", "notes": "Timestamps are Unix epoch seconds (UTC).",
         "paths": ('*/com.apple.commcenter.data.plist',),
         "output_types": "standard", "artifact_icon": "tag",

--- a/scripts/artifacts/slack.py
+++ b/scripts/artifacts/slack.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "slackModelMessages": {
         "name": "Slack - Messages (ModelDatabase)",
         "description": "Slack chat messages from the newer ModelDatabase (ZCOREDATA*) schema",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
         "output_types": "standard", "artifact_icon": "message-circle",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
     "slackModelUsers": {
         "name": "Slack - User Data (ModelDatabase)",
         "description": "Slack users from the newer ModelDatabase (ZCOREDATAUSER) schema",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
         "output_types": "standard", "artifact_icon": "users",
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
     "slackModelChannels": {
         "name": "Slack - Channel Data (ModelDatabase)",
         "description": "Slack channels/DMs from the newer ModelDatabase schema",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "Slack", "notes": "Channel-type value mapping observed in testing; unrecognized values reported as stored.",
         "paths": ('*/mobile/Containers/Shared/AppGroup/*/*/ModelDatabase/db.sqlite*',),
         "output_types": "standard", "artifact_icon": "hash",
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
     "slackMessages": {
         "name": "Slack - Messages",
         "description": "Slack chat messages from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
         "output_types": "standard", "artifact_icon": "message-circle",
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
     "slackUsers": {
         "name": "Slack - User Data",
         "description": "Slack users from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
         "output_types": "standard", "artifact_icon": "users",
@@ -70,7 +70,7 @@ __artifacts_v2__ = {
     "slackAttachments": {
         "name": "Slack - Attachments",
         "description": "Slack messages with shared file attachments (main_db)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
         "output_types": "standard", "artifact_icon": "paperclip",
@@ -82,7 +82,7 @@ __artifacts_v2__ = {
     "slackChannels": {
         "name": "Slack - Channel Data",
         "description": "Slack channels from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
         "output_types": "standard", "artifact_icon": "hash",
@@ -94,7 +94,7 @@ __artifacts_v2__ = {
     "slackTeams": {
         "name": "Slack - Team Data",
         "description": "Slack workspaces/teams from main_db (ZSLK*/ZSLKDEPRECATED* schema)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
         "category": "Slack", "notes": "",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Application Support/Slack/*/*/main_db*',),
         "output_types": "standard", "artifact_icon": "briefcase",

--- a/scripts/artifacts/springboard.py
+++ b/scripts/artifacts/springboard.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "icons_screen": {
         "name": "iOS Home Screen Layout",
         "description": "Home screen layout: apps, folders, widgets and the dock, per screen page",
-        "author": "",
+        "author": "@JamesHabben",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-21",
         "requirements": "none",
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
     "icons_screen_visual": {
         "name": "iOS Home Screen Layout - Visual",
         "description": "Rendered image of each home screen page (apps, folders, widgets, dock)",
-        "author": "",
+        "author": "@JamesHabben",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-21",
         "requirements": "none",

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "teamsMessages": {
         "name": "Teams Messages",
         "description": "Microsoft Teams messages and shared media",
-        "author": "",
+        "author": "@abrignoni",
         "last_update_date": "2026-06-12",
         "requirements": "nska_deserialize",
         "category": "Microsoft Teams",
@@ -33,7 +33,7 @@ __artifacts_v2__ = {
     "teamsContacts": {
         "name": "Teams Contacts",
         "description": "Microsoft Teams contact list",
-        "author": "",
+        "author": "@abrignoni",
         "last_update_date": "2026-06-12",
         "requirements": "nska_deserialize",
         "category": "Microsoft Teams",
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
     "teamsUser": {
         "name": "Teams User Information",
         "description": "Microsoft Teams user profile and sync data",
-        "author": "",
+        "author": "@abrignoni",
         "last_update_date": "2026-06-12",
         "requirements": "nska_deserialize",
         "category": "Microsoft Teams",
@@ -65,7 +65,7 @@ __artifacts_v2__ = {
     "teamsCalls": {
         "name": "Teams Call Logs",
         "description": "Microsoft Teams call history",
-        "author": "",
+        "author": "@abrignoni",
         "last_update_date": "2026-06-12",
         "requirements": "nska_deserialize",
         "category": "Microsoft Teams",
@@ -81,7 +81,7 @@ __artifacts_v2__ = {
     "teamsLocations": {
         "name": "Teams Shared Locations",
         "description": "Microsoft Teams shared location data",
-        "author": "",
+        "author": "@abrignoni",
         "last_update_date": "2026-06-12",
         "requirements": "nska_deserialize",
         "category": "Microsoft Teams",

--- a/scripts/artifacts/teamsSegment.py
+++ b/scripts/artifacts/teamsSegment.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "teamsSegmentLocations": {
         "name": "Microsoft Teams - Locations",
         "description": "Location segments logged by the DriveIQ SDK (observed in Microsoft Teams)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
     "teamsSegmentMotion": {
         "name": "Microsoft Teams - Motion",
         "description": "Motion/activity segments logged by the DriveIQ SDK (observed in Microsoft Teams)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
     "teamsSegmentTimezone": {
         "name": "Microsoft Teams - Timezone",
         "description": "Timezone check segments logged by the DriveIQ SDK (observed in Microsoft Teams)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
     "teamsSegmentPower": {
         "name": "Microsoft Teams - Power Log",
         "description": "Power/battery segments logged by the DriveIQ SDK (observed in Microsoft Teams)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",
@@ -66,7 +66,7 @@ __artifacts_v2__ = {
     "teamsSegmentStateChange": {
         "name": "Microsoft Teams - State Change",
         "description": "State change segments logged by the DriveIQ SDK (observed in Microsoft Teams)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "teleguardMessages": {
         "name": "Teleguard Messages",
         "description": "TeleGuard chat messages and shared media",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-07-03", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-07-03", "requirements": "none",
         "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
         "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',
                   '*/Library/Caches/images/*'),
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
     "teleguardPosts": {
         "name": "Teleguard Posts",
         "description": "TeleGuard channel posts",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
         "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),
         "output_types": "standard", "artifact_icon": "file-text",
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
     "teleguardContacts": {
         "name": "Teleguard Contacts",
         "description": "TeleGuard contacts (with avatar thumbnails)",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Teleguard", "notes": "Timestamps are UTC (epoch milliseconds).",
         "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),
         "output_types": "standard", "artifact_icon": "users",
@@ -47,7 +47,7 @@ __artifacts_v2__ = {
     "teleguardChannels": {
         "name": "Teleguard Channels",
         "description": "TeleGuard channels",
-        "author": "", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
+        "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Teleguard", "notes": "",
         "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),
         "output_types": "standard", "artifact_icon": "radio",

--- a/scripts/artifacts/textinputTyping.py
+++ b/scripts/artifacts/textinputTyping.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "textinputTyping": {
         "name": "Text Input Messages",
         "description": "Typed text captured by the TextInput TypingDESPlugin (.desdata)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",
         "requirements": "none",

--- a/scripts/artifacts/tileApp.py
+++ b/scripts/artifacts/tileApp.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "tileApp": {
         "name": "Tile App Geolocation Logs",
         "description": "Latitude/longitude coordinates recorded in Tile app logs",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",

--- a/scripts/artifacts/tileAppDb.py
+++ b/scripts/artifacts/tileAppDb.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "tileAppDb": {
         "name": "Tile App DB Info & Geolocation",
         "description": "Tile device information and most recent stored coordinates (via the TILESTATE join) from the Tile network database",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-06-23",
         "last_update_date": "2026-07-31",
         "requirements": "none",


### PR DESCRIPTION
80 artifacts in this repo carried `"author": ""`. That field reaches the HTML report and the LAVA manifest, so it rendered blank in output that gets quoted in casework, and it credited nobody for the work.

(Handles below are in backticks deliberately, so opening this PR does not fire a notification at every contributor named in it.)

## How the value was derived

The GitHub account that **created the file** the artifact lives in, resolved through the GitHub API from that file's first commit (`.author.login`). That is the account GitHub itself attaches to the commit, not a guess parsed out of a git name string.

Nothing existing is changed. Where someone is already credited under a different form, this only fills the empty entries alongside them.

## What was tried and rejected

Deriving per artifact key rather than per file. Many of these artifacts were converted from the v1 format in a later commit, so the v2 key first appears in that conversion rather than in the original contribution, which attributed several contributors' work to whoever did the conversion.

## Two files worth a reviewer's eye

Their existing artifacts credit one person while the file was created by another, so the handle added is the file creator and may not be the writer of that particular artifact:

| File | Existing artifacts credit | Handle added | Empty entries filled |
|---|---|---|---|
| `notes.py` | `AlexisBrignoni` | `any333` | 1 |
| `safariTabs.py` | `AlexisBrignoni` | `abrignoni` | 2 |

The second is the same person under a second handle, so it is harmless. The first is a different person. Happy to correct on request.

## Validation

The diff touches the `author` field and nothing else, verified by checking that no changed line lacks `"author"`. Claim-language and HTML-safety checks pass. No behaviour, paths or row counts change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>