### PR TITLE
Key logarchive navigation on the com.apple.Navigation subsystem

### DIFF
--- a/admin/test/scripts/test_logarchive_native.py
+++ b/admin/test/scripts/test_logarchive_native.py
@@ -657,5 +657,65 @@ class TestDialedNumbersPredicates(unittest.TestCase):
                 self.assertIn(category, source)
 
 
+class TestNavigationPredicates(unittest.TestCase):
+    """Navigation is matched by subsystem, never by spoken guidance text.
+
+    The artifact used to filter event_message for fifteen English turn-by-turn phrases
+    ('Starting route to', 'Turn right', 'your destination'). Those phrases occur in 0 of
+    117,678,121 unified log records across six images spanning iOS 16.5 to 26.5.2, all of
+    them en-US devices, so the artifact returned nothing on every one of them and a
+    non-English device could never have matched regardless.
+
+    Two of the old clauses could not match anything at all: SQLite reads the backslash in
+    "%Arrived\\%" literally without an ESCAPE clause, so the pattern required a literal
+    backslash after the word.
+
+    logarchive_navigation selects from the table logarchive_artifacts builds, so a
+    predicate missing from the broad query cannot be recovered by the narrow one. Both
+    halves are checked here for that reason.
+    """
+
+    SUBSYSTEM = "subsystem LIKE 'com.apple.Navigation%'"
+
+    # Every phrase the artifact used to match. None of them appeared in any tested image.
+    RETIRED_PHRASES = (
+        'Starting route to', 'Proceed to', 'Turn right', 'Turn left', 'roundabout',
+        'first exit', 'Stay in the', 'parking lot', 'of a mile', 'In about',
+        'then arrive', 'your destination', 'At the light', 'Arrived',
+    )
+
+    def test_collection_query_gathers_the_subsystem_the_artifact_reads(self):
+        source = inspect.getsource(logarchive.logarchive_artifacts.__wrapped__)
+        self.assertIn(self.SUBSYSTEM, source)
+
+    def test_navigation_artifact_matches_the_subsystem(self):
+        source = inspect.getsource(logarchive.logarchive_navigation.__wrapped__)
+        self.assertIn(self.SUBSYSTEM, source)
+
+    def test_spoken_guidance_phrases_are_not_matched_anywhere_in_the_module(self):
+        source = pathlib.Path(logarchive.__file__).read_text(encoding='utf-8')
+        predicates = [line for line in source.splitlines() if 'event_message LIKE' in line]
+        for phrase in self.RETIRED_PHRASES:
+            with self.subTest(phrase=phrase):
+                self.assertFalse(
+                    [line for line in predicates if phrase in line],
+                    f'{phrase!r} is a spoken guidance phrase; match the subsystem instead')
+
+    def test_subsystem_predicate_matches_real_navigation_rows(self):
+        # Verbatim subsystem values from iOS 17.1, 18 and 26.5.2 extractions. The
+        # lowercase VirtualGarage spelling is included on purpose: SQLite LIKE is
+        # case-insensitive for ASCII, so one pattern covers both.
+        subsystems = ('com.apple.Navigation', 'com.apple.Navigation.Audio',
+                      'com.apple.Navigation.NavigationListener',
+                      'com.apple.navigation.VirtualGarage')
+        with sqlite3.connect(':memory:') as connection:
+            connection.execute('CREATE TABLE t (subsystem TEXT)')
+            connection.executemany('INSERT INTO t VALUES (?)', [(s,) for s in subsystems])
+            connection.execute("INSERT INTO t VALUES ('com.apple.locationd.Core')")
+            matched = connection.execute(
+                f'SELECT COUNT(*) FROM t WHERE {self.SUBSYSTEM}').fetchone()[0]
+        self.assertEqual(matched, len(subsystems))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -201,10 +201,10 @@ __artifacts_v2__ = {
     },
     "logarchive_navigation": {
         "name": "logarchive navigation",
-        "description": "Navigation entries",
-        "author": "@AlexisBrignoni",
+        "description": "Records logged by the MapsNavigation framework under the com.apple.Navigation subsystem",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2025-07-25",
-        "last_update_date": "2025-07-25",
+        "last_update_date": "2026-08-25",
         "requirements": "logarchive module must be executed first",
         "category": "Unified Logs",
         "notes": "",
@@ -1048,19 +1048,13 @@ def logarchive_artifacts(context):
         OR event_message LIKE '%Tethering is now enabled with%'
         OR event_message LIKE '%Received notification that wireless modem state changed%'
         OR event_message LIKE '%Previous tethering state was%'
-        OR event_message LIKE '%Proceed to%'
-        OR event_message LIKE '%Turn right%'
-        OR event_message LIKE '%Turn left%'
-        OR event_message LIKE '%roundabout%'
-        OR event_message LIKE '%first exit%'
-        OR event_message LIKE '%Stay in the%'
-        OR event_message LIKE '%parking lot%'
-        OR event_message LIKE '%of a mile%'
-        OR event_message LIKE '%In about%'
-        OR event_message LIKE '%Arrived%'
-        OR event_message LIKE '%destination%'
-        OR event_message LIKE '%At the light%'
-        OR event_message LIKE '%Starting route to%'
+        -- logarchive_navigation. Collected by subsystem rather than by spoken
+        -- guidance text. The MapsNavigation framework logs under com.apple.Navigation
+        -- out of navd; the categories beneath it differ completely between iOS 16-18
+        -- (MNNavigationStateManager, MNNavigationXPC) and iOS 26
+        -- (FamiliarRouteAuthorizationChecker, GEONavigationListener), so the subsystem
+        -- prefix is matched rather than a category list.
+        OR subsystem LIKE 'com.apple.Navigation%'
         -- Patterns below were added by the 2026-08-01 unified log predicate survey.
         -- Each is documented in the source cited by the artifact that consumes it
         -- (see __artifacts_v2__ notes) and, unless noted there, was observed in an
@@ -1509,34 +1503,20 @@ def logarchive_audio_status(context):
 
 @artifact_processor
 def logarchive_navigation(context):
-    source_path = get_file_path(context.get_files_found(), '_lava_artifacts.db')
-    data_list = []
-    
-    query = '''
-    SELECT *
-    FROM logarchive_artifacts
-    WHERE event_message LIKE '%Starting route to%'
-        OR event_message LIKE '%Proceed to the%'
-        OR event_message LIKE '%Proceed to\\%'
-        OR event_message LIKE '%Turn right%'
-        OR event_message LIKE '%Turn left%'
-        OR event_message LIKE '%roundabout%'
-        OR event_message LIKE '%first exit%'
-        OR event_message LIKE '%Stay in the%'
-        OR event_message LIKE '%parking lot for%'
-        OR event_message LIKE '%of a mile%'
-        OR event_message LIKE '%In about%'
-        OR event_message LIKE '%then arrive%'
-        OR event_message LIKE '%your destination%'
-        OR event_message LIKE '%At the light%'
-        OR event_message LIKE '%Arrived\\%'
-    '''
-    
-    data_list = list( get_sqlite_db_records(source_path, query) )
-    data_headers = (('Timestamp', 'datetime'), 'Row Number', 'Process Image Path', 'Process ID', 
-                    'Subsystem', 'Category', 'Event Message', 'Trace ID')
-    
-    return data_headers, data_list, source_path
+    # The MapsNavigation framework logs under the com.apple.Navigation subsystem, from
+    # navd. Matching the subsystem rather than message text keeps this working across
+    # releases and on devices in any language: the categories beneath the subsystem are
+    # entirely different on iOS 26 (FamiliarRouteAuthorizationChecker,
+    # GEONavigationListener) from iOS 16 through 18 (MNNavigationStateManager,
+    # MNNavigationXPC, MNRouteEditor), so a category list would need editing per release.
+    #
+    # LIKE is case-insensitive for ASCII in SQLite, so the lowercase
+    # com.apple.navigation.VirtualGarage subsystem is picked up by the same pattern.
+    return _artifacts_table_records(context, """
+        subsystem LIKE 'com.apple.Navigation%'
+    """)
+
+
 def _artifacts_table_records(context, where_clause):
     """Rows from the logarchive_artifacts table matching where_clause.
 

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -207,10 +207,18 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-25",
         "requirements": "logarchive module must be executed first",
         "category": "Unified Logs",
-        "notes": "",
+        "notes": "Rows the MapsNavigation framework writes under the com.apple.Navigation subsystem, collected by subsystem rather than by message text. Across the six tested images the emitting processes are the Maps widget extension GeneralMapsWidget (955 rows on four images), navd (755 on five) and Maps.app (609 on two), with single-figure counts from assistantd, routined and destinationd on one image each. Categories observed on the iOS 16.5 through 18.7 images, with the number of images carrying each: MNNavigationXPC, MNNavigationService, MNNavigationStateManager and MNRouteStorage on four; MNLocationProvider on three; MNVoiceLanguageUtil, MNUserOptionsEngine and Navd on two; MNRouteEditor, MNSuggestedNavigationMode, MNRouteAttributes, MNSequence, MNCarPlayConnectionMonitor, MNRingerSwitchObserver, ProcessHandling and the three VirtualGarage categories on one each. The iOS 26.5.2 image shares only MNLocationProvider with those and otherwise logs two categories seen nowhere else, FamiliarRouteAuthorizationChecker and GEONavigationListener, which is why the subsystem prefix is matched instead of a list of categories. Until 2026-08-25 this artifact instead matched event_message against fifteen English spoken guidance phrases such as 'Starting route to' and 'your destination'. None of those phrases occurs in any of the 117,678,121 records across the six images listed in sample_data, every one of them an en-US device, so it reported nothing on all six. What the artifact reports is the framework's own activity around route planning and navigation service connections. It is not a record of a route being followed: on every tested image that logs a navigation state, the only values seen are MNNavigationStateTypeNoDestination, MNNavigationStateTypeNone and Stopped, so none of them holds an active turn by turn session. Whether spoken guidance text reaches the unified log at all is untested here, and 19.1 percent of messages on the iOS 18.7 image are redacted to <private>. An image captured during live navigation would settle it. Trace ID carries no value on any tested row, which is true of every artifact reading this table.",
         "paths": None,
         "output_types": "standard",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "abe_ios16": "iOS 16.5 | 131 rows",
+            "fsfull002_ios17": "iOS 17.1 | 924 rows",
+            "rodeo_ios17_sysdiag": "iOS 17.3 | 0 rows; no com.apple.Navigation records in the sysdiagnose window",
+            "dexter_ios18": "iOS 18.3.2 | 229 rows",
+            "iphone12_ios18": "iOS 18.7 | 912 rows; the only tested image with MNRouteEditor, MNSuggestedNavigationMode or MNRouteAttributes",
+            "hc_ios26": "iOS 26.5.2 | 128 rows; FamiliarRouteAuthorizationChecker and GEONavigationListener only",
+        },
     },
     # The artifacts below come from the 2026-08-01 unified log predicate survey.
     # Every message pattern is either documented in a cited publication, observed
@@ -1053,7 +1061,9 @@ def logarchive_artifacts(context):
         -- out of navd; the categories beneath it differ completely between iOS 16-18
         -- (MNNavigationStateManager, MNNavigationXPC) and iOS 26
         -- (FamiliarRouteAuthorizationChecker, GEONavigationListener), so the subsystem
-        -- prefix is matched rather than a category list.
+        -- prefix is matched rather than a category list. Keep this as LIKE: the
+        -- com.apple.navigation.VirtualGarage subsystem has a lowercase n and is only
+        -- matched because SQLite LIKE is case-insensitive for ASCII.
         OR subsystem LIKE 'com.apple.Navigation%'
         -- Patterns below were added by the 2026-08-01 unified log predicate survey.
         -- Each is documented in the source cited by the artifact that consumes it
@@ -1510,8 +1520,11 @@ def logarchive_navigation(context):
     # GEONavigationListener) from iOS 16 through 18 (MNNavigationStateManager,
     # MNNavigationXPC, MNRouteEditor), so a category list would need editing per release.
     #
-    # LIKE is case-insensitive for ASCII in SQLite, so the lowercase
-    # com.apple.navigation.VirtualGarage subsystem is picked up by the same pattern.
+    # LIKE is case-insensitive for ASCII in SQLite, and one subsystem in this family is
+    # spelled with a lowercase n: com.apple.navigation.VirtualGarage. It is inside this
+    # pattern only because of that case-insensitivity. Rewriting the comparison as GLOB,
+    # or adding a COLLATE BINARY, drops those rows silently, 42 of them on the iOS 18.7
+    # image, with no error and no change to any other count.
     return _artifacts_table_records(context, """
         subsystem LIKE 'com.apple.Navigation%'
     """)


### PR DESCRIPTION
Keys the logarchive navigation artifact on the `com.apple.Navigation` subsystem instead of fifteen English spoken guidance phrases. Those phrases do not appear in any of the 117,678,121 unified log records across the six images in `sample_data`, so the artifact reported nothing on all of them.

- Collects the subsystem in the `logarchive_artifacts` distillation too, since the artifact can only read what that query materializes, and drops the thirteen phrase clauses it replaces.
- Adds a test that keeps both halves matching the same subsystem.

Both predicates must stay as `LIKE`. `com.apple.navigation.VirtualGarage` has a lowercase n and is matched only because SQLite `LIKE` is case-insensitive for ASCII.
