### PR TITLE
Point the manifest message at this repo's own guide

### DIFF
--- a/admin/test/scripts/make_test_data.py
+++ b/admin/test/scripts/make_test_data.py
@@ -102,7 +102,7 @@ def load_image_manifest():
     manifest_path = os.path.join(repo_root, 'admin', 'image_manifest.json')
     if not os.path.exists(manifest_path):
         sys.exit("This repo has no admin/image_manifest.json yet; use --case with --input, "
-                 "or add a manifest (see admin/docs/testing/guide_adding_images.md in iLEAPP).")
+                 "or add a manifest (see admin/docs/testing/guide_adding_images.md).")
     with open(manifest_path, 'r', encoding='utf-8') as f:
         return json.load(f)['images']
 


### PR DESCRIPTION
The missing-manifest message says to see the guide "in iLEAPP", which is where the reader already is. The guide sits at `admin/docs/testing/guide_adding_images.md`, and the other message in the same file already names that path on its own.

The wording came from the port that carried this script to the other cores. RLEAPP and VLEAPP keep it, since neither has a guide of its own yet.

With this the file is byte-identical to ALEAPP's copy again.