### PR TITLE
Fix report checker crash on TSV cells over 128KB

### DIFF
--- a/admin/scripts/check_artifact_output.py
+++ b/admin/scripts/check_artifact_output.py
@@ -86,6 +86,23 @@ def artifact_notes(repo_root):
     return notes
 
 
+def allow_oversized_fields():
+    """Accept cells over csv's 128KB default; a rendered message body exceeds it.
+
+    sys.maxsize overflows the C long on some platforms, so halve until accepted.
+    """
+    limit = sys.maxsize
+    while True:
+        try:
+            csv.field_size_limit(limit)
+            return
+        except OverflowError:
+            limit //= 2
+
+
+allow_oversized_fields()
+
+
 def read_table(path):
     """(column names, rows) for one tab separated export."""
     with open(path, encoding='utf-8-sig', newline='') as handle:


### PR DESCRIPTION
The report output checker died with "field larger than field limit (131072)" on any report whose TSV export holds a cell over csv's default limit; a rendered message body column exceeds it. Raises the limit before reading, halving from sys.maxsize on platforms that reject it.

Same fix as abrignoni/ALEAPP#1206; the script was byte-identical across the five cores. Verified here against a fixture with a 200KB cell: clean run, cell read back intact, findings still detected.