### PR TITLE
Ask artifact PRs without test data for a fixture

### DIFF
--- a/.github/workflows/request_test_data.yml
+++ b/.github/workflows/request_test_data.yml
@@ -1,0 +1,35 @@
+name: Request Test Data
+
+# Asks external contributors for test data when a PR changes artifact modules
+# without any. pull_request_target so the comment can be posted on fork PRs;
+# safe here because the job checks out and runs only the base branch's code.
+# The contributor's files are fetched as text by the script and never executed.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'scripts/artifacts/**'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  request-test-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Check the PR for test data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python admin/scripts/check_pr_test_data.py

--- a/.github/workflows/request_test_data.yml
+++ b/.github/workflows/request_test_data.yml
@@ -22,6 +22,13 @@ jobs:
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
+        with:
+          # Blob-less fetch; the script needs only admin/ sources, not the
+          # committed test fixtures under admin/test/cases/data.
+          sparse-checkout: |
+            /*
+            !/admin/test/cases/data
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/admin/docs/testing/create_module_test_cases.md
+++ b/admin/docs/testing/create_module_test_cases.md
@@ -38,7 +38,7 @@ The script generates the following outputs:
 1. A JSON file containing test case metadata.
     - `admin/test/cases/testdata.<module_name>.json`
 2. Zip files for each artifact, containing the relevant test data files.
-    - `admin/test/cases/data/testdata.<module_name>.<artifact_name>.<case_key>.zip`
+    - `admin/test/cases/data/<module_name>/testdata.<module_name>.<artifact_name>.<case_key>.zip`
 
 ## Example
 

--- a/admin/scripts/check_pr_test_data.py
+++ b/admin/scripts/check_pr_test_data.py
@@ -26,7 +26,6 @@ print intended writes instead of performing them (reads still happen).
 import ast
 import json
 import os
-import sys
 import urllib.error
 import urllib.request
 from pathlib import Path

--- a/admin/scripts/check_pr_test_data.py
+++ b/admin/scripts/check_pr_test_data.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Comments on pull requests that change artifact modules without test data.
+
+Runs from .github/workflows/request_test_data.yml on pull_request_target, so
+the copy of this script that executes is always the one on the base branch,
+never the contributor's. The pull request's own code is fetched as text for
+ast parsing and is never imported or executed.
+
+Decision per changed artifact module:
+
+- the PR also touches admin/test/cases/testdata.<module>.json or anything
+  under admin/test/cases/data/<module>/  -> covered, nothing to ask
+- the module's __artifacts_v2__ sample_data (read at the PR head) cites a
+  corpus key present in admin/image_manifest.json -> a maintainer can
+  generate the fixture from the public image (fixture-needed label)
+- otherwise -> ask the contributor for a fixture (needs-test-data label)
+
+Authors with write or admin permission on the repository, and bot accounts,
+are skipped. The comment is sticky: one marker comment per PR, edited in
+place, including flipping to a resolved note once data arrives. This is a
+request, not a gate: the job succeeds whatever the outcome.
+
+Environment: GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER. Set DRY_RUN=1 to
+print intended writes instead of performing them (reads still happen).
+"""
+import ast
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "admin" / "image_manifest.json"
+MARKER = "<!-- leapp-test-data-check -->"
+LABEL_ASK = "needs-test-data"
+LABEL_FIXTURE = "fixture-needed"
+LABELS = {
+    LABEL_ASK: ("d93f0b", "Artifact PR without test data for the changed modules"),
+    LABEL_FIXTURE: ("c5def5", "Cites a public image; a maintainer can generate the fixture"),
+}
+API = "https://api.github.com"
+
+
+def api_request(token, url, method="GET", body=None, accept="application/vnd.github+json"):
+    """One GitHub API call; returns parsed JSON, raw text, or None on 404."""
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": accept,
+        "X-GitHub-Api-Version": "2022-11-28",
+    })
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+    except urllib.error.HTTPError as ex:
+        if ex.code == 404:
+            return None
+        raise RuntimeError(f"{method} {url} -> HTTP {ex.code}: {ex.read().decode()[:300]}") from ex
+    if accept.endswith("raw+json") or accept.endswith(".raw"):
+        return raw
+    return json.loads(raw) if raw else {}
+
+
+def paginate(token, url):
+    """Yields items from a paginated list endpoint."""
+    page = 1
+    sep = "&" if "?" in url else "?"
+    while True:
+        batch = api_request(token, f"{url}{sep}per_page=100&page={page}")
+        if not batch:
+            return
+        yield from batch
+        if len(batch) < 100:
+            return
+        page += 1
+
+
+def artifact_modules(files):
+    """{module_name: status} for artifact files the PR adds or changes."""
+    modules = {}
+    for f in files:
+        path, status = f["filename"], f["status"]
+        if status == "removed":
+            continue
+        parts = path.split("/")
+        if parts[:2] == ["scripts", "artifacts"] and len(parts) == 3 and path.endswith(".py"):
+            modules[parts[2][:-3]] = status
+    return modules
+
+
+def covered_modules(files, modules):
+    """Modules whose test data the same PR touches."""
+    covered = set()
+    for f in files:
+        if f["status"] == "removed":
+            continue
+        path = f["filename"]
+        for module in modules:
+            if (path == f"admin/test/cases/testdata.{module}.json"
+                    or path.startswith(f"admin/test/cases/data/{module}/")):
+                covered.add(module)
+    return covered
+
+
+def sample_data_keys_from_source(source_text):
+    """Corpus keys cited in a module's __artifacts_v2__ sample_data blocks.
+
+    Parsed with ast only; nothing is imported or executed. A module whose
+    metadata is not a literal yields no keys, which routes it to the full ask.
+    """
+    keys = set()
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return keys
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "__artifacts_v2__" for t in node.targets):
+            continue
+        try:
+            block = ast.literal_eval(node.value)
+        except ValueError:
+            continue
+        if isinstance(block, dict):
+            for info in block.values():
+                sample_data = info.get("sample_data") if isinstance(info, dict) else None
+                if isinstance(sample_data, dict):
+                    keys.update(k for k in sample_data if isinstance(k, str))
+    return keys
+
+
+def manifest_keys(manifest_path=MANIFEST_PATH):
+    """Every name the image manifest answers to (public images only)."""
+    with open(manifest_path, encoding="utf-8") as f:
+        entries = json.load(f)["images"]
+    names = set()
+    for e in entries:
+        names.update(filter(None, (e.get("image_name"), e.get("sample_data_key"))))
+    return names
+
+
+def classify(modules, covered, cited_by_module, public):
+    """Splits uncovered modules into (fixture_modules, ask_modules)."""
+    fixture, ask = {}, []
+    for module in sorted(modules):
+        if module in covered:
+            continue
+        cited = sorted(cited_by_module.get(module, set()) & public)
+        if cited:
+            fixture[module] = cited
+        else:
+            ask.append(module)
+    return fixture, ask
+
+
+def render_comment(repo, fixture, ask):
+    """The sticky comment body for the current state."""
+    doc = f"https://github.com/{repo}/blob/main/admin/docs/testing"
+    if not fixture and not ask:
+        return (f"{MARKER}\nTest data is now included for every changed artifact module. "
+                "Thank you!")
+    lines = [MARKER, "Thanks for the contribution!", ""]
+    if ask:
+        lines += [
+            "This PR changes artifact modules without test data for them. A small fixture "
+            "with each artifact change lets reviewers run the module against real data, and "
+            "the committed case keeps guarding the module after merge.", ""]
+    else:
+        lines += [
+            "The changed artifact modules cite public research images in their `sample_data`, "
+            "so a maintainer can generate the test fixtures from those images. Nothing is "
+            "needed from you, though you are welcome to add the fixtures yourself with "
+            "`admin/test/scripts/make_test_data.py`.", ""]
+    for module, cited in fixture.items():
+        cited_text = ", ".join(f"`{k}`" for k in cited)
+        lines.append(f"- `{module}.py`: cites {cited_text}; a maintainer can generate the fixture.")
+    for module in ask:
+        lines.append(f"- `{module}.py`: please include a fixture with this PR.")
+    if ask:
+        lines += [
+            "", "**Adding a fixture**", "",
+            "Generate it from your extraction with the helper (details in "
+            f"[create_module_test_cases.md]({doc}/create_module_test_cases.md)):", "",
+            "    python admin/test/scripts/make_test_data.py <module> --case <case_number> "
+            "--input <extraction.zip>", "",
+            "It writes `admin/test/cases/testdata.<module>.json` and one zip per artifact "
+            "under `admin/test/cases/data/<module>/`.", "",
+            "Size rules:", "",
+            "- Under 10 MB per zip: commit the files in this PR.",
+            "- 10 to 25 MB: commit the case JSON in the PR and attach the zip to a comment here.",
+            "- Over 25 MB: say so here and a maintainer will arrange a handoff.", "",
+            "If your extraction cannot be shared:", "",
+            "- If the app appears on a public research image, generate the fixture from that "
+            f"instead. [public_corpus_images.md]({doc}/public_corpus_images.md) lists the "
+            "images and where to download them.",
+            "- Or sanitize the real file in place: keep the file the app wrote and overwrite "
+            "only the personal values, which keeps the format honest.",
+            "- Or script a known session: install the app on a test device with a throwaway "
+            "account, perform documented actions, and extract that.", "",
+            "If none of those fit, say so here and we will work it out. The PR can still be "
+            "reviewed and merged with the gap recorded in the artifact's `notes`.", "",
+            "This is a request, not a gate. Nothing here blocks review."]
+    return "\n".join(lines)
+
+
+def desired_labels(fixture, ask):
+    labels = set()
+    if fixture:
+        labels.add(LABEL_FIXTURE)
+    if ask:
+        labels.add(LABEL_ASK)
+    return labels
+
+
+def find_marker_comment(token, repo, pr_number):
+    for comment in paginate(token, f"{API}/repos/{repo}/issues/{pr_number}/comments"):
+        if MARKER in comment.get("body", ""):
+            return comment
+    return None
+
+
+def author_permission(token, repo, login):
+    """Repo permission for a user: admin, write, read, or none."""
+    result = api_request(token, f"{API}/repos/{repo}/collaborators/{login}/permission")
+    return (result or {}).get("permission", "none")
+
+
+def apply_state(token, repo, pr_number, body, labels, dry_run):
+    """Upserts the sticky comment and reconciles our two labels."""
+    existing = find_marker_comment(token, repo, pr_number)
+    resolved = not labels
+    if dry_run:
+        print(f"DRY_RUN: would {'edit' if existing else 'create'} comment; labels -> {sorted(labels)}")
+        print("---- comment body ----")
+        print(body)
+        return
+    if existing:
+        if existing["body"] != body:
+            api_request(token, f"{API}/repos/{repo}/issues/comments/{existing['id']}",
+                        method="PATCH", body={"body": body})
+    elif not resolved:
+        # Never open a resolved-state comment on a PR that was never asked.
+        api_request(token, f"{API}/repos/{repo}/issues/{pr_number}/comments",
+                    method="POST", body={"body": body})
+    current = {l["name"] for l in api_request(token, f"{API}/repos/{repo}/issues/{pr_number}") ["labels"]}
+    for name in labels - current:
+        if api_request(token, f"{API}/repos/{repo}/labels/{name}") is None:
+            color, description = LABELS[name]
+            api_request(token, f"{API}/repos/{repo}/labels", method="POST",
+                        body={"name": name, "color": color, "description": description})
+        api_request(token, f"{API}/repos/{repo}/issues/{pr_number}/labels",
+                    method="POST", body={"labels": [name]})
+    for name in (current & set(LABELS)) - labels:
+        api_request(token, f"{API}/repos/{repo}/issues/{pr_number}/labels/{name}", method="DELETE")
+
+
+def main():
+    token = os.environ["GITHUB_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pr_number = int(os.environ["PR_NUMBER"])
+    dry_run = os.environ.get("DRY_RUN") == "1"
+
+    pr = api_request(token, f"{API}/repos/{repo}/pulls/{pr_number}")
+    login = pr["user"]["login"]
+    if login.endswith("[bot]"):
+        print(f"Author {login} is a bot; skipping.")
+        return
+    permission = author_permission(token, repo, login)
+    if permission in ("admin", "write"):
+        print(f"Author {login} has {permission} access; skipping.")
+        if not dry_run:
+            return
+        print("DRY_RUN: continuing anyway to show the decision.")
+
+    files = list(paginate(token, f"{API}/repos/{repo}/pulls/{pr_number}/files"))
+    modules = artifact_modules(files)
+    if not modules:
+        print("No artifact modules added or changed; nothing to do.")
+        return
+    covered = covered_modules(files, modules)
+
+    cited_by_module = {}
+    contents_by_module = {f["filename"].split("/")[2][:-3]: f.get("contents_url")
+                          for f in files if f["filename"].startswith("scripts/artifacts/")}
+    for module in modules:
+        if module in covered:
+            continue
+        url = contents_by_module.get(module)
+        source = api_request(token, url, accept="application/vnd.github.raw+json") if url else None
+        cited_by_module[module] = sample_data_keys_from_source(source or "")
+
+    fixture, ask = classify(modules, covered, cited_by_module, manifest_keys())
+    print(f"modules: {sorted(modules)}  covered: {sorted(covered)}  "
+          f"fixture: {sorted(fixture)}  ask: {ask}")
+    body = render_comment(repo, fixture, ask)
+    apply_state(token, repo, pr_number, body, desired_labels(fixture, ask), dry_run)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/admin/test/scripts/test_check_pr_test_data.py
+++ b/admin/test/scripts/test_check_pr_test_data.py
@@ -1,0 +1,144 @@
+"""Tests for the pure logic in admin/scripts/check_pr_test_data.py.
+
+The GitHub API layer is not exercised here; these cover file classification,
+sample_data extraction from source text, the decision matrix, and the comment
+rendering, all against synthetic inputs.
+"""
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts')))
+
+import check_pr_test_data as bot  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _files(*pairs):
+    return [{'filename': name, 'status': status} for name, status in pairs]
+
+
+class ArtifactModulesTests(unittest.TestCase):
+    def test_added_and_modified_artifacts_counted(self):
+        files = _files(('scripts/artifacts/foo.py', 'added'),
+                       ('scripts/artifacts/bar.py', 'modified'),
+                       ('scripts/ilapfuncs.py', 'modified'),
+                       ('README.md', 'modified'))
+        self.assertEqual(bot.artifact_modules(files), {'foo': 'added', 'bar': 'modified'})
+
+    def test_removed_artifacts_ignored(self):
+        files = _files(('scripts/artifacts/gone.py', 'removed'))
+        self.assertEqual(bot.artifact_modules(files), {})
+
+    def test_non_python_and_nested_paths_ignored(self):
+        files = _files(('scripts/artifacts/notes.md', 'added'),
+                       ('scripts/artifacts/sub/x.py', 'added'))
+        self.assertEqual(bot.artifact_modules(files), {})
+
+
+class CoveredModulesTests(unittest.TestCase):
+    def test_case_json_covers(self):
+        files = _files(('admin/test/cases/testdata.foo.json', 'added'))
+        self.assertEqual(bot.covered_modules(files, {'foo': 'added'}), {'foo'})
+
+    def test_data_dir_covers(self):
+        files = _files(('admin/test/cases/data/foo/testdata.foo.a.img.zip', 'added'))
+        self.assertEqual(bot.covered_modules(files, {'foo': 'added'}), {'foo'})
+
+    def test_other_modules_data_does_not_cover(self):
+        files = _files(('admin/test/cases/data/bar/testdata.bar.a.img.zip', 'added'))
+        self.assertEqual(bot.covered_modules(files, {'foo': 'added'}), set())
+
+    def test_removed_data_does_not_cover(self):
+        files = _files(('admin/test/cases/testdata.foo.json', 'removed'))
+        self.assertEqual(bot.covered_modules(files, {'foo': 'modified'}), set())
+
+
+class SampleDataKeysTests(unittest.TestCase):
+    def test_keys_collected_across_artifacts(self):
+        source = (
+            '__artifacts_v2__ = {\n'
+            '    "a": {"name": "A", "sample_data": {"hickman_ios15": "5 rows"}},\n'
+            '    "b": {"name": "B", "sample_data": {"dexter_ios18": "1 row",\n'
+            '                                        "hickman_ios15": "2 rows"}},\n'
+            '}\n')
+        self.assertEqual(bot.sample_data_keys_from_source(source),
+                         {'hickman_ios15', 'dexter_ios18'})
+
+    def test_no_sample_data_yields_empty(self):
+        source = '__artifacts_v2__ = {"a": {"name": "A"}}\n'
+        self.assertEqual(bot.sample_data_keys_from_source(source), set())
+
+    def test_non_literal_metadata_yields_empty(self):
+        source = 'V = "x"\n__artifacts_v2__ = {"a": {"name": V}}\n'
+        self.assertEqual(bot.sample_data_keys_from_source(source), set())
+
+    def test_syntax_error_yields_empty(self):
+        self.assertEqual(bot.sample_data_keys_from_source('def broken(:\n'), set())
+
+
+class ClassifyTests(unittest.TestCase):
+    PUBLIC = {'hickman_ios15', 'dexter_ios18'}
+
+    def test_covered_module_needs_nothing(self):
+        fixture, ask = bot.classify({'foo': 'added'}, {'foo'}, {}, self.PUBLIC)
+        self.assertEqual((fixture, ask), ({}, []))
+
+    def test_public_key_routes_to_fixture(self):
+        fixture, ask = bot.classify({'foo': 'added'}, set(),
+                                    {'foo': {'hickman_ios15', 'private_img'}}, self.PUBLIC)
+        self.assertEqual(fixture, {'foo': ['hickman_ios15']})
+        self.assertEqual(ask, [])
+
+    def test_no_public_key_routes_to_ask(self):
+        fixture, ask = bot.classify({'foo': 'added'}, set(),
+                                    {'foo': {'private_img'}}, self.PUBLIC)
+        self.assertEqual((fixture, ask), ({}, ['foo']))
+
+    def test_mixed_pr(self):
+        fixture, ask = bot.classify(
+            {'a': 'added', 'b': 'added', 'c': 'added'}, {'c'},
+            {'a': {'dexter_ios18'}, 'b': set()}, self.PUBLIC)
+        self.assertEqual(fixture, {'a': ['dexter_ios18']})
+        self.assertEqual(ask, ['b'])
+
+
+class RenderCommentTests(unittest.TestCase):
+    REPO = 'abrignoni/iLEAPP'
+
+    def test_ask_comment_has_marker_module_and_ladder(self):
+        body = bot.render_comment(self.REPO, {}, ['foo'])
+        self.assertIn(bot.MARKER, body)
+        self.assertIn('`foo.py`', body)
+        self.assertIn('Under 10 MB', body)
+        self.assertIn('not a gate', body)
+        self.assertIn('admin/test/cases/data/<module>/', body)
+
+    def test_fixture_only_comment_asks_nothing(self):
+        body = bot.render_comment(self.REPO, {'foo': ['hickman_ios15']}, [])
+        self.assertIn('`hickman_ios15`', body)
+        self.assertIn('Nothing is needed from you', body)
+        self.assertNotIn('Size rules', body)
+
+    def test_resolved_comment(self):
+        body = bot.render_comment(self.REPO, {}, [])
+        self.assertIn(bot.MARKER, body)
+        self.assertIn('Thank you', body)
+
+    def test_no_em_dashes_anywhere(self):
+        for body in (bot.render_comment(self.REPO, {}, ['foo']),
+                     bot.render_comment(self.REPO, {'a': ['k']}, []),
+                     bot.render_comment(self.REPO, {}, [])):
+            self.assertNotIn('—', body)
+
+
+class DesiredLabelsTests(unittest.TestCase):
+    def test_matrix(self):
+        self.assertEqual(bot.desired_labels({}, []), set())
+        self.assertEqual(bot.desired_labels({'a': ['k']}, []), {bot.LABEL_FIXTURE})
+        self.assertEqual(bot.desired_labels({}, ['b']), {bot.LABEL_ASK})
+        self.assertEqual(bot.desired_labels({'a': ['k']}, ['b']),
+                         {bot.LABEL_FIXTURE, bot.LABEL_ASK})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a workflow that asks external contributors for test data when a PR changes artifact modules without any.

- Runs on `pull_request_target` and executes only base-branch code; the PR's files are fetched as text and never imported.
- Authors with write access and bot accounts are skipped.
- One sticky comment per PR, edited in place; `needs-test-data` and `fixture-needed` labels track state, and the comment flips to a resolved note once data arrives.
- A module whose `sample_data` cites a public image from the manifest gets the lighter note that a maintainer can generate the fixture.
- Unit tests for the decision logic. Also corrects the fixture output path in create_module_test_cases.md.

The job is informational: it succeeds whatever the outcome.
