### PR TITLE
Update apple_build_id_to_os_version.json

### DIFF
--- a/scripts/data/apple_build_id_to_os_version.json
+++ b/scripts/data/apple_build_id_to_os_version.json
@@ -950,7 +950,8 @@
     "24A5380h": "iOS 27.0 beta 3",
     "24A5390f": "iOS 27.0 beta 4",
     "24A5408d": "iOS 27.0 beta 5",
-    "24A5418b": "iOS 27.0 beta 6"
+    "24A5418b": "iOS 27.0 beta 6",
+    "24A5424a": "iOS 27.0 beta 7"
   },
   "macOS": {
     "4K78": "Mac OS X 10.0",
@@ -2392,6 +2393,7 @@
     "24G824": "macOS 15.7.8",
     "24G830": "macOS 15.7.9",
     "24H16": "macOS 15.8 RC",
+    "24H20": "macOS 15.8 RC 2",
     "25A5279m": "macOS 26.0 beta 1",
     "25A5295e": "macOS 26.0 beta 2",
     "25A5306g": "macOS 26.0 beta 3",
@@ -2456,12 +2458,14 @@
     "25G82": "macOS 26.6.2 RC",
     "25G83": "macOS 26.6.2",
     "25G220": "macOS 26.7 RC",
+    "25G224": "macOS 26.7 RC 2",
     "26A5353q": "macOS 27.0 beta 1",
     "26A5368g": "macOS 27.0 beta 2",
     "26A5378j": "macOS 27.0 beta 3",
     "26A5388g": "macOS 27.0 beta 4",
     "26A5406e": "macOS 27.0 beta 5",
-    "26A5416b": "macOS 27.0 beta 6"
+    "26A5416b": "macOS 27.0 beta 6",
+    "26A5421a": "macOS 27.0 beta 7"
   },
   "visionOS": {
     "21N5165g": "visionOS 1.0 beta 1",
@@ -2595,7 +2599,8 @@
     "24M5316k": "visionOS 27.0 beta 3",
     "24M5326g": "visionOS 27.0 beta 4",
     "24M5348b": "visionOS 27.0 beta 5",
-    "24M5355a": "visionOS 27.0 beta 6"
+    "24M5355a": "visionOS 27.0 beta 6",
+    "24M5359a": "visionOS 27.0 beta 7"
   },
   "watchOS": {
     "12S507": "watchOS 1.0",
@@ -3092,7 +3097,8 @@
     "24R5315i": "watchOS 27.0 beta 3",
     "24R5325h": "watchOS 27.0 beta 4",
     "24R5347a": "watchOS 27.0 beta 5",
-    "24R5353a": "watchOS 27.0 beta 6"
+    "24R5353a": "watchOS 27.0 beta 6",
+    "24R5358a": "watchOS 27.0 beta 7"
   },
   "tvOS": {
     "8M89": "Apple TV Software 4.0",
@@ -3612,7 +3618,8 @@
     "24J5315i": "tvOS 27.0 beta 3",
     "24J5325d": "tvOS 27.0 beta 4",
     "24J5346a": "tvOS 27.0 beta 5",
-    "24J5353b": "tvOS 27.0 beta 6"
+    "24J5353b": "tvOS 27.0 beta 6",
+    "24J5358a": "tvOS 27.0 beta 7"
   },
   "Windows": {
     "6002": "Windows Vista",


### PR DESCRIPTION
Add:
- iOS 27.0 beta 7
- macOS 15.8 RC 2, macOS 26.7 RC 2, macOS 27.0 beta 7
- tvOS 27.0 beta 7
- visionOS 27.0 beta 7
- watchOS 27.0 beta 7