### PR TITLE
Read the remote tier in the Biome In Focus, Now Playing and Bluetooth artifacts

### DIFF
--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -4,20 +4,22 @@ __artifacts_v2__ = {
         "description": "Parses Bluetooth device entries from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-03",
         "requirements": "none",
         "category": "Biome",
         "notes": "Use caution when interpreting this artifact. Lists of Bluetooth devices have been "
                  "observed sharing a single SEGB timestamp, so the presence of a device in this "
                  "stream does not establish that the device was connected to the iOS device at "
                  "that time. Reference: Mattia Epifani, '84 Streams Later, Part 2: Inside Apple "
-                 "Biome', https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
-        "paths": ('*/Biome/streams/restricted/Device.Wireless.Bluetooth/local/*'),
+                 "Biome', https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html\n"
+                 "Records are read from both the local and remote subfolders; the Sync Origin column reports which one a record came from, with the remote folder's device identifier. Remote records were synced from another device on the same account and are not events of this device. Files under a tombstone folder are skipped.",
+        "paths": ('*/Biome/streams/restricted/Device.Wireless.Bluetooth/local/*',
+                  '*/Biome/streams/restricted/Device.Wireless.Bluetooth/remote/*'),
         "output_types": "standard",
         "artifact_icon": "bluetooth",
         "sample_data": {
-            "dexter_ios18": "iOS 18.3.2 | 73 rows",
-            "felix_ios17": "iOS 17.6.1 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 87 rows (14 remote)",
+            "felix_ios17": "iOS 17.6.1 | 420 rows (420 remote)",
             "fsfull002_ios17": "iOS 17.1 | 0 rows",
             "hc_ios18_7": "iOS 18.7.8 | 0 rows",
             "iphone11_ios17": "iOS 17.3 | 4 rows",
@@ -26,6 +28,11 @@ __artifacts_v2__ = {
             "abe_ios16": "iOS 16.5 | 84 rows",
             "felix23_ios16": "iOS 16.5 | 10 rows",
             "magnet_ios16": "iOS 16.1.1 | 0 rows",
+            "adams_iphone12mini": "iOS 17.1.1 | 0 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | 0 rows",
+            "falken_ios26": "iOS 26.2.1 | 0 rows",
+            "hc_ios26": "iOS 26.5.2 | 0 rows",
+            "iphone12_ios18": "iOS 18.7 | 0 rows",
         }
     }
 }
@@ -37,6 +44,18 @@ from datetime import timezone
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor
+
+
+def _sync_origin(file_found):
+    """Local for the device's own stream, Remote (<device id>) for a copy synced from another
+    device on the same account; the id is the folder name Biome keeps under remote/."""
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
 
 
 @artifact_processor
@@ -55,6 +74,7 @@ def get_biomeBluetooth(context):
         else:
             continue
 
+        origin = _sync_origin(file_found)
         source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
@@ -68,11 +88,11 @@ def get_biomeBluetooth(context):
                     desc = protostuff['2']
                 else:
                     desc = protostuff['2'].decode()
-                data_list.append((ts, record.state.name, mac, desc, filename, record.data_start_offset))
+                data_list.append((ts, record.state.name, mac, desc, origin, filename, record.data_start_offset))
 
             elif record.state == EntryState.Deleted:
-                data_list.append((ts, record.state.name, None, None, filename, record.data_start_offset))
+                data_list.append((ts, record.state.name, None, None, origin, filename, record.data_start_offset))
 
-    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'MAC', 'Name', 'Filename', 'Offset')
+    data_headers = (('SEGB Timestamp', 'datetime'), 'SEGB State', 'MAC', 'Name', 'Sync Origin', 'Filename', 'Offset')
 
     return data_headers, data_list, '\n'.join(sorted(source_dirs))

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -4,25 +4,30 @@ __artifacts_v2__ = {
         "description": "Parses InFocus Events from biomes",
         "author": "@JohnHyla",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-03",
         "requirements": "none",
         "category": "Biome",
-        "notes": "The Foreground/Background labels for values 1 and 0 are an interpretation of the App.InFocus stream name; other values are reported as stored.",
-        "paths": ('*/[Bb]iome/streams/restricted/App.InFocus/local/*',),
+        "notes": "The Foreground/Background labels for values 1 and 0 are an interpretation of the App.InFocus stream name; other values are reported as stored. Records are read from both the local and remote subfolders; the Sync Origin column reports which one a record came from, with the remote folder's device identifier. Remote records were synced from another device on the same account and are not events of this device. Files under a tombstone folder are skipped.",
+        "paths": ('*/[Bb]iome/streams/restricted/App.InFocus/local/*',
+                  '*/[Bb]iome/streams/restricted/App.InFocus/remote/*'),
         "output_types": "standard",
         "artifact_icon": "focus-2",
         "sample_data": {
-            "dexter_ios18": "iOS 18.3.2 | 2439 rows",
-            "felix_ios17": "iOS 17.6.1 | 516 rows",
-            "fsfull002_ios17": "iOS 17.1 | 559 rows",
+            "dexter_ios18": "iOS 18.3.2 | 3895 rows (1456 remote)",
+            "felix_ios17": "iOS 17.6.1 | 20368 rows (19852 remote)",
+            "fsfull002_ios17": "iOS 17.1 | 680 rows (121 remote)",
             "hc_ios18_7": "iOS 18.7.8 | 4031 rows",
             "iphone11_ios17": "iOS 17.3 | 4943 rows",
-            "iphone12_ios18": "iOS 18.7 | 1868 rows",
-            "iphone14plus_ios18": "iOS 18.0 | 262 rows",
-            "otto_ios17": "iOS 17.5.1 | 825 rows",
+            "iphone12_ios18": "iOS 18.7 | 2073 rows (205 remote)",
+            "iphone14plus_ios18": "iOS 18.0 | 909 rows (647 remote)",
+            "otto_ios17": "iOS 17.5.1 | 1139 rows (314 remote)",
             "abe_ios16": "iOS 16.5 | 0 rows",
             "felix23_ios16": "iOS 16.5 | 0 rows",
             "magnet_ios16": "iOS 16.1.1 | 0 rows",
+            "adams_iphone12mini": "iOS 17.1.1 | 2357 rows (1490 remote)",
+            "cookbook_ios1751": "iOS 17.5.1 | 947 rows (240 remote)",
+            "falken_ios26": "iOS 26.2.1 | 2374 rows (730 remote)",
+            "hc_ios26": "iOS 26.5.2 | 545 rows (230 remote)",
         }
     }
 }
@@ -34,6 +39,18 @@ from scripts import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
+
+
+def _sync_origin(file_found):
+    """Local for the device's own stream, Remote (<device id>) for a copy synced from another
+    device on the same account; the id is the folder name Biome keeps under remote/."""
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
 
 
 @artifact_processor
@@ -55,6 +72,7 @@ def get_biomeInfocus(context):
         else:
             continue
 
+        origin = _sync_origin(file_found)
         source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
@@ -68,12 +86,12 @@ def get_biomeInfocus(context):
                 state = protostuff['3']
                 foreground = {1: 'Foreground', 0: 'Background'}.get(state, str(state))
 
-                data_list.append((ts, timestart, record.state.name, bundleid, foreground, filename, record.data_start_offset))
+                data_list.append((ts, timestart, record.state.name, bundleid, foreground, origin, filename, record.data_start_offset))
 
             elif record.state == EntryState.Deleted:
-                data_list.append((ts, None, record.state.name, None, None, filename, record.data_start_offset))
+                data_list.append((ts, None, record.state.name, None, None, origin, filename, record.data_start_offset))
 
-    data_headers = (('Timestamp', 'datetime'), ('Start Time', 'datetime'), 'SEGB State', 'Bundle ID', 'Action', 'Filename', 'Offset')
+    data_headers = (('Timestamp', 'datetime'), ('Start Time', 'datetime'), 'SEGB State', 'Bundle ID', 'Action', 'Sync Origin', 'Filename', 'Offset')
 
     return data_headers, data_list, '\n'.join(sorted(source_dirs))
 

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -4,13 +4,16 @@ __artifacts_v2__ = {
         "description": "Parses Now Playing entries from biomes",
         "author": "@JohnHyla, @mattiaepi (Mattia Epifani)",
         "creation_date": "2024-10-17",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-03",
         "requirements": "none",
         "category": "Biome",
-        "notes": "",
+        "notes": "Records are read from both the local and remote subfolders; the Sync Origin column reports which one a record came from, with the remote folder's device identifier. Remote records were synced from another device on the same account and are not events of this device. Files under a tombstone folder are skipped. Remote Now Playing records carry the bundle id and "
+                 "timestamps only: Output, Media Type, Title and Artist are not present in the synced copies "
+                 "and are blank on those rows.",
         "paths": (
             '*/Biome/streams/public/NowPlaying/local/*',
             '*/streams/*/Media.NowPlaying/local/*',
+            '*/streams/*/Media.NowPlaying/remote/*',
         ),
         "output_types": "standard",
         "artifact_icon": "music",
@@ -21,6 +24,16 @@ __artifacts_v2__ = {
             "magnet_ios16": "iOS 16.1.1 | 22 rows",
             "hc_ios18_7": "iOS 18.7.8 | 14 rows",
             "iphone11_ios17": "iOS 17.3 | 242 rows",
+            "adams_iphone12mini": "iOS 17.1.1 | 22 rows (20 remote)",
+            "cookbook_ios1751": "iOS 17.5.1 | 0 rows",
+            "dexter_ios18": "iOS 18.3.2 | 742 rows (108 remote)",
+            "falken_ios26": "iOS 26.2.1 | 116 rows (102 remote)",
+            "felix_ios17": "iOS 17.6.1 | 1986 rows (1976 remote)",
+            "fsfull002_ios17": "iOS 17.1 | 0 rows",
+            "hc_ios26": "iOS 26.5.2 | 6 rows",
+            "iphone12_ios18": "iOS 18.7 | 25 rows",
+            "iphone14plus_ios18": "iOS 18.0 | 0 rows",
+            "otto_ios17": "iOS 17.5.1 | 126 rows",
         }
     }
 }
@@ -32,6 +45,18 @@ from scripts import blackboxprotobuf
 from scripts.ccl_segb.ccl_segb import read_segb_file
 from scripts.ccl_segb.ccl_segb_common import EntryState
 from scripts.ilapfuncs import artifact_processor, webkit_timestampsconv
+
+
+def _sync_origin(file_found):
+    """Local for the device's own stream, Remote (<device id>) for a copy synced from another
+    device on the same account; the id is the folder name Biome keeps under remote/."""
+    normalized = file_found.replace('\\', '/')
+    if '/remote/' in normalized:
+        trailer = normalized.split('/remote/', 1)[1]
+        if '/' in trailer:
+            return f"Remote ({trailer.split('/', 1)[0]})"
+        return 'Remote'
+    return 'Local'
 
 
 @artifact_processor
@@ -71,6 +96,7 @@ def get_biomeNowplaying(context):
         else:
             continue
 
+        origin = _sync_origin(file_found)
         source_dirs.add(os.path.dirname(file_found))
         for record in read_segb_file(file_found):
             ts = record.timestamp1
@@ -91,14 +117,14 @@ def get_biomeNowplaying(context):
                         output = (f"{protostuff['14'][0]['3']} <-> {protostuff['14'][1]['3']}")
                 else:
                     output = ''
-                data_list.append((ts, timestart, record.state.name, bundleid, output, info, info2, info3, filename,
-                                  record.data_start_offset))
+                data_list.append((ts, timestart, record.state.name, bundleid, output, info, info2, info3, origin,
+                                  filename, record.data_start_offset))
 
             elif record.state == EntryState.Deleted:
-                data_list.append((ts, None, record.state.name, None, None, None, None, None, filename,
-                                  record.data_start_offset))
+                data_list.append((ts, None, record.state.name, None, None, None, None, None, origin,
+                                  filename, record.data_start_offset))
 
     data_headers = (('SEGB Timestamp', 'datetime'), ('Timestamp', 'datetime'), 'SEGB State', 'Bundle ID', 'Output',
-                    'Media Type', 'Title', 'Artist', 'Filename', 'Offset')
+                    'Media Type', 'Title', 'Artist', 'Sync Origin', 'Filename', 'Offset')
 
     return data_headers, data_list, '\n'.join(sorted(source_dirs))


### PR DESCRIPTION
Reads the remote/ tier in three Biome artifacts that read local/ only: In Focus, Now Playing and Bluetooth.

- Each stream keeps records synced from the account's other devices under remote/<device id>/. Those records never reached a report before.
- A Sync Origin column reports Local or Remote with the device folder id, following the Siri Remembers artifacts.
- Tombstone folders are still skipped. Local rows are unchanged on every tested image.
- Remote Now Playing copies carry the bundle id and timestamps only; the notes say so.

Also makes the Bluetooth artifact's paths a proper tuple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
