### PR TITLE
fix: skip AppleDouble metadata files when collecting powerlog databases

### DIFF
--- a/scripts/artifacts/powerlog.py
+++ b/scripts/artifacts/powerlog.py
@@ -1228,6 +1228,11 @@ def _powerlog_sources(context, extension=".PLSQL"):
     """
     sources = []
     for path in dict.fromkeys(str(p) for p in context.get_files_found()):
+        if os.path.basename(path).startswith('._'):
+            # AppleDouble metadata written when an extraction is handled on macOS.
+            # ._CurrentPowerlog.PLSQL sits beside the real database and matches the
+            # same glob, and opening it raises "file is not a database".
+            continue
         if path.endswith(extension):
             sources.append((path, path))
         elif extension == ".PLSQL" and path.endswith(".PLSQL.gz"):


### PR DESCRIPTION
## What

`powerlog.py` collects every file its glob `*/[Pp]ower[Ll]og/*.PLSQL*` returns. An extraction handled on macOS carries AppleDouble metadata files (`._<name>`, header `00 05 16 07`) beside the real ones, so `._CurrentPowerlog.PLSQL` and `._powerlog_*.PLSQL.gz` match the same glob. The first raises `file is not a database` on open; the second fails gzip decompression. Files whose basename starts with `._` are now skipped before either path runs.

## Evidence

- On the `hickman_ios13` and `hickman_ios14` images the artifact logged 36 `file is not a database` errors each (one per powerlog sub-artifact hitting the 344-byte `._CurrentPowerlog.PLSQL`), plus `Not a gzipped file (b'\x00\x05')` for the archived copies.
- AppleDouble files are present in 13 of the 21 registered iOS corpora, so any of them handled on macOS can reproduce this.
- The cores already skip `._` files in media check-in and in the report writer; this artifact's own collection loop did not.

## Validation

Sweep of the 24 powerlog artifacts across all 21 iOS corpora from a detached worktree pinned to this commit, compared row-by-row against the pre-change baseline:

- 442 artifact/corpus pairs **identical**, 0 gains, 0 regressions
- `file is not a database` inside powerlog: **72 before → 0 after**
- `Could not decompress .../._*.PLSQL.gz`: **0 after**

Row counts are unchanged because the AppleDouble stubs never yielded rows; they only produced error log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)