### PR TITLE
Fix timezone-dependent timestamp decoding in five artifacts

### DIFF
--- a/scripts/artifacts/home_depot.py
+++ b/scripts/artifacts/home_depot.py
@@ -111,7 +111,7 @@ __artifacts_v2__ = {
         "description": "Cached product image URLs and HTTP Last-Modified timestamps",
         "author": "@jameshabben",
         "creation_date": "2026-06-26",
-        "last_update_date": "2026-06-26",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Home Depot",
         "notes": "",
@@ -332,9 +332,15 @@ def _parse_http_date(value):
     if not value:
         return ''
     try:
-        return parsedate_to_datetime(value)
+        parsed = parsedate_to_datetime(value)
     except (TypeError, ValueError):
         return value
+    if parsed.tzinfo is None:
+        # A '-0000' or unrecognized zone parses to a naive datetime. RFC 5322
+        # (3.3, 4.3) reads both as Universal Time with the sender's zone
+        # unknown, so pin UTC here.
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
 
 
 def _stringify(value):

--- a/scripts/artifacts/iTunesBackupInfo.py
+++ b/scripts/artifacts/iTunesBackupInfo.py
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
                        "Info.plist file of an iTunes backup",
         "author": "@johannplw",
         "creation_date": "2023-10-11",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "The storeCohort date substring's relationship to install time is "
@@ -113,7 +113,8 @@ def itunes_backup_installed_applications(context):
                 if 'date=' in store_cohort:
                     date_start = store_cohort.find('date=') + 5
                     unix_install_timestamp = store_cohort[date_start:date_start + 10]
-                    install_date = datetime.datetime.fromtimestamp(int(unix_install_timestamp)).strftime('%Y-%m-%d')
+                    install_date = datetime.datetime.fromtimestamp(
+                        int(unix_install_timestamp), datetime.timezone.utc).strftime('%Y-%m-%d')
                 download_info = itunes_metadata.get('com.apple.iTunesStore.downloadInfo', '')
                 if download_info:
                     account_info = download_info.get('accountInfo', '')

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -97,7 +97,7 @@ def get_kleinanzeigenmessagecache(context):
         if elem['messages'] == []:
             try:
                 m_text = elem['clientData']['textShortTrimmed']
-                m_rec = datetime.datetime.fromtimestamp(elem['clientData']['receivedDate'] + 978307200).strftime('%Y-%m-%d %H:%M:%S')
+                m_rec = datetime.datetime.fromtimestamp(elem['clientData']['receivedDate'] + 978307200, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
                 # preview row: no message id and no attachments
                 m_id = ''
                 m_att = "none"
@@ -122,7 +122,7 @@ def get_kleinanzeigenmessagecache(context):
             for message in elem['messages']:
                 m_id = message['messageId']
                 # Original timestamp is cocoa time - so 978307200 will be added
-                m_rec = datetime.datetime.fromtimestamp(message['sentDate'] + 978307200).strftime('%Y-%m-%d %H:%M:%S')
+                m_rec = datetime.datetime.fromtimestamp(message['sentDate'] + 978307200, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
                 m_text = message['text']
                 m_att = []
                 for att in message['attachments']:

--- a/scripts/artifacts/pinterest.py
+++ b/scripts/artifacts/pinterest.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses the signed in account record stored by the Pinterest iOS app.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
-        "last_update_date": "2026-08-19",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Pinterest",
         "notes": "Read from the activeUser file in the app's Documents directory, an "
@@ -251,6 +251,7 @@ import re
 import sqlite3
 import urllib.parse
 import xml.parsers.expat
+from datetime import timezone
 from email.utils import parsedate_to_datetime
 from plistlib import UID
 
@@ -494,9 +495,15 @@ def _rfc2822(value):
     if not value or not isinstance(value, str):
         return ''
     try:
-        return parsedate_to_datetime(value)
+        parsed = parsedate_to_datetime(value)
     except (TypeError, ValueError):
         return value
+    if parsed.tzinfo is None:
+        # A '-0000' or unrecognized zone parses to a naive datetime. RFC 5322
+        # (3.3, 4.3) reads both as Universal Time with the sender's zone
+        # unknown, so pin UTC here.
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _text(value):

--- a/scripts/artifacts/uberPlaces.py
+++ b/scripts/artifacts/uberPlaces.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Parses Uber Places Database",
         "author": "Heather Charpentier, @JamesHabben",
         "creation_date": "2024-04-10",
-        "last_update_date": "2026-06-08",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Uber",
         "notes": "",
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
     }
 }
 
-from datetime import datetime
+from datetime import datetime, timezone
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, open_sqlite_db_readonly
 
 @artifact_processor
@@ -78,7 +78,12 @@ def uber_places(context):
                     elif isinstance(last_used, str):
                         try:
                             # Try to convert ISO string to float timestamp for sub-second precision
-                            last_used = datetime.fromisoformat(last_used.replace('Z', '+00:00')).timestamp()
+                            parsed = datetime.fromisoformat(last_used.replace('Z', '+00:00'))
+                            if parsed.tzinfo is None:
+                                # A zone-less string parses naive, and timestamp() would
+                                # read a naive value in the host timezone, so pin UTC.
+                                parsed = parsed.replace(tzinfo=timezone.utc)
+                            last_used = parsed.timestamp()
                         except ValueError:
                             # Fallback to cleaned string if conversion fails
                             last_used = last_used.replace('T', ' ').replace('Z', '')


### PR DESCRIPTION
Applies the mailHeaders timezone fix (#2032) to five more artifacts that decode timestamps the same way.

- pinterest and home_depot: RFC 2822 dates with a -0000 or unrecognized zone are read as UTC per RFC 5322, and offset-carrying values are converted to UTC. A value set mixing GMT and -0000 crashed the Home Depot cache sort before this.
- uberPlaces: a zone-less ISO string no longer shifts the Last Used epoch with the host timezone.
- iTunesBackupInfo and kleinanzeigen.de: epoch decodes now render UTC instead of host-local wall clock.

Output is identical under TZ=UTC and TZ=America/New_York for all five.