### PR TITLE
Stop the FSEvents cache leaking multi-gigabyte temp files

### DIFF
--- a/admin/test/scripts/test_fsevents_cache_cleanup.py
+++ b/admin/test/scripts/test_fsevents_cache_cleanup.py
@@ -1,0 +1,176 @@
+"""Cover the temporary cache the FSEvents artifacts share, and how it gets cleaned up.
+
+The module parses every FSEvents record in the extraction once into a temporary SQLite
+database so its twenty-odd artifacts can query it instead of re-parsing. On a full file
+system extraction that file reaches gigabytes, and it lives in the system temp directory
+under a random mkstemp name, so a copy left behind is invisible: no later run can recognise
+it, and nothing reports it. Three orphans totalling 2.7 GB were found on one machine, the
+largest 1.72 GB.
+
+Two separate failures put them there, and they need different fixes:
+
+  * an exit from the build that is not a successful build. The atexit handler deletes
+    _CACHE["path"], and that slot used to stay empty until after the parse finished, so an
+    exception the build's own handler does not catch, or Ctrl-C, unwound to an atexit that
+    knew nothing about the file. Covered by the registration tests below.
+  * a killed interpreter. atexit does not run at all on SIGKILL or SIGTERM, so nothing
+    in-process can help; the next run has to reap what the last one abandoned. Covered by
+    the sweep tests below.
+
+A clean run has always cleaned up after itself, which is why this went unnoticed.
+"""
+import os
+import pathlib
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.artifacts import fileSystemEvents  # pylint: disable=wrong-import-position
+
+
+class _Context:
+    """The slice of Context that _build_cache touches."""
+
+    def __init__(self, files_found, relative_path_error=None):
+        self._files_found = files_found
+        self._relative_path_error = relative_path_error
+
+    def get_files_found(self):
+        return self._files_found
+
+    def get_relative_path(self, file_found):
+        if self._relative_path_error:
+            raise self._relative_path_error
+        return file_found
+
+
+class CacheRegistrationTests(unittest.TestCase):
+    """The cache path must be known to the cleanup handler for the whole build.
+
+    Registering it only after a successful parse leaves the entire parse - the part that
+    takes minutes and writes the gigabytes - as a window in which the file exists and
+    nothing but a local variable knows its name.
+    """
+
+    def setUp(self):
+        self.original = dict(fileSystemEvents._CACHE)  # pylint: disable=protected-access
+        fileSystemEvents._CACHE.update({"key": None, "path": None})  # pylint: disable=protected-access
+
+    def tearDown(self):
+        fileSystemEvents._remove_cache()  # pylint: disable=protected-access
+        fileSystemEvents._CACHE.update(self.original)  # pylint: disable=protected-access
+
+    def test_uncaught_exception_leaves_the_path_registered_for_atexit(self):
+        # ValueError is not in the build's own (OSError, sqlite3.Error) handler, so it
+        # propagates exactly like a zlib.error on a corrupt member or a Ctrl-C would.
+        context = _Context(['/nonexistent/0000000000000001'],
+                           relative_path_error=ValueError('parse blew up'))
+        with self.assertRaises(ValueError):
+            fileSystemEvents._build_cache(context)  # pylint: disable=protected-access
+
+        registered = fileSystemEvents._CACHE['path']  # pylint: disable=protected-access
+        self.assertIsNotNone(registered, 'cache path was not registered, atexit cannot clean it')
+        self.assertTrue(os.path.exists(registered))
+
+        # atexit calls exactly this, and it has to be enough to remove the file.
+        fileSystemEvents._remove_cache()  # pylint: disable=protected-access
+        self.assertFalse(os.path.exists(registered), 'cache file survived the cleanup handler')
+
+    def test_failed_build_is_never_returned_as_a_cache_hit(self):
+        # Registering the path early must not make a half-written database look usable.
+        context = _Context(['/nonexistent/0000000000000001'],
+                           relative_path_error=ValueError('parse blew up'))
+        with self.assertRaises(ValueError):
+            fileSystemEvents._build_cache(context)  # pylint: disable=protected-access
+        self.assertIsNone(fileSystemEvents._CACHE['key'],  # pylint: disable=protected-access
+                          'a failed build left a key behind, so the next call would query it')
+
+    def test_successful_build_registers_key_and_path(self):
+        context = _Context([])
+        cache_path = fileSystemEvents._build_cache(context)  # pylint: disable=protected-access
+        self.addCleanup(fileSystemEvents._remove_cache)  # pylint: disable=protected-access
+
+        self.assertTrue(os.path.exists(cache_path))
+        self.assertEqual(fileSystemEvents._CACHE['path'], cache_path)  # pylint: disable=protected-access
+        self.assertIsNotNone(fileSystemEvents._CACHE['key'])  # pylint: disable=protected-access
+        with sqlite3.connect(cache_path) as database:
+            self.assertEqual(database.execute('SELECT COUNT(*) FROM events').fetchone()[0], 0)
+
+    def test_second_call_with_the_same_files_reuses_the_cache(self):
+        context = _Context([])
+        first = fileSystemEvents._build_cache(context)  # pylint: disable=protected-access
+        self.addCleanup(fileSystemEvents._remove_cache)  # pylint: disable=protected-access
+        second = fileSystemEvents._build_cache(context)  # pylint: disable=protected-access
+        self.assertEqual(first, second, 'the shared cache was rebuilt for the second artifact')
+
+
+class StaleCacheSweepTests(unittest.TestCase):
+    """What a killed run leaves behind, and what must be left alone.
+
+    The sweep runs against a directory shared with every other program on the machine, and
+    possibly with a second iLEAPP running right now, so being conservative matters more
+    than reclaiming every byte.
+    """
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        patcher = mock.patch.object(fileSystemEvents.tempfile, 'gettempdir',
+                                    return_value=self.tempdir.name)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _make(self, name, age_seconds):
+        path = os.path.join(self.tempdir.name, name)
+        with open(path, 'wb') as handle:
+            handle.write(b'not really a database')
+        stamp = time.time() - age_seconds
+        os.utime(path, (stamp, stamp))
+        return path
+
+    def test_abandoned_cache_is_removed(self):
+        stale = self._make('ileapp_fsevents_abcd1234.sqlite',
+                           fileSystemEvents._STALE_CACHE_AGE_SECONDS + 60)  # pylint: disable=protected-access
+        fileSystemEvents._remove_stale_caches()  # pylint: disable=protected-access
+        self.assertFalse(os.path.exists(stale))
+
+    def test_a_cache_still_in_use_is_left_alone(self):
+        # A concurrent iLEAPP writes its cache at the start of its run. Reaping it would
+        # cost that run a rebuild of everything it has parsed so far.
+        fresh = self._make('ileapp_fsevents_efgh5678.sqlite', 60)
+        fileSystemEvents._remove_stale_caches()  # pylint: disable=protected-access
+        self.assertTrue(os.path.exists(fresh))
+
+    def test_other_peoples_temp_files_are_left_alone(self):
+        others = [
+            self._make('ileapp_logarchive_cache.sqlite', 30 * 24 * 60 * 60),
+            self._make('ileapp_fsevents_notours.txt', 30 * 24 * 60 * 60),
+            self._make('some_other_tool.sqlite', 30 * 24 * 60 * 60),
+        ]
+        fileSystemEvents._remove_stale_caches()  # pylint: disable=protected-access
+        for path in others:
+            self.assertTrue(os.path.exists(path), f'swept a file it does not own: {path}')
+
+    def test_a_missing_file_does_not_raise(self):
+        # Two runs sweeping at once, or a temp cleaner working the same directory.
+        stale = self._make('ileapp_fsevents_racing.sqlite',
+                           fileSystemEvents._STALE_CACHE_AGE_SECONDS + 60)  # pylint: disable=protected-access
+        real_getmtime = os.path.getmtime
+
+        def vanishing(path):
+            os.unlink(path)
+            return real_getmtime(path)
+
+        with mock.patch.object(fileSystemEvents.os.path, 'getmtime', side_effect=vanishing):
+            fileSystemEvents._remove_stale_caches()  # pylint: disable=protected-access
+        self.assertFalse(os.path.exists(stale))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/fileSystemEvents.py
+++ b/scripts/artifacts/fileSystemEvents.py
@@ -317,10 +317,12 @@ __artifacts_v2__ = {
 }
 
 import atexit
+import glob
 import os
 import sqlite3
 import struct
 import tempfile
+import time
 import zlib
 
 from scripts.ilapfuncs import artifact_processor, logfunc
@@ -381,6 +383,12 @@ _REPORT_HEADERS = (
     "Source File",
 )
 _CACHE = {"key": None, "path": None}
+_CACHE_PREFIX = "ileapp_fsevents_"
+
+# How long a cache file must have gone untouched before another run treats it as abandoned.
+# Generous on purpose: the cost of waiting is disk space, the cost of being wrong is making
+# a concurrent run rebuild a cache that took minutes to write.
+_STALE_CACHE_AGE_SECONDS = 24 * 60 * 60
 
 
 def _path_has_component(path, names):
@@ -459,6 +467,30 @@ def _remove_cache():
 
 
 atexit.register(_remove_cache)
+
+
+def _remove_stale_caches():
+    """Delete cache files abandoned by a previous run that could not clean up after itself.
+
+    atexit does not run when the interpreter is killed, so a run ended with SIGKILL or
+    SIGTERM leaves its cache behind under a random mkstemp name that no later run can
+    recognise. Observed on this machine as three orphans totalling 2.7 GB, the largest
+    1.72 GB, from runs that were killed during a multi-corpus sweep.
+
+    Only files untouched for _STALE_CACHE_AGE_SECONDS are removed, so a cache belonging to
+    another iLEAPP running right now is never taken out from under it. Its own cache was
+    written when its run started, which is far inside that window.
+    """
+    pattern = os.path.join(tempfile.gettempdir(), f"{_CACHE_PREFIX}*.sqlite")
+    cutoff = time.time() - _STALE_CACHE_AGE_SECONDS
+    for path in glob.glob(pattern):
+        try:
+            if os.path.getmtime(path) < cutoff:
+                os.unlink(path)
+        except OSError:
+            # Gone already, or held open by a process that still wants it (Windows
+            # refuses the unlink). Either way it is not this run's problem.
+            continue
 
 
 def _decode_flags(flags):
@@ -566,8 +598,18 @@ def _build_cache(context):
         return _CACHE["path"]
 
     _remove_cache()
-    descriptor, cache_path = tempfile.mkstemp(prefix="ileapp_fsevents_", suffix=".sqlite")
+    _remove_stale_caches()
+    descriptor, cache_path = tempfile.mkstemp(prefix=_CACHE_PREFIX, suffix=".sqlite")
     os.close(descriptor)
+
+    # Register the path before the parse rather than after it. _remove_cache() deletes
+    # whatever _CACHE["path"] holds, so for as long as this slot stays empty the only
+    # reference to the file is the local variable above: any exit from here that is not a
+    # successful build - an exception type the handler below does not catch, Ctrl-C,
+    # sys.exit - would unwind to atexit with nothing recorded and leave the file behind.
+    # The key stays None until the build succeeds, so the hit test above can never return a
+    # half-written cache.
+    _CACHE["path"] = cache_path
 
     database = sqlite3.connect(cache_path)
     try:
@@ -624,15 +666,11 @@ def _build_cache(context):
         database.commit()
     except (OSError, sqlite3.Error):
         database.close()
-        try:
-            os.unlink(cache_path)
-        except FileNotFoundError:
-            pass
+        _remove_cache()
         raise
     database.close()
 
     _CACHE["key"] = key
-    _CACHE["path"] = cache_path
     return cache_path
 
 


### PR DESCRIPTION
The FSEvents artifacts parse every record in the extraction once into a temporary
SQLite database, so the module's ten artifacts query that instead of re-parsing.
On a full file system extraction the file reaches gigabytes, it lives in the
system temp directory, and `mkstemp` gives it a random name. A copy left behind
is therefore invisible: no later run can recognise it, and nothing reports it.

Three orphans were sitting on one machine, 305 MB, 919 MB and 1.72 GB, **2.7 GB
in total**, all from runs killed during a multi-corpus sweep three days earlier.

## Two different failures put them there

**1. A registration gap.** `_remove_cache()` deletes whatever path is in `_CACHE`,
and `atexit` calls it, but the path was only recorded *after* the parse finished:

```python
_remove_cache()                                   # clears _CACHE["path"] to None
descriptor, cache_path = tempfile.mkstemp(...)    # the file exists from here
...parse every FSEvents file...                   # minutes, gigabytes
except (OSError, sqlite3.Error):                  # only these two clean up
    ...
_CACHE["path"] = cache_path                       # only NOW is it registered
```

For that whole window the only reference to the file was a local variable. A
`zlib.error` on a corrupt member, a `struct.error` on a truncated stream, a
`ValueError` from the row unpack, a `KeyboardInterrupt` from Ctrl-C, or a
`sys.exit` all sail past that `except`, unwind to `atexit`, and find `None`.

Fixed by recording the path immediately after `mkstemp`. The **key** still waits
for a successful build, so a half-written cache can never be returned as a cache
hit. The error branch now calls `_remove_cache()` rather than duplicating it.

**2. A killed interpreter.** `atexit` does not run on SIGKILL or SIGTERM at all,
so nothing in-process can help and the next run has to reap what the last one
abandoned. `_remove_stale_caches()` does that.

It is deliberately conservative, because it works in a directory shared with
every other program on the machine and possibly with a second iLEAPP running
right now: it matches only its own `ileapp_fsevents_*.sqlite` prefix, only
removes files untouched for 24 hours, and ignores per-file `OSError` so a
Windows open-file refusal or a racing temp cleaner is a skip, not a crash.

A run that finishes normally always cleaned up after itself. That is why this
went unnoticed.

## Testing

New `admin/test/scripts/test_fsevents_cache_cleanup.py`, 8 tests, all passing.

The important one is a real regression test, not a restatement of the new code:
against the unfixed artifact it fails with

```
AssertionError: unexpectedly None : cache path was not registered, atexit cannot clean it
```

The sweep tests run against a patched temp directory, and assert it leaves alone
a fresh cache, a file with a different prefix, and a file with a different
suffix.

**Corpus run**, `jess_ios15`, all ten FSEvents artifacts through a profile:

| artifact | rows | recorded in `sample_data` |
| --- | ---: | --- |
| FSEvents | 16,675 | not previously recorded for this image |
| Communications & Accounts | 96 | 96 ✔ |
| Updates & Mobile Assets | 142 | 142 ✔ |
| App Containers | 801 | 801 ✔ |
| Location Services | 2,601 | 2,601 ✔ |
| Security | 322 | not previously recorded |
| Restore & Backup | 33 | not previously recorded |
| Web | 97 | not previously recorded |
| Removed Paths | 4,227 | not previously recorded |
| Package Management | 0 | not previously recorded |

Every count already recorded for that image reproduces exactly, so parsing is
unchanged. No errors, and **zero temp files left behind** after the run, checked
directly in the system temp directory. I have left `sample_data` alone rather
than widening a cleanup PR; happy to add the newly observed keys separately.

pylint 10.00/10 on both files.

## Scope

Artifact-level, no core change. No sibling core carries `fileSystemEvents.py`
(checked ALEAPP, RLEAPP, VLEAPP, DLEAPP), so there is nothing to level across.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
