### PR TITLE
Record only the image file name in case files

### DIFF
--- a/admin/docs/testing/create_module_test_cases.md
+++ b/admin/docs/testing/create_module_test_cases.md
@@ -67,7 +67,7 @@ The script generates a JSON file (e.g., `testdata.<module_name>.json`) that cont
     "os_name": "iOS",
     "os_version": "12.5.5",
     "make_data": {
-      "input_data_path": "/path/to/iOS12_image.tar.gz",
+      "input_data_path": "iOS12_image.tar.gz",
       "os": "macOS-14.0-...",
       "timestamp": "2024-10-14T10:17:49.432528",
       "last_commit": {
@@ -94,7 +94,7 @@ The script generates a JSON file (e.g., `testdata.<module_name>.json`) that cont
   - `os_name`: Include the name of the operating system this case data originated from (iOS, Android, etc)
   - `os_version`: The specific OS version string (e.g., "12.5.5", "14.1") that this test case represents. `test_module.py` will use this to mock `iOS.get_version()`.
   - `make_data`: Information about the `make_test_data.py` run that generated this case's input data.
-    - `input_data_path`: The path to the original full image/archive used.
+    - `input_data_path`: The file name of the original full image/archive used. Only the name is recorded; the machine-specific location of an image belongs in the git-ignored `admin/image_manifest.local.json`, and `image_name` is what identifies the image.
     - `os`: The operating system on which `make_test_data.py` was run.
     - `timestamp`: The date and time when the input data ZIP was created.
     - `last_commit`: Information about the module's Git commit at the time of data creation.

--- a/admin/test/cases/testdata.BeReal.json
+++ b/admin/test/cases/testdata.BeReal.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:45:26.986823",
       "last_commit": {
@@ -127,7 +127,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:47:55.692232",
       "last_commit": {
@@ -231,7 +231,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:48:54.116457",
       "last_commit": {

--- a/admin/test/cases/testdata.accountConfig.json
+++ b/admin/test/cases/testdata.accountConfig.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-17T13:27:09.586077",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-17T13:44:38.312743",
       "last_commit": {
@@ -61,7 +61,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-17T13:51:51.068948",
       "last_commit": {

--- a/admin/test/cases/testdata.accountData.json
+++ b/admin/test/cases/testdata.accountData.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-17T12:09:27.445682",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-17T13:25:57.671900",
       "last_commit": {
@@ -61,7 +61,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-17T13:26:09.085469",
       "last_commit": {

--- a/admin/test/cases/testdata.addressBook.json
+++ b/admin/test/cases/testdata.addressBook.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:39:59.279736",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:41:13.168777",
       "last_commit": {
@@ -61,7 +61,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:42:26.353851",
       "last_commit": {

--- a/admin/test/cases/testdata.advertisingID.json
+++ b/admin/test/cases/testdata.advertisingID.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T11:06:55.527987",
       "last_commit": {

--- a/admin/test/cases/testdata.appCookies.json
+++ b/admin/test/cases/testdata.appCookies.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T17:23:57.115894",
       "last_commit": {

--- a/admin/test/cases/testdata.appSnapshots.json
+++ b/admin/test/cases/testdata.appSnapshots.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T11:28:16.827742",
       "last_commit": {
@@ -35,7 +35,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T11:38:56.791498",
       "last_commit": {
@@ -67,7 +67,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T16:59:29.866605",
       "last_commit": {

--- a/admin/test/cases/testdata.appStoreSearches.json
+++ b/admin/test/cases/testdata.appStoreSearches.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T17:22:18.565252",
       "last_commit": {

--- a/admin/test/cases/testdata.appleWifiPlist.json
+++ b/admin/test/cases/testdata.appleWifiPlist.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-22T11:24:13.908233",
       "last_commit": {
@@ -66,7 +66,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-22T11:24:58.393129",
       "last_commit": {
@@ -129,7 +129,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-22T11:02:48.636611",
       "last_commit": {

--- a/admin/test/cases/testdata.booking.json
+++ b/admin/test/cases/testdata.booking.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T16:40:56.704564",
       "last_commit": {
@@ -84,7 +84,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T16:45:26.849686",
       "last_commit": {
@@ -165,7 +165,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T16:45:57.374690",
       "last_commit": {

--- a/admin/test/cases/testdata.burnerCache.json
+++ b/admin/test/cases/testdata.burnerCache.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T17:12:06.558196",
       "last_commit": {
@@ -43,7 +43,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T17:43:53.099959",
       "last_commit": {
@@ -97,7 +97,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-20T17:12:43.308634",
       "last_commit": {

--- a/admin/test/cases/testdata.cachev0.json
+++ b/admin/test/cases/testdata.cachev0.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-26T12:41:58.262379",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-26T12:43:19.169419",
       "last_commit": {
@@ -61,7 +61,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-26T12:43:36.470983",
       "last_commit": {

--- a/admin/test/cases/testdata.celWireless.json
+++ b/admin/test/cases/testdata.celWireless.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-22T14:05:35.684911",
       "last_commit": {
@@ -33,7 +33,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-22T14:05:56.214984",
       "last_commit": {
@@ -63,7 +63,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-22T14:06:24.011382",
       "last_commit": {

--- a/admin/test/cases/testdata.cloudkitSharing.json
+++ b/admin/test/cases/testdata.cloudkitSharing.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.7.4-x86_64-i386-64bit",
       "timestamp": "2026-05-27T15:33:22.409614",
       "last_commit": {
@@ -50,7 +50,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.zip",
+      "input_data_path": "iOS_15_Public_Image.zip",
       "os": "macOS-15.7.4-x86_64-i386-64bit",
       "timestamp": "2026-05-28T06:45:31.943111",
       "last_commit": {
@@ -97,7 +97,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.7.4-x86_64-i386-64bit",
       "timestamp": "2026-05-28T09:04:21.116050",
       "last_commit": {

--- a/admin/test/cases/testdata.cloudkit_cache.json
+++ b/admin/test/cases/testdata.cloudkit_cache.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.zip",
+      "input_data_path": "iOS_15_Public_Image.zip",
       "os": "macOS-15.7.4-x86_64-i386-64bit",
       "timestamp": "2026-05-30T11:59:08.496149",
       "last_commit": {

--- a/admin/test/cases/testdata.clubhouse.json
+++ b/admin/test/cases/testdata.clubhouse.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:55:13.502255",
       "last_commit": {

--- a/admin/test/cases/testdata.connectedDevices.json
+++ b/admin/test/cases/testdata.connectedDevices.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-23T09:45:39.397150",
       "last_commit": {

--- a/admin/test/cases/testdata.controlCenter.json
+++ b/admin/test/cases/testdata.controlCenter.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-18T11:28:52.436132",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-18T11:32:11.780817",
       "last_commit": {
@@ -61,7 +61,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-18T11:32:29.308993",
       "last_commit": {

--- a/admin/test/cases/testdata.deviceDatam.json
+++ b/admin/test/cases/testdata.deviceDatam.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:17:07.159048",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:17:25.430415",
       "last_commit": {
@@ -59,7 +59,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:19:44.897355",
       "last_commit": {

--- a/admin/test/cases/testdata.deviceName.json
+++ b/admin/test/cases/testdata.deviceName.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:23:14.245646",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:23:33.880220",
       "last_commit": {

--- a/admin/test/cases/testdata.dhcpl.json
+++ b/admin/test/cases/testdata.dhcpl.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:25:48.749116",
       "last_commit": {
@@ -32,7 +32,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-29T13:26:11.850144",
       "last_commit": {

--- a/admin/test/cases/testdata.discord_cache.json
+++ b/admin/test/cases/testdata.discord_cache.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.zip",
+      "input_data_path": "iOS_15_Public_Image.zip",
       "os": "macOS-15.7.4-x86_64-i386-64bit",
       "timestamp": "2026-05-29T14:27:51.432780",
       "last_commit": {

--- a/admin/test/cases/testdata.gmail.json
+++ b/admin/test/cases/testdata.gmail.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-15T16:07:56.063452",
       "last_commit": {
@@ -42,7 +42,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-15T16:10:47.231161",
       "last_commit": {
@@ -81,7 +81,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-15T16:10:59.816421",
       "last_commit": {

--- a/admin/test/cases/testdata.googleVoice.json
+++ b/admin/test/cases/testdata.googleVoice.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:40:17.001109",
       "last_commit": {

--- a/admin/test/cases/testdata.groupMe.json
+++ b/admin/test/cases/testdata.groupMe.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:44:16.095409",
       "last_commit": {

--- a/admin/test/cases/testdata.keyboard.json
+++ b/admin/test/cases/testdata.keyboard.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-15T16:24:52.443745",
       "last_commit": {
@@ -52,7 +52,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-15T16:29:07.852456",
       "last_commit": {
@@ -98,7 +98,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-10-15T16:29:22.979022",
       "last_commit": {

--- a/admin/test/cases/testdata.locationdCacheEncryptedB.json
+++ b/admin/test/cases/testdata.locationdCacheEncryptedB.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:50:06.978906",
       "last_commit": {
@@ -70,7 +70,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:51:39.615621",
       "last_commit": {

--- a/admin/test/cases/testdata.mailprotect.json
+++ b/admin/test/cases/testdata.mailprotect.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T17:15:31.385425",
       "last_commit": {

--- a/admin/test/cases/testdata.mastodon.json
+++ b/admin/test/cases/testdata.mastodon.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:53:42.240715",
       "last_commit": {

--- a/admin/test/cases/testdata.meWe.json
+++ b/admin/test/cases/testdata.meWe.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:48:24.983117",
       "last_commit": {

--- a/admin/test/cases/testdata.notes.json
+++ b/admin/test/cases/testdata.notes.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T17:25:57.397346",
       "last_commit": {

--- a/admin/test/cases/testdata.safariCache.json
+++ b/admin/test/cases/testdata.safariCache.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:21:07.610298",
       "last_commit": {
@@ -41,7 +41,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:21:12.926339",
       "last_commit": {

--- a/admin/test/cases/testdata.safariDownloads.json
+++ b/admin/test/cases/testdata.safariDownloads.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T17:26:48.917978",
       "last_commit": {

--- a/admin/test/cases/testdata.sms.json
+++ b/admin/test/cases/testdata.sms.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.zip",
+      "input_data_path": "iOS_15_Public_Image.zip",
       "os": "macOS-15.7.4-x86_64-i386-64bit",
       "timestamp": "2026-06-04T12:47:39.824612",
       "last_commit": {

--- a/admin/test/cases/testdata.storeSystem.json
+++ b/admin/test/cases/testdata.storeSystem.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:04:01.460187",
       "last_commit": {
@@ -60,7 +60,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:08:17.340521",
       "last_commit": {

--- a/admin/test/cases/testdata.teams.json
+++ b/admin/test/cases/testdata.teams.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2024-11-04T13:38:37.697695",
       "last_commit": {

--- a/admin/test/cases/testdata.telegramMesssages.json
+++ b/admin/test/cases/testdata.telegramMesssages.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-04-30T07:44:25.544184",
       "last_commit": {
@@ -33,7 +33,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:18:40.816835",
       "last_commit": {
@@ -61,7 +61,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:19:03.578058",
       "last_commit": {

--- a/admin/test/cases/testdata.threeBars.json
+++ b/admin/test/cases/testdata.threeBars.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:34:58.721818",
       "last_commit": {
@@ -60,7 +60,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-29T22:35:04.917476",
       "last_commit": {

--- a/admin/test/cases/testdata.truthSocial.json
+++ b/admin/test/cases/testdata.truthSocial.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:51:19.599220",
       "last_commit": {

--- a/admin/test/cases/testdata.twitterX.json
+++ b/admin/test/cases/testdata.twitterX.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Volumes/data/iOS Extractions/iOS_17/Cellebrite_Extraction/UFED Apple iPhone 11 (N104AP) 2024_07_28 (001)/EXTRACTION_FFS 01/EXTRACTION_FFS.zip",
+      "input_data_path": "EXTRACTION_FFS.zip",
       "os": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
       "timestamp": "2026-07-25T16:58:21.133499",
       "last_commit": {

--- a/admin/test/cases/testdata.voicemail.json
+++ b/admin/test/cases/testdata.voicemail.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar",
+      "input_data_path": "iOS_15_Public_Image.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:23:55.163780",
       "last_commit": {
@@ -34,7 +34,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:25:15.939280",
       "last_commit": {
@@ -65,7 +65,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-06-21T12:26:11.425634",
       "last_commit": {

--- a/admin/test/cases/testdata.whatsApp.json
+++ b/admin/test/cases/testdata.whatsApp.json
@@ -3,7 +3,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/belkasoft/BelkaCTF_6_CASE240405_D201AP.tar",
+      "input_data_path": "BelkaCTF_6_CASE240405_D201AP.tar",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-04-30T08:19:49.129671",
       "last_commit": {
@@ -45,7 +45,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/magnet/00008101-0010541A1130001E_files_full-001.zip",
+      "input_data_path": "00008101-0010541A1130001E_files_full-001.zip",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-04-30T08:20:23.769522",
       "last_commit": {
@@ -92,7 +92,7 @@
     "description": "",
     "maker": "",
     "make_data": {
-      "input_data_path": "/Users/jameshabben/Documents/phone-images/Josh/iOS_15_Public_Image.tar.gz",
+      "input_data_path": "iOS_15_Public_Image.tar.gz",
       "os": "macOS-15.0-x86_64-i386-64bit",
       "timestamp": "2025-04-30T08:20:56.781153",
       "last_commit": {

--- a/admin/test/scripts/make_test_data.py
+++ b/admin/test/scripts/make_test_data.py
@@ -437,7 +437,7 @@ def create_test_data(module_name, image_name=None, case_number=None, input_file=
         "description": "",
         "maker": "",
         "make_data": {
-            "input_data_path": os.path.abspath(input_file),
+            "input_data_path": os.path.basename(input_file),
             "os": platform.platform(),
             "timestamp": datetime.now().isoformat(),
             "last_commit": last_commit_info

--- a/admin/test/scripts/test_case_file_paths.py
+++ b/admin/test/scripts/test_case_file_paths.py
@@ -1,0 +1,35 @@
+"""Structural check: committed case files carry no machine-local paths.
+
+The image manifest split (iLEAPP #2028) keeps machine-independent identity in
+committed files and machine-specific locations in the git-ignored
+admin/image_manifest.local.json. A case entry's make_data.input_data_path is
+display text for the case pickers, which take its basename; recording an
+absolute path there publishes one machine's corpus layout into the repo. This
+guards the make_test_data.py writer and the committed case files together.
+"""
+import glob
+import json
+import os
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+CASES_GLOB = os.path.join(REPO_ROOT, 'admin', 'test', 'cases', 'testdata.*.json')
+
+
+class CaseFilePathTests(unittest.TestCase):
+    def test_input_data_path_is_a_bare_file_name(self):
+        offenders = []
+        for path in sorted(glob.glob(CASES_GLOB)):
+            with open(path, encoding='utf-8') as f:
+                cases = json.load(f)
+            for case_key, case in cases.items():
+                value = case.get('make_data', {}).get('input_data_path', '')
+                if '/' in value or '\\' in value:
+                    offenders.append(f"{os.path.basename(path)} [{case_key}]: {value}")
+        self.assertEqual(offenders, [],
+                         "case files must record only the image file name in "
+                         "make_data.input_data_path:\n" + "\n".join(offenders))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Stops the fixture cutter from writing the absolute local path of the input image into committed case files, and updates the 84 existing case entries to carry the file name alone.

- make_test_data.py records the basename; image locations stay in the git-ignored admin/image_manifest.local.json, and image_name identifies the image.
- All 42 case files updated; the case pickers already display only the basename.
- A structural test keeps machine-local paths out of the case files.

Full gate unchanged: 145 PASS, 1 KNOWN_FAIL before and after.