### PR TITLE
Align the shared test-data tooling with the other cores

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What this changes
+
+<!-- One or two sentences. What does this add, fix or change? -->
+
+## For a new or changed artifact
+
+<!-- Delete this section if the PR does not touch scripts/artifacts. -->
+
+- [ ] Ran the tool against a real extraction and confirmed the row counts, not just that it imports.
+- [ ] Ran `python admin/scripts/check_artifact_output.py <report folder>` on that report and **fixed or documented every finding**. An empty or constant column is often a real result (no group chats, coarse location denied); the fix for those is to say so in the artifact's `notes`, which is also what stops the checker reporting them.
+- [ ] Checked it against a second app data directory where the platform provides one (a second user, account, or container). `--compare <multi-container report>` reads the scaling for you: it should be exactly double.
+- [ ] `notes`, `description` and `sample_data` say only what the data shows, and the numbers were re-derived from the finished run.
+
+## Anything reviewers should know
+
+<!-- Undocumented codes reported as stored, a store that could not be decrypted, a validation gap, etc. -->

--- a/admin/scripts/check_pr_test_data.py
+++ b/admin/scripts/check_pr_test_data.py
@@ -132,7 +132,13 @@ def sample_data_keys_from_source(source_text):
 
 
 def manifest_keys(manifest_path=MANIFEST_PATH):
-    """Every name the image manifest answers to (public images only)."""
+    """Every name the image manifest answers to (public images only).
+
+    A repo without a manifest gets an empty set, which routes every module to
+    the full ask rather than the maintainer-can-generate note.
+    """
+    if not Path(manifest_path).exists():
+        return set()
     with open(manifest_path, encoding="utf-8") as f:
         entries = json.load(f)["images"]
     names = set()

--- a/admin/test/scripts/make_test_data.py
+++ b/admin/test/scripts/make_test_data.py
@@ -100,6 +100,9 @@ def load_image_manifest():
         list: A list of image dictionaries from the manifest.
     """
     manifest_path = os.path.join(repo_root, 'admin', 'image_manifest.json')
+    if not os.path.exists(manifest_path):
+        sys.exit("This repo has no admin/image_manifest.json yet; use --case with --input, "
+                 "or add a manifest (see admin/docs/testing/guide_adding_images.md in iLEAPP).")
     with open(manifest_path, 'r', encoding='utf-8') as f:
         return json.load(f)['images']
 

--- a/admin/test/scripts/test_module.py
+++ b/admin/test/scripts/test_module.py
@@ -53,7 +53,7 @@ def mock_logfunc(message):
     print(f"[LOGFUNC] {message}")
 
 
-def process_artifact(zip_path, module_name, artifact_name, artifact_data, target_os_version=None):
+def process_artifact(zip_path, module_name, artifact_name, _artifact_data, target_os_version=None):
     """
     Processes a specific artifact from a given zip file.
 
@@ -61,7 +61,7 @@ def process_artifact(zip_path, module_name, artifact_name, artifact_data, target
         zip_path (Path): Path to the zip file containing test data.
         module_name (str): Name of the artifact module.
         artifact_name (str): Name of the artifact function to test.
-        artifact_data (dict): Metadata about the artifact from the test case.
+        _artifact_data (dict): Metadata about the artifact from the test case (unused).
         target_os_version (str, optional): OS version to mock for the test.
 
     Returns:
@@ -146,14 +146,14 @@ def process_artifact(zip_path, module_name, artifact_name, artifact_data, target
         mock_lava_db_instance.commit.return_value = None
 
         # <<< NEW MOCKS FOR CHECK_IN_MEDIA >>>
-        def mocked_check_in_media(file_path, *args, **kwargs):
+        def mocked_check_in_media(file_path, *_args, **_kwargs):
             nonlocal check_in_media_call_count
             check_in_media_call_count += 1
             # Simplified return for counter, avoiding deep side effects of original if problematic
             return f"mock_hash_for_{os.path.basename(str(file_path))}"
 
 
-        def mocked_check_in_embedded_media(*args, **kwargs):
+        def mocked_check_in_embedded_media(*_args, **_kwargs):
             nonlocal check_in_media_embedded_call_count
             check_in_media_embedded_call_count += 1
             # Similar to above, call original or return dummy
@@ -270,7 +270,7 @@ def load_test_cases(module_name):
         return json.load(f)
 
 
-def get_artifact_names(module_name, test_cases):
+def get_artifact_names(_module_name, test_cases):
     """
     Retrieves all artifact names defined in the test cases for a module.
 

--- a/admin/test/scripts/test_module.py
+++ b/admin/test/scripts/test_module.py
@@ -196,8 +196,10 @@ def process_artifact(zip_path, module_name, artifact_name, artifact_data, target
 
         ]
 
-        # If a target OS version is provided, mock iOS.get_version()
-        if target_os_version:
+        # If a target OS version is provided, mock iOS.get_version() where the
+        # core defines it (iLEAPP); other cores have no such class to mock.
+        import scripts.ilapfuncs as _ilapfuncs
+        if target_os_version and hasattr(_ilapfuncs, 'iOS'):
             mock_ios_get_version = MagicMock(return_value=target_os_version)
             patches.append(patch('scripts.ilapfuncs.iOS.get_version', mock_ios_get_version))
 


### PR DESCRIPTION
Aligns the shared test-data tooling with the copies now in the other four cores.

- `test_module.py`: the iOS version mock is applied only where the core defines the class.
- `make_test_data.py` and the PR bot tolerate a repo with no image manifest.
- Adds the PR template, generalized from ALEAPP's.

No behavior change for this repo beyond the template.