### PR TITLE
fix: drop the unimplemented bytes header type

### DIFF
--- a/scripts/artifacts/filesApp.py
+++ b/scripts/artifacts/filesApp.py
@@ -311,7 +311,7 @@ def icloud_application_list(context):
         '''
         data_headers = (
             'Application Bundle ID', 'Number of folders', 'Number of files',
-            ('Total size in bytes', 'bytes')
+            'Total size in bytes'
             )
     else:
         query = '''


### PR DESCRIPTION
filesApp declared a ('Total size in bytes', 'bytes') header. No consumer implements a bytes type, so it fails open: ignored at render, written into the LAVA manifest's object_columns where it would activate retroactively the day a renderer exists. Stripped to plain text, same reasoning as the removed url type (#1903). Matching ALEAPP case: #1087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)