### PR TITLE
Declare workflow token permissions explicitly

### DIFF
--- a/.github/workflows/filepath_search_summary.yml
+++ b/.github/workflows/filepath_search_summary.yml
@@ -3,6 +3,9 @@ name: Run Filepath Search List
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run-filepath-search:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - '**.py' # only trigger on python files
+
+permissions:
+  contents: read
+
 jobs:
   lint-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -17,6 +17,9 @@ on:
       - 'ileapp.py'
       - 'ileappGUI.py'
 
+permissions:
+  contents: read
+
 jobs:
   runtime-contract:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_smoke.yml
+++ b/.github/workflows/windows_smoke.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/windows_smoke.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   windows-smoke:
     runs-on: windows-latest


### PR DESCRIPTION
Adds an explicit `permissions` block to the four workflows that had none, so they stop inheriting the repository default of write.

- `python_lint.yml`, `python_runtime_contract.yml` and `windows_smoke.yml` get `contents: read`. None of them writes anything: they check out, install requirements and run scripts.
- `filepath_search_summary.yml` gets `contents: write`, because it commits and pushes the regenerated summary. Same declaration `update_module_info.yml` already carries.

The other five workflows already declare what they need.