### PR TITLE
Fix Mobile Installation parsing and Biome App.Install decoding

### DIFF
--- a/scripts/artifacts/applicationStateDB.py
+++ b/scripts/artifacts/applicationStateDB.py
@@ -37,10 +37,15 @@ __artifacts_v2__ = {
         "description": "Extract information about bundle container path and data path for Applications",
         "author": "@AlexisBrignoni - @mxkrt",
         "creation_date": "2025-08-27",
-        "last_update_date": "2026-08-21",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Installed Apps",
-        "notes": "",
+        "notes": "The bundle identifier is read from each application identifier's compatibilityInfo "
+                 "blob, so an application identifier whose compatibilityInfo is absent or unparseable "
+                 "is logged and left out of this table. Absence of a bundle identifier here therefore "
+                 "means the mapping this parser needs was not available in applicationState.db. It is "
+                 "not evidence that the application was never installed, and other sources such as the "
+                 "Mobile Installation logs may still carry its install and uninstall history.",
         "paths": ('*/mobile/Library/FrontBoard/applicationState.db*'),
         "output_types": ["html","tsv","lava"],
         "artifact_icon": "package",

--- a/scripts/artifacts/biomeAppInstallation.py
+++ b/scripts/artifacts/biomeAppInstallation.py
@@ -15,7 +15,9 @@ __artifacts_v2__ = {
                  "reported. Two 16 byte values accompany each event and are surfaced as hex "
                  "digests; their role is not established. The version and 16 byte fields are read "
                  "with a pinned field type because some of those values are themselves valid "
-                 "protobuf and an inferring decode reports them as empty.",
+                 "protobuf and an inferring decode reports them as empty. Paths containing 'tombstone' "
+                 "are not parsed; across the tested images those files hold the Biome daemons' own "
+                 "record of retired stream files and carried no application event.",
         "paths": ('*/streams/*/App.Installation/local/*',),
         "output_types": "standard",
         "artifact_icon": "download",

--- a/scripts/artifacts/biomeAppInstallation.py
+++ b/scripts/artifacts/biomeAppInstallation.py
@@ -7,18 +7,20 @@ __artifacts_v2__ = {
                        "App.Install and _DKEvent.App.Install streams.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-26",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Biome",
-        "notes": "The event type field takes values 1, 2 and 3 in the sample; which of install, "
-                 "update and removal each denotes is not confirmed, so the raw value is "
+        "notes": "The event type field takes values 0, 1, 2 and 3 in the tested sample; which of "
+                 "install, update and removal each denotes is not confirmed, so the raw value is "
                  "reported. Two 16 byte values accompany each event and are surfaced as hex "
-                 "digests; their role is not established.",
+                 "digests; their role is not established. The version and 16 byte fields are read "
+                 "with a pinned field type because some of those values are themselves valid "
+                 "protobuf and an inferring decode reports them as empty.",
         "paths": ('*/streams/*/App.Installation/local/*',),
         "output_types": "standard",
         "artifact_icon": "download",
         "sample_data": {
-            "hc_ios26": "26.5.2 | 232 rows",
+            "hc_ios26": "iOS 26.5.2 | 232 rows",
         },
     }
 }
@@ -36,6 +38,18 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 _DECODE_ERRORS = (DecodeError, struct.error, KeyError, ValueError, TypeError,
                   IndexError)
+
+# The version strings and the two 16 byte values are sometimes themselves valid protobuf,
+# and an inferring decode reads those as nested messages, which blanks the column. Only
+# these four fields are pinned; everything else is still inferred, so the fixed64 fields
+# keep arriving as integers for _unix_double().
+_TYPEDEF = {
+    '3': {'type': 'message', 'name': '', 'message_typedef': {
+        '2': {'type': 'str', 'name': ''},
+        '3': {'type': 'str', 'name': ''},
+        '4': {'type': 'bytes', 'name': ''},
+        '5': {'type': 'bytes', 'name': ''}}},
+}
 
 
 def _to_str(value):
@@ -85,7 +99,7 @@ def get_biomeAppInstallation(context):
 
             if record.state == EntryState.Written:
                 try:
-                    protostuff, _ = blackboxprotobuf.decode_message(record.data)
+                    protostuff, _ = blackboxprotobuf.decode_message(record.data, _TYPEDEF)
                 except _DECODE_ERRORS as ex:
                     logfunc(f'App Installation: could not decode record at offset '
                             f'{record.data_start_offset} in {filename}: {ex}')

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -1,28 +1,29 @@
 __artifacts_v2__ = {
     "get_biomeAppinstall": {
         "name": "Biome - App Install",
-        "description": "Parses app install entries from biomes",
+        "description": "App install entries from the App.Install and _DKEvent.App.Install Biome streams",
        "author": "@JohnHyla, @Gear-I",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Biome",
-        "notes": "",
+        "notes": "Covers two Biome streams that carry different record layouts. _DKEvent.App.Install records carry the activity, the bundle id, the event and write timestamps and the app display strings. App.Install records carry only a bundle id and one integer, which is reported as stored because no source documenting its meaning was identified. The Stream column names the source stream for each row. Records whose SEGB state is Deleted are reported with their timestamp and offset only. Paths containing 'tombstone' are not parsed.",
         "paths": ('*/Biome/streams/restricted/_DKEvent.App.Install/local/*', '*/Biome/streams/restricted/App.Install/local/*'),
         "output_types": "standard",
         "artifact_icon": "package",
         "sample_data": {
-            "dexter_ios18": "iOS 18.3.2 | 178 rows",
-            "felix_ios17": "iOS 17.6.1 | 228 rows",
-            "fsfull002_ios17": "iOS 17.1 | 120 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 194 rows",
-            "iphone11_ios17": "iOS 17.3 | 151 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 92 rows",
-            "otto_ios17": "iOS 17.5.1 | 244 rows",
-            "iphone12_ios18": "iOS 18.7 | 123 rows",
             "abe_ios16": "iOS 16.5 | 142 rows",
             "felix23_ios16": "iOS 16.5 | 88 rows",
             "magnet_ios16": "iOS 16.1.1 | 64 rows",
+            "felix_ios17": "iOS 17.6.1 | 262 rows",
+            "fsfull002_ios17": "iOS 17.1 | 120 rows",
+            "iphone11_ios17": "iOS 17.3 | 151 rows",
+            "otto_ios17": "iOS 17.5.1 | 244 rows",
+            "dexter_ios18": "iOS 18.3.2 | 179 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 200 rows",
+            "iphone12_ios18": "iOS 18.7 | 168 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 98 rows",
+            "hc_ios26": "iOS 26.5.2 | 266 rows",
         }
     }
 }
@@ -105,6 +106,14 @@ def get_biomeAppinstall(context):
         '10': {'type': 'int', 'name': ''}
     }
 
+    # App.Install records are a different message from _DKEvent.App.Install: a bundle id
+    # and a single integer. Applying the typedef above to them fails on every record, so
+    # the stream directory selects the layout.
+    minimal_typess = {
+        '1': {'type': 'str', 'name': ''},
+        '5': {'type': 'int', 'name': ''}
+    }
+
     data_list = []
     source_dirs = set()
 
@@ -121,12 +130,31 @@ def get_biomeAppinstall(context):
         if 'tombstone' in file_found:
             continue
 
-        source_dirs.add(os.path.dirname(file_found))
+        parent = os.path.dirname(file_found)
+        is_dkevent = '_DKEvent.App.Install' in parent
+        stream = '_DKEvent.App.Install' if is_dkevent else 'App.Install'
+
+        source_dirs.add(parent)
         for record in read_segb_file(file_found):
             ts = record.timestamp1
             ts = ts.replace(tzinfo=timezone.utc)
 
             if record.state == EntryState.Written:
+                if not is_dkevent:
+                    try:
+                        minimal, _ = blackboxprotobuf.decode_message(record.data, minimal_typess)
+                    except (DecodeError, struct.error, KeyError, ValueError, TypeError, IndexError) as ex:
+                        logfunc(f"Skipping biomeAppinstall record due to protobuf decode error: {ex} |"
+                                f"File: {context.get_relative_path(file_found)} | "
+                                f"Offset: {record.data_start_offset}"
+                                )
+                        continue
+                    data_list.append((
+                        ts, None, None, None, record.state.name, stream, None,
+                        minimal.get('1', ''), None, None, None, None,
+                        minimal.get('5', ''), filename, record.data_start_offset
+                    ))
+                    continue
                 try:
                     protostuff, _ = blackboxprotobuf.decode_message(record.data, typess)
 
@@ -161,12 +189,14 @@ def get_biomeAppinstall(context):
                     timeend,
                     timewrite,
                     record.state.name,
+                    stream,
                     activity,
                     bundleid,
                     bundleinfo,
                     appinfo1,
                     appinfo2,
                     actionguid,
+                    '',
                     filename,
                     record.data_start_offset
                 ))
@@ -178,6 +208,8 @@ def get_biomeAppinstall(context):
                     None,
                     None,
                     record.state.name,
+                    stream,
+                    None,
                     None,
                     None,
                     None,
@@ -194,12 +226,14 @@ def get_biomeAppinstall(context):
         ('Time End', 'datetime'),
         ('Time Write', 'datetime'),
         'SEGB State',
+        'Stream',
         'Activity',
         'Bundle ID',
         'Bundle Info',
         'App Info',
         'App Info2',
         'Action GUID',
+        'Event Value (as stored)',
         'Filename',
         'Offset'
     )

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Covers two Biome streams that carry different record layouts. _DKEvent.App.Install records carry the activity, the bundle id, the event and write timestamps and the app display strings. App.Install records carry only a bundle id and one integer, which is reported as stored because no source documenting its meaning was identified. The Stream column names the source stream for each row. Records whose SEGB state is Deleted are reported with their timestamp and offset only. Paths containing 'tombstone' are not parsed.",
+        "notes": "Covers two Biome streams that carry different record layouts. _DKEvent.App.Install records carry the activity, the bundle id, the event and write timestamps and the app display strings. App.Install records carry only a bundle id and one integer, which is reported as stored because no source documenting its meaning was identified. The Stream column names the source stream for each row. Records whose SEGB state is Deleted are reported with their timestamp and offset only. Paths containing 'tombstone' are not parsed. Across the tested images those files hold the Biome daemons' own record of retired stream files, naming the file, a byte size and a record count, and no record in them carried a bundle identifier or an application event.",
         "paths": ('*/Biome/streams/restricted/_DKEvent.App.Install/local/*', '*/Biome/streams/restricted/App.Install/local/*'),
         "output_types": "standard",
         "artifact_icon": "package",

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -1,100 +1,103 @@
 __artifacts_v2__ = {
     "mobileInstall_installed": {
         "name": "Apps - Installed",
-        "description": "Apps whose most recent mobile_installation.log event is an install/update",
-        "author": "@AlexisBrignoni",
+        "description": "Bundle IDs whose most recent installer-reported outcome in mobile_installation.log is a successful install",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Mobile Installation Logs",
-        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time.",
+        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time. State is set only by an installer-reported outcome: an 'Install successful' line, an 'Uninstalling identifier' line, or a 'Destroying container' line. In the tested corpora every 'Destroying container' line was written by MIUninstaller or MIUninstallNotifier. Container bookkeeping ('Made container live', written by makeContainerLiveReplacingContainer, and 'Data container moved', written by _refreshUUIDForContainer) is emitted during installs, updates and cleanup alike, so it is kept in Apps - Historical Combined and does not place a bundle here. A bundle whose install predates the retained log window has no 'Install successful' line and will not appear; absence here is not evidence that an app was never installed. The Source Event column names the line that set the state. The install kind is reported as written: Placeholder is the download stub the installer writes before the app itself installs, and Customer, System and Developer accompany the installed bundle.",
         "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "download",
         "sample_data": {
-            "ctf2020_ios12": "iOS 12.4 | 143 rows",
-            "dexter_ios18": "iOS 18.3.2 | 217 rows",
-            "felix_ios17": "iOS 17.6.1 | 300 rows",
-            "fsfull002_ios17": "iOS 17.1 | 259 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 205 rows",
-            "iphone11_ios17": "iOS 17.3 | 175 rows",
-            "iphone12_ios18": "iOS 18.7 | 245 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 264 rows",
-            "otto_ios17": "iOS 17.5.1 | 232 rows",
-            "abe_ios16": "iOS 16.5 | 218 rows",
-            "felix23_ios16": "iOS 16.5 | 255 rows",
-            "hickman_ios13": "iOS 13.3.1 | 196 rows",
-            "hickman_ios14": "iOS 14.3 | 220 rows",
-            "jess_ios15": "iOS 15.0.2 | 572 rows",
-            "magnet_ios16": "iOS 16.1.1 | 279 rows",
+            "ctf2020_ios12": "iOS 12.4 | 49 rows",
+            "hickman_ios13": "iOS 13.3.1 | 59 rows",
+            "hickman_ios14": "iOS 14.3 | 63 rows",
+            "jess_ios15": "iOS 15.0.2 | 38 rows",
+            "abe_ios16": "iOS 16.5 | 45 rows",
+            "felix23_ios16": "iOS 16.5 | 53 rows",
+            "magnet_ios16": "iOS 16.1.1 | 64 rows",
+            "felix_ios17": "iOS 17.6.1 | 54 rows",
+            "fsfull002_ios17": "iOS 17.1 | 55 rows",
+            "iphone11_ios17": "iOS 17.3 | 32 rows",
+            "otto_ios17": "iOS 17.5.1 | 37 rows",
+            "dexter_ios18": "iOS 18.3.2 | 36 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 36 rows",
+            "iphone12_ios18": "iOS 18.7 | 58 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 51 rows",
+            "hc_ios26": "iOS 26.5.2 | 61 rows",
         }
     },
     "mobileInstall_uninstalled": {
         "name": "Apps - Uninstalled",
-        "description": "Apps whose most recent mobile_installation.log event is an uninstall/destroy",
-        "author": "@AlexisBrignoni",
+        "description": "Bundle IDs whose most recent installer-reported outcome in mobile_installation.log is an uninstall or container destruction",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Mobile Installation Logs",
-        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time.",
+        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time. State is set only by an installer-reported outcome: an 'Install successful' line, an 'Uninstalling identifier' line, or a 'Destroying container' line. In the tested corpora every 'Destroying container' line was written by MIUninstaller or MIUninstallNotifier. Container bookkeeping ('Made container live', written by makeContainerLiveReplacingContainer, and 'Data container moved', written by _refreshUUIDForContainer) is emitted during installs, updates and cleanup alike, so it is kept in Apps - Historical Combined and does not place a bundle here. A bundle whose install predates the retained log window has no 'Install successful' line and will not appear; absence here is not evidence that an app was never installed. The Source Event column names the line that set the state. The install kind is reported as written: Placeholder is the download stub the installer writes before the app itself installs, and Customer, System and Developer accompany the installed bundle.",
         "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "trash",
         "sample_data": {
             "ctf2020_ios12": "iOS 12.4 | 1 row",
-            "dexter_ios18": "iOS 18.3.2 | 0 rows",
-            "felix_ios17": "iOS 17.6.1 | 0 rows",
-            "fsfull002_ios17": "iOS 17.1 | 0 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 1 row",
-            "iphone11_ios17": "iOS 17.3 | 0 rows",
-            "iphone12_ios18": "iOS 18.7 | 0 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
-            "otto_ios17": "iOS 17.5.1 | 0 rows",
-            "abe_ios16": "iOS 16.5 | 0 rows",
-            "felix23_ios16": "iOS 16.5 | 3 rows",
             "hickman_ios13": "iOS 13.3.1 | 21 rows",
             "hickman_ios14": "iOS 14.3 | 27 rows",
             "jess_ios15": "iOS 15.0.2 | 5 rows",
+            "abe_ios16": "iOS 16.5 | 0 rows",
+            "felix23_ios16": "iOS 16.5 | 17 rows",
             "magnet_ios16": "iOS 16.1.1 | 0 rows",
+            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows",
+            "iphone11_ios17": "iOS 17.3 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 0 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 2 rows",
+            "iphone12_ios18": "iOS 18.7 | 0 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
+            "hc_ios26": "iOS 26.5.2 | 0 rows",
         }
     },
     "mobileInstall_historical": {
         "name": "Apps - Historical Combined",
-        "description": "App install/update/uninstall/container/reboot events from mobile_installation.log",
-        "author": "@AlexisBrignoni",
+        "description": "Install, update, patch, uninstall, container and reboot events from mobile_installation.log",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Mobile Installation Logs",
-        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time.",
+        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time. Patch-update lines record an attempt, not a completed update. Install kinds, container personas and version strings are reported as written. Version and Short Version carry the target of a patch attempt or the version of an installable bundle; From Version carries the source of a patch attempt.",
         "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "list",
         "sample_data": {
-            "ctf2020_ios12": "iOS 12.4 | 783 rows",
-            "dexter_ios18": "iOS 18.3.2 | 564 rows",
-            "felix_ios17": "iOS 17.6.1 | 559 rows",
-            "fsfull002_ios17": "iOS 17.1 | 544 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 305 rows",
-            "iphone11_ios17": "iOS 17.3 | 317 rows",
-            "iphone12_ios18": "iOS 18.7 | 489 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 745 rows",
-            "otto_ios17": "iOS 17.5.1 | 584 rows",
-            "abe_ios16": "iOS 16.5 | 686 rows",
-            "felix23_ios16": "iOS 16.5 | 2113 rows",
-            "hickman_ios13": "iOS 13.3.1 | 1389 rows",
-            "hickman_ios14": "iOS 14.3 | 1309 rows",
-            "jess_ios15": "iOS 15.0.2 | 861 rows",
-            "magnet_ios16": "iOS 16.1.1 | 757 rows",
+            "ctf2020_ios12": "iOS 12.4 | 1003 rows",
+            "hickman_ios13": "iOS 13.3.1 | 860 rows",
+            "hickman_ios14": "iOS 14.3 | 798 rows",
+            "jess_ios15": "iOS 15.0.2 | 940 rows",
+            "abe_ios16": "iOS 16.5 | 834 rows",
+            "felix23_ios16": "iOS 16.5 | 918 rows",
+            "magnet_ios16": "iOS 16.1.1 | 895 rows",
+            "felix_ios17": "iOS 17.6.1 | 664 rows",
+            "fsfull002_ios17": "iOS 17.1 | 681 rows",
+            "iphone11_ios17": "iOS 17.3 | 383 rows",
+            "otto_ios17": "iOS 17.5.1 | 713 rows",
+            "dexter_ios18": "iOS 18.3.2 | 763 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 378 rows",
+            "iphone12_ios18": "iOS 18.7 | 591 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 910 rows",
+            "hc_ios26": "iOS 26.5.2 | 455 rows",
         }
     },
     "mobileInstall_reboots": {
         "name": "State - Reboots",
         "description": "Reboot events detected in mobile_installation.log",
-        "author": "@AlexisBrignoni",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-08-25",
         "requirements": "none",
         "category": "Mobile Installation Logs",
         "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time.",
@@ -103,20 +106,21 @@ __artifacts_v2__ = {
         "artifact_icon": "refresh",
         "sample_data": {
             "ctf2020_ios12": "iOS 12.4 | 2 rows",
-            "dexter_ios18": "iOS 18.3.2 | 4 rows",
+            "hickman_ios13": "iOS 13.3.1 | 7 rows",
+            "hickman_ios14": "iOS 14.3 | 5 rows",
+            "jess_ios15": "iOS 15.0.2 | 7 rows",
+            "abe_ios16": "iOS 16.5 | 4 rows",
+            "felix23_ios16": "iOS 16.5 | 3 rows",
+            "magnet_ios16": "iOS 16.1.1 | 7 rows",
             "felix_ios17": "iOS 17.6.1 | 2 rows",
             "fsfull002_ios17": "iOS 17.1 | 15 rows",
-            "hc_ios18_7": "iOS 18.7.8 | 26 rows",
             "iphone11_ios17": "iOS 17.3 | 3 rows",
+            "otto_ios17": "iOS 17.5.1 | 3 rows",
+            "dexter_ios18": "iOS 18.3.2 | 4 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 26 rows",
             "iphone12_ios18": "iOS 18.7 | 6 rows",
             "iphone14plus_ios18": "iOS 18.0 | 6 rows",
-            "otto_ios17": "iOS 17.5.1 | 3 rows",
-            "abe_ios16": "iOS 16.5 | 4 rows",
-            "felix23_ios16": "iOS 16.5 | 23 rows",
-            "hickman_ios13": "iOS 13.3.1 | 12 rows",
-            "hickman_ios14": "iOS 14.3 | 9 rows",
-            "jess_ios15": "iOS 15.0.2 | 7 rows",
-            "magnet_ios16": "iOS 16.1.1 | 7 rows",
+            "hc_ios26": "iOS 26.5.2 | 4 rows",
         }
     }
 }
@@ -128,16 +132,45 @@ import tarfile
 from scripts.ilapfuncs import artifact_processor
 
 _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-_UNINSTALL_ACTIONS = ('Destroying container', 'Uninstalling identifier')
 _TAR_MEMBER_RE = re.compile(r"logs/MobileInstallation/mobile_installation\.log(\.\d+)?$")
 
+# Only an installer-reported outcome sets a bundle's state. Container bookkeeping is
+# written during installs, updates and cleanup alike, so it stays history only.
+_INSTALL_PREFIX = 'Install successful'
+_UNINSTALL_ACTIONS = ('Destroying container', 'Uninstalling identifier')
 
-def _first_group(line, *patterns):
-    for pat in patterns:
-        match = re.search(pat, line)
-        if match:
-            return match.group(1)
-    return ''
+# 'Install Successful for' on every tested release to iOS 18; the tested iOS 26 images
+# write 'Install successful for' and carry no capitalised form at all. The bundle id stops
+# at the first ')' so a trailing '[Distributor: (null)]' is not swallowed. The kind prefix
+# observed across the corpora is Placeholder, Customer, System or Developer.
+_INSTALL_RE = re.compile(r"Install [Ss]uccessful for \(([A-Za-z]+):([^)]*)\)")
+# Two spellings seen across the tested corpora:
+#   'Destroying container with identifier <id> at <path>'         (iOS 12 to 15)
+#   'Destroying container <id> with persona <persona> at <path>'  (iOS 16 onward)
+# The persona is a UUID or the literal '(null)'.
+_DESTROY_RE = re.compile(
+    r"Destroying container (?:with identifier (?P<id_a>\S+)"
+    r"|(?P<id_b>\S+) with persona (?P<persona>\S+)) at (?P<path>.+)$")
+_UNINSTALL_RE = re.compile(r"Uninstalling identifier (?P<bundle>\S+)")
+_DATA_CONTAINER_RE = re.compile(r"Data container for (?P<bundle>\S+) is now at (?P<path>.+)$")
+_LIVE_CONTAINER_RE = re.compile(r"Made container live for (?P<bundle>\S+) at (?P<path>.+)$")
+# Delta appears on every tested release from iOS 12 to iOS 18; Parallel and
+# ParallelWithArchives appear from iOS 16 onward and coexist with Delta.
+_PATCH_RE = re.compile(
+    r"Attempting (?P<kind>[A-Za-z]+) patch update of (?P<bundle>\S+) "
+    r"from (?P<from>.+?) to (?P<to_ver>\S+) \((?P<to_short>[^)]*)\)\s*$")
+# Installing <MIInstallableBundle ID=x; [Persona=y,] Version=n, ShortVersion=s>
+# The class is Bundle, BundlePatch or ParallelPlaceholder across the tested corpora.
+_INSTALLABLE_RE = re.compile(
+    r"Installing <MIInstallable(?P<kind>[A-Za-z]*) ID=(?P<bundle>[^;>]*);"
+    r"(?: Persona=(?P<persona>[^,>]*),)? Version=(?P<version>[^,>]*),"
+    r" ShortVersion=(?P<short>[^>]*)>")
+
+_INSTALLABLE_LABELS = {
+    'Bundle': 'Installing bundle',
+    'BundlePatch': 'Installing bundle patch',
+    'ParallelPlaceholder': 'Installing parallel placeholder',
+}
 
 
 def _parse_timestamp(line):
@@ -157,35 +190,54 @@ def _parse_timestamp(line):
 
 
 def _parse_events(lines):
-    """Return a list of (timestamp_local, action, bundle_id, path) events from mobile_installation.log lines."""
+    """Return (timestamp, action, bundle, persona, version, short_version, from_version, path) events."""
     events = []
     for line in lines:
         ts = _parse_timestamp(line)
         if ts is None:
             continue
-        if 'Install Successful for' in line:
-            bundle = _first_group(line, r"(?<= for \(Placeholder:)(.*)(?=\))",
-                                  r"(?<= for \(Customer:)(.*)(?=\))",
-                                  r"(?<= for \(System:)(.*)(?=\))", r"(?<= for \()(.*)(?=\))")
-            events.append((ts, 'Install successful', bundle, ''))
-        if 'Destroying container ' in line:
-            events.append((ts, 'Destroying container', _first_group(line, r"(?<=identifier )(.*)(?= at )"),
-                           _first_group(line, r"(?<= at )(.*)$")))
-        if 'Data container for' in line:
-            events.append((ts, 'Data container moved', _first_group(line, r"(?<=for )(.*)(?= is now )"),
-                           _first_group(line, r"(?<= at )(.*)$")))
-        if 'Made container live for' in line:
-            events.append((ts, 'Made container live', _first_group(line, r"(?<=for )(.*)(?= at)"),
-                           _first_group(line, r"(?<= at )(.*)$")))
-        if 'Uninstalling identifier ' in line:
-            events.append((ts, 'Uninstalling identifier',
-                           _first_group(line, r"(?<=Uninstalling identifier )(.*)"), ''))
+
+        match = _INSTALL_RE.search(line)
+        if match:
+            events.append((ts, f'{_INSTALL_PREFIX} ({match.group(1)})', match.group(2),
+                           '', '', '', '', ''))
+
+        match = _DESTROY_RE.search(line)
+        if match:
+            bundle = match.group('id_a') or match.group('id_b') or ''
+            events.append((ts, 'Destroying container', bundle, match.group('persona') or '',
+                           '', '', '', match.group('path')))
+
+        match = _DATA_CONTAINER_RE.search(line)
+        if match:
+            events.append((ts, 'Data container moved', match.group('bundle'),
+                           '', '', '', '', match.group('path')))
+
+        match = _LIVE_CONTAINER_RE.search(line)
+        if match:
+            events.append((ts, 'Made container live', match.group('bundle'),
+                           '', '', '', '', match.group('path')))
+
+        match = _UNINSTALL_RE.search(line)
+        if match:
+            events.append((ts, 'Uninstalling identifier', match.group('bundle'),
+                           '', '', '', '', ''))
+
         if 'main: Reboot detected' in line:
-            events.append((ts, 'Reboot detected', '', ''))
-        if 'Attempting Delta patch update of ' in line:
-            events.append((ts, 'Attempting Delta patch',
-                           _first_group(line, r"(?<=Attempting Delta patch update of )(.*)(?= from)"),
-                           _first_group(line, r"(?<= from )(.*)$")))
+            events.append((ts, 'Reboot detected', '', '', '', '', '', ''))
+
+        match = _PATCH_RE.search(line)
+        if match:
+            events.append((ts, f"Attempting {match.group('kind')} patch update", match.group('bundle'),
+                           '', match.group('to_ver'), match.group('to_short'),
+                           match.group('from'), ''))
+
+        match = _INSTALLABLE_RE.search(line)
+        if match:
+            kind = match.group('kind')
+            events.append((ts, _INSTALLABLE_LABELS.get(kind, f'Installing {kind}'),
+                           match.group('bundle'), match.group('persona') or '',
+                           match.group('version'), match.group('short'), '', ''))
     return events
 
 
@@ -219,7 +271,9 @@ def _iter_log_lines(files_found):
 def _events_and_source(context):
     events = []
     sources = []
-    for lines, source in _iter_log_lines(context.get_files_found()):
+    # Sorting the log files fixes the order events are read in, which is what breaks
+    # ties between two state-setting events written in the same second.
+    for lines, source in _iter_log_lines(sorted(str(f) for f in context.get_files_found())):
         rel = context.get_relative_path(source)
         if rel not in sources:
             sources.append(rel)
@@ -227,39 +281,42 @@ def _events_and_source(context):
     return events, ', '.join(sources)
 
 
-def _latest_per_bundle(events):
-    """Most recent event per (non-empty) bundle id; local timestamp strings sort chronologically."""
+def _latest_state_per_bundle(events):
+    """Most recent installer-reported outcome per bundle id."""
     latest = {}
-    for event in events:
-        bundle = event[2]
+    for index, event in enumerate(events):
+        bundle, action = event[2], event[1]
         if not bundle:
             continue
-        if bundle not in latest or event[0] > latest[bundle][0]:
-            latest[bundle] = event
-    return latest
+        if not (action.startswith(_INSTALL_PREFIX) or action in _UNINSTALL_ACTIONS):
+            continue
+        if bundle not in latest or (event[0], index) >= (latest[bundle][0][0], latest[bundle][1]):
+            latest[bundle] = (event, index)
+    return {bundle: event for bundle, (event, _index) in latest.items()}
 
 
 @artifact_processor
 def mobileInstall_installed(context):
-    data_headers = ('Last Installed', 'Bundle ID')
+    data_headers = ('Last Installed', 'Bundle ID', 'Source Event')
     events, source = _events_and_source(context)
-    data_list = [(ev[0], ev[2]) for ev in _latest_per_bundle(events).values()
-                 if ev[1] not in _UNINSTALL_ACTIONS]
+    data_list = [(ev[0], ev[2], ev[1]) for ev in _latest_state_per_bundle(events).values()
+                 if ev[1].startswith(_INSTALL_PREFIX)]
     return data_headers, data_list, source
 
 
 @artifact_processor
 def mobileInstall_uninstalled(context):
-    data_headers = ('Last Uninstalled', 'Bundle ID')
+    data_headers = ('Last Uninstalled', 'Bundle ID', 'Source Event')
     events, source = _events_and_source(context)
-    data_list = [(ev[0], ev[2]) for ev in _latest_per_bundle(events).values()
+    data_list = [(ev[0], ev[2], ev[1]) for ev in _latest_state_per_bundle(events).values()
                  if ev[1] in _UNINSTALL_ACTIONS]
     return data_headers, data_list, source
 
 
 @artifact_processor
 def mobileInstall_historical(context):
-    data_headers = ('Timestamp', 'Event', 'Bundle ID', 'Event Path')
+    data_headers = ('Timestamp', 'Event', 'Bundle ID', 'Persona', 'Version', 'Short Version',
+                    'From Version', 'Event Path')
     events, source = _events_and_source(context)
     return data_headers, events, source
 

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -122,6 +122,37 @@ __artifacts_v2__ = {
             "iphone14plus_ios18": "iOS 18.0 | 6 rows",
             "hc_ios26": "iOS 26.5.2 | 4 rows",
         }
+    },
+    "mobileInstall_container_only": {
+        "name": "Apps - Container Activity Only",
+        "description": "Bundle IDs that mobile_installation.log mentions only through container or patch activity, with no installer-reported install or uninstall",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-25",
+        "last_update_date": "2026-08-25",
+        "requirements": "none",
+        "category": "Mobile Installation Logs",
+        "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time. These bundle IDs appear in the log but never in an 'Install successful', 'Uninstalling identifier' or 'Destroying container' line, so Apps - Installed and Apps - Uninstalled do not list them. That happens when the install predates the retained log window. Presence here shows the log mentioned the bundle; it does not establish that the app was installed, and absence of an install line is not evidence that it was not. App extension bundle IDs appear here because extensions have their own containers. Parent Bundle ID (by prefix) is filled in when another bundle ID in the same log is a dotted prefix of this one, which is Apple's convention for an extension and its host app; it is read from the identifier strings, not from a relationship the log records. The Source Event column names the most recent line that mentioned the bundle.",
+        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "box",
+        "sample_data": {
+            "ctf2020_ios12": "iOS 12.4 | 92 rows",
+            "hickman_ios13": "iOS 13.3.1 | 137 rows",
+            "hickman_ios14": "iOS 14.3 | 157 rows",
+            "jess_ios15": "iOS 15.0.2 | 534 rows",
+            "abe_ios16": "iOS 16.5 | 173 rows",
+            "felix23_ios16": "iOS 16.5 | 168 rows",
+            "magnet_ios16": "iOS 16.1.1 | 215 rows",
+            "felix_ios17": "iOS 17.6.1 | 192 rows",
+            "fsfull002_ios17": "iOS 17.1 | 204 rows",
+            "iphone11_ios17": "iOS 17.3 | 143 rows",
+            "otto_ios17": "iOS 17.5.1 | 158 rows",
+            "dexter_ios18": "iOS 18.3.2 | 145 rows",
+            "hc_ios18_7": "iOS 18.7.8 | 136 rows",
+            "iphone12_ios18": "iOS 18.7 | 174 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 169 rows",
+            "hc_ios26": "iOS 26.5.2 | 160 rows",
+        }
     }
 }
 
@@ -295,6 +326,31 @@ def _latest_state_per_bundle(events):
     return {bundle: event for bundle, (event, _index) in latest.items()}
 
 
+def _latest_non_state_per_bundle(events, stateful):
+    """Most recent event per bundle id that has no installer-reported outcome anywhere in the log."""
+    latest = {}
+    for index, event in enumerate(events):
+        bundle = event[2]
+        if not bundle or bundle in stateful:
+            continue
+        if bundle not in latest or (event[0], index) >= (latest[bundle][0][0], latest[bundle][1]):
+            latest[bundle] = (event, index)
+    return {bundle: event for bundle, (event, _index) in latest.items()}
+
+
+def _parent_by_prefix(bundle, all_bundles):
+    """The longest other bundle id in the same log that this one extends with a dot.
+
+    Apple's convention is that an app extension's bundle id extends its host app's, so
+    this is a string relationship read off the ids, not a link the log records.
+    """
+    best = ''
+    for candidate in all_bundles:
+        if candidate != bundle and bundle.startswith(candidate + '.') and len(candidate) > len(best):
+            best = candidate
+    return best
+
+
 @artifact_processor
 def mobileInstall_installed(context):
     data_headers = ('Last Installed', 'Bundle ID', 'Source Event')
@@ -326,4 +382,16 @@ def mobileInstall_reboots(context):
     data_headers = ('Timestamp (Local Time)', 'Description')
     events, source = _events_and_source(context)
     data_list = [(ev[0], ev[1]) for ev in events if ev[1] == 'Reboot detected']
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def mobileInstall_container_only(context):
+    data_headers = ('Last Seen', 'Bundle ID', 'Parent Bundle ID (by prefix)', 'Source Event')
+    events, source = _events_and_source(context)
+    stateful = set(_latest_state_per_bundle(events))
+    remaining = _latest_non_state_per_bundle(events, stateful)
+    all_bundles = {ev[2] for ev in events if ev[2]}
+    data_list = [(ev[0], ev[2], _parent_by_prefix(ev[2], all_bundles), ev[1])
+                 for ev in remaining.values()]
     return data_headers, data_list, source

--- a/scripts/artifacts/uninstalledApplications.py
+++ b/scripts/artifacts/uninstalledApplications.py
@@ -1,0 +1,68 @@
+__artifacts_v2__ = {
+    "uninstalled_applications_plist": {
+        "name": "Apps - Uninstalled Applications Plist",
+        "description": (
+            "Bundle identifiers and dates recorded in "
+            "/private/var/installd/Library/MobileInstallation/UninstalledApplications.plist, "
+            "a property list whose keys are bundle identifiers and whose values are dates."
+        ),
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-25",
+        "last_update_date": "2026-08-25",
+        "requirements": "none",
+        "category": "Mobile Installation Logs",
+        "notes": (
+            "The file holds one date per bundle identifier, so a bundle that was installed and "
+            "removed more than once carries only the date recorded against it here. The dates are "
+            "read from the property list's own date type, which is stored in UTC. The file is not "
+            "present on every device: it was found on two of the twenty-four tested images. Absence "
+            "of the file, or of a bundle identifier within it, is absence of this source and is not "
+            "evidence that no application was removed."
+        ),
+        "paths": ('*/installd/Library/MobileInstallation/UninstalledApplications.plist',),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "trash-2",
+        "sample_data": {
+            "hc_ios26": "iOS 26.5.2 | 5 rows",
+            "otto_ios17": "iOS 17.5.1 | 5 rows",
+        }
+    }
+}
+
+import datetime
+import plistlib
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+@artifact_processor
+def uninstalled_applications_plist(context):
+    data_headers = (('Date', 'datetime'), 'Bundle ID')
+    data_list = []
+    sources = []
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        try:
+            with open(file_found, 'rb') as fp:
+                parsed = plistlib.load(fp)
+        except (OSError, plistlib.InvalidFileException, ValueError) as ex:
+            logfunc(f'Could not read {context.get_relative_path(file_found)}: {ex}')
+            continue
+
+        if not isinstance(parsed, dict):
+            logfunc(f'Unexpected top-level type in {context.get_relative_path(file_found)}: '
+                    f'{type(parsed).__name__}')
+            continue
+
+        rel = context.get_relative_path(file_found)
+        if rel not in sources:
+            sources.append(rel)
+
+        for bundle_id, value in parsed.items():
+            if isinstance(value, datetime.datetime):
+                # plistlib returns the property list date type as a naive UTC datetime.
+                value = value.replace(tzinfo=datetime.timezone.utc)
+            data_list.append((value, bundle_id))
+
+    return data_headers, data_list, '\n'.join(sources)


### PR DESCRIPTION
Fixes Mobile Installation log parsing and Biome App.Install decoding.

- Mobile Installation: matches the lowercase "Install successful for" written on iOS 26, stops the bundle ID at the first ")" so a trailing "[Distributor: (null)]" is not swallowed, reads the newer "with persona" container destruction form, and parses Parallel and ParallelWithArchives patch attempts plus the installable-bundle lines.
- Installed and uninstalled state now comes only from an installer-reported outcome. Container activity moves to a new Apps - Container Activity Only artifact.
- Biome: App.Install and _DKEvent.App.Install carry different record layouts, so the stream directory selects the layout. App.Installation pins the field types for its version and 16 byte values.
- Adds an artifact for UninstalledApplications.plist.

Undocumented integers are reported as stored. Row counts in sample_data are from runs against sixteen registered images.