### PR TITLE
Fix NameError in the vendored blackboxprotobuf typedef fallback

### DIFF
--- a/scripts/blackboxprotobuf/lib/types/length_delim.py
+++ b/scripts/blackboxprotobuf/lib/types/length_delim.py
@@ -273,8 +273,14 @@ def decode_message(buf, typedef=None, pos=0, end=None, group=False):
                     field_out, message_typedef, pos = decode_lendelim_message(buf, {}, pos)
                     if 'alt_typedefs' in field_typedef:
                         # get the next higher alt field number
+                        # LEAPP fix: upstream 1.0.1 misspells field_typedef here as
+                        # field_tyepdef, so this branch raises NameError instead of
+                        # recording the anonymous typedef. It only runs when a field
+                        # already has alt_typedefs and then needs another one, which is
+                        # why it survived upstream. Observed aborting biomeProactiveMail
+                        # on an iOS 26.2.1 full filesystem extraction.
                         alt_field_number = str(
-                            max(map(int, field_tyepdef['alt_typedefs'].keys()))
+                            max(map(int, field_typedef['alt_typedefs'].keys()))
                             + 1)
                     else:
                         field_typedef['alt_typedefs'] = {}


### PR DESCRIPTION
Upstream blackboxprotobuf 1.0.1 misspells `field_typedef` as `field_tyepdef` in the anonymous-typedef branch of `decode_message`, so that branch raises `NameError` instead of recording the typedef. It only runs when a field already carries `alt_typedefs` and then needs another one, which is why it survives upstream.

It aborts the whole artifact when it fires. On an iOS 26.2.1 full filesystem extraction `biomeProactiveMail` died with `name 'field_tyepdef' is not defined` and reported nothing; with the name corrected the same run returns 941 records.

The deviation is noted in place, matching the existing LEAPP note in this file. The same typo is in ALEAPP's copy and is fixed there separately.