### PR TITLE
Match the modern group-container removal phrasing in containermanagerd logs

### DIFF
--- a/scripts/artifacts/mobileContainerManager.py
+++ b/scripts/artifacts/mobileContainerManager.py
@@ -1,47 +1,70 @@
 __artifacts_v2__ = {
     "mobileContainerManager": {
         "name": "Mobile Container Manager",
-        "description": "Group container removals logged by containermanagerd (last reference removed)",
+        "description": "Group container removals logged by containermanagerd",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Mobile Container Manager",
-        "notes": "",
-        "paths": ('**/containermanagerd.log.*',),
+        "notes": "Two log phrasings are matched. 'Removing group container [id]' from "
+                 "MCMGroupManager _cleanupUnreferencedGroupContainers... is observed on the iOS 15 "
+                 "test image. 'Last reference to group container' from MCMGroupManager "
+                 "_removeGroupContainersIfNeeded... appears in no local corpus log (iOS 12-17) and "
+                 "is kept for older logs (unexercised path). These logs rotate and mostly hold "
+                 "boot-time chatter, so most captures contain no removal lines at all.",
+        "paths": ('**/containermanagerd*.log.*',),
         "output_types": "standard",
         "artifact_icon": "trash",
         "sample_data": {
             "ctf2020_ios12": "iOS 12.4 | 0 rows",
-            "felix_ios17": "iOS 17.6.1 | 0 rows",
-            "iphone11_ios17": "iOS 17.3 | 0 rows",
-            "otto_ios17": "iOS 17.5.1 | 0 rows",
-            "abe_ios16": "iOS 16.5 | 0 rows",
-            "felix23_ios16": "iOS 16.5 | 0 rows",
             "hickman_ios13": "iOS 13.3.1 | 0 rows",
             "hickman_ios14": "iOS 14.3 | 0 rows",
-            "jess_ios15": "iOS 15.0.2 | 0 rows",
+            "jess_ios15": "iOS 15.0.2 | 1 row",
+            "belkactf6": "iOS 16.3 | 0 rows (run against the decrypted filesystem copy)",
+            "abe_ios16": "iOS 16.5 | 0 rows",
+            "felix23_ios16": "iOS 16.5 | 0 rows",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
         }
     }
 }
 
+import re
 from datetime import datetime
 
 from scripts.ilapfuncs import artifact_processor
 
-_MARKER = ('[MCMGroupManager _removeGroupContainersIfNeededforUser:groupContainerClass:identifiers:'
-           'referenceCounts:]: Last reference to group container')
+# iOS <= 12-era phrasing; kept for older logs, not seen in the local corpus.
+_MARKER_LAST_REF = ('[MCMGroupManager _removeGroupContainersIfNeededforUser:groupContainerClass:identifiers:'
+                    'referenceCounts:]: Last reference to group container')
+
+# Observed on the iOS 15 test image:
+# ... -[MCMGroupManager _cleanupUnreferencedGroupContainersForUserIdentity:...]:
+#     Removing group container [group.com.apple.Maps] for <501/...> at <MCMContainerPath: ...>
+_REMOVING_RE = re.compile(r'Removing group container \[([^\]]+)\]')
+
+
+def _line_datetime(txts):
+    '''Datetime from the log prefix: <dow> <Mon> <day> <HH:MM:SS> <year>.'''
+    month_number = datetime.strptime(txts[1], '%b').month
+    return datetime.strptime(f'{txts[4]}-{month_number}-{txts[2]} {txts[3]}',
+                             '%Y-%m-%d %H:%M:%S')
 
 
 @artifact_processor
 def mobileContainerManager(context):
-    data_headers = (('Datetime', 'datetime'), 'Removed', 'Line')
+    data_headers = (('Datetime', 'datetime'), 'Removed', 'Line', 'Source File')
     data_list = []
-    source_path = ''
+    sources = []
 
     for file_found in context.get_files_found():
         file_found = str(file_found)
-        source_path = source_path or file_found
+        rel_path = context.get_relative_path(file_found)
+        sources.append(rel_path)
         try:
             with open(file_found, 'r', encoding='utf-8', errors='ignore') as fp:
                 lines = fp.readlines()
@@ -49,17 +72,24 @@ def mobileContainerManager(context):
             continue
 
         for linecount, line in enumerate(lines, 1):
-            if _MARKER not in line:
+            group = None
+            if _MARKER_LAST_REF in line:
+                txts = line.split()
+                try:
+                    # group id at index 15 in this phrasing
+                    group = txts[15]
+                except IndexError:
+                    continue
+            else:
+                match = _REMOVING_RE.search(line)
+                if match:
+                    group = match.group(1)
+            if group is None:
                 continue
-            txts = line.split()
             try:
-                # log prefix: <dow> <Mon> <day> <HH:MM:SS> <year> ... <group at index 15>
-                month_number = datetime.strptime(txts[1], '%b').month
-                dtime_obj = datetime.strptime(f'{txts[4]}-{month_number}-{txts[2]} {txts[3]}',
-                                              '%Y-%m-%d %H:%M:%S')
-                group = txts[15]
+                dtime_obj = _line_datetime(line.split())
             except (ValueError, IndexError):
                 continue
-            data_list.append((dtime_obj, group, linecount))
+            data_list.append((dtime_obj, group, linecount, rel_path))
 
-    return data_headers, data_list, source_path
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary

`mobileContainerManager` had recorded 0 rows on every corpus image ever tested (its own `sample_data` lists nine images, all 0), and was yellow on all of Mattia Epifani's 21 extractions where the log exists. The marker it searched for (`MCMGroupManager _removeGroupContainersIfNeededforUser...: Last reference to group container`) appears in **none** of the corpus logs, iOS 12 through 17. The phrasing those logs actually use is:

```
-[MCMGroupManager _cleanupUnreferencedGroupContainersForUserIdentity:...]: Removing group container [group.com.apple.Maps] for <501/...> at <MCMContainerPath: ...>
```

observed on the iOS 15 test image.

## Changes

- Match both phrasings: the observed `Removing group container [id]` line, and the legacy `Last reference to group container` marker (kept for older logs; labeled unexercised in the notes since no corpus log contains it).
- Widen the glob to `**/containermanagerd*.log.*` so the same-format `containermanagerd_system.log.*` files are read too.
- Add a Source File column since more than one log can now match per image.
- Notes state plainly that these logs rotate and mostly hold boot-time chatter, so most captures contain no removal lines: a 0 here is expected, not a parser failure.

## Validation (real ileapp.py profile runs, 12 corpora)

| corpus | result |
|---|---|
| jess_ios15 | **1 row**: `group.com.apple.Maps`, 2022-01-06 14:40:55, matching a direct read of the log |
| ctf2020_ios12, hickman_ios13, hickman_ios14, belkactf6 (fs copy), abe_ios16, felix23_ios16, fsfull002_ios17, iphone11_ios17, otto_ios17, cookbook_ios1751, felix_ios17 | 0 rows, matching a direct grep of every corpus log for both phrasings |

Pylint 10.00, claim-language check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)