### PR TITLE
mvs_2026 is iphone14plus_ios18, and trusted_peers was reading the wrong context database

### DIFF
--- a/scripts/artifacts/instagramThreads.py
+++ b/scripts/artifacts/instagramThreads.py
@@ -26,7 +26,6 @@ __artifacts_v2__ = {
         "artifact_icon": "brand-instagram",
         "sample_data": {
             "hickman_ios15": "75 rows; includes messages, VOIP call activity, and conversation view fields",
-            "mvs_2026": "0 rows; verifies multi-DB handling with no matching thread records",
             "ctf2020_ios12": "iOS 12.4 | com.burbn.instagram | 1 row",
             "dexter_ios18": "iOS 18.3.2 | Instagram 400.0.0 | 0 rows",
             "fsfull002_ios17": "iOS 17.1 | Instagram 282.0 | 4 rows",
@@ -56,7 +55,6 @@ __artifacts_v2__ = {
         "artifact_icon": "phone",
         "sample_data": {
             "hickman_ios15": "25 rows; VOIP call activity extracted from Threads messages",
-            "mvs_2026": "0 rows; verifies multi-DB handling with no matching call records",
             "ctf2020_ios12": "iOS 12.4 | com.burbn.instagram | 0 rows",
             "dexter_ios18": "iOS 18.3.2 | Instagram 400.0.0 | 0 rows",
             "fsfull002_ios17": "iOS 17.1 | Instagram 282.0 | 0 rows",

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
         },
         "sample_data": {
             "hickman_ios15": "32 message rows; AwemeContactsV5, TIMMessageORM, TIMMessageKVORM, and TIMMessageNewPropertyORM present",
-            "mvs_2026": "No TikTok AwemeIM.db or ChatFiles db.sqlite found",
+            "iphone14plus_ios18": "No TikTok AwemeIM.db or ChatFiles db.sqlite found",
             "ctf2020_ios12": "iOS 12.4 | com.zhiliaoapp.musically | 0 rows",
             "dexter_ios18": "iOS 18.3.2 | TikTok - Videos, Shop & LIVE 41.8.0 | 63 rows",
             "fsfull002_ios17": "iOS 17.1 | TikTok 28.4.1 | 15 rows",
@@ -61,7 +61,7 @@ __artifacts_v2__ = {
         "artifact_icon": "users",
         "sample_data": {
             "hickman_ios15": "4 contact rows from AwemeContactsV5",
-            "mvs_2026": "No TikTok AwemeIM.db found",
+            "iphone14plus_ios18": "No TikTok AwemeIM.db found",
             "ctf2020_ios12": "iOS 12.4 | com.zhiliaoapp.musically | 1 row",
             "dexter_ios18": "iOS 18.3.2 | TikTok - Videos, Shop & LIVE 41.8.0 | 44 rows",
             "fsfull002_ios17": "iOS 17.1 | TikTok 28.4.1 | 5 rows",

--- a/scripts/artifacts/tikTokReplied.py
+++ b/scripts/artifacts/tikTokReplied.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "artifact_icon": "corner-up-left",
         "sample_data": {
             "hickman_ios15": "2 replied-message rows; TIMMessageKVORM and TIMMessageNewPropertyORM both present",
-            "mvs_2026": "No TikTok AwemeIM.db or ChatFiles db.sqlite found",
+            "iphone14plus_ios18": "No TikTok AwemeIM.db or ChatFiles db.sqlite found",
             "ctf2020_ios12": "iOS 12.4 | com.zhiliaoapp.musically | 0 rows",
             "dexter_ios18": "iOS 18.3.2 | TikTok - Videos, Shop & LIVE 41.8.0 | 3 rows",
             "fsfull002_ios17": "iOS 17.1 | TikTok 28.4.1 | 0 rows",

--- a/scripts/artifacts/trustedPeers.py
+++ b/scripts/artifacts/trustedPeers.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Peer records from TrustedPeersHelper.db (Apple trust-circle data)",
         "author": "Heather Charpentier",
         "creation_date": "2024-12-13",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Trusted Peers",
         "notes": "",
@@ -14,14 +14,14 @@ __artifacts_v2__ = {
         "artifact_icon": "circle-check",
         "sample_data": {
             "hickman_ios15": "23 rows",
-            "mvs_2026": "6 rows but ZPEERINFO is empty",
             "dexter_ios18": "iOS 18.3.2 | 5 rows",
             "felix_ios17": "iOS 17.6.1 | 13 rows",
             "fsfull002_ios17": "iOS 17.1 | 5 rows",
             "hc_ios18_7": "iOS 18.7.8 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 24 rows",
             "iphone12_ios18": "iOS 18.7 | 3 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 6 rows, all in the WAL of the defaultContext "
+                                  "database; ZPEERINFO empty on every row",
             "otto_ios17": "iOS 17.5.1 | 3 rows",
             "abe_ios16": "iOS 16.5 | 6 rows",
             "felix23_ios16": "iOS 16.5 | 2 rows",
@@ -33,12 +33,13 @@ __artifacts_v2__ = {
     }
 }
 
+from pathlib import PurePath
+
 from scripts.ilapfuncs import (
     does_table_exist_in_db,
     artifact_processor,
     convert_cocoa_core_data_ts_to_utc,
     does_column_exist_in_db,
-    get_file_path,
     get_sqlite_db_records, null_absent_columns,
     logfunc,
 )
@@ -112,73 +113,81 @@ def trusted_peers(context):
     """ see artifact description """
     files_found = context.get_files_found()
     data_list = []
-    source_path = get_file_path(files_found, '*TrustedPeersHelper.db')
-    if not source_path:
+    # One database exists per trust-circle context (for example
+    # com.apple.security.keychain-defaultContext.TrustedPeersHelper.db beside
+    # com.apple.security.keychain-.TrustedPeersHelper.db), so every match is
+    # read rather than the first: the first can be an empty context while the
+    # populated one sits beside it.
+    db_paths = [f for f in files_found if PurePath(f).match('*TrustedPeersHelper.db')]
+    if not db_paths:
         logfunc('TrustedPeersHelper.db not found')
         return (), [], ''
 
-    device_color = (
-        'client.ZDEVICECOLOR'
-        if does_column_exist_in_db(source_path, 'ZESCROWCLIENTMETADATA', 'ZDEVICECOLOR')
-        else 'NULL'
-    )
-    device_enclosure_color = (
-        'client.ZDEVICEENCLOSURECOLOR'
-        if does_column_exist_in_db(source_path, 'ZESCROWCLIENTMETADATA', 'ZDEVICEENCLOSURECOLOR')
-        else 'NULL'
-    )
-    peer_info = (
-        'metadata.ZPEERINFO'
-        if does_column_exist_in_db(source_path, 'ZESCROWMETADATA', 'ZPEERINFO')
-        else 'NULL'
-    )
+    for source_path in db_paths:
+        if not does_table_exist_in_db(source_path, 'ZESCROWCLIENTMETADATA'):
+            # This release does not carry the table, so there is nothing to read.
+            # Absence here is not evidence the feature was unused, only that this
+            # schema does not hold it.
+            logfunc(f'Trusted peers: {source_path} has no ZESCROWCLIENTMETADATA table; no rows reported')
+            continue
 
-    query = f'''
-    SELECT DISTINCT
-        client.ZSECUREBACKUPMETADATATIMESTAMP,
-        client.ZDEVICEMODEL,
-        client.ZDEVICEMODELVERSION,
-        client.ZDEVICENAME,
-        metadata.ZSERIAL,
-        client.ZSECUREBACKUPNUMERICPASSPHRASELENGTH,
-        {device_color} AS ZDEVICECOLOR,
-        {device_enclosure_color} AS ZDEVICEENCLOSURECOLOR,
-        {peer_info} AS ZPEERINFO
-    FROM
-        ZESCROWCLIENTMETADATA AS client
-    LEFT JOIN
-        ZESCROWMETADATA AS metadata
-    ON
-        client.ZESCROWMETADATA = metadata.Z_PK;
-    '''
+        device_color = (
+            'client.ZDEVICECOLOR'
+            if does_column_exist_in_db(source_path, 'ZESCROWCLIENTMETADATA', 'ZDEVICECOLOR')
+            else 'NULL'
+        )
+        device_enclosure_color = (
+            'client.ZDEVICEENCLOSURECOLOR'
+            if does_column_exist_in_db(source_path, 'ZESCROWCLIENTMETADATA', 'ZDEVICEENCLOSURECOLOR')
+            else 'NULL'
+        )
+        peer_info = (
+            'metadata.ZPEERINFO'
+            if does_column_exist_in_db(source_path, 'ZESCROWMETADATA', 'ZPEERINFO')
+            else 'NULL'
+        )
 
-    if does_table_exist_in_db(source_path, 'ZESCROWCLIENTMETADATA'):
+        query = f'''
+        SELECT DISTINCT
+            client.ZSECUREBACKUPMETADATATIMESTAMP,
+            client.ZDEVICEMODEL,
+            client.ZDEVICEMODELVERSION,
+            client.ZDEVICENAME,
+            metadata.ZSERIAL,
+            client.ZSECUREBACKUPNUMERICPASSPHRASELENGTH,
+            {device_color} AS ZDEVICECOLOR,
+            {device_enclosure_color} AS ZDEVICEENCLOSURECOLOR,
+            {peer_info} AS ZPEERINFO
+        FROM
+            ZESCROWCLIENTMETADATA AS client
+        LEFT JOIN
+            ZESCROWMETADATA AS metadata
+        ON
+            client.ZESCROWMETADATA = metadata.Z_PK;
+        '''
+
         db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
-    else:
-        # This release does not carry the table, so there is nothing to read.
-        # Absence here is not evidence the feature was unused, only that this
-        # schema does not hold it.
-        logfunc(f'Trusted peers: {source_path} has no ZESCROWCLIENTMETADATA table; no rows reported')
-        db_records = []
 
-    for row in db_records:
-        timestamp = convert_cocoa_core_data_ts_to_utc(row[0])
-        peer_values = _peer_info_values(row[8])
+        relative_path = context.get_relative_path(source_path)
+        for row in db_records:
+            timestamp = convert_cocoa_core_data_ts_to_utc(row[0])
+            peer_values = _peer_info_values(row[8])
 
-        data_list.append((
-            timestamp,
-            row[1],
-            row[2],
-            row[3],
-            row[4],
-            row[5],
-            row[6],
-            row[7],
-            peer_values['OSVersion'],
-            peer_values['ModelName'],
-            peer_values['ComputerName'],
-            peer_values['SerialNumber'],
-        ))
+            data_list.append((
+                timestamp,
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+                peer_values['OSVersion'],
+                peer_values['ModelName'],
+                peer_values['ComputerName'],
+                peer_values['SerialNumber'],
+                relative_path,
+            ))
 
     data_headers = (
         ('Timestamp', 'datetime'),
@@ -193,6 +202,7 @@ def trusted_peers(context):
         'Peer Model Name',
         'Peer Computer Name',
         'Peer Serial Number',
+        'Source File',
     )
 
-    return data_headers, data_list, context.get_relative_path(source_path)
+    return data_headers, data_list, context.get_relative_path(db_paths[0])


### PR DESCRIPTION
Follow-up to #1927, resolving the one corpus key left open there.

## The identity

The Magnet Virtual Summit CTF 2026 iOS download (Hexordia iPhone14Plus.zip, 9.67 GB, MD5 `23075789fe93781a9a99e1db952f47c5`) is a deflate wrapper around three files that match the locally held acquisition byte for byte: the inner `00008110-0008196A2299401E_files_full.zip` matches by size and CRC32 (`3476df68`, exactly what the bundled iPhone14Plus-FFS-Hashes.txt records, whose SHA-256 in turn matches the registered corpus), and the keychain plist and hashes file match by CRC as well. So `mvs_2026` was key drift for the registered `iphone14plus_ios18` after all, and the six citations are renamed.

## The bug the identity exposed

The rename collided with an existing entry: James Habben recorded 6 trusted_peers rows for this image in June, a July corpus sweep recorded 0, and both were faithful records of what the tool returned. Probing the store settled it. The image carries one TrustedPeersHelper.db per trust-circle context:

```
com.apple.security.keychain-.TrustedPeersHelper.db                (empty)
com.apple.security.keychain-defaultContext.TrustedPeersHelper.db  (3 peers, 54 escrow records, all in the WAL)
```

`trusted_peers` read only the first match via `get_file_path`, and the empty no-name context sorts ahead of the populated one, so the artifact reported 0 while 6 rows sat beside it. The 6 rows are the trust-circle device list the artifact exists for: the device itself under two names plus a trusted MacBook Pro, serial numbers included.

The artifact now reads every matched context database and adds a Source File column naming which one each row came from. Same-schema drift handling per database is unchanged.

## Verification

- Fixed artifact on this image: 6 rows, matching James's June record; Peer (ZPEERINFO) columns empty on every row, also matching his note.
- Focused profile runs of the artifact against all 14 corpora with recorded trusted_peers counts: every recorded value reproduced exactly. No other registered image carries a populated second context, so only this image gains rows.
- Instagram duplicate entries collapse to the fuller recorded values; both spellings agreed on 0 rows. The tikTok "No AwemeIM.db found" observations were confirmed against the zip's central directory.
- pylint on the four touched files with CI flags: 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)