### PR TITLE
Report real source paths in the located-at line

### DIFF
--- a/scripts/artifacts/biomeAirpMode.py
+++ b/scripts/artifacts/biomeAirpMode.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses airplane mode entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2020-04-30",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -81,6 +81,7 @@ def get_biomeAirpMode(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -92,6 +93,7 @@ def get_biomeAirpMode(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             offset = record.data_start_offset
             ts = record.timestamp1
@@ -112,6 +114,6 @@ def get_biomeAirpMode(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), ('Timestamp2', 'datetime'), 'SEGB State'
                     , 'Event', 'GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 
 

--- a/scripts/artifacts/biomeAppActivity.py
+++ b/scripts/artifacts/biomeAppActivity.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "such as note titles or map activity details.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The expiration timestamp was observed to be exactly 30 days after the record "
@@ -79,6 +79,7 @@ def _unix_double(value):
 def get_biomeAppActivity(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -90,6 +91,7 @@ def get_biomeAppActivity(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -125,4 +127,4 @@ def get_biomeAppActivity(context):
                     'Activity UUID', 'Session UUID', 'Source', 'Status (raw)', 'Filename',
                     'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeAppInstallation.py
+++ b/scripts/artifacts/biomeAppInstallation.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "App.Install and _DKEvent.App.Install streams.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The event type field takes values 1, 2 and 3 in the sample; which of install, "
@@ -67,6 +67,7 @@ def _unix_double(value):
 def get_biomeAppInstallation(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -78,6 +79,7 @@ def get_biomeAppInstallation(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -113,4 +115,4 @@ def get_biomeAppInstallation(context):
                     'Version', 'Build Version', 'Event Type (raw)', 'Digest 1', 'Digest 2',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeAppIntentsTranscript.py
+++ b/scripts/artifacts/biomeAppIntentsTranscript.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "example a Settings destination or a Focus filter target).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Each record also embeds an NSKeyedArchiver plist holding the full entity "
@@ -102,6 +102,7 @@ def _intent_details(intent):
 def get_biomeAppIntentsTranscript(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -113,6 +114,7 @@ def get_biomeAppIntentsTranscript(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -157,4 +159,4 @@ def get_biomeAppIntentsTranscript(context):
                     'SEGB State', 'Bundle ID', 'Intent Class', 'Parameters', 'Entity Types',
                     'Entity Titles', 'Phrase Template', 'App URL', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeAppLocationActivity.py
+++ b/scripts/artifacts/biomeAppLocationActivity.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
                        "source before relying on it.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Same NSUserActivity record shape as the App.Activity stream, extended with "
@@ -76,6 +76,7 @@ def _unix_double(value):
 def get_biomeAppLocationActivity(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -87,6 +88,7 @@ def get_biomeAppLocationActivity(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -125,4 +127,4 @@ def get_biomeAppLocationActivity(context):
                     'City', 'Postal Code', 'URL', 'Place URL', 'Payload', 'Donation Type',
                     'Activity UUID', 'Source', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeAppRelevantShortcuts.py
+++ b/scripts/artifacts/biomeAppRelevantShortcuts.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "the shortcut should appear in.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Each record embeds an NSKeyedArchiver plist holding the shortcut. The widget "
@@ -83,6 +83,7 @@ def _shortcut_detail(plist):
 def get_biomeAppRelevantShortcuts(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -94,6 +95,7 @@ def get_biomeAppRelevantShortcuts(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -127,4 +129,4 @@ def get_biomeAppRelevantShortcuts(context):
                     'Shortcut Role (raw)', 'Shortcut Title', 'Intent', 'Watch Template',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses app install entries from biomes",
        "author": "@JohnHyla, @Gear-I",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -106,6 +106,7 @@ def get_biomeAppinstall(context):
     }
 
     data_list = []
+    source_dirs = set()
 
     for file_found in context.get_files_found():
         file_found = str(file_found)
@@ -120,6 +121,7 @@ def get_biomeAppinstall(context):
         if 'tombstone' in file_found:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -202,6 +204,6 @@ def get_biomeAppinstall(context):
         'Offset'
     )
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 
 

--- a/scripts/artifacts/biomeAppleIntelligence.py
+++ b/scripts/artifacts/biomeAppleIntelligence.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
                        "the feature was evaluated for.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The three state fields are reported raw; the sample does not establish which "
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
                        "and the OS build at the time.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -57,7 +57,7 @@ __artifacts_v2__ = {
                        "of the feature is not established.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "In test data, this is the highest volume stream of the Apple Intelligence family.",
@@ -75,7 +75,7 @@ __artifacts_v2__ = {
                        "SoftwareUpdateController biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -94,7 +94,7 @@ __artifacts_v2__ = {
                        "even where the payload itself no longer survives.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The sample for this stream held only deleted records, so the written record "
@@ -117,7 +117,7 @@ __artifacts_v2__ = {
                        "the user id it was requested under.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -166,17 +166,23 @@ def _unix_double(value):
         return None
 
 
+def _stream_files(context):
+    """Non-hidden, non-tombstone stream files from the artifact's matched paths."""
+    for file_found in sorted(map(str, context.get_files_found())):
+        if os.path.basename(file_found).startswith('.'):
+            continue
+        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+            continue
+        yield file_found
+
+
+def _source_path(context):
+    return '\n'.join(sorted({os.path.dirname(f) for f in _stream_files(context)}))
+
+
 def _iter_records(context, label):
-    for file_found in sorted(context.get_files_found()):
-        file_found = str(file_found)
+    for file_found in _stream_files(context):
         filename = os.path.basename(file_found)
-        if filename.startswith('.'):
-            continue
-        if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
-                continue
-        else:
-            continue
 
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
@@ -223,7 +229,7 @@ def _delivery_log(context, label):
                           _to_str(event.get('7')), event.get('10', ''),
                           event.get('2', ''), str(result) if result else '',
                           filename, record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -243,7 +249,7 @@ def get_biomeAppleIntelligenceAvailability(context):
                           first.get('1', '') if isinstance(first, dict) else first,
                           second.get('1', '') if isinstance(second, dict) else second,
                           protostuff.get('3', ''), filename, record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor

--- a/scripts/artifacts/biomeAudioMediaRoutes.py
+++ b/scripts/artifacts/biomeAudioMediaRoutes.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
                        "Microphone / MicrophoneBuiltIn / iPhone Microphone).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field 6 distinguishes input from output routes in observed data (1 with "
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
                        "Bluetooth and AirPlay routes carry the accessory identifier and name.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -81,17 +81,23 @@ def _to_str(value):
     return str(value)
 
 
+def _stream_files(context):
+    """Non-hidden, non-tombstone stream files from the artifact's matched paths."""
+    for file_found in sorted(map(str, context.get_files_found())):
+        if os.path.basename(file_found).startswith('.'):
+            continue
+        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+            continue
+        yield file_found
+
+
+def _source_path(context):
+    return '\n'.join(sorted({os.path.dirname(f) for f in _stream_files(context)}))
+
+
 def _iter_records(context, label, typess=None):
-    for file_found in sorted(context.get_files_found()):
-        file_found = str(file_found)
+    for file_found in _stream_files(context):
         filename = os.path.basename(file_found)
-        if filename.startswith('.'):
-            continue
-        if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
-                continue
-        else:
-            continue
 
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
@@ -123,7 +129,7 @@ def get_biomeAudioRoute(context):
                           _to_str(protostuff.get('3', b'')), _to_str(protostuff.get('4', b'')),
                           protostuff.get('1', ''), protostuff.get('5', ''),
                           protostuff.get('6', ''), filename, record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -144,4 +150,4 @@ def get_biomeMediaRoute(context):
                           _to_str(detail.get('1', b'')), detail.get('2', ''),
                           detail.get('3', ''), protostuff.get('1', ''), filename,
                           record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)

--- a/scripts/artifacts/biomeAutonamingMessageIds.py
+++ b/scripts/artifacts/biomeAutonamingMessageIds.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "related to Messages conversation auto-naming (per the stream name).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Message GUIDs and Unix epoch double dates validated against sms.db (guid, date) "
@@ -71,6 +71,7 @@ def _unix_double(value):
 def get_biomeAutonamingMessageIds(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -82,6 +83,7 @@ def get_biomeAutonamingMessageIds(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -109,4 +111,4 @@ def get_biomeAutonamingMessageIds(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Message Timestamp', 'datetime'),
                     'SEGB State', 'Bundle ID', 'Chat ID', 'Message GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses backlight entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -40,6 +40,7 @@ def get_biomeBacklight(context):
     typess = {'1': {'type': 'double', 'name': ''}, '2': {'type': 'int', 'name': ''}}
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -51,6 +52,7 @@ def get_biomeBacklight(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -68,4 +70,4 @@ def get_biomeBacklight(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'State', 'Filename',
                     'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses battery percentage entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -78,6 +78,7 @@ def get_biomeBattperc(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -89,6 +90,7 @@ def get_biomeBattperc(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -116,5 +118,5 @@ def get_biomeBattperc(context):
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Battery Percentage', 'Action GUID',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses Bluetooth device entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Use caution when interpreting this artifact. Lists of Bluetooth devices have been "
@@ -43,6 +43,7 @@ from scripts.ilapfuncs import artifact_processor
 def get_biomeBluetooth(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -54,6 +55,7 @@ def get_biomeBluetooth(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -73,4 +75,4 @@ def get_biomeBluetooth(context):
 
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'MAC', 'Name', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeBootSession.py
+++ b/scripts/artifacts/biomeBootSession.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
                        "gap consistent with the device being powered off.",
         "author": "@abrignoni",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Session state 1 is the opening of a session and 0 its close, established by "
@@ -66,6 +66,7 @@ def _session_id(value):
 def get_biomeBootSession(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -77,6 +78,7 @@ def get_biomeBootSession(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -100,4 +102,4 @@ def get_biomeBootSession(context):
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Session State',
                     'Session State (raw)', 'Session ID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeCameraAutoFocusROI.py
+++ b/scripts/artifacts/biomeCameraAutoFocusROI.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "use and which camera port was in use.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Only the camera port (for example PortTypeBack) is self describing. The "
@@ -74,6 +74,7 @@ def _float32(value):
 def get_biomeCameraAutoFocusROI(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -85,6 +86,7 @@ def get_biomeCameraAutoFocusROI(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -114,4 +116,4 @@ def get_biomeCameraAutoFocusROI(context):
                     'Field 5 (raw)', 'Field 6 (raw)', 'Field 7 (raw)', 'Field 9 (raw)',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeCarplayisconnected.py
+++ b/scripts/artifacts/biomeCarplayisconnected.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses carplay is connected entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -77,6 +77,7 @@ def get_biomeCarplayisconnected(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -88,6 +89,7 @@ def get_biomeCarplayisconnected(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -114,4 +116,4 @@ def get_biomeCarplayisconnected(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Time Start', 'datetime'), ('Time End', 'datetime'),
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Status', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeClockAlarm.py
+++ b/scripts/artifacts/biomeClockAlarm.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Raw state values observed: 0, 1, 2 and 4. Published research states this "
@@ -61,6 +61,7 @@ def _to_str(value):
 def get_biomeClockAlarm(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -72,6 +73,7 @@ def get_biomeClockAlarm(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -94,4 +96,4 @@ def get_biomeClockAlarm(context):
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Alarm ID', 'State (raw)',
                     'Field 1 (raw)', 'Field 4 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeDKEventStreams.py
+++ b/scripts/artifacts/biomeDKEventStreams.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
                        "Bluetooth device) from the _DKEvent.Audio.InputRoute biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -33,7 +33,7 @@ __artifacts_v2__ = {
                        "Bluetooth routes carry the device MAC address and name.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
                        "Clock.Alarm stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Raw state values observed: 0, 1, 2 and 4. Published research states this "
@@ -74,7 +74,7 @@ __artifacts_v2__ = {
                        "_DKEvent.Device.IsLockedImputed biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "This is the imputed variant of the screen lock stream: the stream name "
@@ -94,7 +94,7 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -112,7 +112,7 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-08-15",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Value follows the UIDeviceOrientation enumeration (UIKit, defined in "
@@ -144,7 +144,7 @@ __artifacts_v2__ = {
                        "for each Siri interface session.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The event detail is carried in the metadata entries rather than the value "
@@ -168,7 +168,7 @@ __artifacts_v2__ = {
                        "_DKEvent.Settings.DoNotDisturb biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -283,6 +283,7 @@ def _parse(context, label, value_map):
                     ('End Timestamp', 'datetime'), 'SEGB State', 'Value', 'Value (raw)',
                     'Metadata', 'Event', 'GUID', 'Device UTC Offset', 'Filename', 'Offset')
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -294,6 +295,7 @@ def _parse(context, label, value_map):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -322,7 +324,7 @@ def _parse(context, label, value_map):
                 data_list.append((ts, None, None, record.state.name, None, None, None, None,
                                   None, None, filename, record.data_start_offset))
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 
 
 @artifact_processor

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses DKEvent InFocus Events from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -67,6 +67,7 @@ def get_biomeDKInfocus(context):
         '10': {'type': 'int', 'name': ''}}
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -78,6 +79,7 @@ def get_biomeDKInfocus(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -117,4 +119,4 @@ def get_biomeDKInfocus(context):
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Bundle ID', 'Transition', 'Action GUID',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeDKKeybag.py
+++ b/scripts/artifacts/biomeDKKeybag.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses DKEvent Keybag IsLocked entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2025-04-29",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -80,6 +80,7 @@ def get_biomeDKKeybag(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -91,6 +92,7 @@ def get_biomeDKKeybag(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -111,4 +113,4 @@ def get_biomeDKKeybag(context):
 
     data_headers = (('SEGB Timestamp', 'datetime'), ('Start Time', 'datetime'), ('End Time', 'datetime'), 'isLocked', 'Filename')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeDevTimeZone.py
+++ b/scripts/artifacts/biomeDevTimeZone.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "stream",
         "author": "Cynthia van Dorp, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-09",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -31,6 +31,7 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 def get_biomeDevTimeZone(context):
     typess = {'1': {'type': 'fixed64', 'name': ''}, '2': {'type': 'str', 'name': ''}}
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -42,6 +43,7 @@ def get_biomeDevTimeZone(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -58,4 +60,4 @@ def get_biomeDevTimeZone(context):
 
     data_headers = (('SEGB Timestamp', 'datetime'), 'Timezone', 'Filename')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses (device) WiFi connection entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -42,6 +42,7 @@ def get_biomeDevWifi(context):
     typess = {'1': {'type': 'str', 'name': 'SSID'}, '2': {'type': 'int', 'name': 'Connect'}}
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -54,6 +55,7 @@ def get_biomeDevWifi(context):
             continue
 
         stale_slots = 0
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -88,5 +90,5 @@ def get_biomeDevWifi(context):
 
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'SSID', 'Status', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 

--- a/scripts/artifacts/biomeDeviceMetadata.py
+++ b/scripts/artifacts/biomeDeviceMetadata.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "version/update history that can span years.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Observed builds spanning iOS 16 through 18 in test extractions (e.g. 20B110, "
@@ -58,6 +58,7 @@ def _to_str(value):
 def get_biomeDeviceMetadata(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -69,6 +70,7 @@ def get_biomeDeviceMetadata(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -95,4 +97,4 @@ def get_biomeDeviceMetadata(context):
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'OS Build',
                     'OS Build (Field 4)', 'Type (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
                        "Device.Display.InterfaceOrientation biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-08-15",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Value follows the UIInterfaceOrientation enumeration (UIKit, defined in "
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -67,7 +67,7 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Appears to be the modern counterpart of the _DKEvent.System.AirplaneMode "
@@ -86,7 +86,7 @@ __artifacts_v2__ = {
                        "Device.Wireless.CellularDataEnabled biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -104,7 +104,7 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Appears to be the modern counterpart of the _DKEvent.Carplay.IsConnected "
@@ -123,7 +123,7 @@ __artifacts_v2__ = {
                        "Device.Thermals.BatteryTemperature biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The raw value is temperature in hundredths of a degree Celsius (observed "
@@ -143,7 +143,7 @@ __artifacts_v2__ = {
                        "biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Lock polarity validated against the _DKEvent.Device.IsLockedImputed stream "
@@ -165,7 +165,7 @@ __artifacts_v2__ = {
                        "stream records its locked state over time.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Lock polarity validated against the _DKEvent.Keybag.IsLocked stream on the "
@@ -187,7 +187,7 @@ __artifacts_v2__ = {
                        "stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The level is a percentage stored as a double (observed range 1.0 to 100.0). "
@@ -207,7 +207,7 @@ __artifacts_v2__ = {
                        "Device.Power.PluggedIn biome stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-27",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field 3 is populated only while plugged in and is reported raw as its "
@@ -231,7 +231,7 @@ __artifacts_v2__ = {
                        "stream.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Both fields are reported raw: the sample data does not confirm which energy "
@@ -257,7 +257,7 @@ __artifacts_v2__ = {
                        "reading the switch position at startup).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Reasons observed: RingerSwitchEvent and 'MXSessionManager startup HID ringer "
@@ -320,18 +320,24 @@ def _to_str(value):
     return str(value)
 
 
+def _stream_files(context):
+    """Non-hidden, non-tombstone stream files from the artifact's matched paths."""
+    for file_found in sorted(map(str, context.get_files_found())):
+        if os.path.basename(file_found).startswith('.'):
+            continue
+        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+            continue
+        yield file_found
+
+
+def _source_path(context):
+    return '\n'.join(sorted({os.path.dirname(f) for f in _stream_files(context)}))
+
+
 def _records(context, label, typess=None):
     typess = TYPESS if typess is None else typess
-    for file_found in sorted(context.get_files_found()):
-        file_found = str(file_found)
+    for file_found in _stream_files(context):
         filename = os.path.basename(file_found)
-        if filename.startswith('.'):
-            continue
-        if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
-                continue
-        else:
-            continue
 
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
@@ -359,7 +365,7 @@ def _parse_state(context, label, value_map):
         raw = protostuff.get('1', '')
         data_list.append((ts, record.state.name, value_map.get(raw, ''), raw, filename,
                           record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -395,7 +401,7 @@ def get_biomeCarPlayConnected(context):
         raw = protostuff.get('1', '')
         data_list.append((ts, record.state.name, CONNECTED.get(raw, ''), raw,
                           protostuff.get('2', ''), filename, record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -412,7 +418,7 @@ def get_biomeBatteryTemperature(context):
         celsius = round(raw / 100, 2) if isinstance(raw, int) else ''
         data_list.append((ts, record.state.name, celsius, raw, protostuff.get('2', ''),
                           filename, record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -440,7 +446,7 @@ def get_biomeBatteryLevel(context):
             level = round(level, 2)
         data_list.append((ts, record.state.name, level, protostuff.get('2', ''), filename,
                           record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -458,7 +464,7 @@ def get_biomeDevicePluggedIn(context):
         data_list.append((ts, record.state.name, PLUGGED.get(raw, ''), raw,
                           protostuff.get('2', ''), protostuff.get('3', ''), filename,
                           record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -475,7 +481,7 @@ def get_biomeSilentMode(context):
         data_list.append((ts, record.state.name, SILENT.get(raw, ''), raw,
                           _to_str(protostuff.get('4', b'')), protostuff.get('2', ''), filename,
                           record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -490,4 +496,4 @@ def get_biomeEnergyMode(context):
             continue
         data_list.append((ts, record.state.name, protostuff.get('1', ''),
                           protostuff.get('2', ''), filename, record.data_start_offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses device plugged in entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "A record is written whenever the device is charging, which includes wireless "
@@ -104,6 +104,7 @@ def get_biomeDevplugin(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -115,6 +116,7 @@ def get_biomeDevplugin(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -140,4 +142,4 @@ def get_biomeDevplugin(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Time Start', 'datetime'), ('Time End', 'datetime'),
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Status', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeDiscoverabilitySignals.py
+++ b/scripts/artifacts/biomeDiscoverabilitySignals.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
                        "that accompanied it.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "A high volume stream: the sample held tens of thousands of records across "
@@ -66,6 +66,7 @@ def _raw_repr(value):
 def get_biomeDiscoverabilitySignals(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -77,6 +78,7 @@ def get_biomeDiscoverabilitySignals(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -107,4 +109,4 @@ def get_biomeDiscoverabilitySignals(context):
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Signal', 'Value',
                     'Payload', 'Signal (raw)', 'Context ID (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeEmergencyVoiceCall.py
+++ b/scripts/artifacts/biomeEmergencyVoiceCall.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "the serving network at the time of the call.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field mapped from a small private sample, so read the columns with that in "
@@ -65,6 +65,7 @@ def _to_str(value):
 def get_biomeEmergencyVoiceCall(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -76,6 +77,7 @@ def get_biomeEmergencyVoiceCall(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -105,4 +107,4 @@ def get_biomeEmergencyVoiceCall(context):
                     'Duration Seconds (unconfirmed)', 'Field 4 (raw)', 'Field 5 (raw)',
                     'Field 6 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeEmojiEngagement.py
+++ b/scripts/artifacts/biomeEmojiEngagement.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "joiner sequences stay visible in the report.",
         "author": "@abrignoni",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-26",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The context field decodes to a four character ASCII string that resembles a "
@@ -74,6 +74,7 @@ def _context_ascii(value):
 def get_biomeEmojiEngagement(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -85,6 +86,7 @@ def get_biomeEmojiEngagement(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -116,4 +118,4 @@ def get_biomeEmojiEngagement(context):
                     'Context (decoded)', 'Context (raw)', 'Field 2 (raw)', 'Field 4 (raw)',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
                        "presentation is not established.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "In sample data, records with an empty bundle id corresponded to system or "
@@ -75,6 +75,7 @@ def _unix_double(value):
 def get_biomeFrontBoardDisplayElement(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -86,6 +87,7 @@ def get_biomeFrontBoardDisplayElement(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -121,4 +123,4 @@ def get_biomeFrontBoardDisplayElement(context):
                     'Field 4 (raw)', 'Field 5 (raw)', 'Field 6 (raw)', 'Field 7 (raw)',
                     'Field 8 (raw)', 'Field 10 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeHardware.py
+++ b/scripts/artifacts/biomeHardware.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses hardware reliability entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -44,6 +44,7 @@ def get_biomeHardware(context):
     typess = {'1': {'type': 'str', 'name': ''}}
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -55,6 +56,7 @@ def get_biomeHardware(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -76,4 +78,4 @@ def get_biomeHardware(context):
 
     data_headers = (('SEGB Record Time', 'datetime'), 'SEGB State', 'Hardware', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses InFocus Events from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The Foreground/Background labels for values 1 and 0 are an interpretation of the App.InFocus stream name; other values are reported as stored.",
@@ -43,6 +43,7 @@ def get_biomeInfocus(context):
               '4': {'name': '', 'type': 'double'}, '6': {'name': '', 'type': 'str'}, '9': {'name': '', 'type': 'str'}}
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -54,6 +55,7 @@ def get_biomeInfocus(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -73,5 +75,5 @@ def get_biomeInfocus(context):
 
     data_headers = (('Timestamp', 'datetime'), ('Start Time', 'datetime'), 'SEGB State', 'Bundle ID', 'Action', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses app intent entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Each record is parsed independently: a record that cannot be decoded is "
@@ -262,6 +262,7 @@ def get_biomeIntents(context):
 
     data_list_html = []
     data_list = []
+    source_dirs = set()
     for file_found in files_found:
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -273,6 +274,7 @@ def get_biomeIntents(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             if record.state != EntryState.Written:
                 continue
@@ -290,4 +292,4 @@ def get_biomeIntents(context):
             data_list.append(row)
             data_list_html.append(row_html)
 
-    return data_headers, (data_list, data_list_html), 'see Filename for more info'
+    return data_headers, (data_list, data_list_html), '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeLocationVisit.py
+++ b/scripts/artifacts/biomeLocationVisit.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
                        "is relied on.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Timestamp reliability, observed in the sample data: every record in a stream "
@@ -95,6 +95,7 @@ def _rounded(value, digits):
 def get_biomeLocationVisit(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -106,6 +107,7 @@ def get_biomeLocationVisit(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -155,4 +157,4 @@ def get_biomeLocationVisit(context):
         'Vertical Accuracy', 'Confidence', 'Place Name', 'Place Address', 'Place Category',
         'Place ID', 'Visit ID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses location activity entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -117,6 +117,7 @@ def get_biomeLocationactivity(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -128,6 +129,7 @@ def get_biomeLocationactivity(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -204,4 +206,4 @@ def get_biomeLocationactivity(context):
                     ('Time Write', 'datetime'), 'SEGB State', 'Activity', 'Bundle ID','Bundle ID 2', 'Data 0', 'Data 1',
                     'Data 2', 'Data 3', 'Data 4', 'Data 5', 'Data 6', 'Action GUID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeNetworkingEdgeSelection.py
+++ b/scripts/artifacts/biomeNetworkingEdgeSelection.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "the Device.Networking.EdgeSelection biome stream",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Each record is a network-edge observation: the values are consistent with a "
@@ -65,6 +65,7 @@ def get_biomeNetworkingEdgeSelection(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -73,6 +74,7 @@ def get_biomeNetworkingEdgeSelection(context):
         if 'tombstone' in file_found:  # deletion bookkeeping, not edge observations
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             if record.state != EntryState.Written:
                 continue
@@ -99,4 +101,4 @@ def get_biomeNetworkingEdgeSelection(context):
                     'Prefix Length', 'Interface', 'Radio Technology', 'Field 6', 'Country',
                     'Time Zone', 'Filename')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeNotificationsPub.py
+++ b/scripts/artifacts/biomeNotificationsPub.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses notifications entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -47,6 +47,7 @@ def get_biomeNotificationsPub(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -58,6 +59,7 @@ def get_biomeNotificationsPub(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -86,5 +88,5 @@ def get_biomeNotificationsPub(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Field 1',
                     'Field 2','Field 3','Field 4','Field 5','Field 6', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses Now Playing entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -59,6 +59,7 @@ def get_biomeNowplaying(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -70,6 +71,7 @@ def get_biomeNowplaying(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -99,4 +101,4 @@ def get_biomeNowplaying(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Output',
                     'Media Type', 'Title', 'Artist', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomePhotosSearchInsights.py
+++ b/scripts/artifacts/biomePhotosSearchInsights.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "entered in the Photos app search.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Remaining fields were constant across the sample and are reported raw.",
@@ -60,6 +60,7 @@ def _to_str(value):
 def get_biomePhotosSearchInsights(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -71,6 +72,7 @@ def get_biomePhotosSearchInsights(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -99,4 +101,4 @@ def get_biomePhotosSearchInsights(context):
                     'Region', 'Schema Version', 'Field 1 (raw)', 'Field 5 (raw)',
                     'Field 25 (raw)', 'Field 26 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses safari entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -112,6 +112,7 @@ def get_biomeSafari(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -123,6 +124,7 @@ def get_biomeSafari(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -148,4 +150,4 @@ def get_biomeSafari(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Activity', 'Title',
                     'URL', 'Detail', 'Detail 2', 'Detail 3', 'GUID', "Filename", "Offset")
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSafariNavigations.py
+++ b/scripts/artifacts/biomeSafariNavigations.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
                        "matching History.db visits were gone.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The rounded timestamp is the record timestamp rounded up to the next 30 minute "
@@ -75,6 +75,7 @@ def _unix_double(value):
 def get_biomeSafariNavigations(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -86,6 +87,7 @@ def get_biomeSafariNavigations(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -113,4 +115,4 @@ def get_biomeSafariNavigations(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Rounded Timestamp (30 min)', 'datetime'),
                     'SEGB State', 'Host', 'URL', 'Country', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSafariWebPagePerformance.py
+++ b/scripts/artifacts/biomeSafariWebPagePerformance.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "complements Safari.Navigations and App.WebUsage.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Like Safari.Navigations, the second timestamp is rounded up to the next 30 "
@@ -64,6 +64,7 @@ def _unix_double(value):
 def get_biomeSafariWebPagePerformance(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -75,6 +76,7 @@ def get_biomeSafariWebPagePerformance(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -101,4 +103,4 @@ def get_biomeSafariWebPagePerformance(context):
                     'SEGB State', 'Detail (raw)', 'Field 3 (raw)', 'Field 4 (raw)',
                     'Field 5 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeShareSheetConversation.py
+++ b/scripts/artifacts/biomeShareSheetConversation.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "carries a contact handle for Messages shares.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The conversation identifier follows the service;-;handle form used elsewhere "
@@ -71,6 +71,7 @@ def _unix_double(value):
 def get_biomeShareSheetConversation(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -82,6 +83,7 @@ def get_biomeShareSheetConversation(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -108,4 +110,4 @@ def get_biomeShareSheetConversation(context):
                     'SEGB State', 'Bundle ID', 'Contact Handle', 'Conversation ID',
                     'Field 10 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "list of share targets that were offered.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "In tested data the candidate list contained bundle IDs of apps installed on "
@@ -64,6 +64,7 @@ def _to_str(value):
 def get_biomeShareSheetFeedback(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -75,6 +76,7 @@ def get_biomeShareSheetFeedback(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -106,4 +108,4 @@ def get_biomeShareSheetFeedback(context):
                     'Chosen Activity', 'Activity Type', 'Offered Candidates', 'Event UUID',
                     'Session ID', 'Field 17 (raw)', 'Field 20 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSiriRemembersAssistantSuggestions.py
+++ b/scripts/artifacts/biomeSiriRemembersAssistantSuggestions.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "unread mail.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Shares the intent record shape of the other Siri.Remembers streams, with the "
@@ -104,6 +104,7 @@ def _sync_origin(file_found):
 def get_biomeSiriRemembersAssistantSuggestions(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -116,6 +117,7 @@ def get_biomeSiriRemembersAssistantSuggestions(context):
             continue
         origin = _sync_origin(file_found)
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -147,4 +149,4 @@ def get_biomeSiriRemembersAssistantSuggestions(context):
                     'Intent Class', 'Metadata', 'Event ID', 'Sync Origin', 'Filename',
                     'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSiriRemembersAudioHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersAudioHistory.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "Audiobook and music playback were both observed in test data.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Shares the intent record shape of the other Siri.Remembers streams. The "
@@ -118,6 +118,7 @@ def _sync_origin(file_found):
 def get_biomeSiriRemembersAudioHistory(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -130,6 +131,7 @@ def get_biomeSiriRemembersAudioHistory(context):
             continue
         origin = _sync_origin(file_found)
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -163,4 +165,4 @@ def get_biomeSiriRemembersAudioHistory(context):
                     'Item ID', 'Intent Class', 'Intent UUID', 'Sync Origin', 'Filename',
                     'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSiriRemembersCallHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersCallHistory.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "and third party VoIP calls (WhatsApp, Messenger, LINE, imo and others observed).",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Direction and call timestamps validated against CallHistory.storedata (ZORIGINATED, "
@@ -114,6 +114,7 @@ def _sync_origin(file_found):
 def get_biomeSiriRemembersCallHistory(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -126,6 +127,7 @@ def get_biomeSiriRemembersCallHistory(context):
             continue
         origin = _sync_origin(file_found)
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -175,4 +177,4 @@ def get_biomeSiriRemembersCallHistory(context):
                     'Is Group', 'Conversation ID', 'Call GUID', 'Intent Class', 'Sync Origin',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "donated intents, with the app that donated them.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Shares the intent record schema of the Siri.Remembers.MessageHistory and "
@@ -111,6 +111,7 @@ def _sync_origin(file_found):
 def get_biomeSiriRemembersInteractionHistory(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -123,6 +124,7 @@ def get_biomeSiriRemembersInteractionHistory(context):
             continue
         origin = _sync_origin(file_found)
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -155,4 +157,4 @@ def get_biomeSiriRemembersInteractionHistory(context):
                     'SEGB State', 'Bundle ID', 'Intent Class', 'Domain', 'Parameters',
                     'Intent UUID', 'Item GUID', 'Sync Origin', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "message body content was present in the records examined.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Direction values and message timestamps validated against sms.db (is_from_me, date) "
@@ -115,6 +115,7 @@ def _sync_origin(file_found):
 def get_biomeSiriRemembersMessageHistory(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -127,6 +128,7 @@ def get_biomeSiriRemembersMessageHistory(context):
             continue
         origin = _sync_origin(file_found)
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -178,4 +180,4 @@ def get_biomeSiriRemembersMessageHistory(context):
                     'Recipient Handles', 'Group Name', 'Is Group', 'Chat ID', 'Message GUID',
                     'Intent Class', 'Sync Origin', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeSiriUI.py
+++ b/scripts/artifacts/biomeSiriUI.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
                        "being dismissed.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Dismissal reasons observed: HardwareButton, Punchout, Timeout and "
@@ -63,6 +63,7 @@ def _to_str(value):
 def get_biomeSiriUI(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -74,6 +75,7 @@ def get_biomeSiriUI(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -103,4 +105,4 @@ def get_biomeSiriUI(context):
                     'State (raw)', 'Dismissal Reason', 'Session ID', 'Related ID',
                     'Presentation (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeStreams.py
+++ b/scripts/artifacts/biomeStreams.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "(harvest time, the message date, subject, sender and recipient).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The message date comes from an embedded CFAbsoluteTime value; the harvest time is the SEGB "
@@ -30,7 +30,7 @@ __artifacts_v2__ = {
                        "stream (service and handle, message text, sender).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
                        "time it was read).",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Reference: Mattia Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
@@ -79,7 +79,7 @@ __artifacts_v2__ = {
                        "meaning is not documented and is reported as stored.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "The SEGB record timestamp is used; an embedded timestamp field in this stream is unreliable. "
@@ -102,7 +102,7 @@ __artifacts_v2__ = {
                        "with their frequency.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Some tokens are stored in a non-text form and appear blank. Reference: Mattia Epifani, "
@@ -171,16 +171,25 @@ def _cf_double_to_utc(value):
     return convert_cocoa_core_data_ts_to_utc(seconds)
 
 
-def _records(context):
-    """Yields (segb_ts_utc, state_name, decoded_message_or_None, filename, offset)
-    for each non-tombstone SEGB record across the matched stream files."""
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        if filename.startswith('.'):
+def _stream_files(context):
+    """Non-hidden, non-tombstone stream files from the artifact's matched paths."""
+    for file_found in map(str, context.get_files_found()):
+        if os.path.basename(file_found).startswith('.'):
             continue
         if not os.path.isfile(file_found) or 'tombstone' in file_found:
             continue
+        yield file_found
+
+
+def _source_path(context):
+    return '\n'.join(sorted({os.path.dirname(f) for f in _stream_files(context)}))
+
+
+def _records(context):
+    """Yields (segb_ts_utc, state_name, decoded_message_or_None, filename, offset)
+    for each non-tombstone SEGB record across the matched stream files."""
+    for file_found in _stream_files(context):
+        filename = os.path.basename(file_found)
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
             if record.state == EntryState.Written and record.data:
@@ -207,7 +216,7 @@ def biomeProactiveMail(context):
         data_list.append((ts, state, _cf_double_to_utc(message.get('3')), _txt(message.get('11')),
                           _header(message, 'from'), _header(message, 'to'), _txt(message.get('2')),
                           filename, offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -223,7 +232,7 @@ def biomeProactiveMessages(context):
         sender = _txt(sender.get('1')) if isinstance(sender, dict) else ''
         data_list.append((ts, state, _txt(message.get('2')), _txt(message.get('10')), sender,
                           _txt(message.get('1')), filename, offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -233,7 +242,7 @@ def biomeMessagesRead(context):
     for ts, state, message, filename, offset in _records(context):
         message_id = _txt(message.get('1')) if message else ''
         data_list.append((ts, state, message_id, filename, offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -247,7 +256,7 @@ def biomeScreenTimeAppUsage(context):
             continue
         event = _txt(message.get('1'))
         data_list.append((ts, state, _txt(message.get('3')), event, filename, offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)
 
 
 @artifact_processor
@@ -261,4 +270,4 @@ def biomeKeyboardTokens(context):
         token_field = message.get('1', {})
         token = _txt(token_field.get('1')) if isinstance(token_field, dict) else ''
         data_list.append((ts, state, token, _txt(message.get('3')), filename, offset))
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, _source_path(context)

--- a/scripts/artifacts/biomeSystemSettingsSearchTerms.py
+++ b/scripts/artifacts/biomeSystemSettingsSearchTerms.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "labels recorded with the search.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -50,6 +50,7 @@ def _to_str(value):
 def get_biomeSystemSettingsSearchTerms(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -61,6 +62,7 @@ def get_biomeSystemSettingsSearchTerms(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -100,4 +102,4 @@ def get_biomeSystemSettingsSearchTerms(context):
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Search Term',
                     'Result URI(s)', 'Result Label(s)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeTextinputses.py
+++ b/scripts/artifacts/biomeTextinputses.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses Text Input Session entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field meanings follow published research. Reference: Mattia Epifani, "
@@ -52,6 +52,7 @@ def get_biomeTextinputses(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -63,6 +64,7 @@ def get_biomeTextinputses(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -88,4 +90,4 @@ def get_biomeTextinputses(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Time Start', 'datetime'), 'SEGB State', 'Bundle ID', 'Duration',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses user activity metadata entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-07-25",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -46,6 +46,7 @@ def get_biomeUseractmeta(context):
 
     #typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'str', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'double', 'name': ''}}, 'name': ''}, '5': {'type': 'str', 'name': ''}, '8': {'type': 'double', 'name': ''}, '10': {'type': 'int', 'name': ''}}
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -57,6 +58,7 @@ def get_biomeUseractmeta(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -124,4 +126,4 @@ def get_biomeUseractmeta(context):
                     'Description', 'Bundle ID', 'Title', 'Bplist Data', 'Payload Data','Container Data', 'Filename',
                     'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "pass identifier and a per-transaction UUID.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Field mapped from a private sample of this stream; the stream is absent from "
@@ -61,6 +61,7 @@ def _to_str(value):
 def get_biomeWalletTransaction(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in sorted(context.get_files_found()):
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -72,6 +73,7 @@ def get_biomeWalletTransaction(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -100,4 +102,4 @@ def get_biomeWalletTransaction(context):
     data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'Card Name', 'Pass ID',
                     'Transaction UUID', 'Field 3 (raw)', 'Field 5 (raw)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeWifi.py
+++ b/scripts/artifacts/biomeWifi.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses DKEvent WiFi entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2025-10-31",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "",
@@ -83,6 +83,7 @@ def get_biomeWifi(context):
     }
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -94,6 +95,7 @@ def get_biomeWifi(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -117,4 +119,4 @@ def get_biomeWifi(context):
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Event', 'Device', 'GUID',
                     'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/cnaAutocompleteFeedback.py
+++ b/scripts/artifacts/cnaAutocompleteFeedback.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
                        "suggestion reason.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-30",
-        "last_update_date": "2026-07-30",
+        "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
         "notes": "Biome-format SEGB stream stored outside the Biome folder; location reported by Mattia Epifani. "
@@ -65,6 +65,7 @@ def _compact(value):
 def get_cnaAutocompleteFeedback(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
@@ -76,6 +77,7 @@ def get_cnaAutocompleteFeedback(context):
         else:
             continue
 
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
@@ -145,4 +147,4 @@ def get_cnaAutocompleteFeedback(context):
                     'Recipient Identifier', 'Conversation ID', 'Suggestion Reason', 'Group Name',
                     'Family Suggestion', 'Interaction Detail', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/privacyAccounting.py
+++ b/scripts/artifacts/privacyAccounting.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        'identifier shared by paired records, and the record kind.',
         'author': '@abrignoni, @mattiaepi (Mattia Epifani)',
         'creation_date': '2026-07-31',
-        'last_update_date': '2026-07-31',
+        'last_update_date': '2026-08-20',
         'requirements': 'none',
         'category': 'App Permissions',
         'notes': ('Biome-format SEGB v2 streams stored under PrivacyAccounting/Biome rather than '
@@ -42,7 +42,7 @@ __artifacts_v2__ = {
                        'process; entry timestamps record when the entries were written.',
         'author': '@abrignoni, @mattiaepi (Mattia Epifani)',
         'creation_date': '2026-07-31',
-        'last_update_date': '2026-07-31',
+        'last_update_date': '2026-08-20',
         'requirements': 'none',
         'category': 'App Permissions',
         'notes': ('Tombstone entries accompany pruning of the access streams: privacyaccountingd '
@@ -140,9 +140,11 @@ def _stream_files(context, tombstones):
 def privacyAccountingAccess(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in _stream_files(context, tombstones=False):
         stream = _stream_name(file_found)
         filename = os.path.basename(file_found)
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             if record.state not in (EntryState.Written, EntryState.Deleted):
                 continue
@@ -179,16 +181,18 @@ def privacyAccountingAccess(context):
                     'Client ID Type (as stored)', 'Service (as stored)', 'Kind (as stored)',
                     'Access ID', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))
 
 
 @artifact_processor
 def privacyAccountingTombstones(context):
 
     data_list = []
+    source_dirs = set()
     for file_found in _stream_files(context, tombstones=True):
         stream = _stream_name(file_found)
         filename = os.path.basename(file_found)
+        source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1.replace(tzinfo=timezone.utc)
 
@@ -222,4 +226,4 @@ def privacyAccountingTombstones(context):
                     'Field 2 (as stored)', 'Field 3 (as stored)', 'Field 4 (as stored)',
                     'Process', 'Field 6 (as stored)', 'Filename', 'Offset')
 
-    return data_headers, data_list, 'see Filename for more info'
+    return data_headers, data_list, '\n'.join(sorted(source_dirs))


### PR DESCRIPTION
Fixes #2015.

57 modules (the Biome family plus CNA Autocomplete Feedback and Privacy Accounting) returned the placeholder text 'see Filename for more info' as their source path, so the report's located-at line gave no location. Each artifact now reports the distinct parent directories of the stream files it actually parsed, as extraction-relative paths. The same value reaches the LAVA manifest.

Validated with a profile run against a real iOS 18.7 image: every artifact page shows its stream directory, row counts unchanged, and multi-directory artifacts list each directory.