### PR TITLE
Update apple_build_id_to_os_version.json

### DIFF
--- a/scripts/data/apple_build_id_to_os_version.json
+++ b/scripts/data/apple_build_id_to_os_version.json
@@ -878,6 +878,7 @@
     "22H340": "iOS 18.7.7",
     "22H352": "iOS 18.7.8",
     "22H355": "iOS 18.7.9",
+    "22H373": "iOS 18.7.10",
     "23A5260n": "iOS 26.0 beta 1",
     "23A5260u": "iOS 26.0 beta 1 Update",
     "23A5276f": "iOS 26.0 beta 2",
@@ -941,10 +942,12 @@
     "23G5057c": "iOS 26.6 beta 4",
     "23G5065a": "iOS 26.6 beta 5",
     "23G71": "iOS 26.6",
+    "23G82": "iOS 26.6.1",
     "24A5355q": "iOS 27.0 beta 1",
     "24A5370h": "iOS 27.0 beta 2",
     "24A5380h": "iOS 27.0 beta 3",
-    "24A5390f": "iOS 27.0 beta 4"
+    "24A5390f": "iOS 27.0 beta 4",
+    "24A5408d": "iOS 27.0 beta 5"
   },
   "macOS": {
     "4K78": "Mac OS X 10.0",
@@ -2292,8 +2295,8 @@
     "23J612": "macOS 14.8.8 RC 4",
     "23J615": "macOS 14.8.8 RC 5",
     "23J619": "macOS 14.8.8 RC 6",
-  	"23J620": "macOS 14.8.8",
-  	"23J631": "macOS 14.8.9",
+    "23J620": "macOS 14.8.8",
+    "23J631": "macOS 14.8.9",
     "24A5264n": "macOS 15.0 beta 1",
     "24A5279h": "macOS 15.0 beta 2",
     "24A5289g": "macOS 15.0 beta 3",
@@ -2383,8 +2386,8 @@
     "24G814": "macOS 15.7.8 RC 4",
     "24G817": "macOS 15.7.8 RC 5",
     "24G822": "macOS 15.7.8 RC 6",
-  	"24G824": "macOS 15.7.8",
-  	"24G830": "macOS 15.7.9",
+    "24G824": "macOS 15.7.8",
+    "24G830": "macOS 15.7.9",
     "25A5279m": "macOS 26.0 beta 1",
     "25A5295e": "macOS 26.0 beta 2",
     "25A5306g": "macOS 26.0 beta 3",
@@ -2446,10 +2449,12 @@
     "25G70": "macOS 26.6 RC",
     "25G72": "macOS 26.6",
     "25G76": "macOS 26.6.1",
+    "25G82": "macOS 26.6.2",
     "26A5353q": "macOS 27.0 beta 1",
     "26A5368g": "macOS 27.0 beta 2",
     "26A5378j": "macOS 27.0 beta 3",
-    "26A5388g": "macOS 27.0 beta 4"
+    "26A5388g": "macOS 27.0 beta 4",
+    "26A5406e": "macOS 27.0 beta 5"
   },
   "visionOS": {
     "21N5165g": "visionOS 1.0 beta 1",
@@ -2580,7 +2585,8 @@
     "24M5291p": "visionOS 27.0 beta 1",
     "24M5306i": "visionOS 27.0 beta 2",
     "24M5316k": "visionOS 27.0 beta 3",
-    "24M5326g": "visionOS 27.0 beta 4"
+    "24M5326g": "visionOS 27.0 beta 4",
+    "24M5348b": "visionOS 27.0 beta 5"
   },
   "watchOS": {
     "12S507": "watchOS 1.0",
@@ -3075,7 +3081,8 @@
     "24R5305k": "watchOS 27.0 beta 2",
     "24R5305g": "watchOS 27.0 beta 2",
     "24R5315i": "watchOS 27.0 beta 3",
-    "24R5325h": "watchOS 27.0 beta 4"
+    "24R5325h": "watchOS 27.0 beta 4",
+    "24R5347a": "watchOS 27.0 beta 5"
   },
   "tvOS": {
     "8M89": "Apple TV Software 4.0",
@@ -3593,7 +3600,8 @@
     "24J5289o": "tvOS 27.0 beta 1",
     "24J5305f": "tvOS 27.0 beta 2",
     "24J5315i": "tvOS 27.0 beta 3",
-    "24J5325d": "tvOS 27.0 beta 4"
+    "24J5325d": "tvOS 27.0 beta 4",
+    "24J5346a": "tvOS 27.0 beta 5"
   },
   "Windows": {
     "6002": "Windows Vista",
@@ -3620,6 +3628,6 @@
     "26100": "Windows 11 version 24H2",
     "26200": "Windows 11 version 25H2",
     "28000": "Windows 11 version 26H1",
-	"26300": "Windows 11 version 26H2"
+    "26300": "Windows 11 version 26H2"
   }
 }


### PR DESCRIPTION
Add:
- iOS 18.7.10, iOS 26.6.1, iOS 27.0 beta 5
- macOS 26.6.2, macOS 27.0 beta 5
- tvOS 27.0 beta 5
- visionOS 27.0 beta 5
- watchOS 27.0 beta 5