### PR TITLE
Add Coinbase support for iOS

### DIFF
--- a/admin/test/scripts/test_mmkv_parser.py
+++ b/admin/test/scripts/test_mmkv_parser.py
@@ -1,0 +1,130 @@
+"""Pin the on-disk contract the MMKV reader depends on.
+
+MMKV is append-only between rewrites, so the same key appears more than once and the last
+entry is the live one. A reader that collapses to a dict without honouring that order
+reports a stale value as current, which looks exactly like a correct answer. It also writes
+a removal as a zero-length value rather than deleting the entry, so a naive reader turns a
+removed key into an empty string.
+
+The other trap is varint width. Lengths in these files are small, so a reader that caps the
+varint walk at the five bytes a 32-bit value needs will pass every test written against
+string keys and then silently mis-read a millisecond epoch, which needs six. That is what
+happened here, and it surfaced as a timestamp column holding raw bytes.
+
+Buffers are built by hand rather than taken from an extraction, so this test carries no
+sample data.
+"""
+import pathlib
+import struct
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.mmkv_parser import (  # pylint: disable=wrong-import-position
+    MMKVError,
+    decode_value,
+    read_dict,
+    read_entries,
+)
+
+
+def _varint(value):
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def _string_value(text):
+    encoded = text.encode('utf-8')
+    return _varint(len(encoded)) + encoded
+
+
+def _entry(key, container):
+    encoded_key = key.encode('utf-8')
+    return _varint(len(encoded_key)) + encoded_key + _varint(len(container)) + container
+
+
+def _store(*entries):
+    """An MMKV file is [u32 size][u32 crc][data][zero padding to the page size]."""
+    data = b''.join(entries)
+    return struct.pack('<II', len(data), 0) + data + b'\x00' * 64
+
+
+class MMKVParserTest(unittest.TestCase):
+
+    def _write(self, payload):
+        handle = tempfile.NamedTemporaryFile(suffix='.mmkv', delete=False)
+        handle.write(payload)
+        handle.close()
+        self.addCleanup(lambda: pathlib.Path(handle.name).unlink(missing_ok=True))
+        return handle.name
+
+    def test_reads_strings_and_scalars(self):
+        path = self._write(_store(
+            _entry('channel', _string_value('googleplay')),
+            _entry('version', _varint(33)),
+        ))
+        self.assertEqual(read_dict(path), {'channel': 'googleplay', 'version': 33})
+
+    def test_scalar_wider_than_32_bits_is_not_truncated(self):
+        """A millisecond epoch needs six varint bytes; a five-byte cap returns raw bytes."""
+        milliseconds = 1785482702086
+        path = self._write(_store(_entry('ts', _varint(milliseconds))))
+        self.assertEqual(read_dict(path), {'ts': milliseconds})
+
+    def test_last_entry_for_a_key_wins_and_earlier_ones_remain_visible(self):
+        path = self._write(_store(
+            _entry('checked', _string_value('')),
+            _entry('checked', _string_value('8.11.4')),
+        ))
+        self.assertEqual(
+            read_entries(path),
+            [('checked', _string_value('')), ('checked', _string_value('8.11.4'))])
+        self.assertEqual(read_dict(path), {'checked': '8.11.4'})
+
+    def test_zero_length_value_removes_the_key_rather_than_emptying_it(self):
+        path = self._write(_store(
+            _entry('token', _string_value('abc')),
+            _entry('token', b''),
+        ))
+        self.assertEqual(len(read_entries(path)), 2)
+        self.assertNotIn('token', read_dict(path))
+        self.assertIsNone(decode_value(b''))
+
+    def test_empty_string_is_kept_and_is_not_a_removal(self):
+        path = self._write(_store(_entry('note', _string_value(''))))
+        self.assertEqual(read_dict(path), {'note': ''})
+
+    def test_only_the_recorded_data_region_is_read(self):
+        """Bytes past the recorded size are stale or uninitialised, not live entries."""
+        live = _entry('live', _string_value('yes'))
+        stale = _entry('stale', _string_value('no'))
+        payload = struct.pack('<II', len(live), 0) + live + stale
+        self.assertEqual(read_dict(self._write(payload)), {'live': 'yes'})
+
+    def test_truncated_walk_keeps_what_was_read(self):
+        good = _entry('first', _string_value('kept'))
+        payload = struct.pack('<II', len(good) + 4, 0) + good + b'\x7f\x7f\x7f\x7f'
+        self.assertEqual(read_dict(self._write(payload)), {'first': 'kept'})
+
+    def test_short_file_and_oversized_size_field_raise(self):
+        with self.assertRaises(MMKVError):
+            read_entries(self._write(b'\x00\x01'))
+        with self.assertRaises(MMKVError):
+            read_entries(self._write(struct.pack('<II', 4096, 0) + b'\x01'))
+
+    def test_empty_store_reads_as_no_entries(self):
+        self.assertEqual(read_entries(self._write(struct.pack('<II', 0, 0))), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/coinbase.py
+++ b/scripts/artifacts/coinbase.py
@@ -1,0 +1,241 @@
+__artifacts_v2__ = {
+    "coinbase_wallets": {
+        "name": "Coinbase - Wallets and Balances",
+        "description": "Parses the Coinbase iOS wallet accounts and their balances from the "
+                       "app's offline GraphQL cache.",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
+        "creation_date": "2026-08-20",
+        "last_update_date": "2026-08-20",
+        "requirements": "none",
+        "category": "Coinbase",
+        "notes": "One row per wallet the account holds. Coinbase is a React Native app and "
+                 "keeps its state in an MMKV store, read here with the reader in "
+                 "scripts/mmkv_parser.py. Inside that store the @GraphqlOfflineCache.store "
+                 "value is a normalised Apollo cache: an account record links to its "
+                 "balances by reference, and each reference resolves to an amount record "
+                 "carrying a value and a currency. This artifact reports only the accounts "
+                 "whose balance reference resolves to such an amount, because the same cache "
+                 "holds hundreds of account records for currencies the user does not hold, "
+                 "which are the app's currency catalogue rather than the account's wallets; "
+                 "on the tested device 5 of 429 account records resolved to a balance. Total "
+                 "Balance and Available Balance are in the wallet's own currency and Native "
+                 "Balance is the same total in the account's display currency. Every balance "
+                 "was zero on the tested device, which records that the wallets existed and "
+                 "were empty rather than that the values could not be read. On the tested "
+                 "device every wallet was a primary account of type WALLET and none was marked "
+                 "sanctioned, so those three columns did not distinguish one wallet from another "
+                 "there. The account "
+                 "identifier is stored base64 encoded and is decoded here. Field mapping was "
+                 "done against a private sample provided by Mattia; no sample data is "
+                 "recorded for it.",
+        "paths": ('*/Documents/mmkv/CB_RRN_MMKV_STORAGE',),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "credit-card"
+    },
+    "coinbase_account": {
+        "name": "Coinbase - Account and Device",
+        "description": "Parses the Coinbase iOS account identifiers, login state and app "
+                       "settings from the app's MMKV store.",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
+        "creation_date": "2026-08-20",
+        "last_update_date": "2026-08-20",
+        "requirements": "none",
+        "category": "Coinbase",
+        "notes": "One row per app data directory. The values are top level keys of the "
+                 "app's MMKV store. Wallet Link User ID is the identifier the app records "
+                 "for the account. Logged In is the flag the app keeps for whether it "
+                 "expects to be signed in, reported as stored. Push Token is the notification "
+                 "token registered for the device. App Version is the version the store "
+                 "recorded. The number of wallets is counted from the same GraphQL cache the "
+                 "wallets artifact reads, so the two agree by construction. Field mapping was "
+                 "done against a private sample provided by Mattia; no sample data is "
+                 "recorded for it.",
+        "paths": ('*/Documents/mmkv/CB_RRN_MMKV_STORAGE',),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "user"
+    },
+}
+
+import base64
+import json
+import os
+
+from scripts.mmkv_parser import read_dict
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_STORE = 'CB_RRN_MMKV_STORAGE'
+_CACHE_KEY = '@GraphqlOfflineCache.store'
+
+
+def _stores(files_found):
+    '''Every copy of the app's MMKV store among the matched files.'''
+    seen = []
+    for found in files_found:
+        path = str(found)
+        if os.path.basename(path) == _STORE and path not in seen:
+            seen.append(path)
+    return seen
+
+
+def _read(path):
+    '''(top level dict, Apollo record map) for one MMKV store, or (None, None).'''
+    try:
+        top = read_dict(path)
+    except Exception as error:                   # pylint: disable=broad-except
+        logfunc(f'Coinbase: could not read the MMKV store: {error}')
+        return None, None
+    records = {}
+    cache = top.get(_CACHE_KEY)
+    if cache:
+        try:
+            records = json.loads(cache).get('recordMap', {})
+        except (TypeError, ValueError) as error:
+            logfunc(f'Coinbase: could not parse the offline GraphQL cache: {error}')
+    return top, records
+
+
+def _deref(records, value):
+    '''The record a single Apollo reference points at, or the value unchanged.'''
+    if isinstance(value, dict) and '__ref' in value:
+        return records.get(value['__ref'])
+    return value
+
+
+def _amount(records, value):
+    '''(value, currency) for a referenced amount record, or ('', '').'''
+    record = _deref(records, value)
+    if isinstance(record, dict) and 'value' in record:
+        return _text(record.get('value')), _text(record.get('currency'))
+    return '', ''
+
+
+def _text(value):
+    '''A stored value as text, with a stored null read as absent.'''
+    return '' if value is None else str(value)
+
+
+def _string(top, key):
+    '''A top level MMKV value with any surrounding JSON quotes removed.'''
+    value = top.get(key)
+    if isinstance(value, str) and len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    return _text(value)
+
+
+def _decode_id(identifier):
+    '''A base64 account identifier decoded to text, or the value unchanged.'''
+    try:
+        return base64.b64decode(identifier + '==').decode('utf-8')
+    except (ValueError, UnicodeDecodeError):
+        return identifier
+
+
+def _wallets(records):
+    '''The account records whose balance resolves to an amount.
+
+    The cache holds an account record for every currency the app can display, so a record
+    is a wallet the account actually holds only when its balance reference resolves to an
+    amount. That is what separates the account's wallets from the currency catalogue.
+    '''
+    wallets = []
+    for record in records.values():
+        if not (isinstance(record, dict) and record.get('__typename') == 'Account'):
+            continue
+        total = _deref(records, record.get('totalBalance'))
+        if isinstance(total, dict) and total.get('value') is not None:
+            wallets.append(record)
+    return wallets
+
+
+@artifact_processor
+def coinbase_wallets(context):
+    data_list = []
+    source_files = []
+
+    for path in _stores(context.get_files_found()):
+        _, records = _read(path)
+        if not records:
+            continue
+        relative = context.get_relative_path(path)
+        for account in _wallets(records):
+            total_value, total_currency = _amount(records, account.get('totalBalance'))
+            available_value, available_currency = _amount(records, account.get('availableBalance'))
+            native_value, native_currency = _amount(
+                records, account.get('totalBalanceInNativeCurrency'))
+            source_files.append(relative)
+            data_list.append((
+                _decode_id(_text(account.get('id'))),
+                _text(account.get('uuid')),
+                _text(account.get('type')),
+                _text(account.get('primary')),
+                total_value,
+                total_currency,
+                available_value,
+                available_currency,
+                native_value,
+                native_currency,
+                _text(account.get('isSanctioned')),
+                _text(account.get('platform')),
+                relative,
+            ))
+
+    data_headers = (
+        'Account',
+        'Currency',
+        'Type (as stored)',
+        'Primary',
+        'Total Balance',
+        'Total Balance Currency',
+        'Available Balance',
+        'Available Balance Currency',
+        'Native Balance',
+        'Native Balance Currency',
+        'Sanctioned (as stored)',
+        'Platform (as stored)',
+        'Source File',
+    )
+    return data_headers, data_list, '; '.join(sorted(set(source_files)))
+
+
+@artifact_processor
+def coinbase_account(context):
+    data_list = []
+    source_files = []
+
+    for path in _stores(context.get_files_found()):
+        top, records = _read(path)
+        if top is None:
+            continue
+        relative = context.get_relative_path(path)
+
+        push_token = ''
+        token_cache = top.get('@NotificationRegistrar.PushTokenCache')
+        if token_cache:
+            try:
+                push_token = json.loads(token_cache).get('token', '')
+            except (TypeError, ValueError):
+                push_token = ''
+
+        source_files.append(relative)
+        data_list.append((
+            _string(top, '@walletlink.user_id'),
+            _text(top.get('@OAUTH.IS_EXPECTED_TO_BE_LOGGED_IN')),
+            _string(top, '@UserVersion.version'),
+            _string(top, '@notifications.push_permissions_set_status'),
+            push_token,
+            len(_wallets(records)),
+            _string(top, '@cds_preferences.appearance'),
+            relative,
+        ))
+
+    data_headers = (
+        'Wallet Link User ID',
+        'Logged In (as stored)',
+        'App Version',
+        'Push Permission (as stored)',
+        'Push Token',
+        'Wallets Held',
+        'Appearance (as stored)',
+        'Source File',
+    )
+    return data_headers, data_list, '; '.join(sorted(set(source_files)))

--- a/scripts/mmkv_parser.py
+++ b/scripts/mmkv_parser.py
@@ -1,0 +1,154 @@
+"""MMKV key-value store reader.
+
+MMKV is Tencent's mmap-backed key-value store, used by a number of Android and
+iOS apps in place of SharedPreferences or NSUserDefaults
+(github.com/Tencent/MMKV, BSD-3-Clause). Its on-disk layout is small enough to
+read directly:
+
+    [0:4]   actual size of the data region, uint32 little-endian
+    [4:8]   CRC of the data region, uint32 little-endian
+    [8:8+actual_size]
+            the data region: entries laid end to end, each one
+                varint  key length
+                bytes   key, UTF-8
+                varint  value container length
+                bytes   value container
+    the remainder of the file is zero padding out to the mmap page size
+
+The value container is untyped on disk. MMKV records the type in the calling
+code, not in the file, so this module returns the raw container and leaves the
+reading to the caller. `decode_value` applies the one distinction that can be
+made from the bytes alone: a container that is exactly a varint length followed
+by that many bytes is how MMKV writes a string, and anything else is read as a
+varint scalar, which is how it writes the integer and boolean types.
+
+Two properties matter when reading one of these files as evidence.
+
+**The store is append-only between rewrites.** Setting a key appends a new
+entry rather than editing the existing one, so a key that has been changed
+appears more than once and the earlier entries are superseded values still
+present in the file. `read_entries` returns every entry in file order so those
+remain visible; `read_dict` collapses to the last occurrence, which is the value
+the app reads.
+
+**A zero-length container marks a removal**, not an empty string. `read_dict`
+drops those keys, matching what the app sees. They stay visible in
+`read_entries`.
+
+Nothing here decrypts. MMKV supports an AES-encrypted mode, and a store written
+that way will not produce readable keys; callers should treat an empty or
+garbage result as possibly encrypted rather than as an empty store.
+"""
+
+import struct
+
+
+class MMKVError(Exception):
+    """Raised when a file cannot be read as an MMKV store."""
+
+
+_HEADER_LENGTH = 8
+# Ten sevens covers a 64-bit value, which is the widest scalar MMKV writes.
+# A varint longer than that means the walk has lost alignment.
+_MAX_VARINT_BYTES = 10
+
+
+def _read_varint(data, offset):
+    """Return (value, new_offset) for the varint at offset."""
+    result = 0
+    shift = 0
+    for _ in range(_MAX_VARINT_BYTES):
+        if offset >= len(data):
+            raise MMKVError('varint runs past end of data')
+        byte = data[offset]
+        offset += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, offset
+        shift += 7
+    raise MMKVError('varint longer than 5 bytes')
+
+
+def read_entries(path):
+    """Return [(key, value_container_bytes)] in file order.
+
+    Every entry is returned, including repeats of the same key. Later entries
+    supersede earlier ones; see the module docstring.
+    """
+    with open(path, 'rb') as handle:
+        data = handle.read()
+
+    if len(data) < _HEADER_LENGTH:
+        raise MMKVError('file shorter than an MMKV header')
+
+    actual_size = struct.unpack_from('<I', data, 0)[0]
+    end = _HEADER_LENGTH + actual_size
+    if actual_size == 0:
+        return []
+    if end > len(data):
+        raise MMKVError('recorded data size runs past the end of the file')
+
+    entries = []
+    offset = _HEADER_LENGTH
+    while offset < end:
+        try:
+            key_length, offset = _read_varint(data, offset)
+            if key_length == 0 or offset + key_length > end:
+                break
+            key = data[offset:offset + key_length].decode('utf-8')
+            offset += key_length
+            value_length, offset = _read_varint(data, offset)
+            if offset + value_length > end:
+                break
+        except (MMKVError, UnicodeDecodeError):
+            # Alignment is lost, so nothing after this point can be trusted.
+            # Keep what was read rather than discarding the whole store.
+            break
+        entries.append((key, data[offset:offset + value_length]))
+        offset += value_length
+
+    return entries
+
+
+def decode_value(container):
+    """Decode a value container to a str or an int.
+
+    A container that is exactly a varint length followed by that many bytes is
+    how MMKV writes a string; anything else is read as a varint scalar, which
+    covers its integer and boolean types. Returns None for a removal marker,
+    and the raw bytes when neither reading applies.
+    """
+    if not container:
+        return None
+    try:
+        length, offset = _read_varint(container, 0)
+    except MMKVError:
+        return container
+    if offset + length == len(container):
+        try:
+            return container[offset:offset + length].decode('utf-8')
+        except UnicodeDecodeError:
+            return container[offset:offset + length]
+    try:
+        value, offset = _read_varint(container, 0)
+    except MMKVError:
+        return container
+    if offset == len(container):
+        return value
+    return container
+
+
+def read_dict(path):
+    """Return {key: decoded value} using the last occurrence of each key.
+
+    Removed keys are omitted. Use read_entries when the superseded values
+    matter.
+    """
+    result = {}
+    for key, container in read_entries(path):
+        value = decode_value(container)
+        if value is None:
+            result.pop(key, None)
+        else:
+            result[key] = value
+    return result


### PR DESCRIPTION
Adds Coinbase support for iOS. Two artifacts: wallets and balances, and account and device.

Coinbase is React Native and keeps its state in MMKV. This ports the MMKV reader and its test from ALEAPP, so no new dependency and iLEAPP CI guards the reader too.

The offline GraphQL cache is a normalised Apollo cache: an account links to its balances by reference. The wallets artifact reports only accounts whose balance reference resolves, because the cache also holds a record for every displayable currency (the catalogue, not the account's wallets). On the tested device 5 of 429 were real wallets, all zero balance.

The account artifact reads the wallet-link user id, login flag, push token and app version, and counts the wallets from the same cache. The account id is base64 and is decoded. Every store copy is read, proven against a two-container tree. A cached currency-quotes table was dropped as a downloaded catalogue.