### PR TITLE
Anchor the claim-language pattern on a person (active voice)

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -89,24 +89,9 @@ import sys
 # habitat-related artifact ever lands here, close the stem rather than
 # allowlisting the artifact.
 CLAIM_PATTERN = re.compile(
-    r'\ball\b'
-    r'|\bevery\b'
-    r'|\bcomplete'
-    r'|\bfull list\b'
-    r'|\bentire\b'
-    r'|\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent'
-    r'|created|hid|chose)\b'
-    r'|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b'
-    r'|\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|delet'
-    r'ed|visited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b'
-    r'|\bmanually\b'
-    r'|\bproves?\b'
-    r'|\bdefinitively\b'
-    r'|\balways\b'
-    r'|\breliable'
-    r'|\bvisited\b'
-    r'|\bhabits?\b',
-    re.IGNORECASE)
+    r"\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|\b(?:the|a|an) (?:\w+ )?(?:user|account holder|device owner|subject|owner) (?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chose|chosen|hid|hidden|initiated|follows|saved|added|grouped|submitted|marked|tracked|joined|reacted|installed|removed|configured|voted|opted)\b|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b",
+    re.IGNORECASE,
+)
 
 # `notes` reaches the examiner too, in the report and in the artifact info modal, so
 # the same standard applies to it. It cannot use the same vocabulary, because notes do
@@ -123,19 +108,9 @@ CLAIM_PATTERN = re.compile(
 # What is left is attribution and certainty, which mean the same thing in a note as in
 # a description.
 NOTES_PATTERN = re.compile(
-    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent'
-    r'|created|hid|chose)\b'
-    r'|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b'
-    r'|\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|delet'
-    r'ed|visited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b'
-    r'|\bmanually\b'
-    r'|\bproves?\b'
-    r'|\bdefinitively\b'
-    r'|\balways\b'
-    r'|\breliable'
-    r'|\bvisited\b'
-    r'|\bhabits?\b',
-    re.IGNORECASE)
+    r"\b(?:the|a|an) (?:\w+ )?(?:user|account holder|device owner|subject|owner) (?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chose|chosen|hid|hidden|initiated|follows|saved|added|grouped|submitted|marked|tracked|joined|reacted|installed|removed|configured|voted|opted)\b|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b",
+    re.IGNORECASE,
+)
 
 # A note that *denies* a claim uses the same words as one that makes it: "not terms the
 # user searched for", "does not establish that the user viewed them". That denial is the

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -36,23 +36,10 @@ _spec.loader.exec_module(ccl)
 
 # The vocabulary every core is expected to enforce, written out rather than imported.
 EXPECTED_CLAIM = (
-    r'\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|'
-    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
-    r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
-    r'searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|'
-    r'entered|created|sent|opened|selected|deleted|visited|chosen|hidden|'
-    r'initiated) by (?:the |a |an )?(?:user|account holder|device owner|'
-    r'subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
-    r'\balways\b|\breliable|\bvisited\b|\bhabits?\b'
+    r"\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|\b(?:the|a|an) (?:\w+ )?(?:user|account holder|device owner|subject|owner) (?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chose|chosen|hid|hidden|initiated|follows|saved|added|grouped|submitted|marked|tracked|joined|reacted|installed|removed|configured|voted|opted)\b|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b"
 )
 EXPECTED_NOTES = (
-    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
-    r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
-    r'searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|'
-    r'entered|created|sent|opened|selected|deleted|visited|chosen|hidden|'
-    r'initiated) by (?:the |a |an )?(?:user|account holder|device owner|'
-    r'subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
-    r'\balways\b|\breliable|\bvisited\b|\bhabits?\b'
+    r"\b(?:the|a|an) (?:\w+ )?(?:user|account holder|device owner|subject|owner) (?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chose|chosen|hid|hidden|initiated|follows|saved|added|grouped|submitted|marked|tracked|joined|reacted|installed|removed|configured|voted|opted)\b|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|visited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b"
 )
 EXPECTED_NEGATION = (
     r'\b(not|no|never|nor|neither|without|cannot|rather than|instead of|'
@@ -257,6 +244,48 @@ class PassiveFormsAreAnchoredOnAPerson(unittest.TestCase):
             with self.subTest(verb=verb):
                 self.assertEqual(bool(ccl.CLAIM_PATTERN.search(probe)),
                                  bool(ccl.NOTES_PATTERN.search(probe)))
+
+class ActiveFormsAreAnchoredOnAPerson(unittest.TestCase):
+    """The active family must fire on a person subject however it is worded, and stay
+    silent when the subject is not a person.
+
+    Anchored only on the literal "the user", the check was evadable by naming the app in
+    front of the noun ("the Flipboard user follows", "the Hinge account holder selected")
+    or by a different determiner ("a user tracked"), with nothing about the attribution
+    changed. The subject now takes the same determiners and person-noun set as the
+    passive family, plus an optional descriptor, and the verb set adds the conduct words
+    that recur in these descriptions.
+    """
+
+    PERSON_SUBJECTS = ('the user', 'a user', 'the Flipboard user',
+                       'the Hinge account holder', 'the device owner', 'an account owner')
+    CONDUCT = ('follows', 'saved', 'added', 'grouped', 'submitted', 'marked',
+               'tracked', 'joined', 'reacted', 'selected', 'typed', 'visited')
+
+    def test_a_person_subject_fires_however_worded(self):
+        for subject in self.PERSON_SUBJECTS:
+            for field in ('description', 'notes'):
+                with self.subTest(subject=subject, field=field):
+                    self.assertTrue(fires(field, f'items {subject} added to the list'))
+
+    def test_each_conduct_verb_fires_after_a_person(self):
+        for verb in self.CONDUCT:
+            for field in ('description', 'notes'):
+                with self.subTest(verb=verb, field=field):
+                    self.assertTrue(fires(field, f'things the user {verb}'))
+
+    def test_a_non_person_subject_in_the_active_voice_stays_silent(self):
+        for text in ('the app added a row', 'the parser opened the file',
+                     'the sync service created a record', 'the indexer marked it read',
+                     'the calling app submitted the query'):
+            for field in ('description', 'notes'):
+                with self.subTest(text=text, field=field):
+                    self.assertFalse(fires(field, text))
+
+    def test_the_motivating_case_is_caught(self):
+        # ALEAPP #1332 corrected this description; the anchoring is what stops the class.
+        self.assertTrue(fires('description',
+                              'Topics and magazines the Flipboard user follows'))
 
 
 if __name__ == '__main__':

--- a/scripts/artifacts/grindr.py
+++ b/scripts/artifacts/grindr.py
@@ -55,24 +55,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Grindr",
-        "notes": "One row per conversation record in the app's Realm database. This record holds "
-                 "no message text; the messages themselves are reported by the messages "
-                 "artifact and a conversation links to them. Messages Linked, Tap Messages "
-                 "Linked and Members Linked are the lengths of those link lists, which is "
-                 "what lets a conversation be sized without opening it. On the tested device "
-                 "they totalled 118 message links across 17 conversations and 9 tap links "
-                 "across 9, against 129 rows in the messages artifact, so the two do not "
-                 "reconcile exactly and a message can be present without a conversation "
-                 "linking it. Draft Message is text the account holder typed and did not "
-                 "send, and Name is a conversation name; both were empty on every row of the "
-                 "tested device and are carried because either one is significant wherever it "
-                 "is populated. Pinned, Muted and Unread Count are the values the record "
-                 "carries. Type is reported as stored. Some conversation records are created "
-                 "by the app's marketing framework rather than by a person: their identifiers "
-                 "carry that framework's name, and the Marketing column marks them so they "
-                 "are not read as conversations with another user. Field mapping was done "
-                 "against a private sample provided by Mattia; no sample data is recorded "
-                 "for it.",
+        "notes": "One row per conversation record in the app's Realm database. This record holds no message text; the messages themselves are reported by the messages artifact and a conversation links to them. Messages Linked, Tap Messages Linked and Members Linked are the lengths of those link lists, which is what lets a conversation be sized without opening it. On the tested device they totalled 118 message links across 17 conversations and 9 tap links across 9, against 129 rows in the messages artifact, so the two do not reconcile exactly and a message can be present without a conversation linking it. Draft Message is unsent draft text, and Name is a conversation name; both were empty on every row of the tested device and are carried because either one is significant wherever it is populated. Pinned, Muted and Unread Count are the values the record carries. Type is reported as stored. Some conversation records are created by the app's marketing framework rather than by a person: their identifiers carry that framework's name, and the Marketing column marks them so they are not read as conversations with another user. Field mapping was done against a private sample provided by Mattia; no sample data is recorded for it.",
         "paths": ('*/Documents/DataContainer/Data/*/PersistenceStore.bin',),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "users"

--- a/scripts/artifacts/ornetBrowser.py
+++ b/scripts/artifacts/ornetBrowser.py
@@ -23,8 +23,7 @@ __artifacts_v2__ = {
     },
     "ornet_browser_settings": {
         "name": "OrNET Browser - Settings",
-        "description": "Connection, privacy and clean-up settings from OrNET Browser, including the "
-                       "Tor connection mode and any custom bridge the user configured",
+        "description": "Connection, privacy and clean-up settings from OrNET Browser, including the Tor connection mode and any custom bridge set in the app",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-29",

--- a/scripts/artifacts/quickLook.py
+++ b/scripts/artifacts/quickLook.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "quickLook": {
         "name": "iCloud Quick Look",
-        "description": "Entries from the Quick Look cloudthumbnails.db cache: paths of iCloud files with last-hit dates. A cache entry does not establish that a user viewed the file.",
+        "description": "Entries from the Quick Look cloudthumbnails.db cache: paths of iCloud files with last-hit dates. A cache entry does not establish that the file was viewed.",
         "author": "@abrignoni",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-08-14",

--- a/scripts/artifacts/what3words.py
+++ b/scripts/artifacts/what3words.py
@@ -1,8 +1,7 @@
 __artifacts_v2__ = {
     "what3words_saved_places": {
         "name": "what3words - Saved Places",
-        "description": "Places the user saved in what3words, with the three word address, the label "
-                       "given to it, the nearest place and the coordinates",
+        "description": "Places saved in what3words, with the three word address, the label given to it, the nearest place and the coordinates",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",


### PR DESCRIPTION
Anchors the claim-language checker's active-voice attribution on a person, the way the passive family already is.

It fired only on the literal "the user" plus a fixed verb list, so "the Flipboard user follows", "a user tracked" and "the account holder selected" passed. The active family now takes any of the person nouns, an optional descriptor and the same determiners, plus the conduct verbs that recur in these fields.

4 examiner-facing description(s) or note(s) that the anchored pattern now flags are reworded to state the record rather than attribute the act to a person. The pattern and its pinned test are identical across the five cores, so this same change lands in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
