### PR TITLE
Fix messageRetention losing the retention value on Windows

### DIFF
--- a/scripts/artifacts/messageRetention.py
+++ b/scripts/artifacts/messageRetention.py
@@ -7,29 +7,34 @@ __artifacts_v2__ = {
         "creation_date": "2023-10-03",
         "version": "0.4",
         "date": "2023-10-04",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-13",
         "requirements": "none",
         "category": "Identifiers",
-        "notes": "iOS <=16 / iOS 17+ key naming per tested corpora. Reference: Apple Support, 'Delete messages and attachments', https://support.apple.com/guide/iphone/delete-messages-and-attachments-iph2c9c4bfcb/ios",
-        "paths": ('*/mobile/Library/Preferences/com.apple.MobileSMS.plist', '*/mobile/Library/Preferences/com.apple.mobileSMS.plist'),
+        "notes": "iOS <=16 / iOS 17+ key naming per tested corpora. This directory can hold com.apple.MobileSMS.plist and com.apple.mobileSMS.plist as two different files; 6 of 20 tested images carry both, iOS 14.3 through 26.5.2. Every match is read and each row names the file it was read from. Where the report folder is on a case-insensitive volume the two copies collide under data/, so the preserved copy at a row's path can hold the other file's bytes; the value reported is read before the overwrite. That collision is in the file seeker, not here. On all 6 of those images the lowercase-spelled file held the same three IMDCKBackupController* keys and no retention key, so it is reported as 'No value'. Row counts here are from runs on macOS. Windows cannot tell the two spellings apart, so where both exist it reports whichever single file the extraction preserved. Reference: Apple Support, 'Delete messages and attachments', https://support.apple.com/guide/iphone/delete-messages-and-attachments-iph2c9c4bfcb/ios",
+        "paths": ('*/mobile/Library/Preferences/com.apple.[Mm]obileSMS.plist',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "message-circle",
         "sample_data": {
             "ctf2020_ios12": "iOS 12.4 | 1 row",
-            "dexter_ios18": "iOS 18.3.2 | 3 rows",
+            "dexter_ios18": "iOS 18.3.2 | 3 rows; both spellings present",
             "felix_ios17": "iOS 17.6.1 | 1 row",
             "fsfull002_ios17": "iOS 17.1 | 1 row",
             "hc_ios18_7": "iOS 18.7.8 | 2 rows",
             "iphone11_ios17": "iOS 17.3 | 1 row",
-            "iphone12_ios18": "iOS 18.7 | 3 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 3 rows",
+            "iphone12_ios18": "iOS 18.7 | 3 rows; both spellings present",
+            "iphone14plus_ios18": "iOS 18.0 | 3 rows; both spellings present",
             "otto_ios17": "iOS 17.5.1 | 1 row",
             "abe_ios16": "iOS 16.5 | 1 row",
             "felix23_ios16": "iOS 16.5 | 1 row",
             "hickman_ios13": "iOS 13.3.1 | 1 row",
-            "hickman_ios14": "iOS 14.3 | 2 rows",
+            "hickman_ios14": "iOS 14.3 | 2 rows; both spellings present",
             "jess_ios15": "iOS 15.0.2 | 1 row",
             "magnet_ios16": "iOS 16.1.1 | 1 row",
+            "hickman_ios15": "iOS 15.3.1 | 1 row",
+            "hexordia_ios1651": "iOS 16.5.1 | 1 row",
+            "cookbook_ios1751": "iOS 17.5.1 | 3 rows; both spellings present",
+            "iphone14plus_ios18_mvs2025": "iOS 18.0 | 1 row",
+            "hc_ios26": "iOS 26.5.2 | 3 rows; both spellings present",
         }
     }
 }
@@ -38,88 +43,78 @@ from datetime import datetime
 import os
 from scripts.ilapfuncs import artifact_processor, get_plist_file_content, device_info
 
+# Values observed in tested corpora. Anything else is reported as stored.
+_KEEP_VALUES = {0: 'Forever', 365: '1 Year', 30: '30 Days'}
+
+# The key Apple uses changed between generations; both are read.
+_KEEP_KEYS = (('KeepMessageForDays', 'iOS <=16'), ('SSKeepMessages', 'iOS 17+'))
+
+_PREFERENCES = '*/mobile/Library/Preferences/'
+
+
+def _describe(val):
+    """Retention value as text. Anything unrecognized is reported as stored."""
+    # dict.get would raise on an unhashable value, so only look up what can be a key.
+    if isinstance(val, int):
+        label = _KEEP_VALUES.get(val)
+        if label:
+            return label
+    return f'Unrecognized value: {val}'
+
+
 @artifact_processor
 def messageRetention(context):
     seeker = context.get_seeker()
-    source_path_one = seeker.search('*/mobile/Library/Preferences/com.apple.MobileSMS.plist', return_on_first_hit=True, force=True)
+    data_headers = ('Setting', 'Data Value', 'Path')
     data_list = []
 
-    if source_path_one:
-        pl = get_plist_file_content(source_path_one)
+    # One bracket class, never one pattern per spelling. os.path.normcase folds case on
+    # Windows, so two case-variant patterns compile to the same thing: both searches
+    # return the same first file, its rows are emitted twice, and the other file is
+    # never read.
+    #
+    # Both spellings can be present at once. iOS APFS is case-sensitive and 6 of the 20
+    # tested images carry com.apple.MobileSMS.plist and com.apple.mobileSMS.plist here
+    # as different files, so every spelling is read rather than only the first.
+    matches = seeker.search(_PREFERENCES + 'com.apple.[Mm]obileSMS.plist', force=True)
+    if not matches:
+        return data_headers, data_list, 'File path in the report below'
 
-        indicator = 0
-        
-        for key, val in pl.items():
-            if key == 'KeepMessageForDays':
-                if val == 0:
-                    keep_val = 'Forever'
-                elif val == 365:
-                    keep_val = '1 Year'
-                elif val == 30:
-                    keep_val = '30 Days'
-                else:
-                    keep_val = f'Unrecognized value: {val}'
-                
-                data_list.append(('com.apple.MobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_one))
-                device_info('Messages Settings', 'com.apple.MobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_one)
-                indicator = 1
-                
-            if key == 'SSKeepMessages':
-                if val == 0:
-                    keep_val = 'Forever'
-                elif val == 365:
-                    keep_val = '1 Year'
-                elif val == 30:
-                    keep_val = '30 Days'
-                else:
-                    keep_val = f'Unrecognized value: {val}'
-                
-                data_list.append(('com.apple.MobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_one))
-                device_info('Messages Settings', 'com.apple.MobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_one)
-                indicator = 1
-                            
-        if indicator == 0:
-            data_list.append(('com.apple.MobileSMS.plist - Keep Messages for Days','No value', source_path_one))
-            device_info('Messages Settings', 'com.apple.MobileSMS.plist - Keep Messages for Days','No value', source_path_one)
-            
-    source_path_two = seeker.search('*/mobile/Library/Preferences/com.apple.mobileSMS.plist', return_on_first_hit=True, force=True)
-    if source_path_two:
-        pl = get_plist_file_content(source_path_two)
+    processed = set()
+    for spelling in sorted({os.path.basename(str(p)) for p in matches}):
+        # On Windows the two spellings name one file; process it once.
+        folded = os.path.normcase(spelling)
+        if folded in processed:
+            continue
+        processed.add(folded)
 
-        indicator = 0
-        
-        for key, val in pl.items():
-            if key == 'KeepMessageForDays':
-                if val == 0:
-                    keep_val = 'Forever'
-                elif val == 365:
-                    keep_val = '1 Year'
-                elif val == 30:
-                    keep_val = '30 Days'
-                else:
-                    keep_val = f'Unrecognized value: {val}'
-                
-                data_list.append(('com.apple.mobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_two))
-                device_info('Messages Settings', 'com.apple.mobileSMS.plist - Keep Messages for Days (iOS <=16)', keep_val, source_path_two)
-                indicator = 1
-                
-            if key == 'SSKeepMessages':
-                if val == 0:
-                    keep_val = 'Forever'
-                elif val == 365:
-                    keep_val = '1 Year'
-                elif val == 30:
-                    keep_val = '30 Days'
-                else:
-                    keep_val = f'Unrecognized value: {val}'
-                    
-                data_list.append(('com.apple.mobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_two))
-                device_info('Messages Settings', 'com.apple.mobileSMS.plist - Keep Messages for Days (iOS 17+)', keep_val, source_path_two)
-                indicator = 1
-                
-        if indicator == 0:
-            data_list.append(('com.apple.mobileSMS.plist - Keep Messages for Days', 'No value', source_path_two))
-            device_info('Messages Settings', 'com.apple.mobileSMS.plist - Keep Messages for Days', 'No value', source_path_two)
-        
-    data_headers = ('Setting', 'Data Value', 'Path')
+        # Search for this one spelling and read it before looking for the next. The
+        # seeker copies each match into the report data folder, where the two spellings
+        # collide on a case-insensitive volume and the second copy overwrites the first,
+        # so reading has to happen between the copies rather than after both.
+        source_path = seeker.search(_PREFERENCES + spelling,
+                                    return_on_first_hit=True, force=True)
+        if not source_path:
+            continue
+
+        # Name the file that was actually read, which on a case-insensitive volume is
+        # not necessarily the spelling that was asked for.
+        filename = os.path.basename(source_path)
+        pl = get_plist_file_content(source_path)
+
+        found = False
+        for key, generation in _KEEP_KEYS:
+            if key not in pl:
+                continue
+            keep_val = _describe(pl[key])
+            setting = f'{filename} - Keep Messages for Days ({generation})'
+            data_list.append((setting, keep_val, source_path))
+            device_info('Messages Settings', setting, keep_val, source_path)
+            found = True
+
+        if not found:
+            setting = f'{filename} - Keep Messages for Days'
+            data_list.append((setting, 'No value', source_path))
+            device_info('Messages Settings', setting, 'No value', source_path)
+
     return data_headers, data_list, 'File path in the report below'


### PR DESCRIPTION
## What was wrong

`messageRetention` declared two `paths` patterns differing only in case, and searched each
one separately with `return_on_first_hit`, labelling rows by which spelling it used:

```python
"paths": ('*/mobile/Library/Preferences/com.apple.MobileSMS.plist',
          '*/mobile/Library/Preferences/com.apple.mobileSMS.plist'),
```

`os.path.normcase` folds case on Windows, so both patterns compile to the same thing and
both searches return the **same first match**. One file gets read twice and the other is
never read.

**Both files really exist.** This directory can hold `com.apple.MobileSMS.plist` and
`com.apple.mobileSMS.plist` as two different files, and **6 of the 20** local corpora that
carry this plist have both, from iOS 14.3 to 26.5.2. On all six the lowercase file held the
same three `IMDCKBackupController*` keys and no retention key.

## Measured, before and after

Rows produced under each `normcase` regime, by patching `scripts.search_files.normcase` and
`os.path.normcase` and driving a real `FileSeekerDir`. AFTER is the pinned commit `0e2c563f`.

| configuration | before (macOS / Windows) | after (macOS / Windows) |
|---|---|---|
| only the uppercase file present | 2 / **4** | 2 / 2 |
| both files, case-insensitive output volume | 3 / **2** | 3 / 1 |
| both files, case-sensitive output volume | 3 / **2** | 3 / 1 |

The bolded Windows numbers are the bug:

- With one file, every row was emitted **twice**, half of them labelled
  `com.apple.mobileSMS.plist`, a filename not on the device. That is what a Windows
  validation sweep across 21 extractions was showing.
- With both files, the two rows were **both "No value"**: the real `Keep Messages` setting
  of "Forever" was lost outright, because both searches returned the 630-byte lowercase
  file and the 15 KB file holding the setting was never read. Which file wins depends on
  directory order.

macOS output is unchanged in all three configurations, so there is no regression on the
platform where it already worked.

## The fix

One bracket class replaces the two patterns, and each spelling found is searched for and
read **before the next is looked up**. That ordering is load-bearing: the seeker copies
every match into the report's `data/` folder, where the two spellings collide on a
case-insensitive volume and the second copy overwrites the first. Reading after all the
copying loses a file that reading between them keeps. Rows name the file actually read
rather than a hardcoded spelling.

Two smaller things in the same function:

- A non-scalar value under either retention key went through `dict.get`, which raises on an
  unhashable value. It is now looked up only when it can be a key.
- Rows are emitted in a fixed `iOS <=16` then `iOS 17+` order instead of the plist's own key
  order, which was never stable. Same rows, deterministic order.

## Validation

Real `ileapp.py` profile runs against **all 20 corpora** that hold this plist, extracted to a
case-sensitive APFS volume so both files survive, run from a worktree pinned to the commit.
**All 20 recorded `sample_data` counts reproduce exactly, 0 disagreements.** Five corpora
that previously had no recorded count are added, and the six carrying both spellings are
annotated.

`pylint --disable=C,R` 10.00/10 (was 8.28), `check_claim_language.py` clean,
`validate_sample_data.py` 0 errors.


## Known limitation, pre-existing and not fixed here

On a case-insensitive report volume the two copies collide under `data/`, so for one row the
**preserved copy at the path shown holds the other file's bytes**. The reported *value* is
correct, because each file is read before the next copy overwrites it, but an examiner
opening that path sees a file that does not support the row. Verified against unmodified
`main` as well: it behaves identically, so this is the seeker collision, not something this
change introduces. The artifact `notes` now say so explicitly.

An independent adversarial review of an earlier revision of this branch (`aac07eec`) flagged
the read-after-copy ordering as blocking, which is what prompted the current implementation;
its remaining findings were re-checked against `58ccf7f7` and either fixed or not reproduced.

## Related

An AST sweep of `__artifacts_v2__` `paths` tuples across all five LEAPP cores found exactly
two case-variant tuples: this one, and `setupapiSections` in DLEAPP's `windowsSystem.py`
(`*/Windows/INF/setupapi.dev.log` and `*/WINDOWS/INF/setupapi.dev.log`). Independent
per-core review agents returned the same two. The DLEAPP one is left alone here.

Not fixed, and not an artifact-level problem: `scripts/search_files.py` copies each match
into `data/` keyed by its path, so **any** two evidence files differing only in case collide
there and one silently overwrites the other. This artifact now works around it by reading
between copies; the general case would need a seeker change, which is opt-in in this repo.

Reported by Mattia Epifani.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

