### PR TITLE
Scope TikTok Pitaya and WatchHistory artifacts to TikTok-owned containers

### DIFF
--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -176,7 +176,7 @@ __artifacts_v2__ = {
                        "launch flag and duration as stored.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-16",
-        "last_update_date": "2026-08-21",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "TikTok",
         "notes": (
@@ -188,12 +188,23 @@ __artifacts_v2__ = {
             "Hu and Karabiyik describe the feature_engineering.db of an earlier app "
             "generation as recording user interaction events with millisecond "
             "timestamps; the event table they document is absent from the tested build, "
-            "which carries this session table instead. "
+            "which carries this session table instead. An iOS app container is a GUID "
+            "directory, so the database path alone does not identify the owning app. "
+            "Each matched database is attributed to the app named by its container's "
+            "own .com.apple.mobile_container_manager.metadata.plist (a path "
+            "reconstructed from an iTunes backup names the container by its AppDomain "
+            "bundle id), and only containers owned by com.zhiliaoapp.musically are "
+            "parsed. Databases in containers owned by any other app, or whose owning "
+            "app cannot be established, are skipped and logged. On the tested images "
+            "every matched database is in a TikTok-owned container; the exclusion of "
+            "foreign and unattributable containers is proven with constructed test "
+            "data. "
             "Reference: Xiao Hu and Umit Karabiyik, 'Shopping while Watching: An Updated "
             "Forensic Analysis of TikTok on Android and iOS', ISNCC 2024, "
             "https://doi.org/10.1109/ISNCC62547.2024.10759027"
         ),
-        "paths": ("*/mobile/Containers/Data/Application/*/Library/Pitaya/FE/*/DB/feature_engineering.db*",),
+        "paths": ("*/mobile/Containers/Data/Application/*/Library/Pitaya/FE/*/DB/feature_engineering.db*",
+                  "*/mobile/Containers/Data/Application/*/.com.apple.mobile_container_manager.metadata.plist"),
         "output_types": "standard",
         "artifact_icon": "activity",
         "sample_data": {
@@ -213,7 +224,7 @@ __artifacts_v2__ = {
                        "timestamp, reported as stored.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-16",
-        "last_update_date": "2026-08-21",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "TikTok",
         "notes": (
@@ -227,9 +238,19 @@ __artifacts_v2__ = {
             "id. Whether an entry means the video was viewed or prefetched is not "
             "established here. The Account ID column is the file name's numeric prefix, "
             "which on the tested image matches the ChatFiles account folder name (the "
-            "local account uid)."
+            "local account uid). An iOS app container is a GUID directory, so the store's "
+            "path alone does not identify the owning app. Each matched database is "
+            "attributed to the app named by its container's own "
+            ".com.apple.mobile_container_manager.metadata.plist (a path reconstructed "
+            "from an iTunes backup names the container by its AppDomain bundle id), and "
+            "only containers owned by com.zhiliaoapp.musically are parsed. Databases in "
+            "containers owned by any other app, or whose owning app cannot be "
+            "established, are skipped and logged. On the tested images every matched "
+            "database is in a TikTok-owned container; the exclusion of foreign and "
+            "unattributable containers is proven with constructed test data."
         ),
-        "paths": ("*/mobile/Containers/Data/Application/*/Documents/WatchHistory/*_history_WCDB.sqlite*",),
+        "paths": ("*/mobile/Containers/Data/Application/*/Documents/WatchHistory/*_history_WCDB.sqlite*",
+                  "*/mobile/Containers/Data/Application/*/.com.apple.mobile_container_manager.metadata.plist"),
         "output_types": "standard",
         "artifact_icon": "eye",
         "sample_data": {
@@ -237,6 +258,10 @@ __artifacts_v2__ = {
             "otto_ios17": "iOS 17.5.1 | TikTok 35.6.0 | 1044 rows",
             "abe_ios16": "iOS 16.5 | TikTok 30.0.0 | 1562 rows",
             "hickman_ios15": "iOS 15.3.1 | 8 rows",
+            "dexter_ios18": "iOS 18.3.2 | no WatchHistory store found",
+            "iphone12_ios18": "iOS 18.7 | no WatchHistory store found",
+            "iphone14plus_ios18_mvs2025": "iOS 18.0 | no WatchHistory store found",
+            "hickman_ios13": "iOS 13.3.1 | no WatchHistory store found",
         },
     },
 }
@@ -258,8 +283,10 @@ from scripts.ilapfuncs import (
 
 _TIKTOK_ACCOUNT_KEY = "com.toutiao.account.userdefault.user"
 
-# The IM store names are not unique to TikTok, so a matched file is only parsed
-# when the app that owns its container is TikTok.
+# An iOS app container is a GUID directory, so a matched file's path does not
+# name the owning app. Stores matched by name (IM databases, Pitaya
+# feature_engineering.db, WatchHistory) are only parsed when the app that owns
+# their container is TikTok.
 _TIKTOK_BUNDLE_IDS = ("com.zhiliaoapp.musically",)
 _CONTAINER_METADATA_SUFFIX = ".com.apple.mobile_container_manager.metadata.plist"
 _CONTAINER_SEGMENT_RE = re.compile(r"/Containers/Data/Application/([^/]+)/", re.I)
@@ -668,13 +695,12 @@ def tiktok_account(context):
 def tiktok_watch_history(context):
     """ see artifact description """
     files_found = context.get_files_found()
+    history_dbs = [str(file_found) for file_found in files_found
+                   if str(file_found).endswith("_history_WCDB.sqlite")]
     data_list = []
     source_path = ""
 
-    for file_found in files_found:
-        file_found = str(file_found)
-        if not file_found.endswith("_history_WCDB.sqlite"):
-            continue
+    for file_found in _tiktok_owned(history_dbs, _container_owners(files_found)):
         source_path = source_path or file_found
         account_id = basename(file_found).split("_", 1)[0]
         source_file = context.get_relative_path(file_found)
@@ -742,13 +768,12 @@ def tiktok_published_videos(context):
 def tiktok_app_sessions(context):
     """ see artifact description """
     files_found = context.get_files_found()
+    session_dbs = [str(file_found) for file_found in files_found
+                   if str(file_found).endswith("feature_engineering.db")]
     data_list = []
     source_path = ""
 
-    for file_found in files_found:
-        file_found = str(file_found)
-        if not file_found.endswith("feature_engineering.db"):
-            continue
+    for file_found in _tiktok_owned(session_dbs, _container_owners(files_found)):
         has_table = list(get_sqlite_db_records(
             file_found,
             "SELECT name FROM sqlite_master WHERE type = 'table' "


### PR DESCRIPTION
Extends the container-owner check from #2067 to the two remaining name-keyed TikTok artifacts:

- App Sessions (Library/Pitaya/FE feature_engineering.db)
- Watch History (Documents/WatchHistory)

Each matched database is parsed only when its container's own metadata plist (or the backup AppDomain segment) records com.zhiliaoapp.musically; foreign and unattributable containers are skipped and logged. On the tested images every matched database is in a TikTok-owned container; the exclusion is proven with constructed test data. Watch History gains checked-absence sample_data entries for four corpora.