### PR TITLE
Fix LAVA module name for Chrome Offline Pages

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1605,7 +1605,7 @@ def chromeOfflinePages(context):
             # Generate LAVA output
 
             category = "Chromium"
-            module_name = "chromeTopSites"
+            module_name = "chromeOfflinePages"
 
             table_name, object_columns, column_map = lava_process_artifact(category, module_name, report_name,
                                                                            lava_data_headers, len(data_list),


### PR DESCRIPTION
Fixes the LAVA module name for the Chrome Offline Pages artifact, which was set to `chromeTopSites`.

- The manifest entry for Offline Pages was attributed to the chromeTopSites module and took that artifact's `star` icon instead of its own `wifi-off`.
- The LAVA table name comes from `func_name`, which defaults to the report name, not from `module_name`, so rows were never written to the wrong table.

No corpus currently carries Offline Pages rows, so this was checked against a constructed `OfflinePages.db`. Rows land in `chrome_offline_pages` (2) and `chrome_top_sites` (1) both before and after. ALEAPP's Offline Pages module returns its data to the framework and sets no module name, so it is not affected.