### PR TITLE
Pin the Session Interaction.Variant reference to a commit

### DIFF
--- a/scripts/artifacts/sessionIOS.py
+++ b/scripts/artifacts/sessionIOS.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "direction, author, conversation and body.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-10",
-        "last_update_date": "2026-08-10",
+        "last_update_date": "2026-08-15",
         "requirements": "none",
         "category": "Session",
         "notes": "Session for iOS keeps its database key in the iOS keychain, which is captured "
@@ -26,7 +26,8 @@ __artifacts_v2__ = {
                  "to the Session ID (the account's public key) where no profile is stored.\n"
                  "Reference: Session-iOS, 'Interaction.Variant (standardIncoming = 0, "
                  "standardOutgoing = 1, infoCall = 5000, ...)', "
-                 "https://github.com/session-foundation/session-ios/blob/master/"
+                 "https://github.com/session-foundation/session-ios/blob/"
+                 "7a3b2ba22477f22c301748f23c91165be62a84ef/"
                  "SessionMessagingKit/Database/Models/Interaction.swift. "
                  "Reference: SQLCipher documentation, 'cipher_plaintext_header_size', "
                  "https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_plaintext_header_size",


### PR DESCRIPTION
The session_messages notes cite the Session-iOS Interaction.swift source for the message variant values. The link pointed at the master branch, which keeps resolving while its content moves, so the reference could drift away from the definition it cites.

This repins the link to commit 7a3b2ba2 and bumps last_update_date. The pinned file was fetched back to confirm it defines standardIncoming = 0, standardOutgoing implicitly 1 right after it, and infoCall = 5000, matching what the notes state. The other variants the notes describe (deleted-message tombstones, group events, disappearing-messages updates, screenshot and media-saved notifications, message request acceptances, calls) are all present at that commit too. The commit is on the upstream master history. No parsing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)