### PR TITLE
fix: close the connection null_absent_columns opens

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -1015,21 +1015,26 @@ def null_absent_columns(path, query):
         return query
 
     replaced = []
-    for _ in range(50):                      # a query cannot need more than this
-        try:
-            db.execute('EXPLAIN ' + query)
-            break
-        except sqlite3.OperationalError as ex:
-            match = re.match(r'no such column:\s*(\S+)', str(ex))
-            if not match:
+    try:
+        for _ in range(50):                  # a query cannot need more than this
+            try:
+                db.execute('EXPLAIN ' + query)
                 break
-            reference = match.group(1)
-            if reference in replaced:
-                break                        # not making progress, leave it alone
-            replaced.append(reference)
-            query = _null_out_column(query, reference)
-        except sqlite3.Error:
-            break
+            except sqlite3.OperationalError as ex:
+                match = re.match(r'no such column:\s*(\S+)', str(ex))
+                if not match:
+                    break
+                reference = match.group(1)
+                if reference in replaced:
+                    break                    # not making progress, leave it alone
+                replaced.append(reference)
+                query = _null_out_column(query, reference)
+            except sqlite3.Error:
+                break
+    finally:
+        # Artifacts call this once per query, so an unclosed handle here is one
+        # leak per query for the whole run rather than a one-off.
+        db.close()
 
     if replaced:
         logfunc(f'{os.path.basename(path)}: column(s) absent from this version are reported '


### PR DESCRIPTION
`null_absent_columns` opens a connection through `open_sqlite_db_readonly` to compile the query with `EXPLAIN`, and returns without closing it. Artifacts call it **once per query**, and it is now wired into **534 call sites** in this repo, so this is one held handle per query for the length of a run rather than a one-off.

Same class as the three `does_*_exist_in_db` helpers fixed in [#1778](https://github.com/abrignoni/iLEAPP/pull/1778), which this function postdates.

## Measured, by counting open file descriptors

Garbage collection disabled so a leak cannot be hidden by collection:

| | before | after |
|---|---|---|
| 150 `null_absent_columns` calls | **+150 open fds** | **+0** |

Behaviour is unchanged: the same query still returns with the absent column reported as `NULL` under its own name.

A `ResourceWarning`-based test was tried first and is **not** adequate. That warning is raised during garbage collection, where CPython prints "Exception ignored" rather than propagating, so the test reported "no leak" against the unfixed code too. Descriptor counting was confirmed to fail on the unfixed version before being trusted.

Levelled to the other four cores: [ALEAPP #1081](https://github.com/abrignoni/ALEAPP/pull/1081), [DLEAPP #61](https://github.com/abrignoni/DLEAPP/pull/61), [RLEAPP #401](https://github.com/abrignoni/RLEAPP/pull/401), [VLEAPP #118](https://github.com/abrignoni/VLEAPP/pull/118). Those also carry the #1778 helper fixes, which had not reached them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>