### PR TITLE
Fix iCloud Quick Look never finding the thumbnailcache database

### DIFF
--- a/scripts/artifacts/quickLook.py
+++ b/scripts/artifacts/quickLook.py
@@ -4,16 +4,25 @@ __artifacts_v2__ = {
         "description": "Entries from the Quick Look cloudthumbnails.db cache: paths of iCloud files with last-hit dates. A cache entry does not establish that a user viewed the file.",
         "author": "@abrignoni",
         "creation_date": "2026-06-24",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "iCloud Quick Look",
-        "notes": "Check -wal files for possible data remnants if the DB is missing.",
-        "paths": ('*/Quick Look/cloudthumbnails.db*',),
+        "notes": "On iOS 12 test images the database sits under Library/Application Support/Quick Look/; "
+                 "on iOS 15-26 test images it sits under Library/Caches/com.apple.QuickLook.thumbnailcache/ "
+                 "with the main file a 4 KB shell whose thumbnails table and rows live entirely in the "
+                 "-wal sidecar, so the -wal and -shm files must be collected with the database.",
+        "paths": ('*/Quick Look/cloudthumbnails.db*',
+                  '*/Library/Caches/com.apple.QuickLook.thumbnailcache/cloudthumbnails.db*'),
         "output_types": "standard",
         "artifact_icon": "eye",
         "sample_data": {
             "ctf2020_ios12": "iOS 12.4 | 1 row",
             "hickman_ios13": "iOS 13.3.1 | 2 rows",
+            "abe_ios16": "iOS 16.5 | 4 rows",
+            "felix23_ios16": "iOS 16.5 | 5 rows",
+            "otto_ios17": "iOS 17.5.1 | 4 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 1 row",
+            "hc_ios26": "iOS 26.5.2 | 0 rows",
         }
     }
 }
@@ -28,15 +37,7 @@ def quickLook(context):
         'Last Seen Path',
         'Size')
     data_list = []
-    source_path = ''
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
-        if file_found.endswith('cloudthumbnails.db'):
-            source_path = file_found
-            break
-
-    if not source_path:
-        return data_headers, data_list, ''
+    sources = []
 
     query = '''
     SELECT
@@ -45,7 +46,12 @@ def quickLook(context):
         size
     FROM thumbnails
     '''
-    for row in get_sqlite_db_records(source_path, query):
-        data_list.append((row[0], row[1], row[2]))
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('cloudthumbnails.db'):
+            continue
+        for row in get_sqlite_db_records(file_found, query):
+            data_list.append((row[0], row[1], row[2]))
+        sources.append(context.get_relative_path(file_found))
 
-    return data_headers, data_list, context.get_relative_path(source_path)
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary

`quickLook` was red ("expected file not found") on all 21 extractions in Mattia Epifani's iOS 16.1.1-26.5.2 comparison sheet, and its only recorded rows were iOS 12/13. Cause: the glob only matched `*/Quick Look/cloudthumbnails.db*`, the iOS 12-era location. On every iOS 15-26 image in the local corpus the database sits at `Library/Caches/com.apple.QuickLook.thumbnailcache/`, which that glob cannot match.

## Changes

- Add `*/Library/Caches/com.apple.QuickLook.thumbnailcache/cloudthumbnails.db*` alongside the legacy pattern (different directories, not case variants, so two patterns cannot double-count).
- Iterate every matched database instead of stopping at the first match; sources are joined unique relative paths.
- Note in the artifact metadata: at the new location the main file is a 4 KB shell and the `thumbnails` table plus all rows live entirely in the `-wal` sidecar (observed on every iOS 15-26 corpus image), so the sidecars must be collected with the database.
- Re-derived `sample_data` from real `ileapp.py` profile runs.

## Validation (real ileapp.py profile runs, one per corpus)

| corpus | before | after |
|---|---|---|
| ctf2020_ios12 (12.4) | 1 row | 1 row (no regression) |
| hickman_ios13 (13.3.1) | 2 rows | 2 rows (no regression) |
| abe_ios16 (16.5) | file not found | 4 rows |
| felix23_ios16 (16.5) | file not found | 5 rows |
| otto_ios17 (17.5.1) | file not found | 4 rows |
| iphone14plus_ios18 (18.0) | file not found | 1 row |
| hc_ios26 (26.5.2) | file not found | file found, 0 rows |

Row counts independently cross-checked against direct sqlite reads of the extracted databases (exact match on all seven). Pylint 10.00, claim-language check clean, glob validated with `fnmatch.fnmatchcase` against the recorded corpus path listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)