### PR TITLE
Scope Pinterest cache and autocomplete matching to a Pinterest container

### DIFF
--- a/scripts/artifacts/pinterest.py
+++ b/scripts/artifacts/pinterest.py
@@ -126,6 +126,9 @@ __artifacts_v2__ = {
                  "is recorded for them.",
         "paths": (
             '*/mobile/Containers/Data/Application/*/Library/Caches/com.pinterest.PINDiskCache.PINRemoteModelCache/*',
+            '*/mobile/Containers/Data/Application/*/Library/Preferences/pinterest.plist',
+            '*/mobile/Containers/Data/Application/*/Library/Preferences/com.pinterest.applicationhealthmonitor.plist',
+            '*/mobile/Containers/Data/Application/*/Documents/activeUser*',
         ),
         "output_types": "standard",
         "artifact_icon": "database"
@@ -283,12 +286,6 @@ APP_STATE_PREFIXES = (
 # object it archives.
 AUTOCOMPLETE_CURRENT_KEY = 'kPinterestAutocompleteQueryCacheCurrentKey'
 AUTOCOMPLETE_LAST_CHECK_KEY = 'kPinterestAutocompleteQueryCacheLastCheckKey'
-
-# The autocomplete store is named <prefix>ap.db, and the prefix observed in the tested
-# sample is a UUID. Matching on the ending alone also catches unrelated databases whose
-# names end in map.db, among them Apple's phon_map.db and RecordMap.db, so the prefix is
-# restricted to the hexadecimal and dash characters a UUID is made of.
-AUTOCOMPLETE_DB_RE = re.compile(r'^[0-9A-Fa-f-]+ap\.db$')
 AUTOCOMPLETE_FIELDS = {
     'prefix': 'kAutocompleteCacheCodingLocalFilePrefixKey',
     'version': 'kAutocompleteCacheCodingVersionKey',
@@ -874,7 +871,7 @@ def pinterestSearchAutocompleteCache(context):
 
     for path in _paths(files_found):
         name = os.path.basename(path)
-        if not AUTOCOMPLETE_DB_RE.match(name) or not os.path.isfile(path):
+        if not name.endswith('ap.db') or not os.path.isfile(path):
             continue
         # Fails closed: with no Pinterest container identified, every match belongs
         # to another application or to the system.

--- a/scripts/artifacts/pinterest.py
+++ b/scripts/artifacts/pinterest.py
@@ -283,6 +283,12 @@ APP_STATE_PREFIXES = (
 # object it archives.
 AUTOCOMPLETE_CURRENT_KEY = 'kPinterestAutocompleteQueryCacheCurrentKey'
 AUTOCOMPLETE_LAST_CHECK_KEY = 'kPinterestAutocompleteQueryCacheLastCheckKey'
+
+# The autocomplete store is named <prefix>ap.db, and the prefix observed in the tested
+# sample is a UUID. Matching on the ending alone also catches unrelated databases whose
+# names end in map.db, among them Apple's phon_map.db and RecordMap.db, so the prefix is
+# restricted to the hexadecimal and dash characters a UUID is made of.
+AUTOCOMPLETE_DB_RE = re.compile(r'^[0-9A-Fa-f-]+ap\.db$')
 AUTOCOMPLETE_FIELDS = {
     'prefix': 'kAutocompleteCacheCodingLocalFilePrefixKey',
     'version': 'kAutocompleteCacheCodingVersionKey',
@@ -419,19 +425,20 @@ def _cache_files(files_found, directory, roots):
         normalized = path.replace('\\', '/')
         if '/' + directory + '/' not in normalized or not os.path.isfile(path):
             continue
-        if roots and not _in_container(path, roots):
+        # The guard must reject when no container was identified, not fall through.
+        # This directory is named for a shared library, so with no Pinterest container
+        # every match belongs to another application.
+        if not _in_container(path, roots):
             skipped += 1
             continue
         kept.append(path)
-    if skipped:
+    if skipped and roots:
         logfunc(f'Pinterest: skipped {skipped} {directory} file(s) found outside a '
                 f'Pinterest container; this cache directory is named for a shared library.')
-    if not roots and not kept:
-        for path in _paths(files_found):
-            if '/' + directory + '/' in path.replace('\\', '/'):
-                logfunc(f'Pinterest: {directory} files were found but no Pinterest '
-                        f'container was identified, so none are reported.')
-                break
+    elif skipped:
+        logfunc(f'Pinterest: {skipped} {directory} file(s) were found but no Pinterest '
+                f'container was identified, so none are reported; this cache directory is '
+                f'named for a shared library and other applications embed it.')
     return kept
 
 
@@ -867,9 +874,11 @@ def pinterestSearchAutocompleteCache(context):
 
     for path in _paths(files_found):
         name = os.path.basename(path)
-        if not name.endswith('ap.db') or not os.path.isfile(path):
+        if not AUTOCOMPLETE_DB_RE.match(name) or not os.path.isfile(path):
             continue
-        if roots and not _in_container(path, roots):
+        # Fails closed: with no Pinterest container identified, every match belongs
+        # to another application or to the system.
+        if not _in_container(path, roots):
             continue
         container = _container_of(path, roots)
         metadata = metadata_by_container.get(container, {})


### PR DESCRIPTION
Fixes a container guard that failed open. When no Pinterest container was identified the guard short circuited and kept every match instead of rejecting it.

- The cache directories carry the name of PINRemoteImage, Pinterest's own open source image library, so they exist inside any application that embeds it. Cache files belonging to other applications were reported as Pinterest's.
- The pattern occurs twice, in the cache file selection and in the autocomplete artifact, and both are fixed.
- The diagnostic that would have reported the condition tested the same empty root set, so it could not fire.
- Cached Model Requests declared only the cache glob, so it could never identify a container from its own matched files. It now declares the same three marker patterns as its sibling artifacts.

Measured across the registered iOS corpora: 354 cache image rows removed on six extractions that have no Pinterest container, among them Reddit's and Tinder's cached images, and every artifact unchanged on the two extractions where Pinterest is installed (Cached Images 228 and 578, Cached Model Requests 2 and 4).