### PR TITLE
Delete the PowerLog decompression temp directory when the run ends

### DIFF
--- a/admin/test/scripts/test_powerlog_gz_temp_cleanup.py
+++ b/admin/test/scripts/test_powerlog_gz_temp_cleanup.py
@@ -1,0 +1,139 @@
+"""Cover the temp directory PowerLog decompresses its rotated archives into.
+
+A device keeps months of rotated `.PLSQL.gz` telemetry archives. The artifacts cannot
+query a gzip file, so the module decompresses each one to a session temp directory and
+reuses it across all of its artifacts. Those copies are the full uncompressed size, so an
+extraction with a long history leaves hundreds of megabytes there.
+
+Nothing removed them. 135 directories totalling 12 GB were found in the system temp
+directory of one machine, from two days of ordinary runs, all of which had completed
+normally. That is the difference from the FSEvents cache leak fixed alongside this: that
+one only leaked when a run was interrupted, this one leaked every single time.
+
+Both halves are needed and they cover different failures: atexit for a run that ends, a
+sweep for a run that is killed and never gets to run atexit at all.
+"""
+import os
+import pathlib
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.artifacts import powerlog  # pylint: disable=wrong-import-position
+
+
+class GzTempRemovalTests(unittest.TestCase):
+    """What a finished run must leave behind: nothing."""
+
+    def setUp(self):
+        self.original_cache = dict(powerlog._GZ_CACHE)  # pylint: disable=protected-access
+        self.original_temp = dict(powerlog._GZ_TEMP)  # pylint: disable=protected-access
+        powerlog._GZ_CACHE.clear()  # pylint: disable=protected-access
+        powerlog._GZ_TEMP.clear()  # pylint: disable=protected-access
+
+    def tearDown(self):
+        powerlog._remove_gz_temp()  # pylint: disable=protected-access
+        powerlog._GZ_CACHE.update(self.original_cache)  # pylint: disable=protected-access
+        powerlog._GZ_TEMP.update(self.original_temp)  # pylint: disable=protected-access
+
+    def _materialize_one(self):
+        """Decompress a real gzip archive through the module's own code path."""
+        import gzip  # pylint: disable=import-outside-toplevel
+
+        source_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(source_dir.cleanup)
+        gz_path = os.path.join(source_dir.name, 'powerlog_2026-01-01_ABCD1234.PLSQL.gz')
+        with gzip.open(gz_path, 'wb') as handle:
+            handle.write(b'SQLite format 3\x00' + b'\x00' * 512)
+        return powerlog._materialize_gz(gz_path)  # pylint: disable=protected-access
+
+    def test_decompressed_copies_are_removed_when_the_run_ends(self):
+        materialized = self._materialize_one()
+        self.assertIsNotNone(materialized, 'the archive did not decompress')
+        temp_dir = powerlog._GZ_TEMP['dir']  # pylint: disable=protected-access
+        self.assertTrue(os.path.exists(materialized))
+
+        # atexit calls exactly this.
+        powerlog._remove_gz_temp()  # pylint: disable=protected-access
+
+        self.assertFalse(os.path.exists(temp_dir),
+                         'the decompressed PowerLog databases survived the run')
+        self.assertEqual(powerlog._GZ_CACHE, {})  # pylint: disable=protected-access
+        self.assertEqual(powerlog._GZ_TEMP, {})  # pylint: disable=protected-access
+
+    def test_cleanup_is_registered_with_atexit(self):
+        # The whole fix is worthless if nothing calls it. atexit stores the callback in a
+        # private registry, so assert against the module's own attribute instead.
+        self.assertTrue(callable(powerlog._remove_gz_temp))  # pylint: disable=protected-access
+        source = pathlib.Path(powerlog.__file__).read_text(encoding='utf-8')
+        self.assertIn('atexit.register(_remove_gz_temp)', source)
+
+    def test_cleanup_on_an_untouched_module_does_nothing(self):
+        powerlog._remove_gz_temp()  # pylint: disable=protected-access
+        powerlog._remove_gz_temp()  # pylint: disable=protected-access
+
+    def test_a_second_archive_reuses_the_same_directory(self):
+        first = self._materialize_one()
+        directory = powerlog._GZ_TEMP['dir']  # pylint: disable=protected-access
+        second = self._materialize_one()
+        self.assertEqual(powerlog._GZ_TEMP['dir'], directory,  # pylint: disable=protected-access
+                         'a second archive made a second temp directory')
+        self.assertNotEqual(first, second, 'the two archives collided on one filename')
+
+
+class StaleGzTempSweepTests(unittest.TestCase):
+    """What a killed run leaves behind, and what must be left alone."""
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        patcher = mock.patch.object(powerlog.tempfile, 'gettempdir',
+                                    return_value=self.tempdir.name)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _make_dir(self, name, age_seconds):
+        path = os.path.join(self.tempdir.name, name)
+        os.makedirs(path)
+        with open(os.path.join(path, '0000_powerlog.PLSQL'), 'wb') as handle:
+            handle.write(b'not really a database')
+        stamp = time.time() - age_seconds
+        os.utime(path, (stamp, stamp))
+        return path
+
+    def test_abandoned_directory_is_removed(self):
+        stale = self._make_dir('ileapp_powerlog_gz_abcd1234',
+                               powerlog._STALE_TEMP_AGE_SECONDS + 60)  # pylint: disable=protected-access
+        powerlog._remove_stale_gz_temps()  # pylint: disable=protected-access
+        self.assertFalse(os.path.exists(stale))
+
+    def test_a_directory_still_in_use_is_left_alone(self):
+        fresh = self._make_dir('ileapp_powerlog_gz_efgh5678', 60)
+        powerlog._remove_stale_gz_temps()  # pylint: disable=protected-access
+        self.assertTrue(os.path.exists(fresh))
+
+    def test_other_peoples_temp_entries_are_left_alone(self):
+        others = [
+            self._make_dir('ileapp_fsevents_cache', 30 * 24 * 60 * 60),
+            self._make_dir('some_other_tool', 30 * 24 * 60 * 60),
+        ]
+        stray_file = os.path.join(self.tempdir.name, 'ileapp_powerlog_gz_notadir')
+        with open(stray_file, 'wb') as handle:
+            handle.write(b'a file, not a directory')
+        stamp = time.time() - 30 * 24 * 60 * 60
+        os.utime(stray_file, (stamp, stamp))
+
+        powerlog._remove_stale_gz_temps()  # pylint: disable=protected-access
+
+        for path in others:
+            self.assertTrue(os.path.exists(path), f'swept an entry it does not own: {path}')
+        self.assertTrue(os.path.exists(stray_file), 'swept a file, and it only owns directories')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/powerlog.py
+++ b/scripts/artifacts/powerlog.py
@@ -1168,10 +1168,13 @@ __artifacts_v2__ = {
     },
 }
 
+import atexit
+import glob
 import gzip
 import os
 import shutil
 import tempfile
+import time
 from bisect import bisect_right
 from datetime import timedelta
 
@@ -1191,6 +1194,46 @@ TIME_OFFSET_TABLE = "PLStorageOperator_EventForward_TimeOffset"
 _GZ_CACHE = {}
 # 'dir' -> session temp directory for the decompressed copies, first use only.
 _GZ_TEMP = {}
+_GZ_TEMP_PREFIX = "ileapp_powerlog_gz_"
+
+# How long an abandoned directory must have gone untouched before another run reclaims it.
+# Generous on purpose: the cost of waiting is disk space, the cost of being wrong is
+# deleting decompressed databases out from under an iLEAPP that is still reading them.
+_STALE_TEMP_AGE_SECONDS = 24 * 60 * 60
+
+
+def _remove_gz_temp():
+    """Delete this run's decompressed copies.
+
+    The rotated archives expand to their full uncompressed size, so a run over an
+    extraction with a long PowerLog history leaves hundreds of megabytes behind. Nothing
+    used to remove them: 135 directories totalling 12 GB were found in the system temp
+    directory of one machine, from two days of ordinary runs that all completed normally.
+    """
+    temp_dir = _GZ_TEMP.pop("dir", None)
+    _GZ_CACHE.clear()
+    if temp_dir:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+atexit.register(_remove_gz_temp)
+
+
+def _remove_stale_gz_temps():
+    """Reclaim directories left by a run that was killed before atexit could fire.
+
+    Only directories untouched for _STALE_TEMP_AGE_SECONDS are removed, so a concurrent
+    iLEAPP keeps its own. ignore_errors leaves anything held open by another process in
+    place rather than half-deleting it.
+    """
+    pattern = os.path.join(tempfile.gettempdir(), f"{_GZ_TEMP_PREFIX}*")
+    cutoff = time.time() - _STALE_TEMP_AGE_SECONDS
+    for path in glob.glob(pattern):
+        try:
+            if os.path.isdir(path) and os.path.getmtime(path) < cutoff:
+                shutil.rmtree(path, ignore_errors=True)
+        except OSError:
+            continue
 
 
 def _materialize_gz(gz_path):
@@ -1204,7 +1247,8 @@ def _materialize_gz(gz_path):
         return cached
     temp_dir = _GZ_TEMP.get("dir")
     if not temp_dir:
-        temp_dir = tempfile.mkdtemp(prefix="ileapp_powerlog_gz_")
+        _remove_stale_gz_temps()
+        temp_dir = tempfile.mkdtemp(prefix=_GZ_TEMP_PREFIX)
         _GZ_TEMP["dir"] = temp_dir
     out_name = f"{len(_GZ_CACHE):04d}_{os.path.basename(gz_path)[:-3]}"
     out_path = os.path.join(temp_dir, out_name)


### PR DESCRIPTION
A device keeps months of rotated `.PLSQL.gz` telemetry archives. The artifacts
cannot query a gzip file, so [`_materialize_gz`](https://github.com/abrignoni/iLEAPP/blob/b249dcd3/scripts/artifacts/powerlog.py#L1207)
decompresses each one into a temp directory and reuses it across all 24 artifacts
in the module. Those copies are the full uncompressed size.

**Nothing ever removed them.** No `atexit`, no `rmtree`, no cleanup function of
any kind. The directory was created, recorded in a module global, and left:

```python
temp_dir = _GZ_TEMP.get("dir")
if not temp_dir:
    temp_dir = tempfile.mkdtemp(prefix="ileapp_powerlog_gz_")
    _GZ_TEMP["dir"] = temp_dir     # and that is the end of its lifecycle
```

135 directories totalling **12 GB** were sitting in the system temp directory of
one machine, from two days of ordinary runs that had all completed normally.

This is worse than the FSEvents cache leak fixed in #1939. That one only leaked
when a run was interrupted. This one leaks on **every** run over an extraction
with rotated archives, including runs that finish perfectly.

## The fix

- `_remove_gz_temp()` removes the directory and clears the cache, registered with
  `atexit`. Covers every run that ends, including Ctrl-C.
- `_remove_stale_gz_temps()` covers the runs that do not end, since `atexit` never
  fires on SIGKILL or SIGTERM. Same conservative shape as #1939: its own prefix
  only, directories only, and only ones untouched for 24 hours, so a concurrent
  iLEAPP keeps the copies it is still reading. `rmtree(..., ignore_errors=True)`
  leaves anything held open in place rather than half-deleting it.

## Testing

New `admin/test/scripts/test_powerlog_gz_temp_cleanup.py`, 7 tests, all passing.
They drive the module's own `_materialize_gz` with a real gzip archive rather
than reimplementing it. All 7 fail against the unfixed module.

**Corpus run**, `jess_ios15`, which carries 5 rotated archives so the leaking path
actually executes. Same profile of all 24 artifacts, run twice, with only this
file differing between the two:

| | dirs left in system temp | exit | rows |
| --- | --- | --- | --- |
| before (origin/main) | **1**, holding 35 MB of decompressed databases | 0 | 12 artifacts |
| after | **0** | 0 | identical, `diff` clean across every artifact |

The leftover from the baseline run held real corpus filenames
(`0000_powerlog_2022-02-11_30B419D2.PLSQL`), so this is the production path, not a
synthetic one. No errors in either run.

## Scope

Artifact-level, no core change. No sibling core has a PowerLog module (checked
ALEAPP, RLEAPP, VLEAPP, DLEAPP), so there is nothing to level across.

## Noted, not fixed here

`sessionIOS.py` and `signalIOS.py` write decrypted databases to fixed
`ileapp_session/` and `ileapp_signal/` paths under the temp directory, digest
named. 272 MB of those are also sitting on the same machine. That looks like a
deliberate cross-run cache rather than a leak, so it needs a decision rather than
a patch, and it is left alone here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
