### PR TITLE
Check artifact notes for unsupported claim language

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -214,11 +214,6 @@ ALLOWLIST = {
     # the artifact reads the account holder's own list table.
     ('foursquareSwarm.py', 'foursquare_swarm_saved_lists', 'description'),
 
-    # "one row per visited page" names the record ZBROWSINGHISTORYENTRYMANAGEDOBJECT
-    # holds, alongside the aggregate visit count the app's own column carries. It
-    # describes the table, not what the account holder did.
-    ('duckduckgo.py', 'duckduckgo_history', 'notes'),
-
     # "enumerated beside an account reads as something the user chose" is the reason
     # the downloaded catalogue is summarised rather than listed. The denial follows
     # the phrase instead of preceding it, so the negation lookback cannot see it.

--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -107,11 +107,70 @@ CLAIM_PATTERN = re.compile(
     r'|\balways\b'
     r'|\breliable'
     r'|\bvisited\b'
-    r'|\bhabit',
+    r'|\bhabits?\b',
     re.IGNORECASE)
 
+# `notes` reaches the examiner too, in the report and in the artifact info modal, so
+# the same standard applies to it. It cannot use the same vocabulary, because notes do
+# a job name and description do not: they state what was tested. "empty on all 18
+# copies tested" and "NULL for every account tested" are the coverage discipline this
+# project asks for, not claims about a person, and the completeness words fire on every
+# one of them. Measured 2026-08-29: the full vocabulary flags 368 of the 1,477
+# artifacts carrying notes across the five cores, dominated by `every` and `all`,
+# almost all describing a test set.
+#
+# `read by` comes out for the same reason. In a note it means read by the code, not by
+# a person: "columns are read by position", "not read by this artifact".
+#
+# What is left is attribution and certainty, which mean the same thing in a note as in
+# a description.
+NOTES_PATTERN = re.compile(
+    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent'
+    r'|created|hid|chose)\b'
+    r'|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b'
+    r'|\bsearched by\b'
+    r'|\btyped by\b'
+    r'|\bviewed by\b'
+    r'|\bmanually\b'
+    r'|\bproves?\b'
+    r'|\bdefinitively\b'
+    r'|\balways\b'
+    r'|\breliable'
+    r'|\bvisited\b'
+    r'|\bhabits?\b',
+    re.IGNORECASE)
+
+# A note that *denies* a claim uses the same words as one that makes it: "not terms the
+# user searched for", "does not establish that the user viewed them". That denial is the
+# wording this project asks for, so matching it and demanding an allowlist entry would
+# tax the correct behaviour and grow the allowlist without bound. A match in `notes`
+# preceded by a negation inside the same clause is therefore not reported.
+#
+# The window is deliberately short. A negation two sentences back says nothing about
+# this clause, and a long window would swallow real claims. Suppressed matches are
+# counted and printed under --verbose, because a check that narrows its own scope
+# silently is worse than no check.
+NEGATION_WINDOW = 60
+NEGATION_PATTERN = re.compile(
+    r"\b(not|no|never|nor|neither|without|cannot|rather than|instead of"
+    r"|isn't|doesn't|don't|does not|do not)\b",
+    re.IGNORECASE)
+
+
+def negated(text, start):
+    """True when a negation appears close enough before `start` to govern it."""
+    window = text[max(0, start - NEGATION_WINDOW):start]
+    # A sentence boundary ends the clause, so a negation before it does not govern.
+    window = window.rsplit('. ', 1)[-1]
+    return bool(NEGATION_PATTERN.search(window))
+
+
 # Fields that reach the examiner through the report and the LAVA manifest.
-CHECKED_FIELDS = ('name', 'description')
+CHECKED_FIELDS = {
+    'name': CLAIM_PATTERN,
+    'description': CLAIM_PATTERN,
+    'notes': NOTES_PATTERN,
+}
 
 # Reviewed exceptions, keyed by (filename, artifact_key, field). Every entry
 # needs a comment justifying it. See the module docstring before adding one.
@@ -154,6 +213,26 @@ ALLOWLIST = {
     # A Foursquare list is user-created by the definition of the feature, and
     # the artifact reads the account holder's own list table.
     ('foursquareSwarm.py', 'foursquare_swarm_saved_lists', 'description'),
+
+    # "one row per visited page" names the record ZBROWSINGHISTORYENTRYMANAGEDOBJECT
+    # holds, alongside the aggregate visit count the app's own column carries. It
+    # describes the table, not what the account holder did.
+    ('duckduckgo.py', 'duckduckgo_history', 'notes'),
+
+    # "enumerated beside an account reads as something the user chose" is the reason
+    # the downloaded catalogue is summarised rather than listed. The denial follows
+    # the phrase instead of preceding it, so the negation lookback cannot see it.
+    ('googleSheets.py', 'google_sheets_templates', 'notes'),
+
+    # "originally typed by the user" is quoted verbatim from the CREATE TABLE comment
+    # stored in Apple's own database, which the note says it is quoting.
+    ('keyboard.py', 'keyboardAutocorrectionRejections', 'notes'),
+    ('keyboard.py', 'keyboardInlineCompletionRejections', 'notes'),
+
+    # "It does not establish that the profile was displayed to the user, that the user
+    # viewed it, or that the user acted on it" is a denial governing a list. The
+    # negation sits before the first item and the lookback does not span to the third.
+    ('tinder.py', 'tinderRecommendations', 'notes'),
 }
 
 STANDARD_NOTE = (
@@ -207,30 +286,36 @@ def load_artifacts(path):
 
 
 def scan_file(path):
-    """Return (matches, skip_reason) for one artifact module.
+    """Return (matches, skip_reason, negated_count) for one artifact module.
 
     Each match is a (rel_path, artifact_key, field, text, matched_terms,
     allowlisted) tuple.
     """
     artifacts, skip_reason = load_artifacts(path)
     if artifacts is None:
-        return [], skip_reason
+        return [], skip_reason, 0
 
     filename = os.path.basename(path)
     matches = []
+    negated_count = 0
     for artifact_key, entry in artifacts.items():
         if not isinstance(entry, dict):
             continue
-        for field in CHECKED_FIELDS:
+        for field, pattern in CHECKED_FIELDS.items():
             text = entry.get(field)
             if not isinstance(text, str):
                 continue
-            terms = CLAIM_PATTERN.findall(text)
+            hits = list(pattern.finditer(text))
+            if field == 'notes':
+                kept = [hit for hit in hits if not negated(text, hit.start())]
+                negated_count += len(hits) - len(kept)
+                hits = kept
+            terms = [hit.group(0) for hit in hits]
             if not terms:
                 continue
             allowlisted = (filename, str(artifact_key), field) in ALLOWLIST
             matches.append((path, str(artifact_key), field, text, terms, allowlisted))
-    return matches, None
+    return matches, None, negated_count
 
 
 def repo_root():
@@ -268,9 +353,11 @@ def main():
     allowlisted = []
     skipped = []
     fired = set()
+    negated_total = 0
     for path in paths:
         rel_path = os.path.relpath(path, root)
-        matches, skip_reason = scan_file(path)
+        matches, skip_reason, negated_here = scan_file(path)
+        negated_total += negated_here
         if skip_reason:
             skipped.append((rel_path, skip_reason))
             continue
@@ -301,6 +388,8 @@ def main():
               f'{len(skipped)} skipped.')
         print(f'Allowlist holds {len(ALLOWLIST)} entr(ies); {len(allowlisted)} fired '
               f'this run.')
+        print(f'{negated_total} match(es) in notes were preceded by a negation and '
+              f'not reported.')
         print()
 
     if stale:

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -1,0 +1,179 @@
+"""Prove the claim checker reads notes, reads them with the right vocabulary, and
+that the vocabulary is the same one every core enforces.
+
+Extending the check to `notes` is only worth having if three things hold at once, and
+each fails silently on its own:
+
+* notes are actually matched, or the field is nominally covered and never read;
+* the completeness words do not apply to notes, or the check fires on every artifact
+  that states what it was tested against, which is the wording this project asks for;
+* a denial is not treated as a claim, or the same wording is taxed and the allowlist
+  grows every time somebody writes a limitation down correctly.
+
+The vocabulary is pinned to a literal here. The five cores each carry their own copy of
+the checker, and they had already drifted: four spelled the habit stem open, so
+"habitat" matched, and only one had it closed. A checker that quietly enforces a
+different standard per repo is worse than a strict one, and nothing else compares them.
+This file is identical in all five, so a change made in one repo alone fails that
+repo's own CI.
+
+The expected values are spelled out rather than derived from the patterns under test.
+A fixture built from the constant it verifies moves with the bug.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_claim_language.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_claim_language', _MODULE_PATH)
+ccl = importlib.util.module_from_spec(_spec)
+sys.modules['check_claim_language'] = ccl
+_spec.loader.exec_module(ccl)
+
+# The vocabulary every core is expected to enforce, written out rather than imported.
+EXPECTED_CLAIM = (
+    r'\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|'
+    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
+    r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
+    r'searched|selected|initiated)\b|\bsearched by\b|\btyped by\b|'
+    r'\bviewed by\b|\bread by\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
+    r'\balways\b|\breliable|\bvisited\b|\bhabits?\b'
+)
+EXPECTED_NOTES = (
+    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
+    r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
+    r'searched|selected|initiated)\b|\bsearched by\b|\btyped by\b|'
+    r'\bviewed by\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|'
+    r'\breliable|\bvisited\b|\bhabits?\b'
+)
+EXPECTED_NEGATION = (
+    r'\b(not|no|never|nor|neither|without|cannot|rather than|instead of|'
+    r"isn't|doesn't|don't|does not|do not)\b"
+)
+EXPECTED_FIELDS = ('description', 'name', 'notes')
+
+
+def fires(field, text):
+    """True when the vocabulary for `field` reports a match in `text`, negation applied."""
+    pattern = ccl.CHECKED_FIELDS[field]
+    hits = list(pattern.finditer(text))
+    if field == 'notes':
+        hits = [hit for hit in hits if not ccl.negated(text, hit.start())]
+    return bool(hits)
+
+
+class VocabularyParity(unittest.TestCase):
+    """The five cores must enforce one standard. Drift in any of them fails here."""
+
+    def test_claim_vocabulary_is_the_shared_one(self):
+        self.assertEqual(ccl.CLAIM_PATTERN.pattern, EXPECTED_CLAIM)
+
+    def test_notes_vocabulary_is_the_shared_one(self):
+        self.assertEqual(ccl.NOTES_PATTERN.pattern, EXPECTED_NOTES)
+
+    def test_negation_vocabulary_is_the_shared_one(self):
+        self.assertEqual(ccl.NEGATION_PATTERN.pattern, EXPECTED_NEGATION)
+        self.assertEqual(ccl.NEGATION_WINDOW, 60)
+
+    def test_the_same_three_fields_are_checked(self):
+        self.assertEqual(tuple(sorted(ccl.CHECKED_FIELDS)), EXPECTED_FIELDS)
+
+    def test_the_habit_stem_is_closed(self):
+        # The open stem also matches "habitat". Four cores carried that until 2026-08-29.
+        self.assertFalse(ccl.CLAIM_PATTERN.search('habitat'))
+        self.assertFalse(ccl.NOTES_PATTERN.search('habitat'))
+        self.assertTrue(ccl.CLAIM_PATTERN.search('habits'))
+
+
+class FieldCoverage(unittest.TestCase):
+    def test_notes_is_checked(self):
+        self.assertIn('notes', ccl.CHECKED_FIELDS)
+
+    def test_name_and_description_keep_the_full_vocabulary(self):
+        self.assertIs(ccl.CHECKED_FIELDS['name'], ccl.CLAIM_PATTERN)
+        self.assertIs(ccl.CHECKED_FIELDS['description'], ccl.CLAIM_PATTERN)
+
+    def test_notes_uses_its_own_vocabulary(self):
+        self.assertIs(ccl.CHECKED_FIELDS['notes'], ccl.NOTES_PATTERN)
+
+
+class NotesVocabulary(unittest.TestCase):
+    # Attribution and certainty mean the same thing in a note as in a description.
+    CLAIMS = (
+        'the term the user typed into the search box',
+        'a page the user visited',
+        'a term the user entered',
+        'this proves the account holder sent it',
+        'the column is always populated',
+        'a reliable record of the conversation',
+    )
+    # Notes state what was tested. These must stay silent or the check punishes the
+    # coverage discipline it exists alongside.
+    COVERAGE = (
+        'empty on all 18 copies tested',
+        'NULL for every account tested',
+        'the complete table list is given above',
+        'present on the entire corpus',
+        'columns are read by position over a select star',
+        'the sidecar is not read by this artifact',
+    )
+
+    def test_claims_fire(self):
+        for text in self.CLAIMS:
+            with self.subTest(text=text):
+                self.assertTrue(fires('notes', text))
+
+    def test_coverage_wording_stays_silent(self):
+        for text in self.COVERAGE:
+            with self.subTest(text=text):
+                self.assertFalse(fires('notes', text))
+
+    def test_notes_drops_exactly_the_two_documented_classes(self):
+        """The two vocabularies differ only where the module says they do."""
+        removed = ('all', 'every', 'complete', 'entire', 'full list', 'read by')
+        for word in removed:
+            with self.subTest(word=word, vocabulary='description'):
+                self.assertTrue(ccl.CLAIM_PATTERN.search(word))
+            with self.subTest(word=word, vocabulary='notes'):
+                self.assertFalse(ccl.NOTES_PATTERN.search(word))
+        kept = ('the user typed', 'typed by', 'manually', 'proves', 'always',
+                'reliable', 'visited', 'habits', 'user-created')
+        for word in kept:
+            with self.subTest(word=word):
+                self.assertTrue(ccl.CLAIM_PATTERN.search(word))
+                self.assertTrue(ccl.NOTES_PATTERN.search(word))
+
+    def test_description_still_flags_completeness(self):
+        # The narrowing applies to notes only. Regression guard on the original behaviour.
+        self.assertTrue(fires('description', 'every message in the conversation'))
+        self.assertTrue(fires('description', 'all sites the user visited'))
+
+
+class Negation(unittest.TestCase):
+    def test_denial_in_the_same_clause_is_not_a_claim(self):
+        for text in (
+            'this store holds suggestions the app downloaded, not terms the user searched for',
+            'their presence does not establish that the user viewed them',
+            'they evidence the app running rather than anything the user chose',
+            'the app stores no user created images',
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(fires('notes', text))
+
+    def test_a_negation_in_the_previous_sentence_does_not_carry(self):
+        # "not" governs its own clause. A full stop ends it, so the claim after it stands.
+        text = 'The table is not a cache. It records the term the user typed.'
+        self.assertTrue(fires('notes', text))
+
+    def test_a_distant_negation_does_not_carry(self):
+        # Sixty characters is the window; padding past it must leave the claim visible.
+        text = 'not' + ' x' * 45 + ' the term the user typed'
+        self.assertTrue(fires('notes', text))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/biomeLocationVisit.py
+++ b/scripts/artifacts/biomeLocationVisit.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
                        "is relied on.",
         "author": "@abrignoni, @mattiaepi (Mattia Epifani)",
         "creation_date": "2026-07-25",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Biome",
         "notes": "Timestamp reliability, observed in the sample data: every record in a stream "
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
                  "weeks, so the whole batch was flushed at once. The detection timestamp "
                  "(field 1) ran from hours to more than a day after the recorded departure and "
                  "up to 28 days before the SEGB write. Arrival and departure are internally "
-                 "consistent (arrival always precedes departure, spans from about half an hour "
+                 "consistent (arrival precedes departure, spans from about half an hour "
                  "to just over a day) and are the most usable pair, but they are still not "
                  "independently verified. In tested samples the coordinates, accuracy and "
                  "point of interest details decoded consistently. Latitude, longitude, "

--- a/scripts/artifacts/duckduckgo.py
+++ b/scripts/artifacts/duckduckgo.py
@@ -5,14 +5,15 @@ __artifacts_v2__ = {
                        "the last visit time and the number of trackers the browser blocked on the page",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
-        "last_update_date": "2026-08-15",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "DuckDuckGo",
-        "notes": "Read from the Core Data store History.sqlite. ZBROWSINGHISTORYENTRYMANAGEDOBJECT "
-                 "holds one row per visited page with an aggregate visit count and blocked-tracker "
-                 "count; the timestamps are Core Data (Cocoa) seconds. A store lacking the "
-                 "ZCOOKIEPOPUPBLOCKED column and the tab history table has been observed in a "
-                 "private sample; columns absent from a store are reported empty, not as No.",
+        "notes": "Read from the Core Data store History.sqlite. "
+                 "ZBROWSINGHISTORYENTRYMANAGEDOBJECT holds one row per history entry with an "
+                 "aggregate visit count and blocked-tracker count; the timestamps are Core Data "
+                 "(Cocoa) seconds. A store lacking the ZCOOKIEPOPUPBLOCKED column and the tab "
+                 "history table has been observed in a private sample; columns absent from a "
+                 "store are reported empty, not as No.",
         "paths": ('*/Library/Application Support/History.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "globe",

--- a/scripts/artifacts/logarchive.py
+++ b/scripts/artifacts/logarchive.py
@@ -392,7 +392,7 @@ __artifacts_v2__ = {
                        "VBUS power and CON_DET physical-connection states",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-08-01",
-        "last_update_date": "2026-08-02",
+        "last_update_date": "2026-08-29",
         "requirements": "logarchive module must be executed first",
         "category": "Unified Logs",
         "notes": "Documented at "
@@ -402,7 +402,7 @@ __artifacts_v2__ = {
                  "form. The 'USB Power (VBUS) Present' pattern was added 2026-08-02 as "
                  "version insurance, not as a fix: the cited CarPlay research, revised for "
                  "iOS 26.6, quotes that line without the shim prefix and treats it as the "
-                 "most consistent connection marker, with 'Present: 0' the reliable detach "
+                 "most consistent connection marker, with 'Present: 0' treated as the detach "
                  "signal while CON_DET can remain 1. On our images every VBUS line did "
                  "carry the shim prefix and was therefore already collected (30 records on "
                  "iOS 18.7, 40 on iOS 17.1, none without the prefix), so the pattern is "

--- a/scripts/artifacts/ornetBrowser.py
+++ b/scripts/artifacts/ornetBrowser.py
@@ -27,12 +27,12 @@ __artifacts_v2__ = {
                        "Tor connection mode and any custom bridge the user configured",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
-        "last_update_date": "2026-08-15",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "OrNET Browser",
         "notes": "Values are read directly from the app preferences plist. Each configured custom "
                  "bridge is reported on its own row; a bridge line contains the transport, the "
-                 "relay address and its fingerprint as the user entered them. The app with "
+                 "relay address and its fingerprint, reported as stored. The app with "
                  "bundle id ch.b-eng.tor names itself OrNET Browser in its bundle's Info.plist, "
                  "read from the tested image; iLEAPP releases up to v2026.3.0 labelled these "
                  "artifacts Onion Browser, which is a different app.",


### PR DESCRIPTION
Brings this core in line with ALEAPP #1242, which extended the claim-language check to the artifact `notes` field.

- `notes` is now checked. It reaches the report and the LAVA manifest and was not covered.
- Notes get their own vocabulary. The completeness words are dropped, because a note states what it was tested against ("empty on all 18 copies tested"). `read by` is dropped because in a note it means read by the code.
- A match preceded by a negation in the same clause is not reported, so a note that denies a claim is not flagged for making it. Suppressed matches are counted and printed under `--verbose`.
- Closes the habit stem in the claim vocabulary. The open spelling also matched "habitat". Four of the five cores carried it.
- The new test pins the vocabulary to a literal and is byte-identical in all five cores, so a change made in one repo alone fails that repo's own CI.

Three notes reworded, five reviewed exceptions allowlisted with a reason each.
