### PR TITLE
Let test_module.py run again after the logdevinfo removal

### DIFF
--- a/admin/test/scripts/test_module.py
+++ b/admin/test/scripts/test_module.py
@@ -180,7 +180,7 @@ def process_artifact(zip_path, module_name, artifact_name, artifact_data, target
             }
 
         patches = [
-            patch('scripts.ilapfuncs.logdevinfo', mock_logdevinfo),
+            patch('scripts.ilapfuncs.logdevinfo', mock_logdevinfo, create=True),
             patch(f'scripts.artifacts.{module_name}.logdevinfo', mock_logdevinfo, create=True),
             patch(f'scripts.artifacts.{module_name}.logfunc', mock_logfunc, create=True),
             patch('scripts.lavafuncs.lava_db', mock_lava_db_instance),


### PR DESCRIPTION
Fixes the module test harness, which has not been able to run since `logdevinfo` was removed from `ilapfuncs.py`.

- `admin/test/scripts/test_module.py` patches `scripts.ilapfuncs.logdevinfo`. `mock.patch` refuses to patch a name that does not exist, so it raised `AttributeError` before any artifact ran, for every module. Nothing under `admin/test/results` could be regenerated.
- Adds `create=True`, matching how the same function is already patched in the artifact namespace on the next line.

CI did not catch it: the file matches `test_*.py` discovery but defines no TestCase classes, so unittest imports it and finds nothing to run.

Verified on groupMe, appleWifiPlist, celWireless, deviceDatam and deviceName. `device_info` is not mocked by the harness, and the modules that call it run fine, since it only writes to an in-memory dict.