### PR TITLE
Add TikTok Account and Snapchat Memories Search Index artifacts

### DIFF
--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -188,6 +188,39 @@ __artifacts_v2__ = {
             "ctf2020_ios12": "iOS 12.4 | 0 rows (store predates the snapchatter table)",
         },
     },
+    "snapchatGallerySearch": {
+        "name": "Snapchat - Memories Search Index",
+        "description": "Per-snap rows from the app's gallery_search index: the app's own "
+                       "time, location, visual and meta tags, caption text, and visual "
+                       "concept labels with their stored confidence values.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-16", "last_update_date": "2026-08-16",
+        "requirements": "none", "category": "Snapchat",
+        "notes": "search.sqlite3 (Documents/gallery_search/<n>/<account hash>/) is the "
+                 "index the app builds over Memories snaps so they can be searched. All "
+                 "values are app-generated tags reported as stored, not observations about "
+                 "the media itself: location tags are place-name strings (down to street "
+                 "level on the tested image), visual tags and concepts are the app's "
+                 "labels with their stored confidence, and the time tag is a date string.\n"
+                 "Tag rows live in FTS content tables keyed by docid; docid was verified "
+                 "equal to snap_id_table's rowid on the tested image by matching each "
+                 "row's visual tags against snap_visual_tag_conf_table for the same snap "
+                 "id. The snap id refers to a Memories entry; linking it to media files "
+                 "is not done here.",
+        "paths": ('*/mobile/Containers/Data/Application/*/Documents/gallery_search/*/search.sqlite3*',),
+        "output_types": "standard", "artifact_icon": "search",
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 13 rows",
+            "hickman_ios15": "iOS 15.3.1 | 13 rows",
+            "hickman_ios14": "iOS 14.3 | 9 rows",
+            "hickman_ios13": "iOS 13.3.1 | 11 rows",
+            "dexter_ios18": "iOS 18.3.2 | 2 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 1 row",
+            "abe_ios16": "iOS 16.5 | 1 row",
+            "otto_ios17": "iOS 17.5.1 | 0 rows (index tables empty)",
+            "iphone12_ios18": "iOS 18.7 | no gallery_search search.sqlite3 found",
+        },
+    },
     "snapchatAccount": {
         "name": "Snapchat - Account",
         "description": "Account values from the app's Documents/user.plist: username, user id, "
@@ -804,6 +837,48 @@ def snapchatFriends(context):
                               context.get_relative_path(doc_store)))
     data_headers = ('Username', 'Display Name', 'User ID', 'Mutable Username',
                     'Legacy Username', 'Source File')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def snapchatGallerySearch(context):
+    files_found = context.get_files_found()
+    data_list = []
+    source_path = ''
+    for search_db in sorted({str(f) for f in files_found if str(f).endswith('search.sqlite3')}):
+        source_path = source_path or search_db
+        source_file = context.get_relative_path(search_db)
+        concepts = {}
+        for snap_id, concept, confidence in _rows(search_db, '''
+                SELECT snap_id, concept, conf FROM snap_visual_tag_conf_table
+                ORDER BY snap_id, conf DESC'''):
+            if snap_id and concept:
+                rounded = f'{confidence:.3f}' if isinstance(confidence, float) else confidence
+                concepts.setdefault(snap_id, []).append(f'{concept} ({rounded})')
+        for row in _rows(search_db, '''
+                SELECT ids.snap_id, time_tags.time_tag, ids.language_id,
+                       location_clusters.cluster_name, visual_clusters.cluster_name,
+                       tags.c0time_tag, tags.c1location_tag, tags.c2visual_tag,
+                       tags.c3meta_tag, captions.c0caption
+                FROM snap_id_table AS ids
+                LEFT JOIN snap_tag_table_content AS tags ON tags.docid = ids.rowid
+                LEFT JOIN snap_description_table_content AS captions
+                    ON captions.docid = ids.rowid
+                LEFT JOIN snap_time_tag_table AS time_tags
+                    ON time_tags.snap_id = ids.snap_id
+                LEFT JOIN snap_location_tag_cluster_table AS location_clusters
+                    ON location_clusters.snap_id = ids.snap_id
+                LEFT JOIN snap_visual_tag_cluster_table AS visual_clusters
+                    ON visual_clusters.snap_id = ids.snap_id'''):
+            (snap_id, time_tag, language, location_cluster, visual_cluster,
+             time_tags, location_tags, visual_tags, meta_tags, caption) = row
+            data_list.append((
+                time_tag, snap_id, location_tags, location_cluster, visual_tags,
+                ', '.join(concepts.get(snap_id, [])), visual_cluster, meta_tags,
+                time_tags, caption, language, source_file))
+    data_headers = (('Time Tag', 'date'), 'Snap ID', 'Location Tags', 'Location Cluster',
+                    'Visual Tags', 'Visual Concepts (confidence)', 'Visual Cluster',
+                    'Meta Tags', 'Time Tags', 'Caption', 'Language', 'Source File')
     return data_headers, data_list, source_path
 
 

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -74,6 +74,41 @@ __artifacts_v2__ = {
             "magnet_ios16": "iOS 16.1.1 | TikTok 27.0.1 | 0 rows",
         },
     },
+    "tiktok_account": {
+        "name": "TikTok - Account",
+        "description": "Account values from the com.toutiao.account.userdefault.user record "
+                       "in the app's preferences plist, reported as stored under the app's "
+                       "own key names.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-16",
+        "last_update_date": "2026-08-16",
+        "requirements": "none",
+        "category": "TikTok",
+        "notes": (
+            "The record is an NSKeyedArchiver payload inside "
+            "Library/Preferences/com.zhiliaoapp.musically.plist; its string, number and "
+            "boolean fields are reported one per row and empty values are skipped. On the "
+            "tested image it carried the account's user id, screen name, sec user id, "
+            "avatar URL, session key, and the phone number and email as the app stores "
+            "them, which is partially masked. The sibling "
+            "com.toutiao.account.userdefault.user.* scalar keys (login status, dticket, "
+            "session ids) are included as rows. Other account caches in the same plist "
+            "(NHAccountManager*, AWEUserStorageCacheUserKey, kDYA*) duplicate server "
+            "profile responses and are not parsed."
+        ),
+        "paths": ("*/mobile/Containers/Data/Application/*/Library/Preferences/com.zhiliaoapp.musically.plist",),
+        "output_types": "standard",
+        "artifact_icon": "user",
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | TikTok 35.1.0 | 33 rows",
+            "otto_ios17": "iOS 17.5.1 | TikTok 35.6.0 | 24 rows",
+            "dexter_ios18": "iOS 18.3.2 | 23 rows",
+            "iphone12_ios18": "iOS 18.7 | 30 rows",
+            "abe_ios16": "iOS 16.5 | TikTok 30.0.0 | 32 rows",
+            "hickman_ios15": "iOS 15.3.1 | 32 rows",
+            "hickman_ios14": "iOS 14.3 | 22 rows",
+        },
+    },
     "tiktok_watch_history": {
         "name": "TikTok - Watch History",
         "description": "Entries from the app's WatchHistory store: one row per aid with a "
@@ -97,6 +132,9 @@ __artifacts_v2__ = {
         "artifact_icon": "eye",
         "sample_data": {
             "iphone11_ios17": "iOS 17.3 | TikTok 35.1.0 | 12 rows",
+            "otto_ios17": "iOS 17.5.1 | TikTok 35.6.0 | 1044 rows",
+            "abe_ios16": "iOS 16.5 | TikTok 30.0.0 | 1562 rows",
+            "hickman_ios15": "iOS 15.3.1 | 8 rows",
         },
     },
 }
@@ -107,9 +145,13 @@ from scripts.ilapfuncs import (
     artifact_processor,
     attach_sqlite_db_readonly,
     convert_unix_ts_to_utc,
+    get_plist_content,
+    get_plist_file_content,
     get_sqlite_db_records,
     logfunc,
 )
+
+_TIKTOK_ACCOUNT_KEY = "com.toutiao.account.userdefault.user"
 
 
 def _quote_identifier(identifier):
@@ -418,6 +460,40 @@ def tiktok_contacts(context):
     )
 
     return data_headers, data_list, "see Source File column"
+
+
+@artifact_processor
+def tiktok_account(context):
+    """ see artifact description """
+    files_found = context.get_files_found()
+    data_list = []
+    source_path = ""
+
+    for file_found in files_found:
+        file_found = str(file_found)
+        plist_content = get_plist_file_content(file_found)
+        if not isinstance(plist_content, dict) or _TIKTOK_ACCOUNT_KEY not in plist_content:
+            continue
+        source_path = source_path or file_found
+        source_file = context.get_relative_path(file_found)
+
+        account_blob = plist_content.get(_TIKTOK_ACCOUNT_KEY)
+        account = get_plist_content(account_blob) if isinstance(account_blob, bytes) else {}
+        if isinstance(account, dict):
+            for key in sorted(account):
+                value = account[key]
+                if isinstance(value, (str, int, float, bool)) and value != "":
+                    data_list.append((f"{_TIKTOK_ACCOUNT_KEY}: {key}", str(value), source_file))
+
+        for key in sorted(plist_content):
+            if not key.startswith(f"{_TIKTOK_ACCOUNT_KEY}."):
+                continue
+            value = plist_content[key]
+            if isinstance(value, (str, int, float, bool)) and value != "":
+                data_list.append((key, str(value), source_file))
+
+    data_headers = ("Key", "Value", "Source File")
+    return data_headers, data_list, source_path
 
 
 @artifact_processor


### PR DESCRIPTION
Two artifacts:

- TikTok - Account: the com.toutiao.account.userdefault.user record from the app's preferences plist (user id, screen name, sec user id, session key, avatar URL, phone and email as the app stores them), plus its sibling scalar keys. Values reported as stored under the app's own key names.
- Snapchat - Memories Search Index: per-snap rows from gallery_search/search.sqlite3 with the app's own time, location, visual and meta tags, caption text, and visual concepts with stored confidence. App-generated tags reported as stored.

Also records Watch History sample counts from three more corpora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)