### PR TITLE
Add Keyboard Autocorrection and Inline Completion Rejections artifacts

### DIFF
--- a/scripts/artifacts/keyboard.py
+++ b/scripts/artifacts/keyboard.py
@@ -92,7 +92,119 @@ __artifacts_v2__ = {
             "iphone14plus_ios18": "iOS 18.0 | 0 rows",
             "hc_ios18_7": "iOS 18.7.8 | 0 rows",
         },
-    }
+    },
+    "keyboardAutocorrectionRejections": {
+        "name": "Keyboard Autocorrection Rejections",
+        "description": "Typed text and the corresponding autocorrection held in the "
+                       "rejections table of AutocorrectionRejections.db, with the "
+                       "stored rejection counts and timestamps",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-13",
+        "last_update_date": "2026-08-13",
+        "requirements": "none",
+        "category": "User Activity",
+        "notes": "Column meanings are quoted from the CREATE TABLE comments stored in "
+                 "the database itself: 'typed' is 'originally typed by the user', "
+                 "'correction' is the 'autocorrection performed or rejected', and "
+                 "'performed_count' is 'hard acceptances'. A row therefore does not by "
+                 "itself establish that the correction was rejected rather than "
+                 "applied. The same schema documents both timestamp columns as "
+                 "'seconds since unix epoch'; each defaults to -1e10, and rows still "
+                 "holding that default are reported as an empty cell rather than a "
+                 "date. The schema does not define how a soft rejection differs from a "
+                 "hard one, so those counts are reported as stored. Across the 11 "
+                 "tested images every populated row carried hard_rejections=1, "
+                 "soft_rejections=0, performed_count=0 and journaled NULL, with "
+                 "last_soft_rejection at its default, so the soft-rejection, "
+                 "acceptance and journaled paths are present in the schema but "
+                 "unexercised by the tested data. The file was present on all 11 "
+                 "tested filesystem extractions of iOS 17.1 and later and absent from "
+                 "all 10 tested filesystem extractions of iOS 16.5.1 and earlier; that "
+                 "is an observation about these images, not a statement about when the "
+                 "file was introduced. The schema text was byte-identical across all "
+                 "11, at properties.version 2.",
+        "paths": ("*/mobile/Library/Keyboard/AutocorrectionRejections.db*",),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "keyboard",
+        "sample_data": {
+            "otto_ios17": "iOS 17.5.1 | 5 rows",
+            "iphone12_ios18": "iOS 18.7 | 12 rows",
+            "iphone14plus_ios18_mvs2025": "iOS 18.0 | 3 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 2 rows",
+            "hc_ios26": "iOS 26.5.2 | 2 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 1 row",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "ctf2020_ios12": "iOS 12.4 | 0 rows (file not present)",
+            "hickman_ios13": "iOS 13.3.1 | 0 rows (file not present)",
+            "hickman_ios14": "iOS 14.3 | 0 rows (file not present)",
+            "hickman_ios15": "iOS 15 | 0 rows (file not present)",
+            "jess_ios15": "iOS 15.0.2 | 0 rows (file not present)",
+            "magnet_ios16": "iOS 16.1.1 | 0 rows (file not present)",
+            "belkactf6": "iOS 16.3 | 0 rows (file not present)",
+            "abe_ios16": "iOS 16.5 | 0 rows (file not present)",
+            "felix23_ios16": "iOS 16.5 | 0 rows (file not present)",
+            "hexordia_ios1651": "iOS 16.5.1 | 0 rows (file not present)",
+        },
+    },
+    "keyboardInlineCompletionRejections": {
+        "name": "Keyboard Inline Completion Rejections",
+        "description": "Typed text and the corresponding inline completion held in the "
+                       "inline_completion_rejections table of "
+                       "AutocorrectionRejections.db, with the stored rejection counts "
+                       "and timestamps",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-13",
+        "last_update_date": "2026-08-13",
+        "requirements": "none",
+        "category": "User Activity",
+        "notes": "A second table in the same database as the Keyboard Autocorrection "
+                 "Rejections artifact, carrying the same columns. Its stored CREATE "
+                 "TABLE comments document 'typed' as 'originally typed by the user' "
+                 "and 'correction' as the 'completion performed or rejected', so this "
+                 "table describes completions rather than autocorrections and a row "
+                 "does not by itself establish that the completion was rejected. "
+                 "Unlike the rejections table it carries no comment on "
+                 "'performed_count', and its unique index covers 'correction' alone "
+                 "rather than the typed/correction pair. Timestamps are documented in "
+                 "the schema as 'seconds since unix epoch' and default to -1e10; rows "
+                 "still holding that default are reported as an empty cell. The "
+                 "soft/hard distinction is not defined in the schema, so those counts "
+                 "are reported as stored. Populated on 3 of the 11 tested images, one "
+                 "row each, every one carrying hard_rejections=1, soft_rejections=0, "
+                 "performed_count=0 and journaled NULL. The table is created with IF "
+                 "NOT EXISTS, so it is guarded at read time in case an earlier "
+                 "properties.version predates it.",
+        "paths": ("*/mobile/Library/Keyboard/AutocorrectionRejections.db*",),
+        "output_types": ["html", "tsv", "lava", "timeline"],
+        "artifact_icon": "keyboard",
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 1 row",
+            "iphone12_ios18": "iOS 18.7 | 1 row",
+            "iphone14plus_ios18_mvs2025": "iOS 18.0 | 1 row",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows",
+            "hc_ios26": "iOS 26.5.2 | 0 rows",
+            "ctf2020_ios12": "iOS 12.4 | 0 rows (file not present)",
+            "hickman_ios13": "iOS 13.3.1 | 0 rows (file not present)",
+            "hickman_ios14": "iOS 14.3 | 0 rows (file not present)",
+            "hickman_ios15": "iOS 15 | 0 rows (file not present)",
+            "jess_ios15": "iOS 15.0.2 | 0 rows (file not present)",
+            "magnet_ios16": "iOS 16.1.1 | 0 rows (file not present)",
+            "belkactf6": "iOS 16.3 | 0 rows (file not present)",
+            "abe_ios16": "iOS 16.5 | 0 rows (file not present)",
+            "felix23_ios16": "iOS 16.5 | 0 rows (file not present)",
+            "hexordia_ios1651": "iOS 16.5.1 | 0 rows (file not present)",
+        },
+    },
 }
 
 import plistlib
@@ -205,3 +317,54 @@ def keyboardVulgarWordUsage(context):
     """
     data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
     return data_headers, data_list, context.get_relative_path(source_path)
+
+
+# Both tables in AutocorrectionRejections.db carry identical columns, so one reader
+# serves both artifacts. Column meanings come from the CREATE TABLE comments stored
+# in the database; see the notes in each artifact block.
+_REJECTION_HEADERS = (
+    ("Last Hard Rejection", "datetime"),
+    ("Last Soft Rejection", "datetime"),
+    "Record ID",
+    "Typed Text",
+    "Correction",
+    "Hard Rejections",
+    "Soft Rejections",
+    "Performed Count",
+    "Journaled (as stored)",
+)
+
+
+def _autocorrection_rejection_rows(context, table_name):
+    """Read one rejection table, guarding the sentinel timestamp default of -1e10."""
+    data_list = []
+    source_path = next(
+        (str(path) for path in context.get_files_found()
+         if str(path).endswith("AutocorrectionRejections.db")),
+        "",
+    )
+    if not source_path or not does_table_exist_in_db(source_path, table_name):
+        return _REJECTION_HEADERS, data_list, ""
+
+    query = f"""
+        SELECT CASE WHEN last_hard_rejection > 0
+                    THEN datetime(last_hard_rejection, 'unixepoch') END,
+               CASE WHEN last_soft_rejection > 0
+                    THEN datetime(last_soft_rejection, 'unixepoch') END,
+               ROWID, typed, correction,
+               hard_rejections, soft_rejections, performed_count, journaled
+        FROM {table_name}
+        ORDER BY MAX(last_hard_rejection, last_soft_rejection)
+    """
+    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    return _REJECTION_HEADERS, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def keyboardAutocorrectionRejections(context):
+    return _autocorrection_rejection_rows(context, "rejections")
+
+
+@artifact_processor
+def keyboardInlineCompletionRejections(context):
+    return _autocorrection_rejection_rows(context, "inline_completion_rejections")


### PR DESCRIPTION
Adds parsing for `/private/var/mobile/Library/Keyboard/AutocorrectionRejections.db`, which no existing artifact covered. Reported by Mattia Epifani (@mattiaep) during his FOR585 poster review of the iOS side.

## Two tables, two artifacts

The file holds two tables with identical columns, so both are surfaced:

| table | artifact |
| --- | --- |
| `rejections` | Keyboard Autocorrection Rejections |
| `inline_completion_rejections` | Keyboard Inline Completion Rejections |

The second one is inline completions rather than autocorrections, and its unique index covers `correction` alone instead of the typed/correction pair.

## The column meanings are sourced, not inferred

Apple left comments in the `CREATE TABLE` text, which SQLite stores verbatim, so the labels come from a primary source sitting inside the evidence:

- `typed` is "originally typed by the user"
- `correction` is the "autocorrection performed or rejected"
- `performed_count` is "hard acceptances"
- both timestamp columns are "seconds since unix epoch"

Because that comment says *performed or rejected*, the notes state plainly that a row does not by itself establish the correction was rejected rather than applied.

## Sentinel timestamps

Both timestamp columns default to `-1e10`, which decodes to a nonsense 1653 date. They are guarded with `> 0` and reported as an empty cell instead of a date. Every populated row in every tested image still had `last_soft_rejection` at that default.

## What this does not tell you

The schema never defines how a **soft** rejection differs from a **hard** one, and I found no published source for it. Those counts ship as stored, with the notes saying the distinction is undocumented. `journaled` is an untyped column with no comment, so it is reported as stored too.

Across all tested images every populated row carried `hard_rejections=1`, `soft_rejections=0`, `performed_count=0` and `journaled` NULL. So the soft-rejection, acceptance and journaled paths exist in the schema but are unexercised by the tested data, and the notes say so.

## Validation

Real `ileapp.py` profile runs against real extractions, not a mock harness. Counts matched an independent SQLite read of the same databases in every case:

| corpus | autocorrection | inline |
| --- | ---: | ---: |
| `iphone12_ios18` | 12 | 1 |
| `otto_ios17` | 5 | 0 |
| `iphone11_ios17` | 0 | 1 |
| `hc_ios26` | 2 | 0 |
| `magnet_ios16` | file absent | file absent |

Checked column alignment, epoch decoding, sentinel suppression, LAVA manifest counts against the LAVA table rows, `datetime` typing in `object_columns`, timeline output and HTML.

All 24 registered iOS corpora were enumerated for presence rather than working from a list. The file was found on 11, with one byte-identical schema from iOS 17.1 through 26.5.2 at `properties.version` 2, and no WAL or SHM sidecars on any of them. It was absent from the 10 tested filesystem extractions of iOS 16.5.1 and earlier. That is recorded as an observation about these images, not as a claim about when the file was introduced.

`pylint --disable=C,R` at 10.00, `check_claim_language.py` clean, `check_html_safety.py` clean, and `validate_sample_data.py` at 0 errors adding no new warnings.

No cross-core leveling needed: this is an Apple iOS keyboard file and no sibling core references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


