### PR TITLE
feat: iOS Session (Oxen) messages and contacts, decrypted via the keychain

### DIFF
--- a/scripts/artifacts/sessionIOS.py
+++ b/scripts/artifacts/sessionIOS.py
@@ -1,0 +1,278 @@
+__artifacts_v2__ = {
+    "session_messages": {
+        "name": "Session - Messages",
+        "description": "Parses messages from the encrypted Session (Oxen) database, including "
+                       "direction, author, conversation and body.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-10",
+        "last_update_date": "2026-08-10",
+        "requirements": "none",
+        "category": "Session",
+        "notes": "Session for iOS keeps its database key in the iOS keychain, which is captured "
+                 "separately from the file system extraction, so supply it with --keychain or "
+                 "the keychain field in the GUI. The database is SQLCipher with a 32 byte "
+                 "plaintext header (the file still identifies as SQLite) and the salt held in "
+                 "the keychain entry, decrypted here with the shared pure-python reader.\n"
+                 "Direction is taken from the interaction variant: 0 is an outgoing message and "
+                 "1 an incoming one, which the data bears out (variant 0 rows are authored by "
+                 "the local account and variant 1 rows by the remote party). Other variants are "
+                 "Session's info and control messages, which carry no user body and are reported "
+                 "with the variant shown. The author and conversation names are the display "
+                 "name or nickname from the profile table, falling back to the Session ID "
+                 "(the account's public key) where no profile is stored.\n"
+                 "Reference: Session-iOS, 'Interaction.Variant (standardOutgoing = 0, "
+                 "standardIncoming = 1)', "
+                 "https://github.com/oxen-io/session-ios. "
+                 "Reference: SQLCipher documentation, 'cipher_plaintext_header_size', "
+                 "https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_plaintext_header_size",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/database/Session.sqlite*',
+                  # The keychain is captured separately from the file system, so a keychain
+                  # the extraction carries is available to decrypt with.
+                  '*/extra/KeychainDump/backup_keychain_v2.plist',
+                  '*/keychain-backup.plist'),
+        "output_types": "standard",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Thread ID",
+                "conversationLabelColumn": "Conversation With",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Author",
+            }
+        },
+        "artifact_icon": "message-circle",
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 51 rows",
+            "hickman_ios15": "iOS 15.0.2 | 24 rows",
+            "dexter_ios18": "iOS 18.3.2 | 10 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "felix23_ios16": "iOS 16.5 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows (no keychain in the extraction)",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows (no keychain in the extraction)",
+        },
+    },
+    "session_contacts": {
+        "name": "Session - Contacts",
+        "description": "Parses the contacts and their profile names from the encrypted Session "
+                       "database.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-10",
+        "last_update_date": "2026-08-10",
+        "requirements": "none",
+        "category": "Session",
+        "notes": "Requires the keychain, supplied with --keychain or the keychain field in the "
+                 "GUI. Session ID is the contact's public key. Name and Nickname come from the "
+                 "profile table; the approval and block flags come from the contact table and "
+                 "are reported as stored.",
+        "paths": ('*/mobile/Containers/Shared/AppGroup/*/database/Session.sqlite*',
+                  '*/extra/KeychainDump/backup_keychain_v2.plist',
+                  '*/keychain-backup.plist'),
+        "output_types": "standard",
+        "artifact_icon": "users",
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 3 rows",
+            "dexter_ios18": "iOS 18.3.2 | 2 rows",
+            "felix_ios17": "iOS 17.6.1 | 1 row",
+            "hickman_ios15": "iOS 15.0.2 | 0 rows",
+            "felix23_ios16": "iOS 16.5 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows (no keychain in the extraction)",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows (no keychain in the extraction)",
+        },
+    },
+}
+
+import hashlib
+import os
+import sqlite3
+import tempfile
+
+from scripts.ios_keychain import get_app_secret, active_keychain_path
+from scripts.sqlcipher_decrypt import decrypt_sqlcipher_db
+from scripts.ilapfuncs import artifact_processor, logfunc, convert_unix_ts_to_utc
+
+# Session (Oxen) stores its GRDB database key under its own keychain access
+# group; the entry is a 32 byte key followed by a 16 byte salt, the same shape
+# Signal uses, because both are GRDB SQLCipher apps.
+SESSION_ACCESS_GROUP = 'com.loki-project.loki-messenger'
+KEY_SPEC_ACCOUNT = 'GRDBDatabaseCipherKeySpec'
+KEY_SPEC_LENGTH = 48
+
+# Session keeps the first 32 bytes of the file readable so it still identifies
+# as SQLite, and uses the SQLCipher 4 defaults of SHA512 for the HMAC and KDF.
+PLAINTEXT_HEADER_SIZE = 32
+SESSION_HMAC = 'sha512'
+
+# interaction.variant values that carry a user message. Everything else is an
+# info / control message with no body.
+VARIANT_OUTGOING = 0
+VARIANT_INCOMING = 1
+MESSAGE_DIRECTIONS = {VARIANT_OUTGOING: 'Outgoing', VARIANT_INCOMING: 'Incoming'}
+
+_decrypted_cache = {}
+
+
+def _decrypted_database(database_path):
+    """Decrypt the Session database once per run; return a path or None."""
+    if database_path in _decrypted_cache:
+        return _decrypted_cache[database_path]
+    _decrypted_cache[database_path] = None  # do not retry for every artifact
+
+    key_spec = get_app_secret(SESSION_ACCESS_GROUP, KEY_SPEC_ACCOUNT,
+                              expected_length=KEY_SPEC_LENGTH)
+    if not key_spec:
+        if active_keychain_path():
+            logfunc('Session: the keychain in use has no Session database key, '
+                    'the database stays encrypted')
+        else:
+            logfunc('Session: found an encrypted database but no keychain is available. '
+                    'The extraction does not carry one, so supply it with --keychain or the '
+                    'keychain field in the GUI.')
+        return None
+
+    digest = hashlib.sha1(database_path.encode('utf-8', 'replace')).hexdigest()[:12]
+    output_path = os.path.join(tempfile.gettempdir(), 'ileapp_session', f'session_{digest}.db')
+    try:
+        pages, verified = decrypt_sqlcipher_db(
+            database_path, key_spec[:32], output_path, raw_key=True,
+            external_salt=key_spec[32:KEY_SPEC_LENGTH],
+            plaintext_header_size=PLAINTEXT_HEADER_SIZE,
+            hmac_algorithm=SESSION_HMAC, kdf_algorithm=SESSION_HMAC)
+    except Exception as error:  # pylint: disable=broad-except
+        logfunc(f'Session: decryption failed for {database_path}: {error}')
+        return None
+
+    if not pages or not verified:
+        logfunc('Session: the keychain key did not authenticate the database. It may belong '
+                'to a different device than this extraction.')
+        return None
+    if verified != pages:
+        logfunc(f'Session: {pages - verified} of {pages} decrypted pages failed HMAC '
+                'verification, the recovered data may be incomplete')
+
+    _decrypted_cache[database_path] = output_path
+    return output_path
+
+
+def _open_session_databases(context):
+    """Yield (connection, source_path) for each decryptable Session database."""
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'Session.sqlite':
+            continue
+        decrypted = _decrypted_database(file_found)
+        if not decrypted:
+            continue
+        yield sqlite3.connect(decrypted), file_found
+
+
+@artifact_processor
+def session_messages(context):
+    data_list = []
+    source_path = ''
+    # interaction.threadId is the conversation's Session ID (a public key), which
+    # joins to thread.id. On an outgoing message Session stores the recipient in
+    # authorId rather than the sender, the same shape Signal uses, so the author
+    # is only meaningful on incoming rows and is left blank on outgoing ones.
+    query = '''
+        SELECT
+            i.threadId,
+            COALESCE(cp.nickname, cp.name, t.id) AS conversation,
+            i.variant,
+            COALESCE(ap.nickname, ap.name, i.authorId) AS author,
+            i.body,
+            i.timestampMs,
+            i.receivedAtTimestampMs,
+            CASE i.wasRead WHEN 1 THEN 'Yes' WHEN 0 THEN 'No' END AS was_read,
+            i.serverHash
+        FROM interaction i
+        LEFT JOIN thread t ON t.id = i.threadId
+        LEFT JOIN profile cp ON cp.id = t.id
+        LEFT JOIN profile ap ON ap.id = i.authorId
+        ORDER BY i.timestampMs
+    '''
+    for connection, file_found in _open_session_databases(context):
+        source_path = file_found
+        try:
+            cursor = connection.cursor()
+            cursor.execute(query)
+            rows = cursor.fetchall()
+        except sqlite3.Error as error:
+            logfunc(f'Session: could not read messages from {file_found}: {error}')
+            rows = []
+        finally:
+            connection.close()
+
+        for (thread_id, conversation, variant, author, body,
+             timestamp_ms, received_ms, was_read, server_hash) in rows:
+            direction = MESSAGE_DIRECTIONS.get(variant, f'Info / Control ({variant})')
+            # On an outgoing message authorId is the recipient, not the sender,
+            # so the author is only reported on incoming messages.
+            reported_author = author if variant == VARIANT_INCOMING else ''
+            data_list.append((
+                convert_unix_ts_to_utc(timestamp_ms / 1000) if timestamp_ms else '',
+                convert_unix_ts_to_utc(received_ms / 1000) if received_ms else '',
+                direction,
+                reported_author,
+                conversation,
+                body,
+                was_read,
+                thread_id,
+                server_hash,
+            ))
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        ('Received Timestamp', 'datetime'),
+        'Direction',
+        'Author',
+        'Conversation With',
+        'Message',
+        'Was Read',
+        'Thread ID',
+        'Server Hash',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def session_contacts(context):
+    data_list = []
+    source_path = ''
+    query = '''
+        SELECT
+            c.id,
+            p.name,
+            p.nickname,
+            CASE c.isApproved WHEN 1 THEN 'Yes' WHEN 0 THEN 'No' END,
+            CASE c.didApproveMe WHEN 1 THEN 'Yes' WHEN 0 THEN 'No' END,
+            CASE c.isBlocked WHEN 1 THEN 'Yes' WHEN 0 THEN 'No' END,
+            c.lastKnownClientVersion
+        FROM contact c
+        LEFT JOIN profile p ON p.id = c.id
+        ORDER BY p.name
+    '''
+    for connection, file_found in _open_session_databases(context):
+        source_path = file_found
+        try:
+            cursor = connection.cursor()
+            cursor.execute(query)
+            rows = cursor.fetchall()
+        except sqlite3.Error as error:
+            logfunc(f'Session: could not read contacts from {file_found}: {error}')
+            rows = []
+        finally:
+            connection.close()
+        data_list.extend(rows)
+
+    data_headers = (
+        'Session ID',
+        'Name',
+        'Nickname',
+        'Approved',
+        'Approved Me',
+        'Blocked',
+        'Last Known Client Version',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Adds two iLEAPP artifacts for the **Session** messenger on iOS, parsed from the encrypted `Session.sqlite` in the app group. Session is a GRDB SQLCipher app like Signal, so this **reuses the merged infrastructure rather than adding any**: `scripts/ios_keychain` (examiner-supplied or extraction-carried keychain) and `scripts/sqlcipher_decrypt` (the pure-python reader). **No core changes, no new dependencies.**

- **Session - Messages** — one row per interaction, with a conversation view. Direction from the interaction variant (0 outgoing, 1 incoming — sourced from Session-iOS `Interaction.Variant` and borne out by the data); other variants are info/control messages, labelled and body-less. As with Signal, an outgoing message stores the recipient in `authorId`, so the author is reported only on incoming rows.
- **Session - Contacts** — the contact table joined to profile names.

### Relationship to #1280
This **supersedes the stale draft #1280**. Its keychain + SQLCipher core plumbing and its three added dependencies (`cryptography`, `asn1crypto`, `sqlcipher3-wheels`) already landed differently — `sqlcipher_decrypt.py` (pure-python, PyCryptodome, no new deps) plus the `--keychain` flow used by `signalIOS.py`. Only a leaf Session parser was still wanted, and here it is, built on the merged infrastructure with zero core edits.

### Validation
Decrypts the real databases in the iOS corpora that carry Session **and** a keychain: **iphone11_ios17 (51 messages, 3 contacts, 458/458 pages HMAC-verified)**, hickman_ios15 (24), dexter_ios18 (10 messages, 2 contacts). Extractions that carry `Session.sqlite` but no keychain report zero and say so in the notes. Real decrypted conversation content confirmed (message bodies, incoming/outgoing direction, participant names). Lint and claim-language clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)