### PR TITLE
Fix Reminders returning zero rows on every store generation

### DIFF
--- a/scripts/artifacts/reminders.py
+++ b/scripts/artifacts/reminders.py
@@ -1,68 +1,114 @@
 __artifacts_v2__ = {
     "reminders": {
         "name": "Reminders",
-        "description": "iOS Reminders with creation and last-modified timestamps",
+        "description": "iOS Reminders with creation, modification, due and completion timestamps",
         "author": "@any333",
         "creation_date": "2026-06-24",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Reminders",
-        "notes": "",
-        "paths": ('**/Reminders/Container_v1/Stores/*.sqlite*',),
+        "notes": "Two store generations are read. iOS 16 and later test images keep reminders in a "
+                 "ZREMCDREMINDER table; earlier images keep them as REMCDReminder rows in the "
+                 "single-table ZREMCDOBJECT, with the entity code resolved per file from "
+                 "Z_PRIMARYKEY because the number shifts between releases (23, 24 and 28 on the "
+                 "iOS 13, 14 and 15 test images). On iOS 17 and later the store directory moved "
+                 "from Library/Reminders/Container_v1 to the Reminders app-group container. On the "
+                 "older generation both ZTITLE and ZTITLE1 columns exist and no populated store of "
+                 "that generation was available in the local corpus, so the title is read from "
+                 "whichever column is set (unexercised path). Completed, Flagged and Marked for "
+                 "Deletion are integer flags reported as stored; rows marked for deletion are "
+                 "included.",
+        "paths": ('*/Container_v1/Stores/*.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "bell",
         "sample_data": {
-            "abe_ios16": "iOS 16.5 | 0 rows",
-            "felix23_ios16": "iOS 16.5 | 0 rows",
             "hickman_ios13": "iOS 13.3.1 | 0 rows",
             "hickman_ios14": "iOS 14.3 | 0 rows",
             "jess_ios15": "iOS 15.0.2 | 0 rows",
             "magnet_ios16": "iOS 16.1.1 | 0 rows",
+            "belkactf6": "iOS 16.3 | 14 rows (run against the decrypted filesystem copy)",
+            "abe_ios16": "iOS 16.5 | 2 rows",
+            "felix23_ios16": "iOS 16.5 | 0 rows",
+            "hexordia_ios1651": "iOS 16.5.1 | 0 rows",
+            "fsfull002_ios17": "iOS 17.1 | 2 rows",
+            "otto_ios17": "iOS 17.5.1 | 6 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 3 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 37 rows",
+            "hc_ios26": "iOS 26.5.2 | 0 rows",
         }
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, does_column_exist_in_db
+import os
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    does_table_exist_in_db, does_column_exist_in_db
+
+_COLUMNS = '''
+        DATETIME(ZCREATIONDATE + 978307200, 'UNIXEPOCH'),
+        DATETIME(ZLASTMODIFIEDDATE + 978307200, 'UNIXEPOCH'),
+        DATETIME(ZDUEDATE + 978307200, 'UNIXEPOCH'),
+        DATETIME(ZCOMPLETIONDATE + 978307200, 'UNIXEPOCH'),
+        {title},
+        ZNOTES,
+        ZCOMPLETED,
+        ZFLAGGED,
+        ZMARKEDFORDELETION
+'''
+
+
+def _reminder_entity(file_found):
+    '''Z_ENT code for the REMCDReminder entity, resolved from the file's own
+    Z_PRIMARYKEY table because the numbering shifts between releases.'''
+    for row in get_sqlite_db_records(
+            file_found,
+            "SELECT Z_ENT FROM Z_PRIMARYKEY WHERE Z_NAME = 'REMCDReminder'"):
+        return row[0]
+    return None
 
 
 @artifact_processor
 def reminders(context):
     data_headers = (
         ('Creation Date', 'datetime'),
-        'Title',
-        'Note to Reminder',
         ('Last Modified', 'datetime'),
+        ('Due Date', 'datetime'),
+        ('Completion Date', 'datetime'),
+        'Title',
+        'Notes',
+        'Completed',
+        'Flagged',
+        'Marked for Deletion',
         'File Location')
     data_list = []
     sources = []
-
-    query = '''
-    SELECT
-        DATETIME(ZCREATIONDATE + 978307200, 'UNIXEPOCH'),
-        DATETIME(ZLASTMODIFIEDDATE + 978307200, 'UNIXEPOCH'),
-        ZNOTES,
-        ZTITLE1
-    FROM ZREMCDOBJECT
-    WHERE ZTITLE1 <> ''
-    '''
 
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith('.sqlite'):
             continue
-        if not does_column_exist_in_db(file_found, 'ZREMCDOBJECT', 'ZLASTMODIFIEDDATE'):
+        if os.path.basename(file_found).startswith('._'):
+            continue    # AppleDouble sidecar, not a database
+
+        if does_table_exist_in_db(file_found, 'ZREMCDREMINDER'):
+            query = f'SELECT {_COLUMNS.format(title="ZTITLE")} FROM ZREMCDREMINDER'
+        elif does_table_exist_in_db(file_found, 'ZREMCDOBJECT'):
+            entity = _reminder_entity(file_found)
+            if entity is None:
+                continue
+            title = 'COALESCE(ZTITLE1, ZTITLE)' \
+                if does_column_exist_in_db(file_found, 'ZREMCDOBJECT', 'ZTITLE1') else 'ZTITLE'
+            query = (f'SELECT {_COLUMNS.format(title=title)} '
+                     f'FROM ZREMCDOBJECT WHERE Z_ENT = {int(entity)}')
+        else:
             continue
 
         rel_path = context.get_relative_path(file_found)
-        rows = list( get_sqlite_db_records(file_found, query) )
-        # NOTE: we could actually change this one to just consume the generator
-        #   if we think for more than the 15 seconds I thought of this
-        #   as per previous comments: big change, trying to change as little as
-        #   possible  -- bconstanzo
-        if not rows:
-            continue
-        for row in rows:
-            data_list.append((row[0], row[3], row[2], row[1], rel_path))
-        sources.append(rel_path)
+        rows_seen = False
+        for row in get_sqlite_db_records(file_found, query):
+            data_list.append(tuple(row) + (rel_path,))
+            rows_seen = True
+        if rows_seen:
+            sources.append(rel_path)
 
     return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary

`reminders` had never produced a row on any local corpus image, and was yellow/red on all 21 extractions in Mattia Epifani's iOS 16.1.1-26.5.2 comparison sheet. Two independent causes:

1. **Path drift**: iOS 17+ moved the stores from `Library/Reminders/Container_v1/Stores/` to the Reminders app-group container (`Shared/AppGroup/<GUID>/Container_v1/Stores/`). The old glob required a `Reminders/` path component, so it could never match the new location.
2. **Schema drift**: iOS 16+ dropped `ZTITLE1`/`ZNOTES`/`ZLASTMODIFIEDDATE` from `ZREMCDOBJECT` and moved reminders to a new `ZREMCDREMINDER` table. The artifact's `ZLASTMODIFIEDDATE` column guard silently skipped every modern store.

## Changes

- Glob is now `*/Container_v1/Stores/*.sqlite*`, covering both locations. Across all four recorded corpus path listings, only Reminders uses this layout; a per-file table check keeps anything else inert.
- Reads both generations: `ZREMCDREMINDER` directly on iOS 16+; `REMCDReminder` entity rows from `ZREMCDOBJECT` on older stores, resolving the entity code per file from `Z_PRIMARYKEY` (the number shifts between releases: 23/24/28 on the iOS 13/14/15 test images).
- New columns available in both generations: Due Date, Completion Date, Completed, Flagged, Marked for Deletion (integer flags reported as stored; rows marked for deletion are included).
- On the older generation both `ZTITLE` and `ZTITLE1` exist and no populated store of that generation exists in the corpus, so the title reads whichever is set; labeled as an unexercised path in the notes.

## Validation (real ileapp.py profile runs, one per corpus)

| corpus | before | after | independent cross-check |
|---|---|---|---|
| belkactf6 (16.3, decrypted fs copy) | 0 | **14** | direct sqlite read: 14 |
| iphone14plus_ios18 (18.0) | not found | **37** | direct read: 37 |
| otto_ios17 (17.5.1) | not found | **6** | direct read: 6 |
| cookbook_ios1751 (17.5.1) | not found | **3** | direct read: 3 |
| fsfull002_ios17 (17.1) | not found | **2** | direct read: 2 |
| abe_ios16 (16.5) | 0 | **2** | direct read: 2 |
| hickman_ios13 / hickman_ios14 / jess_ios15 / magnet_ios16 / felix23_ios16 / hexordia_ios1651 / hc_ios26 | 0 / not found | 0 | reminder entity tables directly confirmed empty, so these zeros are data absence, not parser misses |

No errors in any run. Pylint 10.00, claim-language check clean, `validate_sample_data` 0 errors, glob validated against the recorded corpus path listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)