### PR TITLE
fix: read the schema generation each store actually carries

### DIFF
--- a/scripts/artifacts/biomeSetsStores.py
+++ b/scripts/artifacts/biomeSetsStores.py
@@ -5,11 +5,13 @@ __artifacts_v2__ = {
                        "Biome Set.db store.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Biome",
         "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
-                 "Modified timestamps come from the store's instance table.",
+                 "Modified timestamps come from the store's instance table; stores without one "
+                 "(observed on iOS 26) carry metacontent_provenance.written_date instead, "
+                 "reported in the same column.",
         "paths": ('*/Biome/sets/Default/App.InstalledApp/Database/Set.db*',),
         "output_types": "standard",
         "artifact_icon": "package",
@@ -24,11 +26,12 @@ __artifacts_v2__ = {
         "description": "Contact name records from the Contacts.Contact Biome Set.db store.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Biome",
         "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
-                 "Unmapped protobuf fields are preserved in the Other Fields column.",
+                 "Unmapped protobuf fields are preserved in the Other Fields column."
+                 " The Modified column comes from the store's instance table, or metacontent_provenance.written_date on stores without one (observed on iOS 26).",
         "paths": ('*/Biome/sets/Default/Contacts.Contact/Database/Set.db*',),
         "output_types": "standard",
         "artifact_icon": "user",
@@ -44,10 +47,11 @@ __artifacts_v2__ = {
                        "Set.db store.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go."
+                 " The Modified column comes from the store's instance table, or metacontent_provenance.written_date on stores without one (observed on iOS 26).",
         "paths": ('*/Biome/sets/Default/FindMy.Device/Database/Set.db*',),
         "output_types": "standard",
         "artifact_icon": "device-mobile",
@@ -63,10 +67,11 @@ __artifacts_v2__ = {
                        "Location.SignificantLocation Biome Set.db store.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go."
+                 " The Modified column comes from the store's instance table, or metacontent_provenance.written_date on stores without one (observed on iOS 26).",
         "paths": ('*/Biome/sets/Default/Location.SignificantLocation/Database/Set.db*',),
         "output_types": "standard",
         "artifact_icon": "map-pin",
@@ -82,11 +87,12 @@ __artifacts_v2__ = {
                        "(one store per source application).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Biome",
         "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go. "
-                 "Documents which intent phrases installed apps registered with the system.",
+                 "Documents which intent phrases installed apps registered with the system."
+                 " The Modified column comes from the store's instance table, or metacontent_provenance.written_date on stores without one (observed on iOS 26).",
         "paths": ('*/Biome/sets/Default/App.Shortcut.Phrase/*/Database/Set.db*',),
         "output_types": "standard",
         "artifact_icon": "message-circle",
@@ -102,10 +108,11 @@ __artifacts_v2__ = {
                        "Biome Set.db stores (can include user content names such as note titles and board names).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-11",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go.",
+        "notes": "Based on research by North Loop Consulting: https://northloopconsulting.com/blog/f/ready-sets-go."
+                 " The Modified column comes from the store's instance table, or metacontent_provenance.written_date on stores without one (observed on iOS 26).",
         "paths": ('*/Biome/sets/Default/App.Shortcut.Entity/*/Database/Set.db*',),
         "output_types": "standard",
         "artifact_icon": "database",
@@ -130,34 +137,55 @@ SOURCE_APP_RE = re.compile(r'sourceIdentifier=([^/\\]+)')
 
 
 def _set_records(file_found):
-    """Yields (modified_utc, protobuf_dict) for every content record of a
+    """Yields (timestamp_utc, protobuf_dict) for every content record of a
     Set.db store. Records that fail protobuf decoding are logged and skipped."""
     if not does_table_exist_in_db(file_found, 'content'):
         logfunc(f'No content table in {file_found} (unsupported Set.db layout?)')
         return
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
+
+    # Two store layouts observed. Through iOS 18 the timestamp is
+    # instance.modified reached via the provenance table. On the iOS 26 image
+    # (hc_ios26) the instance/provenance pair is gone and
+    # metacontent_provenance links content_hash directly, carrying
+    # written_date in the same epoch-microsecond scale. The protobuf content
+    # blob is identical in both layouts.
+    if does_table_exist_in_db(file_found, 'instance'):
+        query = '''
             SELECT i.modified, c.content
             FROM content c
             JOIN provenance p ON p.content_hash = c.content_hash
             JOIN instance i ON i.provenance_row_id = p.provenance_row_id
-        ''')
+        '''
+    elif does_table_exist_in_db(file_found, 'metacontent_provenance'):
+        query = '''
+            SELECT mp.written_date, c.content
+            FROM content c
+            JOIN metacontent_provenance mp ON mp.content_hash = c.content_hash
+        '''
+    else:
+        logfunc(f'No instance or metacontent_provenance table in {file_found} '
+                '(unsupported Set.db layout?)')
+        return
+
+    db = open_sqlite_db_readonly(file_found)
+    cursor = db.cursor()
+    try:
+        cursor.execute(query)
         rows = cursor.fetchall()
     except Exception as ex:  # pylint: disable=broad-exception-caught
         logfunc(f'Unable to query Set.db {file_found}: {ex}')
         rows = []
     db.close()
 
-    for modified, blob in rows:
+    for timestamp, blob in rows:
         try:
             message, _ = blackboxprotobuf.decode_message(blob)
         except (DecodeError, struct.error, KeyError, ValueError, TypeError, IndexError) as ex:
             logfunc(f'Skipping Set.db record in {file_found} due to protobuf decode error: {ex}')
             continue
-        # instance.modified is Unix epoch microseconds
-        yield convert_unix_ts_to_utc(modified), message
+        # instance.modified / metacontent_provenance.written_date are Unix
+        # epoch microseconds
+        yield convert_unix_ts_to_utc(timestamp), message
 
 
 def _text(message, key):

--- a/scripts/artifacts/duckduckgo.py
+++ b/scripts/artifacts/duckduckgo.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
                        "history entry URL and, where present, the tab the visit belonged to",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
-        "last_update_date": "2026-08-07",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "DuckDuckGo",
         "notes": "ZPAGEVISITMANAGEDOBJECT records one row per visit and links to a history entry and "
@@ -44,6 +44,7 @@ from scripts.ilapfuncs import (
     convert_cocoa_core_data_ts_to_utc,
     get_file_path,
     get_sqlite_db_records, null_absent_columns,
+    does_table_exist_in_db,
 )
 
 
@@ -90,11 +91,22 @@ def duckduckgo_page_visits(context):
     source_path = get_file_path(context.get_files_found(), 'History.sqlite')
     data_list = []
 
-    query = '''
-    SELECT v.ZDATE, h.ZURL, h.ZTITLE, t.ZTABID
+    # Some app versions have no ZTABHISTORYMANAGEDOBJECT table at all
+    # (verified on the felix_ios17 image, which still holds page visits), and
+    # even a LEFT JOIN against a missing table fails the whole query. Join it
+    # only when the file carries it; the Tab ID column stays empty otherwise.
+    if does_table_exist_in_db(source_path, 'ZTABHISTORYMANAGEDOBJECT'):
+        tab_id = 't.ZTABID'
+        tab_join = 'LEFT JOIN ZTABHISTORYMANAGEDOBJECT t ON v.ZTABHISTORY = t.Z_PK'
+    else:
+        tab_id = 'NULL'
+        tab_join = ''
+
+    query = f'''
+    SELECT v.ZDATE, h.ZURL, h.ZTITLE, {tab_id} AS ZTABID
     FROM ZPAGEVISITMANAGEDOBJECT v
     LEFT JOIN ZBROWSINGHISTORYENTRYMANAGEDOBJECT h ON v.ZHISTORYENTRY = h.Z_PK
-    LEFT JOIN ZTABHISTORYMANAGEDOBJECT t ON v.ZTABHISTORY = t.Z_PK
+    {tab_join}
     ORDER BY v.ZDATE
     '''
     for record in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):

--- a/scripts/artifacts/mailprotect.py
+++ b/scripts/artifacts/mailprotect.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Apple Mail messages from the Envelope Index and Protected Index databases (iOS 13+)",
         "author": "@abrignoni - @stark4n6",
         "creation_date": "2020-05-07",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Apple Mail",
         "notes": ("Supports iOS 13 and later. The recipients.type = 1 = To mapping was "
@@ -59,7 +59,8 @@ import sqlite3
 
 from scripts.ilapfuncs import (artifact_processor, attach_sqlite_db_readonly,
                                get_sqlite_db_records, logfunc,
-                               convert_unix_ts_to_utc)
+                               convert_unix_ts_to_utc,
+                               does_table_exist_in_db, does_column_exist_in_db)
 
 # Recipient rows are typed; only To recipients (type 1) are decoded here.
 # In the examined corpora no CC/BCC recipients appeared in this table; they
@@ -69,7 +70,40 @@ _RECIPIENT_TYPE_TO = 1
 # LEFT JOINs throughout on purpose. Joining subjects/addresses/summaries with
 # inner joins silently drops every message that has no summary row, which on a
 # real mailbox is the majority of them.
-_QUERY = f'''
+#
+# The attachment link table changed name and key between Envelope Index
+# generations. Current schemas carry message_attachments keyed on
+# global_message_id; the iOS 13/14 generation instead carries
+# attachments(message -> messages.ROWID, name) with no size column, and on
+# iOS 13 messages has no global_message_id column either (verified against the
+# Josh Hickman iOS 13.3.1 and 14.3 images). _build_query assembles the variant
+# the file at hand supports; the shared column list stays identical.
+def _build_query(envelope_db):
+    if does_table_exist_in_db(envelope_db, 'message_attachments'):
+        attachment_names = '''
+    (SELECT GROUP_CONCAT(ma.name, ', ')
+       FROM main.message_attachments ma
+      WHERE ma.global_message_id = main.messages.global_message_id)'''
+        attachment_sizes = '''
+    (SELECT GROUP_CONCAT(att.size, ', ')
+       FROM main.message_attachments ma
+       JOIN main.attachments att ON att.ROWID = ma.attachment
+      WHERE ma.global_message_id = main.messages.global_message_id)'''
+    else:
+        attachment_names = '''
+    (SELECT GROUP_CONCAT(a.name, ', ')
+       FROM main.attachments a
+      WHERE a.message = main.messages.ROWID)'''
+        # The old attachments table records no size.
+        attachment_sizes = 'NULL'
+
+    global_message_id = (
+        'main.messages.global_message_id'
+        if does_column_exist_in_db(envelope_db, 'messages', 'global_message_id')
+        else 'NULL'
+    )
+
+    return f'''
 SELECT
     datetime(main.messages.date_sent, 'UNIXEPOCH'),
     datetime(main.messages.date_received, 'UNIXEPOCH'),
@@ -86,14 +120,9 @@ SELECT
     main.messages.flagged,
     main.messages.deleted,
     main.mailboxes.url,
-    (SELECT GROUP_CONCAT(ma.name, ', ')
-       FROM main.message_attachments ma
-      WHERE ma.global_message_id = main.messages.global_message_id) AS attachment_names,
-    (SELECT GROUP_CONCAT(att.size, ', ')
-       FROM main.message_attachments ma
-       JOIN main.attachments att ON att.ROWID = ma.attachment
-      WHERE ma.global_message_id = main.messages.global_message_id) AS attachment_sizes,
-    main.messages.global_message_id
+    {attachment_names} AS attachment_names,
+    {attachment_sizes} AS attachment_sizes,
+    {global_message_id} AS global_message_id
 FROM main.messages
 LEFT JOIN main.mailboxes ON main.mailboxes.ROWID = main.messages.mailbox
 LEFT JOIN PI.subjects ON PI.subjects.ROWID = main.messages.subject
@@ -123,7 +152,8 @@ def mailprotect(context):
     head = os.path.split(envelope_db)[0]
     attach_query = attach_sqlite_db_readonly(os.path.join(head, 'Protected Index'), 'PI')
     try:
-        rows = get_sqlite_db_records(envelope_db, _QUERY, attach_query=attach_query)
+        rows = get_sqlite_db_records(envelope_db, _build_query(envelope_db),
+                                     attach_query=attach_query)
     except sqlite3.Error as ex:
         logfunc(f'Error reading Apple Mail (iOS 13+ schema expected): {ex}')
         return data_headers, data_list, context.get_relative_path(head)

--- a/scripts/artifacts/mastodon.py
+++ b/scripts/artifacts/mastodon.py
@@ -48,7 +48,7 @@ __artifacts_v2__ = {
         'description': 'Mastodon accounts cached by the application, with follow relationships',
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-25',
-        'last_update_date': '2026-07-25',
+        'last_update_date': '2026-08-09',
         'requirements': 'none',
         'category': 'Mastodon',
         'notes': '',
@@ -328,7 +328,36 @@ def mastodonUsers(context):
 
     local_user_id = _get_local_user_id(source_path)
 
-    query = '''
+    # Core Data names the many-to-many following table and its columns after
+    # the MastodonUser entity number, and that number shifts between app
+    # versions as entities are added (7 on the magnet_ios16 image, 8 on the
+    # images this artifact was built against). Resolve it from the file's own
+    # Z_PRIMARYKEY table instead of hardcoding it.
+    following_table = ''
+    for row in get_sqlite_db_records(
+            source_path,
+            "SELECT Z_ENT FROM Z_PRIMARYKEY WHERE Z_NAME = 'MastodonUser'"):
+        candidate = f'Z_{row[0]}FOLLOWING'
+        if does_table_exist_in_db(source_path, candidate):
+            following_table = candidate
+        break
+
+    if following_table:
+        followed_by_holder = f'''
+        EXISTS(SELECT 1 FROM {following_table} f
+                JOIN ZMASTODONUSER me ON me.Z_PK = f.{following_table}BY
+               WHERE f.{following_table} = u.Z_PK AND me.ZID = :localUserId)'''
+        follows_holder = f'''
+        EXISTS(SELECT 1 FROM {following_table} f
+                JOIN ZMASTODONUSER me ON me.Z_PK = f.{following_table}
+               WHERE f.{following_table}BY = u.Z_PK AND me.ZID = :localUserId)'''
+    else:
+        # No following join table in this file; the relationship columns stay
+        # empty rather than guessed.
+        followed_by_holder = 'NULL'
+        follows_holder = 'NULL'
+
+    query = f'''
     SELECT
         u.ZCREATEDAT,
         u.ZUPDATEDAT,
@@ -346,12 +375,8 @@ def mastodonUsers(context):
         u.ZSUSPENDED AS suspended,
         u.ZURL AS url,
         u.ZAVATARSTATIC AS avatarUrl,
-        EXISTS(SELECT 1 FROM Z_8FOLLOWING f
-                JOIN ZMASTODONUSER me ON me.Z_PK = f.Z_8FOLLOWINGBY
-               WHERE f.Z_8FOLLOWING = u.Z_PK AND me.ZID = :localUserId) AS followedByHolder,
-        EXISTS(SELECT 1 FROM Z_8FOLLOWING f
-                JOIN ZMASTODONUSER me ON me.Z_PK = f.Z_8FOLLOWING
-               WHERE f.Z_8FOLLOWINGBY = u.Z_PK AND me.ZID = :localUserId) AS followsHolder
+        {followed_by_holder} AS followedByHolder,
+        {follows_holder} AS followsHolder
     FROM ZMASTODONUSER u
     ORDER BY u.ZACCT
     '''

--- a/scripts/artifacts/telegramAccounts.py
+++ b/scripts/artifacts/telegramAccounts.py
@@ -170,7 +170,7 @@ __artifacts_v2__ = {
         ),
         "author": "@AlexisBrignoni",
         "creation_date": "2026-08-05",
-        "last_update_date": "2026-08-05",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Telegram",
         "notes": "Table t12 is the Postbox MessageHistoryTagsTable (tableSpec(12) in "
@@ -946,6 +946,11 @@ def telegramMessageTags(context):
             continue
         try:
             cursor = db.cursor()
+            # Older postbox layouts predate the tag table entirely (observed on
+            # the felix_ios17 image); absence means nothing to read, not an error.
+            cursor.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 't12'")
+            if cursor.fetchone() is None:
+                continue
             names = _peer_names(cursor)
             cursor.execute('SELECT key FROM t12')
             for (key,) in cursor.fetchall():

--- a/scripts/artifacts/tileAppDb.py
+++ b/scripts/artifacts/tileAppDb.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Tile device information and most recent stored coordinates (via the TILESTATE join) from the Tile network database",
         "author": "@abrignoni",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Locations",
         "notes": "Timestamps are Cocoa/Mac absolute time (seconds since 2001-01-01 UTC), converted to UTC.",
@@ -18,7 +18,8 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, null_absent_columns
+from scripts.ilapfuncs import (artifact_processor, get_sqlite_db_records,
+                               null_absent_columns, does_table_exist_in_db)
 
 
 @artifact_processor
@@ -38,7 +39,18 @@ def tileAppDb(context):
     if not source_path:
         return data_headers, data_list, ''
 
-    query = '''
+    # Older app schemas have no ZTILENTITY_TILESTATE table; there the lost
+    # state lives on ZTILENTITY_NODE itself and the location/timestamp columns
+    # this query takes from the state table do not exist anywhere (verified on
+    # the abe_ios16 and otto_ios17 images). null_absent_columns nulls those, so
+    # the column list stays identical across both generations.
+    state_join = (
+        'INNER JOIN ZTILENTITY_TILESTATE ON ZTILENTITY_NODE.ZTILE_STATE = ZTILENTITY_TILESTATE.Z_PK'
+        if does_table_exist_in_db(source_path, 'ZTILENTITY_TILESTATE')
+        else ''
+    )
+
+    query = f'''
     SELECT
         datetime(ZTIMESTAMP + 978307200, 'unixepoch'),
         ZNAME,
@@ -53,7 +65,7 @@ def tileAppDb(context):
         ZIS_LOST,
         datetime(ZLAST_LOST_TILE_COMMUNITY_CONNECTION + 978307200, 'unixepoch')
     FROM ZTILENTITY_NODE
-    INNER JOIN ZTILENTITY_TILESTATE ON ZTILENTITY_NODE.ZTILE_STATE = ZTILENTITY_TILESTATE.Z_PK
+    {state_join}
     '''
     for row in get_sqlite_db_records(source_path, null_absent_columns(source_path, query)):
         data_list.append(tuple(row))

--- a/scripts/artifacts/whatsApp.py
+++ b/scripts/artifacts/whatsApp.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         'description': 'Extract call history from WhatsApp',
         'author': '@Vinceckert',
         'creation_date': '2024-05-31',
-        'last_update_date': '2026-07-31',
+        'last_update_date': '2026-08-09',
         'requirements': 'none',
         'category': 'WhatsApp',
         'notes': 'Call outcome value mapping observed in testing; unrecognized values reported as stored.',
@@ -127,8 +127,12 @@ def whatsAppCallHistory(context):
         base2.ZPHONENUMBER
     '''
 
+    # LEFT JOIN on purpose: the address book is an enrichment, not a filter.
+    # With INNER JOIN a call whose participant is not in ZWAADDRESSBOOKCONTACT
+    # disappeared entirely (on the hickman_ios14 image all 4 calls were dropped
+    # because the caller was not among the 5 stored contacts).
     tables_join = '''
-    INNER JOIN ContactsV2.ZWAADDRESSBOOKCONTACT base2 ON ZWACDCALLEVENTPARTICIPANT.ZJIDSTRING = base2.ZWHATSAPPID
+    LEFT JOIN ContactsV2.ZWAADDRESSBOOKCONTACT base2 ON ZWACDCALLEVENTPARTICIPANT.ZJIDSTRING = base2.ZWHATSAPPID
     '''
 
     # Older releases have no group-call creator column. The query is built here


### PR DESCRIPTION
## What

Seven modules failed, or silently returned nothing, on schema generations present in the registered iOS corpora. Every fix is at the artifact level and keyed off the file itself (table/column probes or the file's own `Z_PRIMARYKEY`), never off hardcoded assumptions about the app version.

| Module | Defect on the affected generation | Recovery |
|---|---|---|
| `mailprotect` | iOS 13/14 Envelope Index has `attachments(message, name)` instead of `message_attachments` keyed on `global_message_id`; no size column; iOS 13 also lacks `messages.global_message_id` | **214 messages** on hickman_ios13, **869** on hickman_ios14 |
| `whatsApp` (call history) | Address-book join was `INNER`, so calls whose participant is not a stored contact were dropped entirely | **4 calls** on hickman_ios14 (caller absent from the 5 stored contacts), **+2** on otto_ios17 |
| `mastodon` (users) | Core Data following join table is named after the MastodonUser entity number: `Z_7FOLLOWING` on magnet_ios16, `Z_8FOLLOWING` on newer builds. Number now resolved from the file's `Z_PRIMARYKEY` | **61 users** on magnet_ios16 |
| `tileAppDb` | Older schema has no `ZTILENTITY_TILESTATE`; lost-state lives on `ZTILENTITY_NODE`, and the state-only location/timestamp columns are nulled via `null_absent_columns` | 1 tile each on abe_ios16, otto_ios17 |
| `duckduckgo` (page visits) | Some versions have no `ZTABHISTORYMANAGEDOBJECT`; even a LEFT JOIN against a missing table fails the whole query | **6 visits** on felix_ios17 |
| `biomeSetsStores` (6 artifacts) | iOS 26 Set.db drops the `instance`/`provenance` pair for `metacontent_provenance`, which links `content_hash` directly and carries `written_date` in the same epoch-microsecond scale | **1,645 rows** across the six stores on hc_ios26 |
| `telegramAccounts` (message tags) | Older postbox layouts predate table `t12`; probed via `sqlite_master` instead of erroring | correct empty, error line gone |

The biome artifacts' notes now state which column feeds the Modified value per layout, and `last_update_date` is bumped on every touched artifact.

## Validation

All artifacts of the seven touched modules (28) swept across the 21 registered iOS corpora from a detached worktree pinned to this commit, compared row-by-row against the current-main reference runs:

- **191 artifact/corpus pairs identical, 14 gains, 0 losses**
- SQLite error pairs among these artifacts: **14 before → 1 after**; the survivor is `mailprotect` on ctf2020_ios12, whose protected-class files are 8-byte stubs in that extraction (corpus property, not reachable by a query fix)
- `admin/scripts/lint_changed.py`: no new warnings; `check_claim_language.py` clean

Old-schema shapes were verified by direct probes of the databases inside the corpus sources (`.schema`, `PRAGMA table_info`, `Z_PRIMARYKEY` contents) before any query was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)