### PR TITLE
Restore the KML output for Lidl Plus store searches

### DIFF
--- a/scripts/artifacts/lidl_plus.py
+++ b/scripts/artifacts/lidl_plus.py
@@ -152,7 +152,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/mobile/Containers/Data/Application/*/Library/"
                   "Caches/com.lidl.eci.lidl.plus/Cache.db*",),
-        "output_types": [ "standard" ],
+        "output_types": [ "all" ],
         "artifact_icon": "search"
     },
     "lidl_offers": {


### PR DESCRIPTION
`lidl_store_searches` declares `Latitude` and `Longitude`, and those are the request coordinates pulled from the search URL query string (`lidl_plus.py`, `request_lat` / `request_lon`), so they are the device's own position at the time of the search rather than the store's. `Store Latitude` and `Store Longitude` hold the store.

The artifact arrived in #1934 with `output_types: ["all"]` and was changed to `["standard"]` in the same commit that fixed the report escaping, which dropped the KML. This puts it back. `"all"` is `"standard"` plus KML (`check_output_types` in `scripts/ilapfuncs.py`), so nothing else about the artifact changes.

`Last Known Location` was unaffected and keeps its KML.

**Verification.** Built the artifact's stripped headers and called `kmlgen()` with a row shaped like its output. One placemark is written, at the request coordinates and not the store's, named from the `Timestamp` column. Pylint clean at 10.00/10.

One row is emitted per returned store, so the request coordinate repeats across every result row for a single search and those pins stack on the same point. That is existing behaviour and not something this change introduces.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
