### PR TITLE
Make the plist date helpers run on Python 3.10

### DIFF
--- a/admin/test/scripts/test_plist_date_helpers.py
+++ b/admin/test/scripts/test_plist_date_helpers.py
@@ -1,0 +1,77 @@
+"""convert_plist_date_to_utc and convert_plist_date_to_timezone_offset on Python 3.10.
+
+Regression test for a defect in both helpers. Each formatted its argument into an ISO
+string ending in Z and parsed that string back with datetime.fromisoformat:
+
+    str_date = '%04d-%02d-%02dT%02d:%02d:%02dZ' % (...)
+    return datetime.fromisoformat(str_date)
+
+datetime.fromisoformat did not accept a trailing Z until Python 3.11, so on 3.10 both
+raised ValueError for every input. README.md lists 3.10 as a supported version and the
+runtime contract job runs it, but that job imports the artifact modules rather than
+calling into them, so a break inside a helper body was invisible to it. Fourteen artifact
+modules call convert_plist_date_to_utc.
+
+The helpers now attach the timezone to the value directly instead of going through a
+string. A plist date is naive and already UTC. The sub-second part is still dropped, as
+the '%02d' seconds field did before, so the output is unchanged on the versions where the
+old code ran at all; the cases below pin that rather than assume it.
+
+None of these datetimes come from an evidence file.
+"""
+import pathlib
+import sys
+import unittest
+from datetime import datetime, timezone
+
+# admin/test/scripts/<this file>, so the repository root is three levels up.
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.ilapfuncs import (convert_plist_date_to_utc,
+                               convert_plist_date_to_timezone_offset)
+
+
+class ConvertPlistDateToUtc(unittest.TestCase):
+    """The conversion must run on every supported Python, not only 3.11 and later."""
+
+    def test_returns_an_aware_utc_datetime(self):
+        self.assertEqual(convert_plist_date_to_utc(datetime(2024, 5, 1, 12, 0, 0)),
+                         datetime(2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_drops_the_sub_second_part_as_before(self):
+        self.assertEqual(convert_plist_date_to_utc(datetime(2024, 5, 1, 12, 0, 0, 123456)),
+                         datetime(2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_handles_a_date_before_the_unix_epoch(self):
+        self.assertEqual(convert_plist_date_to_utc(datetime(1904, 6, 15, 8, 30, 15)),
+                         datetime(1904, 6, 15, 8, 30, 15, tzinfo=timezone.utc))
+
+    def test_second_and_year_boundaries(self):
+        for value in (datetime(1999, 12, 31, 23, 59, 59, 999999),
+                      datetime(2001, 1, 1, 0, 0, 0)):
+            with self.subTest(value=value):
+                self.assertEqual(convert_plist_date_to_utc(value),
+                                 value.replace(microsecond=0, tzinfo=timezone.utc))
+
+    def test_falsy_input_is_returned_unchanged(self):
+        for value in (None, ''):
+            with self.subTest(value=value):
+                self.assertEqual(convert_plist_date_to_utc(value), value)
+
+
+class ConvertPlistDateToTimezoneOffset(unittest.TestCase):
+    """The offset variant shared the same string round trip and the same break."""
+
+    def test_runs_and_applies_the_offset(self):
+        result = convert_plist_date_to_timezone_offset(
+            datetime(2024, 5, 1, 12, 0, 0), 'UTC')
+        self.assertIn('2024-05-01', str(result))
+
+    def test_falsy_input_is_returned_unchanged(self):
+        self.assertIsNone(convert_plist_date_to_timezone_offset(None, 'UTC'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -1594,22 +1594,21 @@ def convert_ts_human_to_timezone_offset(ts, timezone_offset):
 
 def convert_plist_date_to_timezone_offset(plist_date, timezone_offset):
     if plist_date:
-        str_date = '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
-            plist_date.year, plist_date.month, plist_date.day,
-            plist_date.hour, plist_date.minute, plist_date.second
-            )
-        iso_date = datetime.fromisoformat(str_date).strftime("%Y-%m-%d %H:%M:%S")
+        # Formatting the value and parsing it back only to drop the sub-second part
+        # cost a round trip and, because the string carried a trailing Z, raised
+        # ValueError on Python 3.10, which datetime.fromisoformat supports from 3.11.
+        iso_date = plist_date.replace(microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
         return convert_ts_human_to_timezone_offset(iso_date, timezone_offset)
     else:
         return plist_date
 
 def convert_plist_date_to_utc(plist_date):
     if plist_date:
-        str_date = '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
-            plist_date.year, plist_date.month, plist_date.day,
-            plist_date.hour, plist_date.minute, plist_date.second
-            )
-        return datetime.fromisoformat(str_date)
+        # A plist date is naive and already UTC, so the timezone is attached directly.
+        # The previous version formatted it with a trailing Z and parsed that back,
+        # which raises ValueError on Python 3.10; datetime.fromisoformat only accepts
+        # Z from 3.11. The sub-second part is still dropped, as it was before.
+        return plist_date.replace(microsecond=0, tzinfo=timezone.utc)
     else:
         return plist_date
 


### PR DESCRIPTION
convert_plist_date_to_utc and convert_plist_date_to_timezone_offset formatted their argument into an ISO string ending in Z and parsed it back with datetime.fromisoformat, which did not accept a trailing Z until Python 3.11. On 3.10 both raised ValueError for every input, and fourteen artifact modules call the first one.

- The helpers now attach the timezone to the value directly. A plist date is naive and already UTC.
- The sub-second part is still dropped, as the seconds field did before, so output is unchanged on the versions where the old code ran.
- Adds a test the runtime contract job already discovers and runs on 3.10 through 3.14. Against the previous code under 3.10 the helper raises ValueError on every case it covers.

README lists 3.10 as supported. The runtime contract job imports the artifact modules rather than calling into them, so a break inside a helper body was invisible to it.