### PR TITLE
ci: add Windows import smoke test

### DIFF
--- a/.github/workflows/windows_smoke.yml
+++ b/.github/workflows/windows_smoke.yml
@@ -1,0 +1,31 @@
+name: Windows Smoke Test
+
+# Imports every artifact module on Windows to catch OS-specific breakage
+# (extracted paths use backslash separators on Windows) that the ubuntu-only
+# lint job cannot. This checks importability, not parsing correctness.
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - '.github/workflows/windows_smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: python -m pip install --prefer-binary -r requirements.txt
+
+      - name: Import all artifact modules on Windows
+        run: python admin/test/scripts/test_artifact_imports.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ numpy>=2.1; python_version >= "3.13"
 packaging==24.1
 pandas
 pathlib2==2.3.5
-PGPy
+PGPy>=0.6.0  # the newest PGPy wheel is 0.5.4, which breaks on cryptography>=38; only the 0.6.0 sdist works, so keep wheel-preferring installs off 0.5.4
 standard-imghdr; python_version >= "3.13"  # PGPy imports stdlib imghdr, removed in Python 3.13 (PEP 594)
 pillow
 pillow_heif


### PR DESCRIPTION
Ports ALEAPP's Windows Smoke Test workflow, byte-identical. It imports every artifact module on windows-latest on each pull request, catching OS-specific breakage (backslash path separators in extracted paths) that the ubuntu-only lint and runtime-contract jobs cannot see.

The script it runs, admin/test/scripts/test_artifact_imports.py, already exists in this repo and is exercised on ubuntu by the runtime contract, so this adds the Windows dimension only. The workflow triggers on its own file, so this PR runs it as its own proof.

**The first run caught a real bug**, so this PR also carries the fix: PGPy publishes 0.6.0 only as an sdist, and its newest wheel is 0.5.4, which calls cryptography.utils.register_interface, removed in cryptography 38. Any wheel-preferring install (pip --prefer-binary, as this job and many users use) resolved to the broken 0.5.4 and protonMail.py failed to import. requirements.txt now floors PGPy at 0.6.0. Verified locally: PGPy>=0.6.0 installs under --prefer-binary on 3.14 and imports cleanly against cryptography 50.

Part of a CI leveling pass across the five cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)