### PR TITLE
fix: read the iOS schemas these artifacts actually meet

### DIFF
--- a/scripts/artifacts/FitnessWorkoutsLocationData.py
+++ b/scripts/artifacts/FitnessWorkoutsLocationData.py
@@ -71,7 +71,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, does_table_exist_in_db
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, null_absent_columns, does_table_exist_in_db
 
 _ACTIVITY_TYPE_CASE = '''CASE activity_type
     WHEN 1 THEN "American Football"
@@ -200,9 +200,9 @@ def fitnessWorkoutsAnalysis(context):
         GROUP BY location_series_data.series_identifier
         ORDER BY workout_activities.start_date
     '''
-    # for row in get_sqlite_db_records(db_path, query):
+    # for row in get_sqlite_db_records(db_path, null_absent_columns(db_path, query)):
     #     data_list.append(tuple(row))
-    data_list = list( get_sqlite_db_records(db_path, query) )
+    data_list = list( get_sqlite_db_records(db_path, null_absent_columns(db_path, query)) )
 
     return data_headers, data_list, context.get_relative_path(db_path)
 
@@ -234,8 +234,8 @@ def fitnessWorkoutsLocation(context):
         LEFT OUTER JOIN associations on associations.child_id = data_series.data_id
         LEFT OUTER JOIN workout_activities on workout_activities.owner_id = associations.parent_id
     '''
-    # for row in get_sqlite_db_records(db_path, query):
+    # for row in get_sqlite_db_records(db_path, null_absent_columns(db_path, query)):
     #     data_list.append(tuple(row))
-    data_list = list( get_sqlite_db_records(db_path, query) )
+    data_list = list( get_sqlite_db_records(db_path, null_absent_columns(db_path, query)) )
 
     return data_headers, data_list, context.get_relative_path(db_path)

--- a/scripts/artifacts/Ph001BasicAssetData.py
+++ b/scripts/artifacts/Ph001BasicAssetData.py
@@ -88,7 +88,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph001_1AssetBasicDataPhDaPsql(context):
@@ -158,7 +158,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -185,7 +185,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         'zAddAssetAttr-zPK-17',
         'zAsset-UUID = store.cloudphotodb-18',
         'zAddAssetAttr-Master Fingerprint-19')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
     # NOTE: commenting it out because it overwrites the previously processed
     #   results, will do the same on all the other instances where this
     #   happens all over the file, and the other artifacts too
@@ -249,7 +249,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -279,7 +279,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-20',
         'zAddAssetAttr-Master Fingerprint-21')
 
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -357,7 +357,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
             LEFT JOIN ZCLOUDMASTER zCldMast ON zAsset.ZMASTER = zCldMast.Z_PK
         ORDER BY zAsset.ZDATECREATED
         '''
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -389,7 +389,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         'zAddAssetAttr-zPK-22',
         'zAsset-UUID = store.cloudphotodb-23',
         'zAddAssetAttr-Master Fingerprint-24')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -473,7 +473,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
             LEFT JOIN ZCLOUDMASTER zCldMast ON zAsset.ZMASTER = zCldMast.Z_PK
         ORDER BY zAsset.ZDATECREATED
         '''
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -507,7 +507,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         'zAddAssetAttr-zPK-24',
         'zAsset-UUID = store.cloudphotodb-25',
         'zAddAssetAttr-Master Fingerprint-26')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -598,7 +598,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -636,7 +636,7 @@ def Ph001_1AssetBasicDataPhDaPsql(context):
         'zAddAssetAttr-Original Stable Hash-27',
         'zAddAssetAttr.Adjusted Stable Hash-28')
 
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -708,7 +708,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -735,7 +735,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         'zAddAssetAttr-zPK-17',
         'zAsset-UUID = store.cloudphotodb-18',
         'zAddAssetAttr-Master Fingerprint-19')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -796,7 +796,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -825,7 +825,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         'zAddAssetAttr-zPK-19',
         'zAsset-UUID = store.cloudphotodb-20',
         'zAddAssetAttr-Master Fingerprint-21')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -904,7 +904,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -936,7 +936,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         'zAddAssetAttr-zPK-22',
         'zAsset-UUID = store.cloudphotodb-23',
         'zAddAssetAttr-Master Fingerprint-24')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1021,7 +1021,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1055,7 +1055,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         'zAddAssetAttr-zPK-24',
         'zAsset-UUID = store.cloudphotodb-25',
         'zAddAssetAttr-Master Fingerprint-26')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1146,7 +1146,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1183,7 +1183,7 @@ def Ph001_2AssetBasicDataSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-26',
         'zAddAssetAttr-Original Stable Hash-27',
         'zAddAssetAttr.Adjusted Stable Hash-28')
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1291,7 +1291,7 @@ def Ph001_3AssetBasicDataGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1329,6 +1329,6 @@ def Ph001_3AssetBasicDataGenPlayPsql(context):
         'zAddAssetAttr-Original Stable Hash-27',
         'zAddAssetAttr.Adjusted Stable Hash-28')
 
-    # data_list = get_sqlite_db_records(source_path, query)
+    # data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph002BasicAssetandAlbumData.py
+++ b/scripts/artifacts/Ph002BasicAssetandAlbumData.py
@@ -101,7 +101,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
@@ -268,7 +268,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -325,7 +325,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-45',
         'zAsset-UUID = store.cloudphotodb-46',
         'zAddAssetAttr-Master Fingerprint-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -477,7 +477,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -534,7 +534,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-45',
         'zAsset-UUID = store.cloudphotodb-46',
         'zAddAssetAttr-Master Fingerprint-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -750,7 +750,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -827,7 +827,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-63',
         'zAsset-UUID = store.cloudphotodb-64',
         'zAddAssetAttr-Master Fingerprint-65')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1057,7 +1057,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1141,7 +1141,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-70',
         'zAsset-UUID = store.cloudphotodb-71',
         'zAddAssetAttr-Master Fingerprint-72')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1392,7 +1392,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1482,7 +1482,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-75',
         'zAsset-UUID = store.cloudphotodb-76',
         'zAddAssetAttr-Master Fingerprint-77')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1739,7 +1739,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1831,7 +1831,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-77',
         'zAsset-UUID = store.cloudphotodb-78',
         'zAddAssetAttr-Master Fingerprint-79')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2089,7 +2089,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2182,7 +2182,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-78',
         'zAsset-UUID = store.cloudphotodb-79',
         'zAddAssetAttr-Master Fingerprint-80')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2440,7 +2440,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2533,7 +2533,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAddAssetAttr-zPK-78',
         'zAsset-UUID = store.cloudphotodb-79',
         'zAddAssetAttr-Master Fingerprint-80')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2798,7 +2798,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2895,7 +2895,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-81',
         'zAddAssetAttr-Original Stable Hash-82',
         'zAddAssetAttr.Adjusted Stable Hash-83')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3160,7 +3160,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3257,7 +3257,7 @@ def Ph002_1AssetBasicGenAlbumDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-81',
         'zAddAssetAttr-Original Stable Hash-82',
         'zAddAssetAttr.Adjusted Stable Hash-83')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -3427,7 +3427,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3484,7 +3484,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-45',
         'zAsset-UUID = store.cloudphotodb-46',
         'zAddAssetAttr-Master Fingerprint-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3637,7 +3637,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3694,7 +3694,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-45',
         'zAsset-UUID = store.cloudphotodb-46',
         'zAddAssetAttr-Master Fingerprint-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3911,7 +3911,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3988,7 +3988,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-63',
         'zAsset-UUID = store.cloudphotodb-64',
         'zAddAssetAttr-Master Fingerprint-65')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -4218,7 +4218,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
             LEFT JOIN ZGENERICALBUM zGenAlbum ON zGenAlbum.Z_PK = z26Assets.Z_26ALBUMS
         ORDER BY zAsset.ZDATECREATED
         '''
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4302,7 +4302,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-70',
         'zAsset-UUID = store.cloudphotodb-71',
         'zAddAssetAttr-Master Fingerprint-72')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -4554,7 +4554,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4644,7 +4644,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-75',
         'zAsset-UUID = store.cloudphotodb-76',
         'zAddAssetAttr-Master Fingerprint-77')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -4902,7 +4902,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4994,7 +4994,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-77',
         'zAsset-UUID = store.cloudphotodb-78',
         'zAddAssetAttr-Master Fingerprint-79')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5252,7 +5252,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -5345,7 +5345,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-78',
         'zAsset-UUID = store.cloudphotodb-79',
         'zAddAssetAttr-Master Fingerprint-80')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5603,7 +5603,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -5696,7 +5696,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAddAssetAttr-zPK-78',
         'zAsset-UUID = store.cloudphotodb-79',
         'zAddAssetAttr-Master Fingerprint-80')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5961,7 +5961,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -6058,7 +6058,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-81',
         'zAddAssetAttr-Original Stable Hash-82',
         'zAddAssetAttr.Adjusted Stable Hash-83')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -6323,7 +6323,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -6420,7 +6420,7 @@ def Ph002_2AssetBasicConversationDataSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-81',
         'zAddAssetAttr-Original Stable Hash-82',
         'zAddAssetAttr.Adjusted Stable Hash-83')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -6702,7 +6702,7 @@ def Ph002_3AssetBasicGenAlbumGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -6799,7 +6799,7 @@ def Ph002_3AssetBasicGenAlbumGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-81',
         'zAddAssetAttr-Original Stable Hash-82',
         'zAddAssetAttr.Adjusted Stable Hash-83')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -7064,7 +7064,7 @@ def Ph002_3AssetBasicGenAlbumGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -7161,6 +7161,6 @@ def Ph002_3AssetBasicGenAlbumGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-81',
         'zAddAssetAttr-Original Stable Hash-82',
         'zAddAssetAttr.Adjusted Stable Hash-83')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph003TrashedRemovedfromCamRoll.py
+++ b/scripts/artifacts/Ph003TrashedRemovedfromCamRoll.py
@@ -92,7 +92,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
@@ -142,7 +142,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         ORDER BY zAsset.ZTRASHEDSTATE      
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10]))
@@ -158,7 +158,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         'zAddAssetAttr-zPK-8',
         'zAsset-UUID = store.cloudphotodb-9',
         'zAddAssetAttr-Master Fingerprint-10')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -193,7 +193,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         ORDER BY zAsset.ZTRASHEDSTATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10]))
@@ -209,7 +209,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         'zAddAssetAttr-zPK-8',
         'zAsset-UUID = store.cloudphotodb-9',
         'zAddAssetAttr-Master Fingerprint-10')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -255,7 +255,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         ORDER BY zAsset.ZTRASHEDSTATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -273,7 +273,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         'zAddAssetAttr-zPK-10',
         'zAsset-UUID = store.cloudphotodb-11',
         'zAddAssetAttr-Master Fingerprint-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -326,7 +326,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         ORDER BY zAsset.ZTRASHEDSTATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16]))
@@ -348,7 +348,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         'zAddAssetAttr-zPK-14',
         'zAsset-UUID = store.cloudphotodb-15',
         'zAddAssetAttr-Master Fingerprint-16')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -402,7 +402,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         ORDER BY zAsset.ZTRASHEDSTATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17]))
@@ -425,7 +425,7 @@ def Ph003_1TrashedRecentlyDeletedPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-15',
         'zAddAssetAttr-Original Stable Hash-16',
         'zAddAssetAttr.Adjusted Stable Hash-17')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -490,7 +490,7 @@ def Ph003_2RemovedfromCameraRollSyndPL(context):
         ORDER BY zAddAssetAttr.ZLASTUPLOADATTEMPTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13]))
@@ -509,7 +509,7 @@ def Ph003_2RemovedfromCameraRollSyndPL(context):
         'zAddAssetAttr-zPK-11',
         'zAsset-UUID = store.cloudphotodb-12',
         'zAddAssetAttr-Master Fingerprint-13')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -564,7 +564,7 @@ def Ph003_2RemovedfromCameraRollSyndPL(context):
         ORDER BY zAddAssetAttr.ZLASTUPLOADATTEMPTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17]))
@@ -587,7 +587,7 @@ def Ph003_2RemovedfromCameraRollSyndPL(context):
         'zAddAssetAttr-zPK-15',
         'zAsset-UUID = store.cloudphotodb-16',
         'zAddAssetAttr-Master Fingerprint-17')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -641,7 +641,7 @@ def Ph003_2RemovedfromCameraRollSyndPL(context):
         ORDER BY zAsset.ZTRASHEDSTATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17]))
@@ -664,7 +664,7 @@ def Ph003_2RemovedfromCameraRollSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-15',
         'zAddAssetAttr-Original Stable Hash-16',
         'zAddAssetAttr.Adjusted Stable Hash-17')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -735,7 +735,7 @@ def Ph003_3TrashedRecentlyDeletedGenPlayPsql(context):
         ORDER BY zAsset.ZTRASHEDSTATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17]))
@@ -758,6 +758,6 @@ def Ph003_3TrashedRecentlyDeletedGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-15',
         'zAddAssetAttr-Original Stable Hash-16',
         'zAddAssetAttr.Adjusted Stable Hash-17')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph004Hidden.py
+++ b/scripts/artifacts/Ph004Hidden.py
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph004_1HiddenPhDaPsql(context):
@@ -109,7 +109,7 @@ def Ph004_1HiddenPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10]))
@@ -125,7 +125,7 @@ def Ph004_1HiddenPhDaPsql(context):
         'zAddAssetAttr-zPK-8',
         'zAsset-UUID = store.cloudphotodb-9',
         'zAddAssetAttr-Master Fingerprint-10')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -160,7 +160,7 @@ def Ph004_1HiddenPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10]))
@@ -176,7 +176,7 @@ def Ph004_1HiddenPhDaPsql(context):
         'zAddAssetAttr-zPK-8',
         'zAsset-UUID = store.cloudphotodb-9',
         'zAddAssetAttr-Master Fingerprint-10')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -212,7 +212,7 @@ def Ph004_1HiddenPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11]))
@@ -229,7 +229,7 @@ def Ph004_1HiddenPhDaPsql(context):
         'zAddAssetAttr-zPK-9',
         'zAsset-UUID = store.cloudphotodb-10',
         'zAddAssetAttr-Master Fingerprint-11')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -266,7 +266,7 @@ def Ph004_1HiddenPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -284,7 +284,7 @@ def Ph004_1HiddenPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-10',
         'zAddAssetAttr-Original Stable Hash-11',
         'zAddAssetAttr.Adjusted Stable Hash-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -338,7 +338,7 @@ def Ph004_3HiddenGenPlayPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -356,6 +356,6 @@ def Ph004_3HiddenGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-10',
         'zAddAssetAttr-Original Stable Hash-11',
         'zAddAssetAttr.Adjusted Stable Hash-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph005HasLocations.py
+++ b/scripts/artifacts/Ph005HasLocations.py
@@ -96,7 +96,7 @@ import os
 import plistlib
 import nska_deserialize as nd
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
@@ -169,7 +169,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_geoplaceresult = ''
@@ -224,7 +224,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         'zAddAssetAttr-zPK-15',
         'zAsset-UUID = store.cloudphotodb-16',
         'zAddAssetAttr-Master Fingerprint-17')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -312,7 +312,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -384,7 +384,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         'zAddAssetAttr-zPK-21',
         'zAsset-UUID = store.cloudphotodb-22',
         'zAddAssetAttr-Master Fingerprint-23')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -480,7 +480,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -556,7 +556,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         'zAddAssetAttr-zPK-24',
         'zAsset-UUID = store.cloudphotodb-25',
         'zAddAssetAttr-Master Fingerprint-26')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -653,7 +653,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -730,7 +730,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         'zAddAssetAttr-zPK-25',
         'zAsset-UUID = store.cloudphotodb-26',
         'zAddAssetAttr-Master Fingerprint-27')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -828,7 +828,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -906,7 +906,7 @@ def Ph005_1AssetshavevalidlocationsPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-26',
         'zAddAssetAttr-Original Stable Hash-27',
         'zAddAssetAttr.Adjusted Stable Hash-28')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -981,7 +981,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_geoplaceresult = ''
@@ -1036,7 +1036,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         'zAddAssetAttr-zPK-15',
         'zAsset-UUID = store.cloudphotodb-16',
         'zAddAssetAttr-Master Fingerprint-17')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1124,7 +1124,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -1196,7 +1196,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         'zAddAssetAttr-zPK-21',
         'zAsset-UUID = store.cloudphotodb-22',
         'zAddAssetAttr-Master Fingerprint-23')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1292,7 +1292,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -1368,7 +1368,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         'zAddAssetAttr-zPK-24',
         'zAsset-UUID = store.cloudphotodb-25',
         'zAddAssetAttr-Master Fingerprint-26')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1465,7 +1465,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -1542,7 +1542,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         'zAddAssetAttr-zPK-25',
         'zAsset-UUID = store.cloudphotodb-26',
         'zAddAssetAttr-Master Fingerprint-27')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1640,7 +1640,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -1718,7 +1718,7 @@ def Ph005_2AssetshavevalidlocationsSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-26',
         'zAddAssetAttr-Original Stable Hash-27',
         'zAddAssetAttr.Adjusted Stable Hash-28')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1833,7 +1833,7 @@ def Ph005_3AssetshavevalidlocationsGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zAddAssetAttr.ZSHIFTEDLOCATIONDATA-PLIST
             aaashiftedlocation_postal_address = ''
@@ -1911,6 +1911,6 @@ def Ph005_3AssetshavevalidlocationsGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-26',
         'zAddAssetAttr-Original Stable Hash-27',
         'zAddAssetAttr.Adjusted Stable Hash-28')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph006ViewedPlayData.py
+++ b/scripts/artifacts/Ph006ViewedPlayData.py
@@ -83,7 +83,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, does_column_exist_in_db, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, does_column_exist_in_db, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph006_1ViewandPlayDataPhDaPsql(context):
@@ -139,7 +139,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13]))
@@ -158,7 +158,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -195,7 +195,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14]))
@@ -215,7 +215,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -252,7 +252,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14]))
@@ -272,7 +272,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -310,7 +310,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15]))
@@ -331,7 +331,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -369,7 +369,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15]))
@@ -390,7 +390,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -429,7 +429,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16]))
@@ -451,7 +451,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAddAssetAttr-zPK-14',
         'zAsset-UUID = store.cloudphotodb-15',
         'zAddAssetAttr-Master Fingerprint-16')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -496,7 +496,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18]))
@@ -520,7 +520,7 @@ def Ph006_1ViewandPlayDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-16',
         'zAddAssetAttr-Original Stable Hash-17',
         'zAddAssetAttr.Adjusted Stable Hash-18')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -578,7 +578,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13]))
@@ -597,7 +597,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -634,7 +634,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14]))
@@ -654,7 +654,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -691,7 +691,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14]))
@@ -711,7 +711,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -749,7 +749,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15]))
@@ -770,7 +770,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -808,7 +808,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15]))
@@ -829,7 +829,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -868,7 +868,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16]))
@@ -890,7 +890,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAddAssetAttr-zPK-14',
         'zAsset-UUID = store.cloudphotodb-15',
         'zAddAssetAttr-Master Fingerprint-16')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -935,7 +935,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18]))
@@ -959,7 +959,7 @@ def Ph006_2ViewandPlayDataSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-16',
         'zAddAssetAttr-Original Stable Hash-17',
         'zAddAssetAttr.Adjusted Stable Hash-18')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -1027,7 +1027,7 @@ def Ph006_3ViewandPlayDataGenPlayPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18]))
@@ -1051,6 +1051,6 @@ def Ph006_3ViewandPlayDataGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-16',
         'zAddAssetAttr-Original Stable Hash-17',
         'zAddAssetAttr.Adjusted Stable Hash-18')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph007Favorite.py
+++ b/scripts/artifacts/Ph007Favorite.py
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph007_1FavoritePhDaPsql(context):
@@ -108,7 +108,7 @@ def Ph007_1FavoritePhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10]))
@@ -124,7 +124,7 @@ def Ph007_1FavoritePhDaPsql(context):
         'zAddAssetAttr-zPK-8',
         'zAsset-UUID = store.cloudphotodb-9',
         'zAddAssetAttr-Master Fingerprint-10')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -158,7 +158,7 @@ def Ph007_1FavoritePhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10]))
@@ -174,7 +174,7 @@ def Ph007_1FavoritePhDaPsql(context):
         'zAddAssetAttr-zPK-8',
         'zAsset-UUID = store.cloudphotodb-9',
         'zAddAssetAttr-Master Fingerprint-10')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -209,7 +209,7 @@ def Ph007_1FavoritePhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11]))
@@ -226,7 +226,7 @@ def Ph007_1FavoritePhDaPsql(context):
         'zAddAssetAttr-zPK-9',
         'zAsset-UUID = store.cloudphotodb-10',
         'zAddAssetAttr-Master Fingerprint-11')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -262,7 +262,7 @@ def Ph007_1FavoritePhDaPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -280,7 +280,7 @@ def Ph007_1FavoritePhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-10',
         'zAddAssetAttr-Original Stable Hash-11',
         'zAddAssetAttr.Adjusted Stable Hash-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -333,7 +333,7 @@ def Ph007_3FavoriteGenPlayPsql(context):
         ORDER BY zAsset.ZMODIFICATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -351,6 +351,6 @@ def Ph007_3FavoriteGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-10',
         'zAddAssetAttr-Original Stable Hash-11',
         'zAddAssetAttr.Adjusted Stable Hash-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph008HasAdjustment.py
+++ b/scripts/artifacts/Ph008HasAdjustment.py
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph008_1HasAdjustmentPhDaPsql(context):
@@ -135,7 +135,7 @@ def Ph008_1HasAdjustmentPhDaPsql(context):
         ORDER BY zUnmAdj.ZADJUSTMENTTIMESTAMP
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15]))
@@ -156,7 +156,7 @@ def Ph008_1HasAdjustmentPhDaPsql(context):
         'zAddAssetAttr-zPK',
         'zAsset-UUID = store.cloudphotodb',
         'zAddAssetAttr-Master Fingerprint')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -218,7 +218,7 @@ def Ph008_1HasAdjustmentPhDaPsql(context):
         ORDER BY zUnmAdj.ZADJUSTMENTTIMESTAMP
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16]))
@@ -240,7 +240,7 @@ def Ph008_1HasAdjustmentPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-14',
         'zAddAssetAttr-Master Fingerprint-15',
         'zAddAssetAttr.Adjusted Fingerprint-16')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -337,7 +337,7 @@ def Ph008_1HasAdjustmentPhDaPsql(context):
         ORDER BY zUnmAdj.ZADJUSTMENTTIMESTAMP
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -377,7 +377,7 @@ def Ph008_1HasAdjustmentPhDaPsql(context):
         'zCompSyncAttr-Cloud_Compute_State_Adjustment_Fingerprint-30',
         'zExtAttr-Generative_AI_Type-31',
         'zExtAttr-Credit-32')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -491,7 +491,7 @@ def Ph008_3HasAdjustmentGenPlayPsql(context):
         ORDER BY zUnmAdj.ZADJUSTMENTTIMESTAMP
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -531,6 +531,6 @@ def Ph008_3HasAdjustmentGenPlayPsql(context):
         'zCompSyncAttr-Cloud_Compute_State_Adjustment_Fingerprint-30',
         'zExtAttr-Generative_AI_Type-31',
         'zExtAttr-Credit-32')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph009BurstAvalanche.py
+++ b/scripts/artifacts/Ph009BurstAvalanche.py
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph009_1BurstAvalanchePhDaPsql(context):
@@ -130,7 +130,7 @@ def Ph009_1BurstAvalanchePhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED    
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -148,7 +148,7 @@ def Ph009_1BurstAvalanchePhDaPsql(context):
         'zAddAssetAttr-zPK-10',
         'zAsset-UUID = store.cloudphotodb-11',
         'zAddAssetAttr-Master Fingerprint-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -204,7 +204,7 @@ def Ph009_1BurstAvalanchePhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED    
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12]))
@@ -222,7 +222,7 @@ def Ph009_1BurstAvalanchePhDaPsql(context):
         'zAddAssetAttr-zPK-10',
         'zAsset-UUID = store.cloudphotodb-11',
         'zAddAssetAttr-Master Fingerprint-12')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -284,7 +284,7 @@ def Ph009_1BurstAvalanchePhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED    
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14]))
@@ -304,7 +304,7 @@ def Ph009_1BurstAvalanchePhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-12',
         'zAddAssetAttr-Original Stable Hash-13',
         'zAddAssetAttr.Adjusted Stable Hash-14')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -383,7 +383,7 @@ def Ph009_3BurstAvalancheGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED    
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14]))
@@ -403,6 +403,6 @@ def Ph009_3BurstAvalancheGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-12',
         'zAddAssetAttr-Original Stable Hash-13',
         'zAddAssetAttr.Adjusted Stable Hash-14')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph011KwrdsCapsTitlesDescripsBasicAssetData.py
+++ b/scripts/artifacts/Ph011KwrdsCapsTitlesDescripsBasicAssetData.py
@@ -71,7 +71,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
@@ -240,7 +240,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -322,7 +322,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         'zAddAssetAttr-zPK-68',
         'zAsset-UUID = store.cloudphotodb-69',
         'zAddAssetAttr-Master Fingerprint-70')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -500,7 +500,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -588,7 +588,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         'zAddAssetAttr-zPK-73',
         'zAsset-UUID = store.cloudphotodb-74',
         'zAddAssetAttr-Master Fingerprint-75')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -772,7 +772,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -862,7 +862,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         'zAddAssetAttr-zPK-75',
         'zAsset-UUID = store.cloudphotodb-76',
         'zAddAssetAttr-Master Fingerprint-77')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1046,7 +1046,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1136,7 +1136,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         'zAddAssetAttr-zPK-75',
         'zAsset-UUID = store.cloudphotodb-76',
         'zAddAssetAttr-Master Fingerprint-77')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1326,7 +1326,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED       
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1418,7 +1418,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-77',
         'zAddAssetAttr-Original Stable Hash-78',
         'zAddAssetAttr.Adjusted Stable Hash-79')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1608,7 +1608,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED       
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1700,7 +1700,7 @@ def Ph011_1KwrdsCapsTitlesDescripsLikesBasicAsstDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-77',
         'zAddAssetAttr-Original Stable Hash-78',
         'zAddAssetAttr.Adjusted Stable Hash-79')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -1907,7 +1907,7 @@ def Ph011_3KwrdsCapsTitlesDescripsLikesBasicAsstDataGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED       
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1999,7 +1999,7 @@ def Ph011_3KwrdsCapsTitlesDescripsLikesBasicAsstDataGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-77',
         'zAddAssetAttr-Original Stable Hash-78',
         'zAddAssetAttr.Adjusted Stable Hash-79')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2189,7 +2189,7 @@ def Ph011_3KwrdsCapsTitlesDescripsLikesBasicAsstDataGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED       
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2281,6 +2281,6 @@ def Ph011_3KwrdsCapsTitlesDescripsLikesBasicAsstDataGenPlayPsql(context):
         'zAsset-UUID = store.cloudphotodb-77',
         'zAddAssetAttr-Original Stable Hash-78',
         'zAddAssetAttr.Adjusted Stable Hash-79')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph015PeopleandDetFacesNAD.py
+++ b/scripts/artifacts/Ph015PeopleandDetFacesNAD.py
@@ -70,7 +70,7 @@ __artifacts_v2__ = {
 import os
 import nska_deserialize as nd
 from packaging import version
-from scripts.ilapfuncs import media_to_html, artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import media_to_html, artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph015_1PeopleFacesNADPhDaPsql(context):
@@ -366,7 +366,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -504,7 +504,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         'zPerson-Person UUID-89',
         'zPerson-Person URI-90',
         'zDetFaceGroup-UUID-91')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -873,7 +873,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -1028,7 +1028,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         'zPerson-Person UUID-105',
         'zPerson-Person URI-106',
         'zDetFaceGroup-UUID-107')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1399,7 +1399,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -1557,7 +1557,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         'zPerson-Person UUID-107',
         'zPerson-Person URI-108',
         'zDetFaceGroup-UUID-109')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1932,7 +1932,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -2094,7 +2094,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         'zPerson-Person UUID-111',
         'zPerson-Person URI-112',
         'zDetFaceGroup-UUID-113')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2470,7 +2470,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -2633,7 +2633,7 @@ def Ph015_1PeopleFacesNADPhDaPsql(context):
         'zPerson-Person UUID-112',
         'zPerson-Person URI-113',
         'zDetFaceGroup-UUID-114')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2931,7 +2931,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -3069,7 +3069,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         'zPerson-Person UUID-89',
         'zPerson-Person URI-90',
         'zDetFaceGroup-UUID-91')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3438,7 +3438,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -3593,7 +3593,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         'zPerson-Person UUID-105',
         'zPerson-Person URI-106',
         'zDetFaceGroup-UUID-107')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3964,7 +3964,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -4122,7 +4122,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         'zPerson-Person UUID-107',
         'zPerson-Person URI-108',
         'zDetFaceGroup-UUID-109')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -4497,7 +4497,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -4659,7 +4659,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         'zPerson-Person UUID-111',
         'zPerson-Person URI-112',
         'zDetFaceGroup-UUID-113')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5035,7 +5035,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         ORDER BY zDetFace.Z_PK
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -5199,7 +5199,7 @@ def Ph015_2PeopleFacesNADSyndPL(context):
         'zPerson-Person UUID-112',
         'zPerson-Person URI-113',
         'zDetFaceGroup-UUID-114')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 

--- a/scripts/artifacts/Ph016AssetPeopleandDetFaces.py
+++ b/scripts/artifacts/Ph016AssetPeopleandDetFaces.py
@@ -71,7 +71,7 @@ __artifacts_v2__ = {
 import os
 import nska_deserialize as nd
 from packaging import version
-from scripts.ilapfuncs import media_to_html, artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import media_to_html, artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
@@ -416,7 +416,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -582,7 +582,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         'zAddAssetAttr-zPK-114',
         'zAsset-UUID = store.cloudphotodb-115',
         'zAddAssetAttr-Master Fingerprint-116')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1003,7 +1003,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -1191,7 +1191,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         'zAddAssetAttr-zPK-133',
         'zAsset-UUID = store.cloudphotodb-134',
         'zAddAssetAttr-Master Fingerprint-135')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1615,7 +1615,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -1805,7 +1805,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         'zAddAssetAttr-zPK-136',
         'zAsset-UUID = store.cloudphotodb-137',
         'zAddAssetAttr-Master Fingerprint-138')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2233,7 +2233,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -2428,7 +2428,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         'zAddAssetAttr-zPK-140',
         'zAsset-UUID = store.cloudphotodb-141',
         'zAddAssetAttr-Master Fingerprint-142')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2863,7 +2863,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -3060,7 +3060,7 @@ def Ph016_1PeopleFacesAssetDataPhDaPsql(context):
         'zAsset-UUID = store.cloudphotodb-143',
         'zAddAssetAttr-Original Stable Hash-144',
         'zAddAssetAttr.Adjusted Stable Hash-145')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3407,7 +3407,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -3573,7 +3573,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         'zAddAssetAttr-zPK-114',
         'zAsset-UUID = store.cloudphotodb-115',
         'zAddAssetAttr-Master Fingerprint-116')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -3994,7 +3994,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -4182,7 +4182,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         'zAddAssetAttr-zPK-133',
         'zAsset-UUID = store.cloudphotodb-134',
         'zAddAssetAttr-Master Fingerprint-135')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -4606,7 +4606,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -4796,7 +4796,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         'zAddAssetAttr-zPK-136',
         'zAsset-UUID = store.cloudphotodb-137',
         'zAddAssetAttr-Master Fingerprint-138')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5224,7 +5224,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -5419,7 +5419,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         'zAddAssetAttr-zPK-140',
         'zAsset-UUID = store.cloudphotodb-141',
         'zAddAssetAttr-Master Fingerprint-142')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5854,7 +5854,7 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             # zPerson.ZCONTACTMATCHINGDICTIONARY-PLIST
             personcontactmatchingdictionary = ''
@@ -6051,6 +6051,6 @@ def Ph016_2PeopleFacesAssetDataSyndPL(context):
         'zAsset-UUID = store.cloudphotodb-143',
         'zAddAssetAttr-Original Stable Hash-144',
         'zAddAssetAttr.Adjusted Stable Hash-145')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph017GenAIDetected.py
+++ b/scripts/artifacts/Ph017GenAIDetected.py
@@ -91,7 +91,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph017_1GenAIDetectedPhDaPsql(context):
@@ -206,7 +206,7 @@ def Ph017_1GenAIDetectedPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -246,7 +246,7 @@ def Ph017_1GenAIDetectedPhDaPsql(context):
         'zExtAttr-Generative_AI_Type-29',
         'zExtAttr-Credit-30')
 
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -365,7 +365,7 @@ def Ph017_2GenAIDetectedSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -404,7 +404,7 @@ def Ph017_2GenAIDetectedSyndPL(context):
         'zAddAssetAttr.Adjusted Stable Hash-28',
         'zExtAttr-Generative_AI_Type-29',
         'zExtAttr-Credit-30')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -523,7 +523,7 @@ def Ph017_3GenAIDetectedGenPlayPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -563,6 +563,6 @@ def Ph017_3GenAIDetectedGenPlayPsql(context):
         'zExtAttr-Generative_AI_Type-29',
         'zExtAttr-Credit-30')
 
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph020AlbumsNAD.py
+++ b/scripts/artifacts/Ph020AlbumsNAD.py
@@ -100,7 +100,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph020_1AlbumRecordswithNADPhDaPsql(context):
@@ -162,7 +162,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZSTARTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11]))
@@ -179,7 +179,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-UUID',
         'zGenAlbum-Cloud GUID')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -228,7 +228,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -247,7 +247,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-UUID',
         'zGenAlbum-Cloud GUID')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -296,7 +296,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -315,7 +315,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-UUID',
         'zGenAlbum-Cloud GUID')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -364,7 +364,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -383,7 +383,7 @@ def Ph020_1AlbumRecordswithNADPhDaPsql(context):
         ('zGenAlbum-Trash Date-11', 'datetime'),
         'zGenAlbum-UUID-12',
         'zGenAlbum-Cloud GUID-13')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -447,7 +447,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ORDER BY zGenAlbum.ZSTARTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11]))
@@ -464,7 +464,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-UUID',
         'zGenAlbum-Cloud GUID')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -513,7 +513,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -532,7 +532,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-UUID',
         'zGenAlbum-Cloud GUID')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -581,7 +581,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -600,7 +600,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-UUID',
         'zGenAlbum-Cloud GUID')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -649,7 +649,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -668,7 +668,7 @@ def Ph020_2AlbumRecordswithNADSyndPL(context):
         ('zGenAlbum-Trash Date-11', 'datetime'),
         'zGenAlbum-UUID-12',
         'zGenAlbum-Cloud GUID-13')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -734,7 +734,7 @@ def Ph020_3AlbumRecordswithNADGenPlayPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13]))
@@ -753,6 +753,6 @@ def Ph020_3AlbumRecordswithNADGenPlayPsql(context):
         ('zGenAlbum-Trash Date-11', 'datetime'),
         'zGenAlbum-UUID-12',
         'zGenAlbum-Cloud GUID-13')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph021AlbumsNonSharedNAD.py
+++ b/scripts/artifacts/Ph021AlbumsNonSharedNAD.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
@@ -207,7 +207,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZSTARTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -250,7 +250,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Custom Query Type',
         'zGenAlbum-Trashed State',
         ('zGenAlbum-Trash Date', 'datetime'))
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -414,7 +414,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZSTARTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -460,7 +460,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Trashed State',
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-Cloud Delete State')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -634,7 +634,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -683,7 +683,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Trashed State',
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-Cloud Delete State')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -868,7 +868,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -921,7 +921,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Trashed State',
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-Cloud Delete State')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1106,7 +1106,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1159,7 +1159,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Trashed State',
         ('zGenAlbum-Trash Date', 'datetime'),
         'zGenAlbum-Cloud Delete State')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1362,7 +1362,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1419,7 +1419,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-45',
         'zGenAlbum-Duplicate Type-46',
         'zGenAlbum-Privacy State-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1622,7 +1622,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1679,7 +1679,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-45',
         'zGenAlbum-Duplicate Type-46',
         'zGenAlbum-Privacy State-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1882,7 +1882,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1939,7 +1939,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-45',
         'zGenAlbum-Duplicate Type-46',
         'zGenAlbum-Privacy State-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2142,7 +2142,7 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2199,6 +2199,6 @@ def Ph021NonSharedAlbumRecordswithNADPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-45',
         'zGenAlbum-Duplicate Type-46',
         'zGenAlbum-Privacy State-47')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph022AssetsInNonSharedAlbums.py
+++ b/scripts/artifacts/Ph022AssetsInNonSharedAlbums.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
@@ -244,7 +244,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -310,7 +310,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Custom Query Type-53',
         'zGenAlbum-Trashed State-54',
         ('zGenAlbum-Trash Date-55', 'datetime'))
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -512,7 +512,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -580,7 +580,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Trashed State-55',
         ('zGenAlbum-Trash Date-56', 'datetime'),
         'zGenAlbum-Cloud Delete State-57')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -792,7 +792,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -863,7 +863,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Trashed State-58',
         ('zGenAlbum-Trash Date-59', 'datetime'),
         'zGenAlbum-Cloud Delete State-60')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1092,7 +1092,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1170,7 +1170,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Trashed State-64',
         ('zGenAlbum-Trash Date-65', 'datetime'),
         'zGenAlbum-Cloud Delete State-66')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1418,7 +1418,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1499,7 +1499,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Trashed State-67',
         ('zGenAlbum-Trash Date-68', 'datetime'),
         'zGenAlbum-Cloud Delete State-69')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1770,7 +1770,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1857,7 +1857,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-72',
         'zGenAlbum-Duplicate Type-73',
         'zGenAlbum-Privacy State-74')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2128,7 +2128,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2215,7 +2215,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-72',
         'zGenAlbum-Duplicate Type-73',
         'zGenAlbum-Privacy State-74')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2492,7 +2492,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2581,7 +2581,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-74',
         'zGenAlbum-Duplicate Type-75',
         'zGenAlbum-Privacy State-76')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2858,7 +2858,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2947,7 +2947,7 @@ def Ph022AssetsinNonSharedAlbumsPhDaPsql(context):
         'zGenAlbum-Search Index Rebuild State-74',
         'zGenAlbum-Duplicate Type-75',
         'zGenAlbum-Privacy State-76')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 

--- a/scripts/artifacts/Ph023AlbumsSharedNAD.py
+++ b/scripts/artifacts/Ph023AlbumsSharedNAD.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
@@ -247,7 +247,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZSTARTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -315,7 +315,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Album GUID-55',
         'zCldShareAlbumInvRec-Cloud GUID-56',
         'zAlbumList-Needs Reordering Number-57')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -513,7 +513,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZSTARTDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -581,7 +581,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Album GUID-55',
         'zCldShareAlbumInvRec-Cloud GUID-56',
         'zAlbumList-Needs Reordering Number-57')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -788,7 +788,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -862,7 +862,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-61',
         'zGenAlbum-Project Render UUID-62',
         'zAlbumList-Needs Reordering Number-63')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1075,7 +1075,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1152,7 +1152,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-63',
         'zGenAlbum-Project Render UUID-64',
         'zAlbumList-Needs Reordering Number-65')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1365,7 +1365,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1442,7 +1442,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-63',
         'zGenAlbum-Project Render UUID-64',
         'zAlbumList-Needs Reordering Number-65')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1674,7 +1674,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1755,7 +1755,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-67',
         'zGenAlbum-Project Render UUID-68',
         'zAlbumList-Needs Reordering Number-69')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1987,7 +1987,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2068,7 +2068,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-67',
         'zGenAlbum-Project Render UUID-68',
         'zAlbumList-Needs Reordering Number-69')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2300,7 +2300,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         ORDER BY zGenAlbum.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2381,7 +2381,7 @@ def Ph023SharedAlbumRecordsInviteswithNADPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-67',
         'zGenAlbum-Project Render UUID-68',
         'zAlbumList-Needs Reordering Number-69')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 

--- a/scripts/artifacts/Ph024AssetsInSharedAlbums.py
+++ b/scripts/artifacts/Ph024AssetsInSharedAlbums.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
@@ -286,7 +286,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -376,7 +376,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Album GUID-75',
         'zCldShareAlbumInvRec-Cloud GUID-76',
         'zAlbumList-Needs Reordering Number-77')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -614,7 +614,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -704,7 +704,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Album GUID-75',
         'zCldShareAlbumInvRec-Cloud GUID-76',
         'zAlbumList-Needs Reordering Number-77')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -951,7 +951,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1048,7 +1048,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-81',
         'zGenAlbum-Project Render UUID-82',
         'zAlbumList-Needs Reordering Number-83')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1307,7 +1307,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1408,7 +1408,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-85',
         'zGenAlbum-Project Render UUID-86',
         'zAlbumList-Needs Reordering Number-87')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1685,7 +1685,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1789,7 +1789,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-88',
         'zGenAlbum-Project Render UUID-89',
         'zAlbumList-Needs Reordering Number-90')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2091,7 +2091,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2202,7 +2202,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-94',
         'zGenAlbum-Project Render UUID-95',
         'zAlbumList-Needs Reordering Number-96')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2504,7 +2504,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2615,7 +2615,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-94',
         'zGenAlbum-Project Render UUID-95',
         'zAlbumList-Needs Reordering Number-96')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2918,7 +2918,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3030,7 +3030,7 @@ def Ph024AssetinSharedAlbumsInvitesPhDaPsql(context):
         'zCldShareAlbumInvRec-Cloud GUID-95',
         'zGenAlbum-Project Render UUID-96',
         'zAlbumList-Needs Reordering Number-97')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 

--- a/scripts/artifacts/Ph025SWYConvAlbumsNAD.py
+++ b/scripts/artifacts/Ph025SWYConvAlbumsNAD.py
@@ -70,7 +70,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
@@ -182,7 +182,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18]))
@@ -206,7 +206,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         'SWYConverszGenAlbum-Trashed State',
         ('SWYConverszGenAlbum-Trash Date', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -309,7 +309,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -335,7 +335,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -438,7 +438,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -464,7 +464,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -567,7 +567,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -593,7 +593,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -696,7 +696,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -722,7 +722,7 @@ def Ph025_1SWYConversationRecordswithNADPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -836,7 +836,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18]))
@@ -860,7 +860,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         'SWYConverszGenAlbum-Trashed State',
         ('SWYConverszGenAlbum-Trash Date', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -963,7 +963,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -989,7 +989,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1092,7 +1092,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1118,7 +1118,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1221,7 +1221,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1247,7 +1247,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1350,7 +1350,7 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ORDER BY SWYConverszGenAlbum.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1376,6 +1376,6 @@ def Ph025_2SWYConversationRecordswithNADSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-17', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-18',
         'SWYConverszGenAlbum-Privacy State-19')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph026SyndicationPLAssets.py
+++ b/scripts/artifacts/Ph026SyndicationPLAssets.py
@@ -88,7 +88,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph026_1SyndicationIDAssetsPhDaPsql(context):
@@ -258,7 +258,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -310,7 +310,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         'SWYConverszGenAlbum-Trashed State-41',
         ('SWYConverszGenAlbum-Trash Date-42', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-43')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -477,7 +477,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -533,7 +533,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-44', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-45',
         'SWYConverszGenAlbum-Privacy State-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -700,7 +700,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -756,7 +756,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-44', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-45',
         'SWYConverszGenAlbum-Privacy State-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -924,7 +924,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -981,7 +981,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-45', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-46',
         'SWYConverszGenAlbum-Privacy State-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1149,7 +1149,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1206,7 +1206,7 @@ def Ph026_1SyndicationIDAssetsPhDaPsql(context):
         ('SWYConverszGenAlbum-Trash Date-45', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-46',
         'SWYConverszGenAlbum-Privacy State-47')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -1378,7 +1378,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1430,7 +1430,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         'SWYConverszGenAlbum-Trashed State-41',
         ('SWYConverszGenAlbum-Trash Date-42', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-43')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1597,7 +1597,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1653,7 +1653,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-44', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-45',
         'SWYConverszGenAlbum-Privacy State-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1820,7 +1820,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1876,7 +1876,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-44', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-45',
         'SWYConverszGenAlbum-Privacy State-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2044,7 +2044,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2101,7 +2101,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-45', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-46',
         'SWYConverszGenAlbum-Privacy State-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2269,7 +2269,7 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2326,6 +2326,6 @@ def Ph026_2SyndicationPLAssetsSyndPL(context):
         ('SWYConverszGenAlbum-Trash Date-45', 'datetime'),
         'SWYConverszGenAlbum-Cloud Delete State-46',
         'SWYConverszGenAlbum-Privacy State-47')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph030iCloudShareMethodsNAD.py
+++ b/scripts/artifacts/Ph030iCloudShareMethodsNAD.py
@@ -40,7 +40,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
@@ -155,7 +155,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -194,7 +194,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         'zShare-Trashed State-29',
         'zShare-Cloud Delete State-30',
         'zShare-zENT-31')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -347,7 +347,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -406,7 +406,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-47', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-48', 'datetime'),
         'zShare-zENT-49')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -559,7 +559,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -618,7 +618,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-47', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-48', 'datetime'),
         'zShare-zENT-49')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -771,7 +771,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -830,7 +830,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-47', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-48', 'datetime'),
         'zShare-zENT-49')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -982,7 +982,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1040,7 +1040,7 @@ def Ph030iCloudSharedMethodswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-46', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-47', 'datetime'),
         'zShare-zENT-48')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 

--- a/scripts/artifacts/Ph031iCloudSharePhotoLibraryNAD.py
+++ b/scripts/artifacts/Ph031iCloudSharePhotoLibraryNAD.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
@@ -148,7 +148,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -180,7 +180,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         'zShare-Trashed State-23',
         'zShare-Cloud Delete State-24',
         'zShare-zENT-25')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -328,7 +328,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -380,7 +380,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-41', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-42', 'datetime'),
         'zShare-zENT-43')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -528,7 +528,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -580,7 +580,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-41', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-42', 'datetime'),
         'zShare-zENT-43')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -728,7 +728,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -780,7 +780,7 @@ def Ph031iCloudSPLwithParticipantswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-41', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-42', 'datetime'),
         'zShare-zENT-43')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 

--- a/scripts/artifacts/Ph032AssetsIniCldSPLwContrib.py
+++ b/scripts/artifacts/Ph032AssetsIniCldSPLwContrib.py
@@ -40,7 +40,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
@@ -233,7 +233,7 @@ def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED     
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -293,7 +293,7 @@ def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
         'SPLzSharePartic-z54SHARE-48',
         'SPLzShare-Status-49',
         'SPLzShare-Scope Type-50')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -471,7 +471,7 @@ def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED     
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -531,7 +531,7 @@ def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
         'SPLzSharePartic-z55SHARE-48',
         'SPLzShare-Status-49',
         'SPLzShare-Scope Type-50')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -719,7 +719,7 @@ def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED     
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -782,6 +782,6 @@ def Ph032iCloudSPLAssetswithContributorPhDaPsql(context):
         'SPLzShare-Cloud Video Count-SPL-51',
         'zExtAttr-Generative_AI_Type-52',
         'zExtAttr-Credit-53')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph033AssetsIniCldSPLfromOtherContrib.py
+++ b/scripts/artifacts/Ph033AssetsIniCldSPLfromOtherContrib.py
@@ -40,7 +40,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph033iCldSPLAssetsfromothercontribPhDaPsql(context):
@@ -215,7 +215,7 @@ def Ph033iCldSPLAssetsfromothercontribPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED     
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -272,7 +272,7 @@ def Ph033iCldSPLAssetsfromothercontribPhDaPsql(context):
         'SPLzShare-Cloud Photo Count-SPL-45',
         'SPLzShare-Assets AddedByCamera SmartSharing-46',
         'SPLzShare-Cloud Video Count-SPL-47')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -460,7 +460,7 @@ def Ph033iCldSPLAssetsfromothercontribPhDaPsql(context):
         ORDER BY zAsset.ZDATECREATED     
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -523,6 +523,6 @@ def Ph033iCldSPLAssetsfromothercontribPhDaPsql(context):
         'SPLzShare-Cloud Video Count-SPL-51',
         'zExtAttr-Generative_AI_Type-52',
         'zExtAttr-Credit-53')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph034iCloudSharedLinksNAD.py
+++ b/scripts/artifacts/Ph034iCloudSharedLinksNAD.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
@@ -151,7 +151,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -190,7 +190,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         'zShare-Trashed State-29',
         'zShare-Cloud Delete State-30',
         'zShare-zENT-31')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -341,7 +341,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16],
@@ -397,7 +397,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-44', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-45', 'datetime'),
         'zShare-zENT-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -548,7 +548,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16],
@@ -604,7 +604,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-44', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-45', 'datetime'),
         'zShare-zENT-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -755,7 +755,7 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7],
             row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16],
@@ -811,6 +811,6 @@ def Ph034iCloudSharedLinkRecordswithNADPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-44', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-45', 'datetime'),
         'zShare-zENT-46')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph035iCloudSharedLinkAssets.py
+++ b/scripts/artifacts/Ph035iCloudSharedLinkAssets.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
@@ -197,7 +197,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE        
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -260,7 +260,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         'zShare-Trashed State-51',
         'zShare-Cloud Delete State-52',
         'zShare-zENT-53')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -423,7 +423,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -490,7 +490,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         'zShare-Trashed State-54',
         'zShare-Cloud Delete State-55',
         'zShare-zENT-56')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -739,7 +739,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -828,7 +828,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-74', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-75', 'datetime'),
         'zShare-zENT-76')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1098,7 +1098,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1192,7 +1192,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-79', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-80', 'datetime'),
         'zShare-zENT-81')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1462,7 +1462,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1556,7 +1556,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-79', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-80', 'datetime'),
         'zShare-zENT-81')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1826,7 +1826,7 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ORDER BY zShare.ZCREATIONDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1920,6 +1920,6 @@ def Ph035iCloudSharedLinkAssetsPhDaPsql(context):
         ('zShare-LastParticipant Asset Trash Notification Date-79', 'datetime'),
         ('zShare-Last Participant Asset Trash Notification View Date-80', 'datetime'),
         'zShare-zENT-81')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph050AssetIntResouData.py
+++ b/scripts/artifacts/Ph050AssetIntResouData.py
@@ -106,7 +106,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph050_1AssetIntResouPhDaPsql(context):
@@ -852,7 +852,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1123,7 +1123,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-236',
         'zMedAnlyAstAttr-zOpt-237',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-238')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -1936,7 +1936,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2234,7 +2234,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-260',
         'zMedAnlyAstAttr-zOpt-261',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-262')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -3081,7 +3081,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3389,7 +3389,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-269',
         'zMedAnlyAstAttr-zOpt-270',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-271')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -4242,7 +4242,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4553,7 +4553,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-272',
         'zMedAnlyAstAttr-zOpt-273',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-274')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -5471,7 +5471,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -5814,7 +5814,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-301',
         'zMedAnlyAstAttr-zOpt-302',
         'zMedAnlyAstAttr-Asset= zAsset-Zpk-303')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -6718,7 +6718,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -7060,7 +7060,7 @@ def Ph050_1AssetIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zOpt-299',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-300')
 
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -7808,7 +7808,7 @@ def Ph050_2AssetIntResouSyndPL(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -8079,7 +8079,7 @@ def Ph050_2AssetIntResouSyndPL(context):
         'zMedAnlyAstAttr-zEnt-236',
         'zMedAnlyAstAttr-zOpt-237',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-238')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -8892,7 +8892,7 @@ def Ph050_2AssetIntResouSyndPL(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -9190,7 +9190,7 @@ def Ph050_2AssetIntResouSyndPL(context):
         'zMedAnlyAstAttr-zEnt-260',
         'zMedAnlyAstAttr-zOpt-261',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-262')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -10037,7 +10037,7 @@ def Ph050_2AssetIntResouSyndPL(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -10345,7 +10345,7 @@ def Ph050_2AssetIntResouSyndPL(context):
         'zMedAnlyAstAttr-zEnt-269',
         'zMedAnlyAstAttr-zOpt-270',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-271')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -11198,7 +11198,7 @@ def Ph050_2AssetIntResouSyndPL(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -11509,7 +11509,7 @@ def Ph050_2AssetIntResouSyndPL(context):
         'zMedAnlyAstAttr-zEnt-272',
         'zMedAnlyAstAttr-zOpt-273',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-274')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -12427,7 +12427,7 @@ def Ph050_2AssetIntResouSyndPL(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -12770,7 +12770,7 @@ def Ph050_2AssetIntResouSyndPL(context):
         'zMedAnlyAstAttr-zEnt-301',
         'zMedAnlyAstAttr-zOpt-302',
         'zMedAnlyAstAttr-Asset= zAsset-Zpk-303')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -13674,7 +13674,7 @@ def Ph050_2AssetIntResouSyndPL(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -14016,7 +14016,7 @@ def Ph050_2AssetIntResouSyndPL(context):
         'zMedAnlyAstAttr-zOpt-299',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-300')
 
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -14951,7 +14951,7 @@ def Ph050_3AssetIntResouGenPlayPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -15294,7 +15294,7 @@ def Ph050_3AssetIntResouGenPlayPsql(context):
         'zMedAnlyAstAttr-zEnt-301',
         'zMedAnlyAstAttr-zOpt-302',
         'zMedAnlyAstAttr-Asset= zAsset-Zpk-303')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -16198,7 +16198,7 @@ def Ph050_3AssetIntResouGenPlayPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -16540,6 +16540,6 @@ def Ph050_3AssetIntResouGenPlayPsql(context):
         'zMedAnlyAstAttr-zOpt-299',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-300')
 
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph051PossOptimizedAssetsIntResouData.py
+++ b/scripts/artifacts/Ph051PossOptimizedAssetsIntResouData.py
@@ -42,7 +42,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, does_column_exist_in_db, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, does_column_exist_in_db, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
@@ -779,7 +779,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -1044,7 +1044,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-231',
         'zMedAnlyAstAttr-zOpt-232',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-233')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -1842,7 +1842,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -2134,7 +2134,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-255',
         'zMedAnlyAstAttr-zOpt-256',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-257')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -2966,7 +2966,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3269,7 +3269,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-265',
         'zMedAnlyAstAttr-zOpt-266',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-267')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -4123,7 +4123,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4434,7 +4434,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-272',
         'zMedAnlyAstAttr-zOpt-273',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-274')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5353,7 +5353,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -5696,7 +5696,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zEnt-300',
         'zMedAnlyAstAttr-zOpt-301',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-302')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -6601,7 +6601,7 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
 		ORDER BY zAsset.ZDATECREATED
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -6943,6 +6943,6 @@ def Ph051PossibleOptimizedAssetsIntResouPhDaPsql(context):
         'zMedAnlyAstAttr-zOpt-299',
         'zMedAnlyAstAttr-Asset= zAsset-zPK-300')
 
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph094Ios14REFforAssetAnalysis.py
+++ b/scripts/artifacts/Ph094Ios14REFforAssetAnalysis.py
@@ -74,7 +74,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph094_1iOS14RefforAssetAnalysisPhDaPsql(context):
@@ -3158,7 +3158,7 @@ def Ph094_1iOS14RefforAssetAnalysisPhDaPsql(context):
 		ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4594,7 +4594,7 @@ def Ph094_1iOS14RefforAssetAnalysisPhDaPsql(context):
         'z26Assets-26Albums= zGenAlbum-zPK-1267',
         'z26Assets-3Asset Key= zAsset-zPK in the Album-1268',
         'z26Asset-FOK-3Assets= zAsset.Z_FOK_CLOUDFEEDASSETSENTRY-1269')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -7680,7 +7680,7 @@ def Ph094_2iOS14RefforAssetAnalysisSyndPL(context):
 		ORDER BY zAsset.ZADDEDDATE
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -9116,6 +9116,6 @@ def Ph094_2iOS14RefforAssetAnalysisSyndPL(context):
         'z26Assets-26Albums= zGenAlbum-zPK-1267',
         'z26Assets-3Asset Key= zAsset-zPK in the Album-1268',
         'z26Asset-FOK-3Assets= zAsset.Z_FOK_CLOUDFEEDASSETSENTRY-1269')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph095iOS15REFforAssetAnalysis.py
+++ b/scripts/artifacts/Ph095iOS15REFforAssetAnalysis.py
@@ -74,7 +74,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph095_1iOS15RefforAssetAnalysisPhDaPsql(context):
@@ -2182,7 +2182,7 @@ def Ph095_1iOS15RefforAssetAnalysisPhDaPsql(context):
 		ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
 
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
@@ -3142,7 +3142,7 @@ def Ph095_1iOS15RefforAssetAnalysisPhDaPsql(context):
         'z27Assets-27Albums= zGenAlbum-zPK-848',
         'z27Assets-3Asset Key= zAsset-zPK in the Album-849',
         'z27Asset-FOK-3Assets= zAsset.Z_FOK_CLOUDFEEDASSETSENTRY-850')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -5252,7 +5252,7 @@ def Ph095_2iOS15RefforAssetAnalysisSyndPL(context):
 		ORDER BY zAsset.ZADDEDDATE
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -6211,6 +6211,6 @@ def Ph095_2iOS15RefforAssetAnalysisSyndPL(context):
         'z27Assets-27Albums= zGenAlbum-zPK-848',
         'z27Assets-3Asset Key= zAsset-zPK in the Album-849',
         'z27Asset-FOK-3Assets= zAsset.Z_FOK_CLOUDFEEDASSETSENTRY-850')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph096iOS16REFforAssetAnalysis.py
+++ b/scripts/artifacts/Ph096iOS16REFforAssetAnalysis.py
@@ -74,7 +74,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph096_1iOS16RefforAssetAnalysisPhDaPsql(context):
@@ -2696,7 +2696,7 @@ def Ph096_1iOS16RefforAssetAnalysisPhDaPsql(context):
 		ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3918,7 +3918,7 @@ def Ph096_1iOS16RefforAssetAnalysisPhDaPsql(context):
         'z3MemoryBCAs-44Memories Being Custom User Assets-1080',
         'z3MemoryBCAs-3Custom User Assets-1081',
         'z3MemoryBCAs-FOK-3Custom User Assets-1082')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -6542,7 +6542,7 @@ def Ph096_2iOS16RefforAssetAnalysisSyndPL(context):
 		ORDER BY zAsset.ZADDEDDATE
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -7764,6 +7764,6 @@ def Ph096_2iOS16RefforAssetAnalysisSyndPL(context):
         'z3MemoryBCAs-44Memories Being Custom User Assets-1080',
         'z3MemoryBCAs-3Custom User Assets-1081',
         'z3MemoryBCAs-FOK-3Custom User Assets-1082')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph097iOS17REFforAssetAnalysis.py
+++ b/scripts/artifacts/Ph097iOS17REFforAssetAnalysis.py
@@ -74,7 +74,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph097_1iOS17RefforAssetAnalysisPhDaPsql(context):
@@ -2724,7 +2724,7 @@ def Ph097_1iOS17RefforAssetAnalysisPhDaPsql(context):
 		ORDER BY zAsset.ZADDEDDATE
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -3958,7 +3958,7 @@ def Ph097_1iOS17RefforAssetAnalysisPhDaPsql(context):
         'z3MemoryBCAs-44Memories Being Custom User Assets-1091',
         'z3MemoryBCAs-3Custom User Assets-1092',
         'z3MemoryBCAs-FOK-3Custom User Assets-1093')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -6593,7 +6593,7 @@ def Ph097_1iOS17RefforAssetAnalysisPhDaPsql(context):
 		ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -7827,7 +7827,7 @@ def Ph097_1iOS17RefforAssetAnalysisPhDaPsql(context):
         'z3MemoryBCAs-45Memories Being Custom User Assets-1091',
         'z3MemoryBCAs-3Custom User Assets-1092',
         'z3MemoryBCAs-FOK-3Custom User Assets-1093')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -10478,7 +10478,7 @@ def Ph097_2iOS17RefforAssetAnalysisSyndPL(context):
 		ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -11712,7 +11712,7 @@ def Ph097_2iOS17RefforAssetAnalysisSyndPL(context):
         'z3MemoryBCAs-44Memories Being Custom User Assets-1091',
         'z3MemoryBCAs-3Custom User Assets-1092',
         'z3MemoryBCAs-FOK-3Custom User Assets-1093')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -14347,7 +14347,7 @@ def Ph097_2iOS17RefforAssetAnalysisSyndPL(context):
 		ORDER BY zAsset.ZADDEDDATE
 		'''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -15581,6 +15581,6 @@ def Ph097_2iOS17RefforAssetAnalysisSyndPL(context):
         'z3MemoryBCAs-45Memories Being Custom User Assets-1091',
         'z3MemoryBCAs-3Custom User Assets-1092',
         'z3MemoryBCAs-FOK-3Custom User Assets-1093')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph098iOS18REFforAssetAnalysis.py
+++ b/scripts/artifacts/Ph098iOS18REFforAssetAnalysis.py
@@ -94,7 +94,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph098_1iOS18RefforAssetAnalysisPhDaPsql(context):
@@ -2843,7 +2843,7 @@ def Ph098_1iOS18RefforAssetAnalysisPhDaPsql(context):
 		ORDER BY zAsset.ZADDEDDATE			
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4153,7 +4153,7 @@ def Ph098_1iOS18RefforAssetAnalysisPhDaPsql(context):
         'z3MemoryBCAs-51Memories Being Custom User Assets-1157',
         'z3MemoryBCAs-3Custom User Assets-1158',
         'z3MemoryBCAs-FOK-3Custom User Assets-1159')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -6907,7 +6907,7 @@ def Ph098_2iOS18RefforAssetAnalysisSyndPL(context):
 		ORDER BY zAsset.ZADDEDDATE		
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -8217,7 +8217,7 @@ def Ph098_2iOS18RefforAssetAnalysisSyndPL(context):
         'z3MemoryBCAs-51Memories Being Custom User Assets-1157',
         'z3MemoryBCAs-3Custom User Assets-1158',
         'z3MemoryBCAs-FOK-3Custom User Assets-1159')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path
 
@@ -10968,7 +10968,7 @@ def Ph098_3iOS18RefforAssetAnalysisGenPlayPsql(context):
 		ORDER BY zAsset.ZADDEDDATE			
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -12278,6 +12278,6 @@ def Ph098_3iOS18RefforAssetAnalysisGenPlayPsql(context):
         'z3MemoryBCAs-51Memories Being Custom User Assets-1157',
         'z3MemoryBCAs-3Custom User Assets-1158',
         'z3MemoryBCAs-FOK-3Custom User Assets-1159')
-# data_list = get_sqlite_db_records(source_path, query)
+# data_list = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/Ph126iOS26REFforAssetAnalysis.py
+++ b/scripts/artifacts/Ph126iOS26REFforAssetAnalysis.py
@@ -60,7 +60,7 @@ __artifacts_v2__ = {
 
 import os
 from packaging import version
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, logfunc, iOS
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, logfunc, iOS
 
 @artifact_processor
 def Ph126_1iOS26RefforAssetAnalysisPhDaPsql(context):
@@ -2942,7 +2942,7 @@ def Ph126_1iOS26RefforAssetAnalysisPhDaPsql(context):
         ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -4359,7 +4359,7 @@ def Ph126_1iOS26RefforAssetAnalysisPhDaPsql(context):
         'z3MemoryBCAs-56Memories Being Custom User Assets-1251',
         'z3MemoryBCAs-3Custom User Assets-1252',
         'z3MemoryBCAs-FOK-3Custom User Assets-1253')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -7242,7 +7242,7 @@ def Ph126_2iOS26RefforAssetAnalysisSyndPL(context):
         ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -8659,7 +8659,7 @@ def Ph126_2iOS26RefforAssetAnalysisSyndPL(context):
         'z3MemoryBCAs-56Memories Being Custom User Assets-1251',
         'z3MemoryBCAs-3Custom User Assets-1252',
         'z3MemoryBCAs-FOK-3Custom User Assets-1253')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path
 
@@ -11543,7 +11543,7 @@ def Ph126_3iOS26RefforAssetAnalysisGenPlayPsql(context):
         ORDER BY zAsset.ZADDEDDATE
         '''
 
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for row in db_records:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
             row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18],
@@ -12960,6 +12960,6 @@ def Ph126_3iOS26RefforAssetAnalysisGenPlayPsql(context):
         'z3MemoryBCAs-56Memories Being Custom User Assets-1251',
         'z3MemoryBCAs-3Custom User Assets-1252',
         'z3MemoryBCAs-FOK-3Custom User Assets-1253')
-        data_list = list(get_sqlite_db_records(source_path, query))
+        data_list = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, data_list, source_path

--- a/scripts/artifacts/cloudkit_cache.py
+++ b/scripts/artifacts/cloudkit_cache.py
@@ -66,7 +66,7 @@ import nska_deserialize as nd
 
 from scripts.ilapfuncs import (
     artifact_processor,
-    get_sqlite_db_records,
+    get_sqlite_db_records, null_absent_columns,
     open_sqlite_db_readonly,
     convert_unix_ts_to_utc,
     convert_plist_date_to_utc
@@ -224,7 +224,7 @@ def cloudkit_files(context):
             LEFT JOIN Files ON Files.manifestID = Manifests.manifestID
         '''
 
-        db_records = get_sqlite_db_records(file_found, query)
+        db_records = get_sqlite_db_records(file_found, null_absent_columns(file_found, query))
         for record in db_records:
             modified_ts = convert_unix_ts_to_utc(record[1]) if record[1] else ""
 

--- a/scripts/artifacts/duckduckgo.py
+++ b/scripts/artifacts/duckduckgo.py
@@ -43,7 +43,7 @@ from scripts.ilapfuncs import (
     artifact_processor,
     convert_cocoa_core_data_ts_to_utc,
     get_file_path,
-    get_sqlite_db_records,
+    get_sqlite_db_records, null_absent_columns,
 )
 
 
@@ -58,7 +58,7 @@ def duckduckgo_history(context):
     FROM ZBROWSINGHISTORYENTRYMANAGEDOBJECT
     ORDER BY ZLASTVISIT
     '''
-    for record in get_sqlite_db_records(source_path, query):
+    for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         data_list.append((
             convert_cocoa_core_data_ts_to_utc(record[0]),
             record[1],
@@ -97,7 +97,7 @@ def duckduckgo_page_visits(context):
     LEFT JOIN ZTABHISTORYMANAGEDOBJECT t ON v.ZTABHISTORY = t.Z_PK
     ORDER BY v.ZDATE
     '''
-    for record in get_sqlite_db_records(source_path, query):
+    for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         data_list.append((
             convert_cocoa_core_data_ts_to_utc(record[0]),
             record[1],

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -42,6 +42,7 @@ from scripts.ilapfuncs import (
     utf8_in_extended_ascii,
     check_in_media,
     convert_ts_human_to_utc,
+    logfunc,
 )
 
 _FLATTEN_ERRORS = (TypeError, AttributeError, KeyError, ValueError)
@@ -66,6 +67,11 @@ class ProtectedDict(dict):
 class ProtectedSet(set):
     pass
 
+
+
+GUID_RE = re.compile(
+    r"[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}",
+    re.IGNORECASE)
 
 def aa_flatten_dict_tu(
         v,
@@ -250,10 +256,24 @@ def google_chat(context):
             continue
 
         source_path = file_found
-        result = re.findall(
-            r"([0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}+)",
-            file_found)
-        guid = result[0]
+        # The container as iOS lays it out, .../Application/<GUID>/. Taking the first
+        # match anywhere in the path meant an output directory or case folder whose
+        # name looks like a GUID could be picked instead, and the media lookup below
+        # would then search a directory that does not exist and quietly find nothing.
+        parts = os.path.normpath(file_found).split(os.sep)
+        guid = ''
+        for index in range(len(parts) - 1, 0, -1):
+            if GUID_RE.fullmatch(parts[index]) and parts[index - 1] == 'Application':
+                guid = parts[index]
+                break
+        else:
+            for part in reversed(parts):
+                if GUID_RE.fullmatch(part):
+                    guid = part
+                    break
+        if not guid:
+            logfunc(f'Google Chat: no app container GUID in {file_found}; '
+                    'attachments cannot be matched for this database')
         account_id = os.path.basename(os.path.dirname(file_found))
 
         db = open_sqlite_db_readonly(file_found)

--- a/scripts/artifacts/mastodon.py
+++ b/scripts/artifacts/mastodon.py
@@ -98,7 +98,7 @@ import json
 import re
 
 from scripts.ilapfuncs import artifact_processor, logfunc, \
-    get_file_path, get_sqlite_db_records, does_table_exist_in_db, \
+    get_file_path, get_sqlite_db_records, does_table_exist_in_db, null_absent_columns, \
     convert_cocoa_core_data_ts_to_utc
 
 HTML_TAG_RE = re.compile(r'<[^>]+>')
@@ -178,7 +178,7 @@ def _get_local_user_id(source_path):
         'SELECT ZUSERID FROM ZMASTODONAUTHENTICATION WHERE ZUSERID IS NOT NULL LIMIT 1',
         'SELECT ZUSERID FROM ZNOTIFICATION WHERE ZUSERID IS NOT NULL LIMIT 1',
     ):
-        records = list(get_sqlite_db_records(source_path, query))
+        records = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
         if records and records[0]['ZUSERID']:
             return records[0]['ZUSERID']
     return None
@@ -233,7 +233,7 @@ def mastodonDirectMessages(context):
     local_user_id = _get_local_user_id(source_path)
     query = STATUS_QUERY.format(where="WHERE s.ZVISIBILITYRAW = 'direct'")
 
-    for record in get_sqlite_db_records(source_path, query):
+    for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         attachment_urls, attachment_descriptions = _parse_attachments(record['attachments'])
         mentions = _parse_mentions(record['mentions'])
         author_id = record['authorId']
@@ -281,7 +281,7 @@ def mastodonStatuses(context):
     if not source_path:
         return data_headers, data_list, ''
 
-    for record in get_sqlite_db_records(source_path, STATUS_QUERY.format(where='')):
+    for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, STATUS_QUERY.format(where=''))):
         attachment_urls, attachment_descriptions = _parse_attachments(record['attachments'])
 
         data_list.append((
@@ -409,7 +409,7 @@ def mastodonNotifications(context):
     ORDER BY n.ZCREATEAT
     '''
 
-    for record in get_sqlite_db_records(source_path, query):
+    for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         data_list.append((
             convert_cocoa_core_data_ts_to_utc(record['ZCREATEAT']) if record['ZCREATEAT'] else '',
             record['notificationType'],
@@ -463,7 +463,7 @@ def mastodonAccount(context):
     WHERE u.ZID = '{local_user_id}'
     '''
 
-    for record in get_sqlite_db_records(source_path, query):
+    for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         data_list.append((
             record['displayName'],
             record['acct'],

--- a/scripts/artifacts/photosMigration.py
+++ b/scripts/artifacts/photosMigration.py
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, \
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, \
     convert_cocoa_core_data_ts_to_utc
 
 
@@ -73,7 +73,7 @@ def photos_migration(context):
         'Source Model Version', 'Model Version', 'OS Build', 'OS Version', 'Origin',
         'Store UUID')
 
-    db_records = get_sqlite_db_records(data_source, query)
+    db_records = get_sqlite_db_records(data_source, null_absent_columns(data_source, query))
 
     for record in db_records:
         os_version = context.get_apple_os_version(record[9])

--- a/scripts/artifacts/splitwise.py
+++ b/scripts/artifacts/splitwise.py
@@ -99,7 +99,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, convert_unix_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, convert_unix_ts_to_utc
 from scripts.html_safe import esc
 
 @artifact_processor
@@ -136,7 +136,7 @@ def splitwiseUsers(context):
         'Country', 
         'Registration Status')
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
     
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
@@ -183,7 +183,7 @@ def splitwiseExpenses(context):
         'Expense ID', 
         'Expense GUID')
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
     
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
@@ -222,7 +222,7 @@ def splitwiseExpenseBalances(context):
         'Owed Share', 
         'Paid Share')
     
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
     
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
@@ -257,7 +257,7 @@ def splitwiseTotalBalances(context):
         'Balance', 
         'Currency')
     
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
     
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
@@ -308,7 +308,7 @@ def splitwiseGroups(context):
         'Avatar URL', 
         'Cover Photo URL')
     
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])
@@ -351,7 +351,7 @@ def splitwiseNotifications(context):
         'Source Type', 
         'Notification ID')
     
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
         created_ts = convert_unix_ts_to_utc(record[0])

--- a/scripts/artifacts/tileAppDb.py
+++ b/scripts/artifacts/tileAppDb.py
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, null_absent_columns
 
 
 @artifact_processor
@@ -55,7 +55,7 @@ def tileAppDb(context):
     FROM ZTILENTITY_NODE
     INNER JOIN ZTILENTITY_TILESTATE ON ZTILENTITY_NODE.ZTILE_STATE = ZTILENTITY_TILESTATE.Z_PK
     '''
-    for row in get_sqlite_db_records(source_path, query):
+    for row in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         data_list.append(tuple(row))
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/trustedPeers.py
+++ b/scripts/artifacts/trustedPeers.py
@@ -38,7 +38,7 @@ from scripts.ilapfuncs import (
     convert_cocoa_core_data_ts_to_utc,
     does_column_exist_in_db,
     get_file_path,
-    get_sqlite_db_records,
+    get_sqlite_db_records, null_absent_columns,
     logfunc,
 )
 
@@ -151,7 +151,7 @@ def trusted_peers(context):
         client.ZESCROWMETADATA = metadata.Z_PK;
     '''
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for row in db_records:
         timestamp = convert_cocoa_core_data_ts_to_utc(row[0])

--- a/scripts/artifacts/voiceRecordings.py
+++ b/scripts/artifacts/voiceRecordings.py
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import (
-    artifact_processor, get_file_path, get_sqlite_db_records,
+    artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns,
     convert_cocoa_core_data_ts_to_utc, check_in_media
 )
 
@@ -67,7 +67,7 @@ def voice_memos(context):
         """
 
     if source_path:
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
         for record in db_records:
             timestamp = convert_cocoa_core_data_ts_to_utc(record["ZDATE"])
             if record["ZPATH"]:

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -501,10 +501,24 @@ def get_app_id(plist_file, context) -> str:
         parts = Path(source_path_str).parts
         bundle_id_candidate = ''
 
-        for part in parts:
-            # Priority 1 — file system UUID
+        # Priority 1 — the container UUID as iOS lays it out, .../Application/<UUID>/.
+        # Anchoring on the parent matters: the identifier used to be taken from the
+        # first UUID-shaped component anywhere in the path, so an output directory,
+        # case folder or export path whose name happens to look like a UUID was
+        # picked instead of the app container. Every artifact here then looked for
+        # its databases inside a directory that does not exist and reported nothing,
+        # with no error to show for it.
+        for index in range(len(parts) - 1, 0, -1):
+            if UUID_RE.match(parts[index]) and parts[index - 1] == 'Application':
+                return parts[index]
+
+        # Otherwise the UUID nearest the file, so anything ahead of the evidence
+        # in the path cannot win over the evidence itself.
+        for part in reversed(parts):
             if UUID_RE.match(part):
                 return part
+
+        for part in parts:
 
             # Priority 2 — raw backup AppDomain prefix
             m = APPDOMAIN_RE.match(part)

--- a/scripts/artifacts/whatsApp.py
+++ b/scripts/artifacts/whatsApp.py
@@ -107,7 +107,7 @@ from pathlib import Path
 from scripts.ilapfuncs import (
     artifact_processor,
     get_file_path,
-    get_sqlite_db_records,
+    get_sqlite_db_records, null_absent_columns,
     attach_sqlite_db_readonly,
     check_in_media,
     convert_cocoa_core_data_ts_to_utc
@@ -168,7 +168,7 @@ def whatsAppCallHistory(context):
         data_headers.extend(
             ['Contact Fullname', ('Phone Number', 'phonenumber')])
     else:
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
         start_time = convert_cocoa_core_data_ts_to_utc(record[0])
@@ -212,7 +212,7 @@ def whatsAppContacts(context):
         'Whatsapp ID',
         'Identifier')
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
 
@@ -277,7 +277,7 @@ def whatsAppMessages(context):
         'Chat Name',
         )
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
         message_date = convert_cocoa_core_data_ts_to_utc(

--- a/scripts/artifacts/wickr.py
+++ b/scripts/artifacts/wickr.py
@@ -262,7 +262,7 @@ import re
 from scripts.ios_keychain import active_keychain_path, find_keychain_secrets
 from scripts.ilapfuncs import (artifact_processor, convert_cocoa_core_data_ts_to_utc,
                                convert_unix_ts_to_utc, does_column_exist_in_db,
-                               does_table_exist_in_db, get_sqlite_db_records, logfunc)
+                               does_table_exist_in_db, get_sqlite_db_records, null_absent_columns, logfunc)
 
 PAYLOAD_RE = re.compile(r'^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}):\d+\s+Payload: (\{"messageId".*\})\s*$')
 DOWNLOAD_RE = re.compile(r'^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}):\d+\s+Download Message with Type: (\d+), '
@@ -300,7 +300,7 @@ def _find_join(path, entities, entity_a, entity_b):
     Returns (table, column_for_entity_a, column_for_entity_b) or None."""
     query = ("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'Z\\_%' "
              "ESCAPE '\\' AND name NOT IN ('Z_PRIMARYKEY','Z_METADATA','Z_MODELCACHE')")
-    for record in get_sqlite_db_records(path, query):
+    for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
         table = record[0]
         columns = {}
         for column in get_sqlite_db_records(path, f'PRAGMA table_info("{table}")'):
@@ -380,7 +380,7 @@ def wickr_messages(context):
             for record in get_sqlite_db_records(path, 'SELECT Z_PK, ZGUID FROM ZWICKR_FILE'):
                 guids[record[0]] = record[1] or ''
             query = f'SELECT {file_column}, {message_column} FROM {table}'
-            for record in get_sqlite_db_records(path, query):
+            for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
                 files_by_message.setdefault(record[1], []).append(guids.get(record[0], ''))
 
         read_ts = _optional(path, 'ZWICKR_MESSAGE', 'ZREADTIMESTAMP')
@@ -396,7 +396,7 @@ def wickr_messages(context):
         LEFT JOIN ZSECEX_USER u ON m.ZUSERSENDER = u.Z_PK
         ORDER BY m.ZTIMESTAMP
         '''
-        for record in get_sqlite_db_records(path, query):
+        for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
             data_list.append((
                 _cocoa(record[1]),
                 _cocoa(record[2]),
@@ -460,7 +460,7 @@ def wickr_conversations(context):
         FROM ZSECEX_CONVO
         ORDER BY ZLASTTIMESTAMP
         '''
-        for record in get_sqlite_db_records(path, query):
+        for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
             data_list.append((
                 _unix(record[3]),
                 _unix(record[4]),
@@ -520,7 +520,7 @@ def wickr_users(context):
         FROM ZSECEX_USER
         ORDER BY ZLASTACTIVITYTIME
         '''
-        for record in get_sqlite_db_records(path, query):
+        for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
             data_list.append((
                 _unix(record[0]),
                 _text(record[1]),
@@ -581,7 +581,7 @@ def wickr_files(context):
             LEFT JOIN ZWICKR_MESSAGE m ON j.{message_column} = m.Z_PK
             LEFT JOIN ZSECEX_CONVO c ON m.ZCONVO = c.Z_PK
             '''
-            for record in get_sqlite_db_records(path, query):
+            for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
                 messages[record[0]] = (record[1], record[2], record[3])
 
         for record in get_sqlite_db_records(path, 'SELECT Z_PK, ZGUID, ZSTATUS FROM ZWICKR_FILE'):
@@ -630,7 +630,7 @@ def wickr_account(context):
                {censorship}, ZLASTMSGSEQUENCE, ZHIGHE, ZLASTAPID, ZIDCPCOUNT
         FROM ZSECEX_ACCOUNT
         '''
-        for record in get_sqlite_db_records(path, query):
+        for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
             data_list.append((
                 _unix(network_timestamp) if network_timestamp != 'NULL' else '',
                 record[0],
@@ -694,7 +694,7 @@ def wickr_devices(context):
         LEFT JOIN ZSECEX_USER u ON a.ZUSER = u.Z_PK
         ORDER BY a.Z_PK
         '''
-        for record in get_sqlite_db_records(path, query):
+        for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
             data_list.append((
                 _text(record[2]),
                 record[3] or (f'User {record[6]}' if record[6] else ''),
@@ -725,7 +725,7 @@ def wickr_recent_searches(context):
             continue
         source_path = path
         query = 'SELECT ZTIMESTAMP, ZSEARCHQUERY FROM ZRECENT_SEARCH ORDER BY ZTIMESTAMP'
-        for record in get_sqlite_db_records(path, query):
+        for record in get_sqlite_db_records(path, null_absent_columns(path, query)):
             data_list.append((
                 _cocoa(record[0]),
                 _text(record[1]),


### PR DESCRIPTION
A sweep of **806 artifacts across all 21 registered iOS corpora** produced **225 error lines**. Most were the same shape: a query naming a column the store in front of it does not have. SQLite fails the whole statement, so the artifact returns nothing and logs a line nobody reads. An empty table looks exactly like "this person never used the app".

## Column drift, 45 modules

Queries now route through `null_absent_columns`, which substitutes `NULL` for references the database lacks and **keeps the column name**, because artifacts read rows by name as well as by position.

The Photos family dominates: **42 `Ph*` modules, 480 call sites**, all failing on the same handful of columns newer iOS adds — `zAsset.ZISRECENTLYSAVED`, `zAddAssetAttr.ZIMPORTEDBYDISPLAYNAME`, `ZDUPLICATEDETECTORPERCEPTUALPROCESSING`, `zGenAlbum.ZCREATORBUNDLEID`. All 42 are wrapped rather than only the 16 that happened to fail on these corpora, since they share one schema and one failure mode and the untouched ones would drift on the next image.

Also `wickr`, `FitnessWorkoutsLocationData`, `voiceRecordings`, `cloudkit_cache`, `duckduckgo`, `mastodon`, `whatsApp`, `splitwise`, `tileAppDb`, `photosMigration`, `trustedPeers`.

## Container resolution, waze and googleChat

Both worked out the app container by taking the **first UUID-shaped component anywhere in the path**. An output directory, case folder or export path whose name looks like a UUID gets picked instead of the container, and every lookup that follows searches a directory that does not exist.

This is why all eight plist-derived Waze artifacts reported nothing while `user.db` and `tts.db` sat there intact. `googleChat` has the same defect and uses the value to find **media attachments**, so its failure mode is silently missing media; it also had an unguarded `result[0]` that raises `IndexError` when no match is found.

Both now anchor on `.../Application/<UUID>/` and search from the evidence end, so nothing ahead of the evidence in the path can win.

## Validation

Unmodified code from a detached worktree versus this change, **both on the same drive, both writing to UUID-free output paths**:

| | |
|---|---|
| artifact/corpus pairs identical | **6,973** |
| pairs with more rows | **37** |
| **regressions** | **0** |
| error lines | **225 → 154** |

Recovered where artifacts previously returned zero: `Ph097` 4,579 rows on `otto_ios17` and 2,088 on `iphone11_ios17`, `cloudkit_files` 7,176 on `ctf2020_ios12` and 6,432 on `hickman_ios13`, `Ph050` 601 on `magnet_ios16`, `Ph094` 381 on `hickman_ios14`, `mastodonStatuses` 214, plus Wickr accounts, conversations, devices and users across two images.

**The container fix is not covered by that sweep**, having been made after it started. It is verified directly instead: with an output directory named like a UUID, every Waze artifact reports no data before the fix and returns its rows after, on the same input and the same directory. Path handling is additionally covered by a table of cases including UUID case folders, two UUIDs ahead of the evidence, Windows separators, and both backup layouts, which still resolve to `com.waze.iphone`.

Rebased onto current `main` and re-verified afterwards on `fsfull002_ios17`: 402 artifact results identical to the swept run, so the eight intervening commits change nothing here.

`check_claim_language.py`, `check_html_safety.py` and `lint_changed.py` all pass with no new warnings. All 47 files byte-compile.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>