### PR TITLE
Use sparse checkouts in the pull request workflows

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -13,6 +13,12 @@ jobs:
         with:
           # Required to fetch the base branch for comparison
           fetch-depth: 0
+          # Blob-less fetch; materialize everything except the committed test
+          # fixtures under admin/test/cases/data, which no step here reads.
+          sparse-checkout: |
+            /*
+            !/admin/test/cases/data
+          sparse-checkout-cone-mode: false
 
       - name: Get changed Python files
         id: changed-files-py

--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -29,6 +29,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Blob-less fetch; materialize everything except the committed test
+          # fixtures under admin/test/cases/data, which no step here reads.
+          sparse-checkout: |
+            /*
+            !/admin/test/cases/data
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/validate_sample_data.yml
+++ b/.github/workflows/validate_sample_data.yml
@@ -28,6 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Blob-less fetch; materialize everything except the committed test
+        # fixtures under admin/test/cases/data, which no step here reads.
+        sparse-checkout: |
+          /*
+          !/admin/test/cases/data
+        sparse-checkout-cone-mode: false
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/windows_smoke.yml
+++ b/.github/workflows/windows_smoke.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Blob-less fetch; materialize everything except the committed test
+          # fixtures under admin/test/cases/data, which no step here reads.
+          sparse-checkout: |
+            /*
+            !/admin/test/cases/data
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Speeds up CI checkouts by excluding the committed test fixtures.

- The four pull request workflows materialize everything except `admin/test/cases/data`, which none of their steps read. `actions/checkout` fetches blob-less when `sparse-checkout` is set, so the fixture blobs never transfer.
- Measured on a real clone: 24 MB transferred instead of the full pack. The admin suite is identical without the directory, 315 tests and 35 skips, matching the current CI baseline.
- This PR's own checks run with the sparse checkout, so the green run is the verification.

Push-triggered and manual workflows are unchanged.
