### PR TITLE
Fix Media Library artifacts never finding MediaLibrary.sqlitedb

### DIFF
--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -1,29 +1,84 @@
 __artifacts_v2__ = {
     "mediaLibrary": {
         "name": "Media Library",
-        "description": "Media items (music, video, podcasts, e-books) from Medialibrary.sqlitedb",
+        "description": "Media items (music, video, podcasts, e-books) from MediaLibrary.sqlitedb",
         "author": "@ydkhatri",
         "creation_date": "2023-11-21",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-13",
         "requirements": "none",
         "category": "Media Library",
-        "notes": "Media-kind value mapping observed in testing; not documented by a published source; unrecognized values are reported as stored.",
-        "paths": ('**/Medialibrary.sqlitedb*',),
+        "notes": (
+            "Media-kind value mapping observed in testing; not documented by a published source; "
+            "unrecognized values are reported as stored. "
+            "An item that carries more than one artwork_token row is reported once per token, so the "
+            "row count can exceed the number of media items: on one tested iOS 18.3.2 image 1099 items "
+            "produced 1339 rows, 240 of them having two tokens each. "
+            "Date Purchased is left blank when item_store.date_purchased is 0, which is how the "
+            "column reads for items with no stored purchase date; it was 0 on 3529 of 3533 rows "
+            "across the seven tested images that hold media items."),
+        "paths": ('**/[Mm]edia[Ll]ibrary.sqlitedb*',),
         "output_types": "standard",
-        "artifact_icon": "music"
+        "artifact_icon": "music",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 0 rows; item table empty",
+            "hickman_ios13": "iOS 13.3.1 | 301 rows",
+            "hickman_ios14": "iOS 14.3 | 643 rows",
+            "jess_ios15": "0 rows; item table empty",
+            "hickman_ios15": "iOS 15.3.1 | 688 rows",
+            "magnet_ios16": "iOS 16.1.1 | 0 rows; item table empty",
+            "felix23_ios16": "iOS 16.5 | 0 rows; item table empty",
+            "abe_ios16": "iOS 16.5 | 9 rows",
+            "hexordia_ios1651": "iOS 16.5.1 | 0 rows; item table empty",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows; item table empty",
+            "iphone11_ios17": "iOS 17.3 | 839 rows",
+            "otto_ios17": "iOS 17.5.1 | 7 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 0 rows; item table empty",
+            "felix_ios17": "iOS 17.6.1 | 0 rows; item table empty",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows; item table empty",
+            "iphone14plus_ios18_mvs2025": "iOS 18.0 | 0 rows; item table empty",
+            "dexter_ios18": "iOS 18.3.2 | 1339 rows",
+            "iphone12_ios18": "iOS 18.7 | 0 rows; item table empty",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows; item table empty",
+            "hc_ios26": "iOS 26.5.2 | 0 rows; item table empty"
+        }
     },
     "mediaLibraryInfo": {
         "name": "Media Library - Database Properties",
-        "description": "iCloud/account properties from the Medialibrary.sqlitedb _MLDATABASEPROPERTIES table",
+        "description": "Key/value rows from the MediaLibrary.sqlitedb _MLDatabaseProperties table",
         "author": "@ydkhatri",
         "creation_date": "2023-11-21",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-08-13",
         "requirements": "none",
         "category": "Media Library",
-        "notes": "",
-        "paths": ('**/Medialibrary.sqlitedb*',),
+        "notes": (
+            "Every key/value row in the table is reported as stored; the meaning of the individual "
+            "keys is not documented by a published source. In 20 tested images the table held "
+            "between 8 and 37 keys each, 42 distinct keys across all of them."),
+        "paths": ('**/[Mm]edia[Ll]ibrary.sqlitedb*',),
         "output_types": "standard",
-        "artifact_icon": "info-circle"
+        "artifact_icon": "info-circle",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 20 rows",
+            "hickman_ios13": "iOS 13.3.1 | 31 rows",
+            "hickman_ios14": "iOS 14.3 | 31 rows",
+            "jess_ios15": "11 rows",
+            "hickman_ios15": "iOS 15.3.1 | 29 rows",
+            "magnet_ios16": "iOS 16.1.1 | 12 rows",
+            "felix23_ios16": "iOS 16.5 | 18 rows",
+            "abe_ios16": "iOS 16.5 | 22 rows",
+            "hexordia_ios1651": "iOS 16.5.1 | 12 rows",
+            "fsfull002_ios17": "iOS 17.1 | 18 rows",
+            "iphone11_ios17": "iOS 17.3 | 37 rows",
+            "otto_ios17": "iOS 17.5.1 | 19 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 20 rows",
+            "felix_ios17": "iOS 17.6.1 | 19 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 8 rows",
+            "iphone14plus_ios18_mvs2025": "iOS 18.0 | 12 rows",
+            "dexter_ios18": "iOS 18.3.2 | 35 rows",
+            "iphone12_ios18": "iOS 18.7 | 8 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 13 rows",
+            "hc_ios26": "iOS 26.5.2 | 13 rows"
+        }
     }
 }
 
@@ -41,7 +96,10 @@ SELECT
     ite.track_number, art.artwork_token,
     itev.extended_content_rating, itev.movie_info,
     ext.description_long, sto.account_id,
-    datetime(sto.date_purchased + 978307200, 'unixepoch'),
+    CASE
+        WHEN sto.date_purchased IS NULL OR sto.date_purchased = 0 THEN NULL
+        ELSE datetime(sto.date_purchased + 978307200, 'unixepoch')
+    END,
     sto.store_item_id, sto.purchase_history_id, ext.copyright
 FROM item_extra ext
 JOIN item_store sto USING (item_pid)
@@ -59,9 +117,12 @@ LEFT JOIN artwork_token art ON sto.item_pid = art.entity_pid
 
 
 def _find_db(context):
+    # The file is named MediaLibrary.sqlitedb on every tested image. Match without
+    # regard to case so a differently-cased path cannot silently yield no rows, and
+    # so the -wal and -shm siblings the glob also returns are skipped.
     for file_found in context.get_files_found():
         file_found = str(file_found)
-        if file_found.endswith('Medialibrary.sqlitedb'):
+        if file_found.lower().endswith('medialibrary.sqlitedb'):
             return file_found
     return ''
 
@@ -100,16 +161,14 @@ def mediaLibraryInfo(context):
     if not source_path:
         return data_headers, data_list, ''
 
-    wanted = ('MLJaliscoAccountID', 'MPDateLastSynced', 'MPDateToSyncWithUbiquitousStore',
-              'OrderingLanguage')
     try:
-        rows = get_sqlite_db_records(source_path, 'SELECT * FROM _MLDATABASEPROPERTIES')
+        rows = get_sqlite_db_records(
+            source_path, 'SELECT key, value FROM _MLDatabaseProperties ORDER BY key')
     except sqlite3.Error as ex:
         logfunc(f'Error reading Media Library properties: {ex}')
         return data_headers, data_list, context.get_relative_path(source_path)
 
     for row in rows:
-        if row[0] in wanted:
-            data_list.append((row[0], row[1]))
+        data_list.append((row[0], row[1]))
 
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## What was wrong

Both Media Library artifacts returned zero rows on every image tested. Mattia Epifani found
this while validating nearly all iLEAPP plugins against 21 extractions covering iOS 16, 17,
18 and 26: `mediaLibrary` and `mediaLibraryInfo` came back empty on all 21, while the
database was present every time and his queries returned records when run by hand.

The file is named `MediaLibrary.sqlitedb`, with a capital **L**. The module looked for
`Medialibrary.sqlitedb`. That one letter failed in two places, and the two failures look
different depending on the platform:

| | glob `**/Medialibrary.sqlitedb*` | `_find_db` `str.endswith` |
|---|---|---|
| macOS / Linux | no match, `normcase` is identity | never reached |
| Windows | matches, `normcase` folds case | no match, `endswith` has no `normcase` |

So the artifacts logged "No file found" on macOS and Linux, and on Windows found the file
and then silently produced no rows. The second is what a 21-image sweep on Windows sees.

## Evidence

`MediaLibrary.sqlitedb`, capital L, on **20 of 20** local corpora that carry it, iOS 12.4
through 26.5.2, and in all four recorded listings in `admin/data/filepath-lists`
(1,405,336 paths). The lowercase spelling the module declared appears nowhere.

Old pattern against the recorded listings: **0** hits case-sensitively, 12 case-insensitively.
New pattern: 12 hits under both, and 12 rather than 24 on Windows, since it is one bracket
class and not a second pattern.

## Also fixed, visible only once rows are produced again

**Date Purchased asserted a date that was not stored.** The query ran
`datetime(date_purchased + 978307200)` with no guard, so a stored `0` printed as
`2001-01-01 00:00:00`. `date_purchased` is `0` on **3,529 of 3,533** `item_store` rows across
the seven corpora holding media, so the column claimed a purchase date on 99.9% of the rows
it appeared on. It is now blank when the stored value is `0` or NULL. The four real dates on
`abe_ios16` are unchanged and were checked after the change.

**mediaLibraryInfo reported 4 keys out of up to 37.** It filtered `_MLDatabaseProperties`
through a hardcoded four-key allowlist and emitted 2 to 4 rows. The table holds 8 to 37 keys
per image, 42 distinct across the corpus, including `MLStorefrontID` (20/20),
`MLCloudAccountID` and `MPExplicitContentAllowedBoolean`. All key/value rows are now reported
as stored. No claim is made about what any key means; the headers stay `Key` / `Value`.

## Validation

Row counts in `sample_data` come from real `ileapp.py` profile runs against each corpus, one
run per corpus, 20 corpora, **0 errors logged**. Every count agrees exactly with an
independent direct-SQL probe of the same databases.

`mediaLibraryInfo` now returns rows on all 20. `mediaLibrary` returns rows on 7; on the other
13 the `item` table is genuinely empty, which `sample_data` records as such so a future reader
can tell a gap from a bug.

| corpus | iOS | Media Library | Properties |
|---|---|---:|---:|
| ctf2020_ios12 | 12.4 | 0 (item table empty) | 20 |
| hickman_ios13 | 13.3.1 | 301 | 31 |
| hickman_ios14 | 14.3 | 643 | 31 |
| hickman_ios15 | 15.3.1 | 688 | 29 |
| abe_ios16 | 16.5 | 9 | 22 |
| iphone11_ios17 | 17.3 | 839 | 37 |
| otto_ios17 | 17.5.1 | 7 | 19 |
| dexter_ios18 | 18.3.2 | 1339 | 35 |
| hc_ios26 | 26.5.2 | 0 (item table empty) | 13 |

Full set of 20 is in `sample_data`. The WAL matters: on 12 of the 20 the committed database
and the WAL-applied read disagree, and on `hc_ios18_7` the main file is 4 KB against a 2.6 MB
WAL, so the trailing `*` in the glob that brings `-wal` and `-shm` along is load-bearing.

`pylint --disable=C,R` 10.00/10, `check_claim_language.py` clean, `validate_sample_data.py`
0 errors.

## Not changed here

An item carrying more than one `artwork_token` row is reported once per token, so the row
count can exceed the number of media items: 1099 items produce 1339 rows on `dexter_ios18`,
240 of them having two tokens each. That is pre-existing behaviour, now written into the
artifact notes so nobody reads the row count as an item count. Happy to address it separately
if you want one row per item.

`belkactf6` is not in `sample_data`: it is an AES-encrypted zip my extraction path could not
open, so I have no run for it. Its recorded path listing does show the file, with a capital L.

Reported by Mattia Epifani.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
