### PR TITLE
Add a logarchive dialed numbers artifact (Thesis Friday #24)

### DIFF
--- a/admin/test/scripts/test_logarchive_native.py
+++ b/admin/test/scripts/test_logarchive_native.py
@@ -16,6 +16,7 @@ json export or from tracev3 data read natively, the column order and meaning hav
 identical or those artifacts silently return nothing.
 """
 import datetime
+import inspect
 import os
 import pathlib
 import shutil
@@ -23,6 +24,7 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+import unittest.mock
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
@@ -579,6 +581,80 @@ class TestColumnContract(unittest.TestCase):
         self.assertEqual(row[6], 'Airplane Mode is now On')  # Event Message
         self.assertEqual(row[7], '')                        # Trace ID, not emitted by the parser
         self.assertEqual(row[1], 1)                         # Row Number starts at 1
+
+
+class TestDialedNumbersPredicates(unittest.TestCase):
+    """The dialed numbers query runs against a fixture shaped like logarchive_artifacts.
+
+    Every clause in that artifact pairs a category with a message pattern, and the reason
+    is a false positive that only shows up at corpus scale: locationd logs
+    'kPhoneNumberStatusNotification' under category Emergency, which carries no number at
+    all. A bare '%kPhoneNumber%' predicate collected 7 of those on an iOS 16.5 image and 44
+    on an iOS 17.1 image, against 3 genuine CommCenter setup blocks in the whole sweep. The
+    rows below are the shapes that mattered, so a later loosening of the query fails here
+    rather than in someone's report.
+    """
+
+    COMMCENTER = '/System/Library/Frameworks/CoreTelephony.framework/Support/CommCenter'
+
+    ROWS = [
+        # (subsystem, category, process, event_message, should_match)
+        ('com.apple.CommCenter', 'call.provider', COMMCENTER,
+         '#I {\n\t"kActionType": 0,\n\t"kUuid": "U1",\n\t"kPhoneNumber": "+15555550100"\n}', True),
+        ('com.apple.CommCenter', 'call.provider', COMMCENTER,
+         '#I {\n\t"kActionType": 2,\n\t"kUuid": "U1"\n}', True),
+        ('com.apple.CommCenter', 'call', COMMCENTER,
+         '#N ### Call(StatusUpdate) InitializingMedia -> Dialing for call <private>', True),
+        ('com.apple.calls.mobilephone', 'ContactSearchManager', '/Applications/MobilePhone.app/MobilePhone',
+         'Searching for 5555550', True),
+        # The false positive the scoping exists for: no number, wrong process, wrong category.
+        ('com.apple.locationd.Position', 'Emergency', '/usr/libexec/locationd',
+         '#EmergCon,EMERGENCY:notification,kPhoneNumberStatusNotification', False),
+        # Ordinary call.provider bookkeeping stays in the collection table, not this report.
+        ('com.apple.CommCenter', 'call.provider', COMMCENTER,
+         '#I Updating caller id/phone number to <private>', False),
+        # 'Searching for' is not a dial field on its own.
+        ('com.apple.contacts', 'api-triage', '/usr/libexec/suggestd',
+         '0x1 Searching for 1 identifier: ABCDEF:ABPerson', False),
+    ]
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        self.db_path = os.path.join(self.tempdir, '_lava_artifacts.db')
+        conn = sqlite3.connect(self.db_path)
+        conn.execute('''CREATE TABLE logarchive_artifacts (
+            timestamp TEXT, row_number INTEGER, process_image_path TEXT, process_id INTEGER,
+            subsystem TEXT, category TEXT, event_message TEXT, trace_id TEXT)''')
+        for number, (subsystem, category, process, message, _) in enumerate(self.ROWS, start=1):
+            conn.execute('INSERT INTO logarchive_artifacts VALUES (?,?,?,?,?,?,?,?)',
+                         ('2026-08-14 00:00:00', number, process, 102,
+                          subsystem, category, message, ''))
+        conn.commit()
+        conn.close()
+
+    def run_artifact(self):
+        context = unittest.mock.Mock()
+        context.get_files_found.return_value = [self.db_path]
+        _headers, rows, _source = logarchive.logarchive_dialed_numbers.__wrapped__(context)
+        return [row[6] for row in rows]
+
+    def test_only_the_scoped_rows_come_back(self):
+        returned = self.run_artifact()
+        expected = [row[3] for row in self.ROWS if row[4]]
+        self.assertEqual(sorted(returned), sorted(expected))
+
+    def test_locationd_notification_is_not_reported_as_a_dialed_number(self):
+        self.assertNotIn('#EmergCon,EMERGENCY:notification,kPhoneNumberStatusNotification',
+                         self.run_artifact())
+
+    def test_collection_query_gathers_the_categories_the_artifact_reads(self):
+        # The dependent query can only find what logarchive_artifacts materialized.
+        source = inspect.getsource(logarchive.logarchive_artifacts.__wrapped__)
+        for category in ("category = 'call.provider'", "category = 'call'",
+                         "category = 'ContactSearchManager'"):
+            with self.subTest(category=category):
+                self.assertIn(category, source)
 
 
 if __name__ == '__main__':

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -234,11 +234,57 @@ __artifacts_v2__ = {
                  "and observed on iOS 18.7. The open-request entries name the process that "
                  "asked for the call UI (touch, Siri, or a Bluetooth accessory). Keypad tone "
                  "entries come from mediaserverd in the cited research and from audiomxd on "
-                 "iOS 18.7, and only appear when keypad sounds are enabled. Number payloads "
-                 "are redacted to <private>.",
+                 "iOS 18.7, and only appear when keypad sounds are enabled. The number "
+                 "payloads in these particular entries are redacted to <private>; the "
+                 "dialed numbers artifact collects the CommCenter call.provider block that "
+                 "carries the number in the clear.",
         "paths": None,
         "output_types": "standard",
         "artifact_icon": "phone",
+    },
+    "logarchive_dialed_numbers": {
+        "name": "logarchive dialed numbers",
+        "description": "Unified log entries from CommCenter and the Phone app: the "
+                       "call.provider setup block whose kPhoneNumber field holds a dialed "
+                       "number, the teardown block carrying the same kUuid, the "
+                       "Call(StatusUpdate) state chain, and MobilePhone "
+                       "ContactSearchManager entries whose message text holds the contents "
+                       "of the Phone app dial field",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-08-14",
+        "last_update_date": "2026-08-14",
+        "requirements": "logarchive module must be executed first",
+        "category": "Unified Logs",
+        "notes": "Patterns documented by Tim Korver, 'Recovering a dialed number from the "
+                 "Unified Log' "
+                 "(https://thesisfriday.com/thesis-friday-24-recovering-a-dialed-number-from-the-unified-log/), "
+                 "from six recordings on one iPhone 14 running iOS 26.6. Both families were "
+                 "observed here, on different images. kPhoneNumber: on an iOS 26.5.2 full "
+                 "file system image, three kActionType 0 blocks each carried a phone number "
+                 "in the clear in E.164 form, and each was followed by a kActionType 2 "
+                 "block with the same kUuid, matching the cited structure; kActionType "
+                 "values 1 and 7 also appeared there and are reported as stored, since no "
+                 "source read for this artifact defines them. Other call.provider entries "
+                 "on that image render caller id as <private>, so the kPhoneNumber block is "
+                 "where the value survived. ContactSearchManager: 752 entries on an iOS "
+                 "18.7 image, 301 of them the 'Searching for' and 'Search cancelled for' "
+                 "pairs, whose digit strings lengthen one step at a time up to a ten-digit "
+                 "value, as the cited research describes. Four images were swept for both "
+                 "families (iOS 16.5, 17.1, 18.7 and 26.5.2). Only the 26.5.2 one carried "
+                 "any kActionType block and only the 18.7 one carried ContactSearchManager, "
+                 "although call.provider activity was present on all four. That is a set of "
+                 "single-image observations, not an established version range, and no "
+                 "absence here is evidence the family is unavailable on that release. The "
+                 "cited research reports a setup block with no matching "
+                 "teardown as a dialed attempt, which does not establish that a call "
+                 "connected, and reports ContactSearchManager firing for digits entered on "
+                 "the device keypad but not for entry on a CarPlay screen; contact, Recents "
+                 "and Siri dialing were not tested there. A bare 'Searching for' predicate "
+                 "is deliberately not used: that text alone matched 808 unrelated records "
+                 "on the iOS 26.5.2 image, so the category is matched instead.",
+        "paths": None,
+        "output_types": "standard",
+        "artifact_icon": "phone-outgoing",
     },
     "logarchive_typing": {
         "name": "logarchive keyboard activity",
@@ -1027,6 +1073,19 @@ def logarchive_artifacts(context):
         OR event_message LIKE '%Received trusted open application request%'
         OR event_message LIKE '%Resuming to tab type%'
         OR event_message LIKE '%tab bar tab changed%'
+        -- logarchive_dialed_numbers. The whole call.provider category is collected
+        -- rather than a message pattern: the teardown block carries only kActionType
+        -- and kUuid, with no distinctive text to anchor on. On the iOS 26.5.2 image
+        -- the category held 328 records across three calls, and 1,482 records on the
+        -- iOS 18.7 image, so the volume is small either way. The sibling 'call'
+        -- category, 199 records on that image, carries the Call(StatusUpdate) state
+        -- chain the artifact reads plus the surrounding CommCenter call bookkeeping.
+        -- ContactSearchManager is matched by category for the same reason its message
+        -- text is not: 'Searching for' on its own matched 808 unrelated records on
+        -- the iOS 26.5.2 image.
+        OR category = 'call.provider'
+        OR category = 'call'
+        OR category = 'ContactSearchManager'
         -- logarchive_calls (keypad tones) and logarchive_typing (key sounds); the
         -- actionID space also carries other UI sounds, which stay in this table
         -- for context without a dedicated artifact
@@ -1502,6 +1561,24 @@ def logarchive_calls(context):
         OR event_message LIKE '%tab bar tab changed%'
         -- Keypad tones: actionID 1200-1209 map to keypad digits 0-9
         OR event_message LIKE '%Incoming Request : actionID 120%'
+    ''')
+
+@artifact_processor
+def logarchive_dialed_numbers(context):
+    # kActionType selects the setup and teardown blocks out of the call.provider
+    # narrative; Call(StatusUpdate) carries the state chain the cited research uses to
+    # separate a connected call from a dialed attempt. The rest of the category stays in
+    # the collection table for context.
+    #
+    # Every clause is scoped to the category on purpose. A bare '%kPhoneNumber%' also
+    # matches locationd's 'kPhoneNumberStatusNotification' under category Emergency,
+    # which carries no number: 7 such records on the iOS 16.5 image and 44 on the
+    # iOS 17.1 one, against 3 real setup blocks on the iOS 26.5.2 image.
+    return _artifacts_table_records(context, '''
+        (category = 'call.provider' AND event_message LIKE '%kPhoneNumber%')
+        OR (category = 'call.provider' AND event_message LIKE '%kActionType%')
+        OR (category = 'call' AND event_message LIKE '%Call(StatusUpdate)%')
+        OR category = 'ContactSearchManager'
     ''')
 
 @artifact_processor


### PR DESCRIPTION
Tim Korver's [Thesis Friday #24](https://thesisfriday.com/thesis-friday-24-recovering-a-dialed-number-from-the-unified-log/) shows the dialed number sitting unredacted in CommCenter's `call.provider` transaction block as `kPhoneNumber`, with `kUuid` pairing setup to teardown, and MobilePhone's `ContactSearchManager` logging the dial field on every change so the sequence reconstructs the digits going in one at a time. We collected none of it. `logarchive_calls` carried callservicesd tracking, Phone app open requests and keypad tone actionIDs, and its notes said number payloads redact to `<private>`.

## What this adds

A `logarchive dialed numbers` artifact covering the setup and teardown blocks, the `Call(StatusUpdate)` state chain the research uses to separate a connected call from a dialed attempt, and the `ContactSearchManager` entries. The master collection query gains three categories: `call.provider`, `call` and `ContactSearchManager`. The teardown block carries nothing but `kActionType` and `kUuid`, so there is no message text to anchor on, and the volume is small either way (328 and 199 records on the iOS 26.5.2 image, 1,482 `call.provider` on the iOS 18.7 one).

## Validation

Four corpora were swept with the bundled `unifiedlog_iterator`. Each one's record total matched its recorded `sample_data`, which is the harness check.

| Image | iOS | Log records | `call.provider` | `kActionType` blocks | `ContactSearchManager` |
|---|---|---:|---:|---:|---:|
| iPhone 8 Plus | 16.5 | 19,419,414 | 1,534 | 0 | 0 |
| iPhone 11 Pro | 17.1 | 30,362,747 | 172 | 0 | 0 |
| iPhone 12 | 18.7 | 20,491,691 | 1,482 | 0 | 752 |
| iPhone | 26.5.2 | 15,146,256 | 328 | 8 | 0 |

The iOS 26.5.2 image reproduces the published structure on a different device, iOS version and carrier region: three `kActionType: 0` blocks each carrying a number in the clear in E.164 form, each followed by a `kActionType: 2` block with the same `kUuid`. Values 1 and 7 also appear and are reported as stored, since no source read for this artifact defines them. The iOS 18.7 image reproduces the typing chain: 301 of its 752 `ContactSearchManager` entries are the `Searching for` and `Search cancelled for` pairs, digit strings lengthening one step at a time to a ten-digit value.

Full `ileapp.py` profile runs over the whole module: **29 rows on iOS 26.5.2** (8 transaction blocks plus 21 `Call(StatusUpdate)`) and **752 on iOS 18.7**, with the HTML page, TSV export, LAVA table and manifest entry all present and no parser errors.

Neither family appeared on the other's image. The notes state that as a set of single-image observations rather than a version range, and say no absence here shows a family is unavailable on that release.

## Why every clause is scoped to a category

The sweep found the loose alternative is wrong. A bare `%kPhoneNumber%` also matches locationd's `kPhoneNumberStatusNotification` under category `Emergency`, which carries no number at all: 7 of those on the iOS 16.5 image and 44 on the iOS 17.1 one, against 3 genuine setup blocks in the whole sweep. A bare `%Searching for%` matched 808 unrelated records on one image, none of them a dial field.

`Call(StatusUpdate)` also lives under category `call`, not `call.provider`. The first version of the predicate returned zero for it, and a full run is what exposed that.

## Tests

`admin/test/scripts/test_logarchive_native.py` gains a fixture covering both false-positive shapes and the four row shapes that should match. The test was proved by loosening the query back to a bare `%kPhoneNumber%` and confirming it fails.

`pylint --disable=C,R` 10.00/10, `check_claim_language.py` clean, 42 tests pass.

## Not cross-core

Only iLEAPP has a logarchive module. DLEAPP and RLEAPP reference the module name for artifact ordering only.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
