### PR TITLE
Correct artifact notes against the tested data

### DIFF
--- a/scripts/artifacts/chromeSessionTabs.py
+++ b/scripts/artifacts/chromeSessionTabs.py
@@ -2,8 +2,8 @@ __artifacts_v2__ = {
     "chrome_session_tabs": {
         "name": "Chromium Session Tabs - Navigation Entries",
         "description": "Pages held in the tab restore file of a Chromium browser, with the "
-                       "address, page title, visit time and HTTP status the browser stored for "
-                       "each entry, and the tab it belongs to.",
+                       "address, page title and visit time the browser stored for each entry, and "
+                       "the tab it belongs to.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-04",
         "last_update_date": "2026-09-04",
@@ -11,9 +11,9 @@ __artifacts_v2__ = {
         "category": "Chromium Sessions",
         "notes": "Read from the Sessions/Tabs_<number> files a Chromium browser writes under "
                  "Library/Application Support, with the vendored snss_parser. The pattern carries "
-                 "no bundle name because an app's data container is named by a identifier, so the "
-                 "Browser column reports the vendor and browser folders the file sits under and "
-                 "the same pattern covers Chrome and Edge.\n"
+                 "no bundle name because an app's data container is named by an identifier, so "
+                 "the Browser column reports the vendor and browser folders the file sits under "
+                 "and the same pattern covers Chrome and Edge.\n"
                  "One row per navigation entry, taken from the command Chromium calls "
                  "kCommandUpdateTabNavigation. Timestamp is the entry's stored time, microseconds "
                  "since 1601. Tab ID and Index identify the tab and the position of the entry in "
@@ -23,15 +23,15 @@ __artifacts_v2__ = {
                  "components/sessions/core/serialized_navigation_entry.cc, which sets the field "
                  "order, and components/sessions/core/tab_restore_service_impl.cc, which sets the "
                  "command ids.\n"
-                 "The format also carries an HTTP status, an original request URL, a post data flag, a "
-                 "user agent override flag and a page state blob holding form and scroll state. On "
-                 "every one of the 19 entries across the tested images those were empty, zero or "
-                 "false, which is why they are not reported here and why an entry written on this "
-                 "platform is a fraction of the size of one written on Android. Every Chrome entry "
-                 "consumed its record exactly. The Edge entries left four trailing bytes unread, one "
-                 "further value the format allows after the fields read here, which Chromium's own "
-                 "reader also treats as optional; the reported fields decode the same way in both "
-                 "browsers.\n"
+                 "The format also carries an HTTP status, an original request URL, a post data "
+                 "flag, a user agent override flag and a page state blob holding form and scroll "
+                 "state. On every one of the 19 entries across the tested images those were "
+                 "empty, zero or false, which is why they are not reported here and why an entry "
+                 "written on this platform is a fraction of the size of one written on Android. "
+                 "Every Chrome entry consumed its record exactly. The Edge entries left four "
+                 "trailing bytes unread, one further value the format allows after the fields "
+                 "read here, which Chromium's own reader also treats as optional; the reported "
+                 "fields decode the same way in both browsers.\n"
                  "This is the browser's own restore file, so a row means the page was in a tab "
                  "the browser was holding, not that it was open when the device was seized, and "
                  "the file keeps a limited number of tabs rather than a full history. A page here "

--- a/scripts/artifacts/discordAcct.py
+++ b/scripts/artifacts/discordAcct.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "app cached for each, and the profile text the account published.",
         "author": "@abrignoni, Claude",
         "creation_date": "2020-09-15",
-        "last_update_date": "2026-09-03",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Discord",
         "notes": "Read from the app's MMKV store (Documents/mmkv/mmkv.default) with the vendored "
@@ -14,15 +14,16 @@ __artifacts_v2__ = {
                  "path pattern matches every app's mmkv.default because an iOS data container is "
                  "named by a GUID, so a store is read only when it carries Discord's own keys "
                  "(user_id_cache, MultiAccountStore or UserStore-snapshot) and is skipped "
-                 "otherwise. One row per account in MultiAccountStore, which lists every "
-                 "account signed in on the device, joined to the fuller record in "
-                 "UserStore-snapshot and UserProfileStore-snapshot where the same id appears; an "
-                 "account present only in the older user_id_cache and email_cache keys is still "
-                 "reported from those. Token Status is reported as stored. The account's "
-                 "authentication tokens and push tokens are in the same store and are not "
-                 "reported. Email is what the app cached, not a verified identifier. Profile Fetched At and Legacy Username come from "
-                 "UserProfileStore-snapshot and are present only where that key is; it was on one of "
-                 "the fifteen tested extractions.",
+                 "otherwise. One row per account in MultiAccountStore, which lists every account "
+                 "signed in on the device, joined to the fuller record in UserStore-snapshot and "
+                 "UserProfileStore-snapshot where the same id appears; an account present only in "
+                 "the older user_id_cache and email_cache keys is still reported from those. "
+                 "Token Status is reported as stored. The account's authentication tokens and "
+                 "push tokens are in the same store and are not reported. Email is what the app "
+                 "cached, not a verified identifier. Profile Fetched At and Legacy Username come "
+                 "from UserProfileStore-snapshot and are present only where that key is; the key "
+                 "was present on four of the eleven tested extractions that held a Discord store "
+                 "and carried those two fields on one of them.",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default',),
         "output_types": "standard",
         "artifact_icon": "brand-discord",
@@ -51,25 +52,25 @@ __artifacts_v2__ = {
                        "measured as nearest.",
         "author": "@abrignoni, Claude",
         "creation_date": "2026-09-03",
-        "last_update_date": "2026-09-03",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Discord",
         "notes": "Read from the app's MMKV store. One row per store. First Run is the "
-                 "first_run_date_key value and First Use the firstUse value of RequestReviewStore, "
-                 "both Unix milliseconds. Last Sync, Session Started and Last Heartbeat are the "
-                 "lastSyncTime, LATEST_SESSION_INITIALIZED_TIMESTAMP and the newest of the "
-                 "LATEST_SESSION_TIMESTAMP and LATEST_HEARTBEAST_TIMESTAMP values; the store is "
-                 "append-only so the heartbeat key can carry dozens of superseded writes, and the "
-                 "count of those writes is reported as Heartbeat Writes; Session UUID, Session Started "
-                 "and Last Heartbeat are present only where the app wrote those keys (two of fifteen "
-                 "tested extractions). Device fields come from "
-                 "the deviceProperties JSON as stored: OS, client, device model, system locale, "
-                 "client version, release channel and the device vendor identifier. Preferred "
-                 "Voice Region and Region Test At come from RTCRegionStore; the region is the one "
-                 "the app measured as nearest at that time and is a coarse indication, not a "
-                 "location. Camera and Microphone Permission are the app's recorded permission "
-                 "states as stored. Values are what the app cached and are reported without "
-                 "interpretation.",
+                 "first_run_date_key value and First Use the firstUse value of "
+                 "RequestReviewStore, both Unix milliseconds. Last Sync, Session Started and Last "
+                 "Heartbeat are the lastSyncTime, LATEST_SESSION_INITIALIZED_TIMESTAMP and the "
+                 "newest of the LATEST_SESSION_TIMESTAMP and LATEST_HEARTBEAST_TIMESTAMP values; "
+                 "the store is append-only so the heartbeat key can carry dozens of superseded "
+                 "writes, and the count of those writes is reported as Heartbeat Writes; Session "
+                 "UUID, Session Started and Last Heartbeat are present only where the app wrote "
+                 "those keys (two of the eleven tested extractions that held a Discord store). "
+                 "Device fields come from the deviceProperties JSON as stored: OS, client, device "
+                 "model, system locale, client version, release channel and the device vendor "
+                 "identifier. Preferred Voice Region and Region Test At come from RTCRegionStore; "
+                 "the region is the one the app measured as nearest at that time and is a coarse "
+                 "indication, not a location. Camera and Microphone Permission are the app's "
+                 "recorded permission states as stored. Values are what the app cached and are "
+                 "reported without interpretation.",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default',),
         "output_types": "standard",
         "artifact_icon": "device-mobile",
@@ -96,15 +97,15 @@ __artifacts_v2__ = {
         "description": "Times the Discord app recorded a session start, by day.",
         "author": "@abrignoni, Claude",
         "creation_date": "2026-09-03",
-        "last_update_date": "2026-09-03",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Discord",
         "notes": "Read from the UsageStatisticsStore JSON in the app's MMKV store, whose _state "
                  "holds a sessions map from a calendar day to a list of startTimestamp values in "
                  "Unix milliseconds. One row per start. The day string is the app's own bucket "
                  "and is reported as stored beside the rendered UTC time. This key was present on "
-                 "two of the fifteen tested extractions; where it is absent the artifact reports "
-                 "nothing for that store.",
+                 "two of the eleven tested extractions that held a Discord store; where it is "
+                 "absent the artifact reports nothing for that store.",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default',),
         "output_types": "standard",
         "artifact_icon": "clock",
@@ -128,23 +129,23 @@ __artifacts_v2__ = {
     },
     "discordDrafts": {
         "name": "Discord - Message Drafts",
-        "description": "Text the account typed into a channel's message box and had not sent when "
-                       "the app saved it, with the time of each save, including superseded "
-                       "versions that show the text as it was being typed.",
+        "description": "Draft text the app saved for a channel's message box and had not sent at "
+                       "the time of the save, with the time of each save, including superseded "
+                       "saves that show how the text changed.",
         "author": "@abrignoni, Claude",
         "creation_date": "2026-09-03",
-        "last_update_date": "2026-09-03",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Discord",
         "notes": "Read from every write of the DraftStore key in the app's MMKV store, not only "
                  "the current one: the store is append-only, so each save of the draft box is a "
-                 "separate entry, and one tested extraction held 120 rows tracing a message being "
-                 "typed a few characters at a time. Each write's _state maps an account id to a "
-                 "channel id to a draft type to a timestamp and the draft text; one row per "
-                 "(write, account, channel, type). Superseded Write is True for every entry "
-                 "except the newest, and Write Index is that entry's position in the store. Draft "
-                 "Type is reported as stored. Channel IDs are Discord snowflakes and are not "
-                 "resolved to names here.",
+                 "separate entry, and one tested extraction held 120 rows in which the draft text "
+                 "grew by a few characters from one save to the next. Each write's _state maps an "
+                 "account id to a channel id to a draft type to a timestamp and the draft text; "
+                 "one row per (write, account, channel, type). Superseded Write is True for every "
+                 "entry except the newest, and Write Index is that entry's position in the store. "
+                 "Draft Type is reported as stored. Channel IDs are Discord snowflakes and are "
+                 "not resolved to names here.",
         "paths": ('*/mobile/Containers/Data/Application/*/Documents/mmkv/mmkv.default',),
         "output_types": "standard",
         "artifact_icon": "edit",

--- a/scripts/artifacts/familyHub.py
+++ b/scripts/artifacts/familyHub.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "registered, and which app features were switched on.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-02",
-        "last_update_date": "2026-09-02",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Samsung Family Hub",
         "notes": "Read from Library/Preferences/com.samsung.familyhub.plist, including the "
@@ -47,8 +47,9 @@ __artifacts_v2__ = {
                  "on the tested extraction none of the refrigerator features had been used. The "
                  "SafariViewService web cache beside the app holds the Samsung account sign-in "
                  "page and its static assets and is not reported. The app's data container was "
-                 "present on 1 of the 24 registered iOS corpora swept for it, and no Android "
-                 "corpus of 28 holds the app.",
+                 "present on 1 of the 26 registered iOS test extractions and on none of the 31 "
+                 "Android ones when every registered archive was scanned for the package name on "
+                 "2026-09-04.",
         "paths": ('*/Library/Preferences/com.samsung.familyhub.plist',
                   '*/Library/Caches/com.samsung.familyhub/Cache.db*'),
         "output_types": ["html", "tsv", "lava"],

--- a/scripts/artifacts/ifttt.py
+++ b/scripts/artifacts/ifttt.py
@@ -5,20 +5,19 @@ __artifacts_v2__ = {
                        "address and time zone the app held for it.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-02",
-        "last_update_date": "2026-09-02",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "IFTTT",
         "notes": "Read from class_UserRecord in the app's Realm store (Documents/default.realm) "
                  "with the vendored realm_parser. The store is Realm file format 9, which the "
-                 "parser reads through its pre-Cluster path. An iOS data container is named by "
-                 "a GUID, so the path pattern cannot carry the bundle identifier and matches "
-                 "any Documents/default.realm; every candidate is then required to carry an "
-                 "IFTTT class before it is read, and a store without one is skipped and "
-                 "logged, so another app's Realm cannot be reported under IFTTT's name. Time "
-                 "Zone is the zone the account holds in the IFTTT service, not a device "
-                 "setting. These are values the account held in the app, which the app "
-                 "received from its service; they are not verified identifiers. User Type and "
-                 "Home Screen Preference are reported as stored.",
+                 "parser reads through its pre-Cluster path. An iOS data container is named by a "
+                 "GUID, so the path pattern cannot carry the bundle identifier and matches any "
+                 "Documents/default.realm; every candidate is then required to carry an IFTTT "
+                 "class before it is read, and a store without one is skipped and logged, so "
+                 "another app's Realm cannot be reported under IFTTT's name. Time Zone is the "
+                 "timezone value of the account record, as stored. These are values the account "
+                 "held in the app, which the app received from its service; they are not verified "
+                 "identifiers. User Type and Home Screen Preference are reported as stored.",
         "paths": ('*/Documents/default.realm',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
@@ -32,24 +31,23 @@ __artifacts_v2__ = {
                        "it runs on, who published it and when the app first recorded it.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-02",
-        "last_update_date": "2026-09-02",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "IFTTT",
         "notes": "Read from class_LiveConnectionRecord in the app's Realm store, which is where "
                  "the connected applets are held on the tested extraction; class_AppletRecord, "
                  "which the name suggests would carry them, held no rows. The service name is "
-                 "joined from class_LiveServiceRecord through the row's own primaryService "
-                 "link. Author is the applet's publisher as the service supplied it, not the "
-                 "account on this device: an applet published by someone else and switched on "
-                 "by this account shows that publisher. Created At is when the app first "
-                 "recorded the applet locally, which is not the same as when the applet last "
-                 "ran; no run history was present, see the Activity note below. Status and Kind "
-                 "are reported as stored. The store's installsCount is how many IFTTT accounts "
-                 "had that applet and is service-supplied popularity rather than anything about "
-                 "this device, so it is not reported. Activity: class_ActivityItemRecord, "
-                 "class_WidgetRunRecord and class_RegionEvent were present in the schema and "
-                 "held no rows on the tested extraction, so no applet run, widget run or "
-                 "geofence event was recovered.",
+                 "joined from class_LiveServiceRecord through the row's own primaryService link. "
+                 "Author is the applet's publisher as the service supplied it, not the account on "
+                 "this device: an applet published by someone else and switched on by this "
+                 "account shows that publisher. Created At is when the app first recorded the "
+                 "applet locally, which is not the same as when the applet last ran; no run "
+                 "history was present, see the Activity note below. Status and Kind are reported "
+                 "as stored. The store's installsCount is a service-supplied count for the applet "
+                 "that says nothing about this device, so it is not reported. Activity: "
+                 "class_ActivityItemRecord, class_WidgetRunRecord and class_RegionEvent were "
+                 "present in the schema and held no rows on the tested extraction, so no applet "
+                 "run, widget run or geofence event was recovered.",
         "paths": ('*/Documents/default.realm',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "zap",


### PR DESCRIPTION
Corrects four recently merged modules against the images they were validated on.

- Discord: the profile snapshot key was on four of the eleven stores and carried its two fields on one; the session keys were on two of eleven. Drafts are described as saved text rather than as typing.
- IFTTT: time zone and installsCount are reported as stored, with no service-side meaning asserted.
- Chromium Session Tabs: the description no longer names an HTTP status the iOS entries never carry.
- Samsung Family Hub: the corpus presence sentence restated against the current registry (1 of 26 iOS, 0 of 31 Android, scanned 2026-09-04).

Row counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
