### PR TITLE
Stop iCloudWifi matching the LaunchDaemons daemon configuration

### DIFF
--- a/scripts/artifacts/iCloudWifi.py
+++ b/scripts/artifacts/iCloudWifi.py
@@ -4,31 +4,25 @@ __artifacts_v2__ = {
         "description": "Wi-Fi networks synced via iCloud (com.apple.wifid.plist)",
         "author": "@ydkhatri",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Wifi Connections",
-        "notes": "In local test images this plist carried no entries. "
+        "notes": "The synced-data plist lives at Library/SyncedPreferences/com.apple.wifid.plist "
+                 "and, in the only local test image carrying it (iOS 12.4), holds an empty values "
+                 "dictionary. The earlier glob matched any com.apple.wifid.plist and so reported "
+                 "the unrelated /System/Library/LaunchDaemons daemon configuration as the found "
+                 "file on most images; the narrower path stops that. "
                  "Reference: cheeky4n6monkey (based on research by M. Epifani, H. Mahalik), "
                  "'iOS_sysdiagnose_forensic_scripts', "
                  "https://github.com/cheeky4n6monkey/iOS_sysdiagnose_forensic_scripts",
-        "paths": ('**/com.apple.wifid.plist',),
+        "paths": ('*/SyncedPreferences/com.apple.wifid.plist',),
         "output_types": "standard",
         "artifact_icon": "wifi",
         "sample_data": {
-            "ctf2020_ios12": "iOS 12.4 | 0 rows",
-            "dexter_ios18": "iOS 18.3.2 | 0 rows",
-            "felix_ios17": "iOS 17.6.1 | 0 rows",
-            "fsfull002_ios17": "iOS 17.1 | 0 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 0 rows",
-            "iphone11_ios17": "iOS 17.3 | 0 rows",
-            "iphone12_ios18": "iOS 18.7 | 0 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
-            "otto_ios17": "iOS 17.5.1 | 0 rows",
-            "abe_ios16": "iOS 16.5 | 0 rows",
-            "felix23_ios16": "iOS 16.5 | 0 rows",
-            "hickman_ios13": "iOS 13.3.1 | 0 rows",
-            "hickman_ios14": "iOS 14.3 | 0 rows",
-            "magnet_ios16": "iOS 16.1.1 | 0 rows",
+            "ctf2020_ios12": "iOS 12.4 | 0 rows (plist present, values dictionary empty)",
+            "iphone11_ios17": "iOS 17.3 | 0 rows (file not present)",
+            "hc_ios18_7": "iOS 18.7.8 | 0 rows (file not present)",
+            "hc_ios26": "iOS 26.5.2 | 0 rows (file not present)",
         }
     }
 }


### PR DESCRIPTION
## Summary

`iCloudWifi` used the glob `**/com.apple.wifid.plist`, which matches `/System/Library/LaunchDaemons/com.apple.wifid.plist`: a launch-daemon configuration carrying no Wi-Fi data, present on nearly every image. The artifact therefore reported "file found, 0 rows" on 19 of Mattia Epifani's 21 extractions and on all 14 images in its recorded `sample_data`. That reads as "empty data store" when no data store was ever examined.

## Changes

- Glob anchored to `*/SyncedPreferences/com.apple.wifid.plist`, the synced-data location (reference already cited in the artifact notes: cheeky4n6monkey's iOS_sysdiagnose_forensic_scripts, based on research by M. Epifani and H. Mahalik).
- Notes updated to state the observed situation plainly: in the only local image carrying the file (iOS 12.4) the `values` dictionary is empty, and the old glob's found-file reports were the unrelated daemon plist.
- `sample_data` re-derived from real runs; the 14 false-match zeros are dropped.

## Validation (real ileapp.py profile runs)

| corpus | before | after |
|---|---|---|
| ctf2020_ios12 (12.4) | "found" (daemon plist), 0 rows | finds the SyncedPreferences plist, 0 rows (values dict empty) |
| iphone11_ios17, hc_ios18_7, hc_ios26 | "found" (daemon plist), 0 rows | file not found (honest) |

A namelist scan of every registered corpus zip confirms the SyncedPreferences copy exists only on ctf2020_ios12, so "file not found" elsewhere is data absence. Pylint 10.00, claim-language check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)