### PR TITLE
Link image manifest entries to sample_data corpus keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ instance/
 # Personal Claude Code context, not shared with the team
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Per-machine image locations for make_test_data.py, see admin/docs/testing/guide_adding_images.md
+admin/image_manifest.local.json

--- a/admin/docs/testing/guide_adding_images.md
+++ b/admin/docs/testing/guide_adding_images.md
@@ -24,11 +24,9 @@ This guide outlines the process of adding a new test image to the LEAPP project'
 ```json
 {
   "image_name": "unique_image_name",
+  "sample_data_key": "corpus_key_used_in_sample_data",
   "description": "Brief description of the image and its contents",
-  "local_image_paths": [
-    "~/path/to/image/on/your/system.tar.gz",
-    "/alternative/path/to/image.zip"
-  ],
+  "published_file": "Image-Filename-As-Published.zip",
   "file_path_list": "admin/data/filepath-lists/your-image-name.csv.zip",
   "download_url": "https://example.com/download/link/for/image",
   "author": {
@@ -51,9 +49,31 @@ This guide outlines the process of adding a new test image to the LEAPP project'
 }
 ```
 
-5. **Verify Local Paths**:
-   - Ensure that at least one of the `local_image_paths` exists on your system.
-   - Add multiple paths to accommodate different contributor environments.
+   - `sample_data_key` is the corpus key artifacts cite in `sample_data` and in
+     [public_corpus_images.md](public_corpus_images.md). For new entries make it the same
+     string as `image_name`.
+   - `published_file` is the exact filename the publisher distributes, with no path.
+   - Manifest entries carry no machine-specific paths. Older entries still list
+     `local_image_paths` and those keep working, but do not add that field to new entries.
+
+5. **Record Your Local Path**:
+   - Machine-specific locations live in `admin/image_manifest.local.json`, which is
+     git-ignored. Map the image directly, or name folders to search for `published_file`:
+
+```json
+{
+  "image_paths": {
+    "unique_image_name": "~/phone-images/Image-Filename-As-Published.zip"
+  },
+  "search_roots": [
+    "~/phone-images"
+  ]
+}
+```
+
+   - `image_paths` keys can be either the `image_name` or the `sample_data_key`.
+   - A direct `image_paths` mapping is checked first and is the reliable option when your
+     copy is renamed or is the un-nested inner image rather than the published wrapper.
 
 6. **Commit Changes**:
    - Commit the updated `image_manifest.json` file to the repository.
@@ -66,6 +86,6 @@ This guide outlines the process of adding a new test image to the LEAPP project'
 
 ## Troubleshooting
 
-- If the `make_test_data.py` script fails to locate your image, check that at least one of the `local_image_paths` is correct for your system.
+- If the `make_test_data.py` script fails to locate your image, check your mapping in `admin/image_manifest.local.json`, and that the mapped file exists.
 - Ensure that the `file_path_list` points to a valid CSV zip file in the correct directory.
 

--- a/admin/docs/testing/public_corpus_images.md
+++ b/admin/docs/testing/public_corpus_images.md
@@ -111,10 +111,17 @@ genuinely useful contribution. See [guide_adding_images.md](guide_adding_images.
 
 ## Relationship to `image_manifest.json`
 
-[`admin/image_manifest.json`](../../image_manifest.json) is a different and narrower thing. It
-exists so `make_test_data.py` can find an image on a contributor's disk to generate committed test
-cases, and it covers four images. Its `image_name` values are an older vocabulary and do not match
-the `sample_data` keys:
+[`admin/image_manifest.json`](../../image_manifest.json) exists so `make_test_data.py` can find
+an image on a contributor's disk to generate committed test cases. Every publicly available
+image above has an entry, and every entry carries a `sample_data_key` field naming the corpus
+key used in `sample_data` and in this document, so `make_test_data.py --image` accepts either
+name. Keys from the non-public table stay out of the manifest deliberately: a manifest entry is
+a statement that the image can be obtained.
+
+Machine-specific locations do not live in the manifest. Record yours in the git-ignored
+`admin/image_manifest.local.json`; see [guide_adding_images.md](guide_adding_images.md). The
+four oldest entries keep their original `image_name` vocabulary and their committed
+`local_image_paths` for compatibility:
 
 | `image_manifest.json` `image_name` | `sample_data` key |
 | --- | --- |

--- a/admin/image_manifest.json
+++ b/admin/image_manifest.json
@@ -1,111 +1,376 @@
 {
-    "images": [
-      {
-        "image_name": "josh_ios15_ffs",
-        "description": "iPhone 8 extraction with sample data for testing",
-        "local_image_paths": [
-            "~/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
-            "~/Documents/phone-images/Josh/iOS_15_Public_Image.zip",
-            "/home/user/images/iphone_001.zip"
-        ],
-        "file_path_list": "admin/data/filepath-lists/josh-hickman-ios15.csv.zip",
-        "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
-        "author": {
-          "name": "Josh Hickman"
-        },
-        "image_info": {
-          "creation_date": "2023-05-20",
-          "os_name": "iPhone OS",
-          "os_version": "15.3.1",
-          "device_model": "iPhone 8",
-          "extraction_method": "Full Filesystem",
-          "extraction_tool": "Cellebrite"
-        },
-        "file_info": {
-          "file_count": 474300,
-          "md5_hash": "b1ec40d5cd835621326b821d6fa12ff5"
-        },
-        "notes": ""
+  "images": [
+    {
+      "image_name": "josh_ios15_ffs",
+      "sample_data_key": "hickman_ios15",
+      "description": "iPhone 8 extraction with sample data for testing",
+      "local_image_paths": [
+        "~/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+        "~/Documents/phone-images/Josh/iOS_15_Public_Image.zip",
+        "/home/user/images/iphone_001.zip"
+      ],
+      "file_path_list": "admin/data/filepath-lists/josh-hickman-ios15.csv.zip",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
       },
-      {
-        "image_name": "josh_ios17_ffs",
-        "description": "iPhone 11 extraction with sample data for testing; successor to the iOS 15 public image and carries the same third-party app set",
-        "local_image_paths": [
-            "~/Documents/phone-images/Josh/iOS_17_Public_Image.zip",
-            "/Volumes/Corpus/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip"
-        ],
-        "file_path_list": "admin/data/filepath-lists/josh-hickman-ios17.csv.zip",
-        "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
-        "author": {
-          "name": "Josh Hickman"
-        },
-        "image_info": {
-          "creation_date": "2024-07-28",
-          "os_name": "iPhone OS",
-          "os_version": "17.3",
-          "device_model": "iPhone 11",
-          "extraction_method": "Full Filesystem",
-          "extraction_tool": "Cellebrite"
-        },
-        "file_info": {
-          "file_count": 830298,
-          "md5_hash": ""
-        },
-        "notes": ""
+      "image_info": {
+        "creation_date": "2023-05-20",
+        "os_name": "iPhone OS",
+        "os_version": "15.3.1",
+        "device_model": "iPhone 8",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
       },
-      {
-        "image_name": "mvs_ios_2023",
-        "description": "Magnet Virtual Summit 2023 iOS image for forensic testing and training",
-        "local_image_paths": [
-            "~/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
-            "/home/user/images/magnet_mvs_2023_ios.zip",
-            "/Volumes/Corpus/iOS Extractions/00008101-0010541A1130001E_files_full-001.zip"
-        ],
-        "file_path_list": "admin/data/filepath-lists/magnet-mvs-2023-ios.csv.zip",
-        "download_url": "https://cfreds.nist.gov/all/MagnetForensics/MagnetVirtualSummit2023",
-        "author": {
-          "name": "Magnet Forensics",
-          "organization": "Magnet Forensics"
-        },
-        "image_info": {
-          "creation_date": "2023-01-01",
-          "os_name": "iPhone OS",
-          "os_version": "16.1.1",
-          "device_model": "Unknown",
-          "extraction_method": "Full Filesystem",
-          "extraction_tool": "Magnet"
-        },
-        "file_info": {
-          "file_count": 338104,
-          "md5_hash": "067606649297d7adcf6082e5ed0acbb9"
-        },
-        "notes": "Image from Magnet Virtual Summit 2023. Contains full file system data."
+      "file_info": {
+        "file_count": 474300,
+        "md5_hash": "b1ec40d5cd835621326b821d6fa12ff5"
       },
-      {
-        "image_name": "belkasoft_ctf6_ios_device1",
-        "description": "BelkaSoft CTF 6 iOS 16 Device 1 image for forensic analysis and competition",
-        "local_image_paths": [
-          "~/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar"
-        ],
-        "file_path_list": "admin/data/filepath-lists/belkasoft-ctf6-ios-dev1.csv.zip",
-        "download_url": "https://cfreds.nist.gov/all/Belkasoft/BelkaCTF6BogusBill",
-        "author": {
-          "name": "BelkaSoft",
-          "organization": "BelkaSoft"
-        },
-        "image_info": {
-          "creation_date": "2023-01-01",
-          "os_name": "iPhone OS",
-          "os_version": "16.3",  
-          "device_model": "Unknown",
-          "extraction_method": "Unknown",
-          "extraction_tool": "Unknown"
-        },
-        "file_info": {
-          "file_count": 65000,
-          "md5_hash": "0da3a6df28802cd19d41ef1fde884e7c"
-        },
-        "notes": "Image extracted from zip for BelkaSoft CTF 6, iOS Device 1. "
-      }
-    ]
-  }
+      "notes": "",
+      "published_file": "iOS_15_Public_Image.tar.gz"
+    },
+    {
+      "image_name": "josh_ios17_ffs",
+      "sample_data_key": "iphone11_ios17",
+      "description": "iPhone 11 extraction with sample data for testing; successor to the iOS 15 public image and carries the same third-party app set",
+      "local_image_paths": [
+        "~/Documents/phone-images/Josh/iOS_17_Public_Image.zip",
+        "/Volumes/Corpus/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip"
+      ],
+      "file_path_list": "admin/data/filepath-lists/josh-hickman-ios17.csv.zip",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
+      },
+      "image_info": {
+        "creation_date": "2024-07-28",
+        "os_name": "iPhone OS",
+        "os_version": "17.3",
+        "device_model": "iPhone 11",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
+      },
+      "file_info": {
+        "file_count": 830298,
+        "md5_hash": ""
+      },
+      "notes": "",
+      "published_file": "iOS_17_Public_Image.tar.gz"
+    },
+    {
+      "image_name": "mvs_ios_2023",
+      "sample_data_key": "magnet_ios16",
+      "description": "Magnet Virtual Summit 2023 iOS image for forensic testing and training",
+      "local_image_paths": [
+        "~/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+        "/home/user/images/magnet_mvs_2023_ios.zip",
+        "/Volumes/Corpus/iOS Extractions/00008101-0010541A1130001E_files_full-001.zip"
+      ],
+      "file_path_list": "admin/data/filepath-lists/magnet-mvs-2023-ios.csv.zip",
+      "download_url": "https://cfreds.nist.gov/all/MagnetForensics/MagnetVirtualSummit2023",
+      "author": {
+        "name": "Magnet Forensics",
+        "organization": "Magnet Forensics"
+      },
+      "image_info": {
+        "creation_date": "2023-01-01",
+        "os_name": "iPhone OS",
+        "os_version": "16.1.1",
+        "device_model": "Unknown",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Magnet"
+      },
+      "file_info": {
+        "file_count": 338104,
+        "md5_hash": "067606649297d7adcf6082e5ed0acbb9"
+      },
+      "notes": "Image from Magnet Virtual Summit 2023. Contains full file system data.",
+      "published_file": "00008101-0010541A1130001E_files_full-001.zip"
+    },
+    {
+      "image_name": "belkasoft_ctf6_ios_device1",
+      "sample_data_key": "belkactf6",
+      "description": "BelkaSoft CTF 6 iOS 16 Device 1 image for forensic analysis and competition",
+      "local_image_paths": [
+        "~/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar"
+      ],
+      "file_path_list": "admin/data/filepath-lists/belkasoft-ctf6-ios-dev1.csv.zip",
+      "download_url": "https://cfreds.nist.gov/all/Belkasoft/BelkaCTF6BogusBill",
+      "author": {
+        "name": "BelkaSoft",
+        "organization": "BelkaSoft"
+      },
+      "image_info": {
+        "creation_date": "2023-01-01",
+        "os_name": "iPhone OS",
+        "os_version": "16.3",
+        "device_model": "Unknown",
+        "extraction_method": "Unknown",
+        "extraction_tool": "Unknown"
+      },
+      "file_info": {
+        "file_count": 65000,
+        "md5_hash": "0da3a6df28802cd19d41ef1fde884e7c"
+      },
+      "notes": "Image extracted from zip for BelkaSoft CTF 6, iOS Device 1. ",
+      "published_file": "BelkaCTF_6_CASE240405_D201AP.zip"
+    },
+    {
+      "image_name": "ctf2020_ios12",
+      "sample_data_key": "ctf2020_ios12",
+      "description": "iOS 12.4. Magnet Forensics, Magnet Virtual Summit CTF 2020.",
+      "published_file": "2020 CTF - iOS.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Magnet Forensics"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "12.4"
+      },
+      "file_info": {
+        "md5_hash": "8134dfb212393099573ab5c3123172f3"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "hickman_ios13",
+      "sample_data_key": "hickman_ios13",
+      "description": "iOS 13.3.1. Josh Hickman, public images.",
+      "published_file": "ios_13_3_1.zip",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "13.3.1"
+      },
+      "file_info": {
+        "md5_hash": "6641ce1395d392661921cb0ca321e4b7"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "hickman_ios14",
+      "sample_data_key": "hickman_ios14",
+      "description": "iPhone SE, iOS 14.3. Josh Hickman, public images.",
+      "published_file": "iOS 14-3 - Apple iPhone SE.tar",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "14.3",
+        "device_model": "iPhone SE"
+      },
+      "file_info": {
+        "md5_hash": "7e7cb4d7e6204089758bf41d5d2c5efc"
+      },
+      "notes": "Published MD5 is of the published file and matches a held copy byte for byte. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "abe_ios16",
+      "sample_data_key": "abe_ios16",
+      "description": "iPhone X, iOS 16.5. Cellebrite CTF 2023 (\"Abe\").",
+      "published_file": "CellebriteCTF23_Abe_.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "16.5",
+        "device_model": "iPhone X",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
+      },
+      "file_info": {
+        "md5_hash": "e6aace42d05f400889bc9b9be31ceb46"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "felix23_ios16",
+      "sample_data_key": "felix23_ios16",
+      "description": "iPhone 8 Plus, iOS 16.5. Cellebrite CTF 2023 (\"Felix\").",
+      "published_file": "CellebriteCTF23_Felix.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "16.5",
+        "device_model": "iPhone 8 Plus",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
+      },
+      "file_info": {
+        "md5_hash": "996a913b1301ab011ca7dd8ca93a9400"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "hexordia_ios1651",
+      "sample_data_key": "hexordia_ios1651",
+      "description": "iOS 16.5.1. Hexordia, Magnet Virtual Summit CTF 2024.",
+      "published_file": "00008110-000925383620A01E_files_full.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Hexordia"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "16.5.1",
+        "extraction_method": "Full Filesystem"
+      },
+      "file_info": {
+        "md5_hash": "56ebd62968d37b67e656ad58eee7a985"
+      },
+      "notes": "Published MD5 is of the published file and matches a held copy byte for byte. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "cookbook_ios1751",
+      "sample_data_key": "cookbook_ios1751",
+      "description": "iOS 17.5.1. Cody Bounds, Digital Forensics Cookbook Datasets.",
+      "published_file": "Apple iOS.7z",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cody Bounds"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "17.5.1"
+      },
+      "file_info": {
+        "md5_hash": "374891eae84e4d380c632b9b47acbb9d"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md. Distributed as Apple iOS.7z; LEAPP reads the inner Apple iPhone.zip."
+    },
+    {
+      "image_name": "otto_ios17",
+      "sample_data_key": "otto_ios17",
+      "description": "iPhone 11 Pro, iOS 17.5.1. Cellebrite CTF 2024 (\"Otto\").",
+      "published_file": "CellebriteCTF24_Otto.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "17.5.1",
+        "device_model": "iPhone 11 Pro",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
+      },
+      "file_info": {
+        "md5_hash": "54e581d2209a62eb431b06cefd786b1a"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "felix_ios17",
+      "sample_data_key": "felix_ios17",
+      "description": "iPhone 8, iOS 17.6.1. Cellebrite CTF 2024 (\"Felix\").",
+      "published_file": "CellebriteCTF24_Felix.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "17.6.1",
+        "device_model": "iPhone 8",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
+      },
+      "file_info": {
+        "md5_hash": "986fb9022e9af1bf143126be4e65aaaf"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "iphone14plus_ios18",
+      "sample_data_key": "iphone14plus_ios18",
+      "description": "iPhone 14 Plus, iOS 18.0. Hexordia, Magnet Virtual Summit CTF 2026.",
+      "published_file": "iPhone14Plus.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Hexordia"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "18.0",
+        "device_model": "iPhone 14 Plus",
+        "extraction_method": "Full Filesystem"
+      },
+      "file_info": {
+        "md5_hash": "23075789fe93781a9a99e1db952f47c5"
+      },
+      "notes": "Published MD5 is of the published file and matches a held copy byte for byte. See admin/docs/testing/public_corpus_images.md. The published zip is a wrapper around 00008110-0008196A2299401E_files_full.zip. Hexordia's 2025 CTF acquisition of the same device uses the same inner filename with a different MD5, so check the hash rather than the filename."
+    },
+    {
+      "image_name": "iphone14plus_ios18_mvs2025",
+      "sample_data_key": "iphone14plus_ios18_mvs2025",
+      "description": "iPhone 14 Plus, iOS 18.0. Hexordia, Magnet Virtual Summit CTF 2025.",
+      "published_file": "00008110-0008196A2299401E_files_full.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Hexordia"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "18.0",
+        "device_model": "iPhone 14 Plus",
+        "extraction_method": "Full Filesystem"
+      },
+      "file_info": {
+        "md5_hash": "a8e9df3fc94c5c66f8ca8824773c0332"
+      },
+      "notes": "Published MD5 is of the published file and matches a held copy byte for byte. See admin/docs/testing/public_corpus_images.md. Same device serial as iphone14plus_ios18 but a distinct acquisition, published for the 2025 CTF under the same inner filename; check the hash rather than the filename."
+    },
+    {
+      "image_name": "dexter_ios18",
+      "sample_data_key": "dexter_ios18",
+      "description": "iPhone 16, iOS 18.3.2. Cellebrite CTF 2025 (\"Dexter King\").",
+      "published_file": "2025CellebriteCTF_DexterKing.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "18.3.2",
+        "device_model": "iPhone 16",
+        "extraction_method": "Full Filesystem",
+        "extraction_tool": "Cellebrite"
+      },
+      "file_info": {
+        "md5_hash": "4d455f968c61ec43960ab6b66b55ac4a"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    },
+    {
+      "image_name": "iphone12_ios18",
+      "sample_data_key": "iphone12_ios18",
+      "description": "iPhone 12, iOS 18.7. MSAB, Mobile Forensics Digital Summit CTF 2026.",
+      "published_file": "iPhone12.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "MSAB"
+      },
+      "image_info": {
+        "os_name": "iPhone OS",
+        "os_version": "18.7",
+        "device_model": "iPhone 12",
+        "extraction_method": "Full Filesystem"
+      },
+      "file_info": {
+        "md5_hash": "0e1d586e89098ec0ebc4e6c12852f462"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/testing/public_corpus_images.md."
+    }
+  ]
+}

--- a/admin/test/scripts/make_test_data.py
+++ b/admin/test/scripts/make_test_data.py
@@ -114,32 +114,98 @@ def expand_user_path(path):
     """
     return os.path.expanduser(path)
 
-def get_image_info(image_name):
-    """Finds an image in the manifest and validates its local path.
+LOCAL_CONFIG_FILENAME = 'image_manifest.local.json'
+
+def load_local_image_config(config_path=None):
+    """Loads the per-machine image location file, if present.
+
+    The manifest itself carries only machine-independent identity; where an
+    image lives on a given machine is recorded in a git-ignored
+    admin/image_manifest.local.json:
+
+        {
+          "image_paths": {"<image_name or sample_data_key>": "/path/to/image.zip"},
+          "search_roots": ["/path/to/a/folder/of/images"]
+        }
 
     Args:
-        image_name (str): The name of the image to look up.
+        config_path (str): Override for the config location (used by tests).
 
     Returns:
-        dict: The image's metadata dictionary from the manifest, with an
-              'input_file' key added for the validated local path.
-
-    Raises:
-        ValueError: If the image is not found in the manifest.
-        FileNotFoundError: If no valid local path for the image can be found.
+        dict: The parsed config, or an empty dict when the file is absent.
     """
-    manifest = load_image_manifest()
-    image_data = next((img for img in manifest if img['image_name'] == image_name), None)
-    if not image_data:
-        raise ValueError(f"Image '{image_name}' not found in manifest")
+    if config_path is None:
+        config_path = os.path.join(repo_root, 'admin', LOCAL_CONFIG_FILENAME)
+    if not os.path.exists(config_path):
+        return {}
+    with open(config_path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def resolve_image_path(image_data, local_config):
+    """Finds an existing local copy of a manifest image.
+
+    Tried in order: an explicit "image_paths" mapping in the local config
+    (keyed by image_name or sample_data_key), the entry's legacy
+    local_image_paths list, then each local config "search_roots" directory
+    walked for a file named exactly like the entry's published_file.
+
+    Args:
+        image_data (dict): One entry from the image manifest.
+        local_config (dict): Result of load_local_image_config().
+
+    Returns:
+        str: An existing path, or None when nothing resolves.
+    """
+    mapped = local_config.get('image_paths', {})
+    for key in (image_data.get('image_name'), image_data.get('sample_data_key')):
+        if key and key in mapped:
+            candidate = expand_user_path(mapped[key])
+            if os.path.exists(candidate):
+                return candidate
+            print(f"Warning: {LOCAL_CONFIG_FILENAME} maps '{key}' to a missing path: {candidate}")
 
     for path in image_data.get('local_image_paths', []):
         expanded_path = expand_user_path(path)
         if os.path.exists(expanded_path):
-            image_data['input_file'] = expanded_path
-            return image_data
+            return expanded_path
 
-    raise FileNotFoundError(f"No valid path found for image '{image_name}'. Please add your local path to the manifest.")
+    published = image_data.get('published_file')
+    if published:
+        for root in local_config.get('search_roots', []):
+            for dirpath, _dirnames, filenames in os.walk(expand_user_path(root)):
+                if published in filenames:
+                    return os.path.join(dirpath, published)
+    return None
+
+def get_image_info(image_name, config_path=None):
+    """Finds an image in the manifest and resolves its local path.
+
+    Args:
+        image_name (str): The image_name or sample_data_key to look up.
+        config_path (str): Override for the local config location (tests).
+
+    Returns:
+        dict: The image's metadata dictionary from the manifest, with an
+              'input_file' key added for the resolved local path.
+
+    Raises:
+        ValueError: If the image is not found in the manifest.
+        FileNotFoundError: If no local copy of the image can be found.
+    """
+    manifest = load_image_manifest()
+    image_data = next((img for img in manifest
+                       if image_name in (img.get('image_name'), img.get('sample_data_key'))), None)
+    if not image_data:
+        raise ValueError(f"Image '{image_name}' not found in manifest")
+
+    resolved = resolve_image_path(image_data, load_local_image_config(config_path))
+    if resolved:
+        image_data['input_file'] = resolved
+        return image_data
+
+    raise FileNotFoundError(
+        f"No local copy found for image '{image_name}'. Map it in admin/{LOCAL_CONFIG_FILENAME} "
+        "(see admin/docs/testing/guide_adding_images.md).")
 
 def read_filepath_list(file_path_list):
     """Reads a zipped CSV file containing a list of file paths from an image.

--- a/admin/test/scripts/test_image_manifest_resolution.py
+++ b/admin/test/scripts/test_image_manifest_resolution.py
@@ -1,0 +1,150 @@
+"""Tests for image location resolution in make_test_data.py.
+
+The image manifest carries machine-independent identity; locations come from a
+git-ignored admin/image_manifest.local.json or from an entry's legacy
+local_image_paths list. Everything here runs against temporary files, except
+the last class, which is a read-only structural check of the shipped manifest.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.append(os.path.dirname(__file__))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+
+import make_test_data  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class LoadLocalImageConfigTests(unittest.TestCase):
+    def test_missing_file_returns_empty_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, 'image_manifest.local.json')
+            self.assertEqual(make_test_data.load_local_image_config(missing), {})
+
+    def test_reads_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'image_manifest.local.json')
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump({'image_paths': {'a': '/x'}}, f)
+            self.assertEqual(make_test_data.load_local_image_config(path),
+                             {'image_paths': {'a': '/x'}})
+
+
+class ResolveImagePathTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmpdir = tmp.name
+        self.image_file = os.path.join(self.tmpdir, 'published_image.zip')
+        with open(self.image_file, 'wb') as f:
+            f.write(b'zip')
+
+    def test_direct_mapping_by_image_name(self):
+        entry = {'image_name': 'img_a', 'sample_data_key': 'key_a'}
+        config = {'image_paths': {'img_a': self.image_file}}
+        self.assertEqual(make_test_data.resolve_image_path(entry, config), self.image_file)
+
+    def test_direct_mapping_by_sample_data_key(self):
+        entry = {'image_name': 'img_a', 'sample_data_key': 'key_a'}
+        config = {'image_paths': {'key_a': self.image_file}}
+        self.assertEqual(make_test_data.resolve_image_path(entry, config), self.image_file)
+
+    def test_mapped_but_missing_path_falls_through(self):
+        entry = {'image_name': 'img_a',
+                 'local_image_paths': [self.image_file]}
+        config = {'image_paths': {'img_a': os.path.join(self.tmpdir, 'gone.zip')}}
+        self.assertEqual(make_test_data.resolve_image_path(entry, config), self.image_file)
+
+    def test_legacy_local_image_paths(self):
+        entry = {'image_name': 'img_a',
+                 'local_image_paths': [os.path.join(self.tmpdir, 'nope.zip'), self.image_file]}
+        self.assertEqual(make_test_data.resolve_image_path(entry, {}), self.image_file)
+
+    def test_search_roots_find_published_file_in_nested_dir(self):
+        nested = os.path.join(self.tmpdir, 'a', 'b')
+        os.makedirs(nested)
+        target = os.path.join(nested, 'nested_only.zip')
+        with open(target, 'wb') as f:
+            f.write(b'zip')
+        entry = {'image_name': 'img_a', 'published_file': 'nested_only.zip'}
+        config = {'search_roots': [self.tmpdir]}
+        self.assertEqual(make_test_data.resolve_image_path(entry, config), target)
+
+    def test_nothing_resolves(self):
+        entry = {'image_name': 'img_a', 'published_file': 'absent.zip'}
+        config = {'search_roots': [self.tmpdir]}
+        self.assertIsNone(make_test_data.resolve_image_path(entry, config))
+
+
+class GetImageInfoTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmpdir = tmp.name
+        self.image_file = os.path.join(self.tmpdir, 'img.zip')
+        with open(self.image_file, 'wb') as f:
+            f.write(b'zip')
+        self.config_path = os.path.join(self.tmpdir, 'image_manifest.local.json')
+        with open(self.config_path, 'w', encoding='utf-8') as f:
+            json.dump({'image_paths': {'key_a': self.image_file}}, f)
+        self.entry = {'image_name': 'legacy_name', 'sample_data_key': 'key_a'}
+
+    def test_lookup_by_sample_data_key_resolves(self):
+        with mock.patch.object(make_test_data, 'load_image_manifest',
+                               return_value=[dict(self.entry)]):
+            info = make_test_data.get_image_info('key_a', config_path=self.config_path)
+        self.assertEqual(info['input_file'], self.image_file)
+
+    def test_lookup_by_image_name_resolves(self):
+        with mock.patch.object(make_test_data, 'load_image_manifest',
+                               return_value=[dict(self.entry)]):
+            info = make_test_data.get_image_info('legacy_name', config_path=self.config_path)
+        self.assertEqual(info['input_file'], self.image_file)
+
+    def test_unknown_image_raises_value_error(self):
+        with mock.patch.object(make_test_data, 'load_image_manifest', return_value=[]):
+            with self.assertRaises(ValueError):
+                make_test_data.get_image_info('nope', config_path=self.config_path)
+
+    def test_unresolvable_image_raises_file_not_found(self):
+        entry = {'image_name': 'other', 'sample_data_key': 'key_b'}
+        with mock.patch.object(make_test_data, 'load_image_manifest', return_value=[entry]):
+            with self.assertRaises(FileNotFoundError):
+                make_test_data.get_image_info('key_b', config_path=self.config_path)
+
+
+class ShippedManifestTests(unittest.TestCase):
+    """Structural checks on the committed manifest (read-only)."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+        with open(os.path.join(repo_root, 'admin', 'image_manifest.json'),
+                  encoding='utf-8') as f:
+            cls.entries = json.load(f)['images']
+
+    def test_every_entry_has_unique_names_and_keys(self):
+        names = [e.get('image_name') for e in self.entries]
+        keys = [e.get('sample_data_key') for e in self.entries]
+        self.assertTrue(all(names) and all(keys))
+        self.assertEqual(len(names), len(set(names)))
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_every_entry_is_resolvable_in_principle(self):
+        for e in self.entries:
+            self.assertTrue(e.get('published_file') or e.get('local_image_paths'),
+                            f"{e.get('image_name')} has no published_file or local_image_paths")
+
+    def test_md5_values_are_lowercase_hex(self):
+        for e in self.entries:
+            md5 = (e.get('file_info') or {}).get('md5_hash')
+            if md5:
+                self.assertRegex(md5, r'^[0-9a-f]{32}$',
+                                 f"{e.get('image_name')} md5 not lowercase hex")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Connects `admin/image_manifest.json` to the corpus keys artifacts cite in `sample_data`.

- Every entry now carries a `sample_data_key`; the four existing entries are matched by recorded MD5s and paths.
- Adds the 13 other publicly available images, identity only: published filename, MD5 as published, source, device and OS.
- `make_test_data.py` resolves image locations from a git-ignored `admin/image_manifest.local.json` (direct mapping or search roots), keeps `local_image_paths` as a fallback, and `--image` accepts either name.
- Unit tests for the resolution order; testing docs updated.

Non-public corpus keys stay out of the manifest deliberately.
