### PR TITLE
Shorten the Unified Logs progress line so it fits the GUI log pane

### DIFF
--- a/admin/test/scripts/test_logarchive_native.py
+++ b/admin/test/scripts/test_logarchive_native.py
@@ -330,10 +330,10 @@ class TestImportProgress(unittest.TestCase):
         line = self.lines[0]
         self.assertIn('8,192 records', line)
         self.assertIn('40% of source data', line)
-        self.assertIn('records/s', line)
+        self.assertIn('rec/s', line)
         self.assertIn('elapsed 0:25', line)
         # 400 bytes in 25s -> 600 remaining at 16 B/s = 37.5s
-        self.assertIn('about 0:37 left', line)
+        self.assertIn('~0:37 left', line)
 
     def test_no_percent_or_eta_when_total_unknown(self):
         progress = self._make(total_bytes=0)
@@ -352,7 +352,23 @@ class TestImportProgress(unittest.TestCase):
         progress.finish()
         self.assertIn('finished: 100 records', self.lines[-1])
         self.assertIn('0:10', self.lines[-1])
-        self.assertIn('10 records/s', self.lines[-1])
+        self.assertIn('10 rec/s', self.lines[-1])
+
+    def test_report_line_fits_the_gui_log_pane(self):
+        # The GUI log pane holds roughly 120 fixed-width characters at the window's
+        # 890px minimum width (TkFixedFont, minus frame padding and the scrollbar).
+        # A worst-case line - 100M records, hour-scale elapsed and estimate - has to
+        # fit inside that with margin, so nobody has to widen the window to read it.
+        progress = self._make(total_bytes=10 ** 12)
+        progress.records = 100_000_000 - unifiedlogs.ImportProgress.CHECK_EVERY
+        progress.set_bytes_done(3 * 10 ** 11)
+        self.now[0] = 4289.0
+        for _ in range(unifiedlogs.ImportProgress.CHECK_EVERY):
+            progress.add_record()
+        line = self.lines[-1]
+        self.assertIn('1:11:29', line)  # elapsed rendered at hour scale
+        self.assertIn('left', line)
+        self.assertLessEqual(len(line), 110, f'progress line too wide for the GUI: {line}')
 
     def test_bytes_done_clamped_to_total(self):
         # A stale size map must never produce 130% progress in a report.

--- a/scripts/unifiedlogs.py
+++ b/scripts/unifiedlogs.py
@@ -276,18 +276,21 @@ class ImportProgress:
     Percent is by BYTES of source consumed, not records, because the total record
     count is unknowable without a second pass. The callers know their bytes:
     the tracev3 path advances on evidence-file transitions (each record names its
-    source file), the json path uses the file read position. The estimate is
-    labelled "about" because parse rate varies between log streams; it converges
-    as the import runs.
+    source file), the json path uses the file read position. The remaining time
+    carries a "~" because parse rate varies between log streams; it converges as
+    the import runs.
 
     The per-record cost has to survive 30M calls, so add_record() is a counter
     increment plus one modulo check; the clock is consulted at most once per 8192
     records.
+
+    The line is kept short enough to fit the GUI log pane at the window's minimum
+    width (roughly 120 fixed-width characters) without anyone having to widen it.
     """
 
     CHECK_EVERY = 8192
 
-    def __init__(self, total_bytes, label='Unified Logs import', interval=20.0,
+    def __init__(self, total_bytes, label='Unified Logs', interval=20.0,
                  clock=time.monotonic, log=logfunc):
         self.total_bytes = max(0, int(total_bytes or 0))
         self.label = label
@@ -318,16 +321,16 @@ class ImportProgress:
             percent = 100.0 * self.bytes_done / self.total_bytes
             parts.append(f'{percent:.0f}% of source data')
         if elapsed > 0:
-            parts.append(f'{self.records / elapsed:,.0f} records/s')
+            parts.append(f'{self.records / elapsed:,.0f} rec/s')
         parts.append(f'elapsed {_format_duration(elapsed)}')
         if self.total_bytes and 0 < self.bytes_done < self.total_bytes and elapsed > 0:
             remaining = (self.total_bytes - self.bytes_done) / (self.bytes_done / elapsed)
-            parts.append(f'about {_format_duration(remaining)} left')
+            parts.append(f'~{_format_duration(remaining)} left')
         self.log(' | '.join(parts))
 
     def finish(self):
         elapsed = self.clock() - self.started
-        rate = f', {self.records / elapsed:,.0f} records/s' if elapsed > 0 else ''
+        rate = f', {self.records / elapsed:,.0f} rec/s' if elapsed > 0 else ''
         self.log(f'{self.label} finished: {self.records:,} records '
                  f'in {_format_duration(elapsed)}{rate}')
 


### PR DESCRIPTION
The logarchive import progress line was too long for the GUI log pane. The
window had to be widened to read the time remaining.

## Numbers

The pane holds roughly 120 fixed-width characters at the window's 890px
minimum width (TkFixedFont, minus the frame padding and the scrollbar), so
the old line sat right at the edge:

```
before (112): Unified Logs import: 12,345,678 records | 42% of source data | 30,333 records/s | elapsed 6:47 | about 9:22 left
after  ( 96): Unified Logs: 12,345,678 records | 42% of source data | 30,333 rec/s | elapsed 6:47 | ~9:22 left

before (118): Unified Logs import: 99,999,744 records | 30% of source data | 23,315 records/s | elapsed 1:11:29 | about 2:46:47 left
after  (102): Unified Logs: 99,999,744 records | 30% of source data | 23,315 rec/s | elapsed 1:11:29 | ~2:46:47 left
```

## What changed

Three trims, and no number is dropped:

| | before | after |
| --- | --- | --- |
| label | `Unified Logs import` | `Unified Logs` |
| rate | `records/s` | `rec/s` |
| estimate | `about 9:22 left` | `~9:22 left` |

The percent keeps its `of source data` wording. It is measured in bytes of
source consumed rather than in records, and a bare `42%` would read as the
latter.

The finish line inherits the shorter label and rate unit:
`Unified Logs finished: 12,345,678 records in 15:00, 13,717 rec/s`

## Testing

`admin/test/scripts/test_logarchive_native.py`, 39 tests, all passing. The two
tests that pinned the old wording are updated, and a new one renders a
worst-case line (100M records, hour-scale elapsed and estimate) and asserts it
stays under 110 characters, so the line cannot creep back up.

pylint 10.00/10 on both changed files.

This is iLEAPP only. `ImportProgress` does not exist in the sibling cores, so
there is nothing to level across.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
