### PR TITLE
Add the artifact description gate to the lint job

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -56,6 +56,15 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/scripts/check_claim_language.py
 
+      # An artifact's description is the one line the report, the LAVA manifest and
+      # casework quote for it. One that is missing, runs to several lines, only repeats
+      # the name, or duplicates a sibling's in the same module says nothing about the
+      # rows it fronts. Whether a description claims past its own notes is a judgement
+      # the script cannot make; its --review mode lays the pair out for that pass.
+      - name: Guard against an artifact description that says nothing
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_artifact_descriptions.py
+
       # A conversation artifact's columns are ordered from the roles it declares in
       # data_views: timestamp, other dates, direction, sender, conversation label,
       # message text, media, then the rest. See admin/docs/conversation_column_order.md.

--- a/admin/scripts/check_artifact_descriptions.py
+++ b/admin/scripts/check_artifact_descriptions.py
@@ -1,0 +1,192 @@
+"""Fail CI when an artifact's description is missing, runs to more than one line,
+only repeats the artifact's name, or duplicates another artifact's in the same module.
+
+Every artifact module declares an `__artifacts_v2__` dict whose `description` is the
+one line the HTML report, the LAVA manifest and the module index quote for it. It is
+the sentence somebody reads to decide what the artifact is. Four defects in it are
+purely mechanical and this script fails on them:
+
+* missing, or not a string;
+* empty once stripped;
+* more than one line;
+* the same text as the artifact's `name`, which says nothing the name did not;
+* the same text as another artifact's description in the same module, which cannot be
+  right for both, since two artifacts exist because they report different things.
+  The commonest cause is a block copied for a sibling and not finished.
+
+The other half of a description audit is not mechanical and this script does not try
+to be a gate for it: whether a description claims past a limit the artifact's own notes
+already concede. Seven merged artifacts were found doing exactly that in one day by
+reading each description beside the sentences in its notes that concede a limit. That
+is a judgement pass and it belongs before the pull request. `--review` lays the pair
+out for it: for each artifact in the named modules it prints the description and every
+sentence of the notes that carries limiting vocabulary, and never fails.
+
+Usage:
+  check_artifact_descriptions.py [--root REPO_ROOT]
+  check_artifact_descriptions.py --review MODULE [MODULE ...]
+
+Exit status 0 when every description passes the mechanical rules, 1 when any fails,
+2 when the artifact tree cannot be found.
+"""
+import argparse
+import ast
+import os
+import re
+import sys
+
+# Vocabulary that marks a sentence in `notes` as conceding a limit. This drives the
+# review listing only; nothing here is a claim in itself.
+CONCESSION = re.compile(
+    r"\b(?:not established|not evidence|is not|are not|was not|were not|does not|"
+    r"do not|did not|cannot|could not|never|no row|not reported|not parsed|"
+    r"not decoded|not resolved|ships with|already present|only|absence of|"
+    r"blank|empty|unexercised|as stored)\b", re.IGNORECASE)
+
+STANDARD_NOTE = (
+    'A description is the one line quoted for the artifact. Say what the rows are and '
+    'where they come from; a description that repeats the name or a sibling says '
+    'nothing, and one that claims past its own notes is the defect --review exists '
+    'to surface.')
+
+
+def artifact_blocks(path):
+    """The __artifacts_v2__ dict of one module as {key: info}, or (None, problem)."""
+    try:
+        with open(path, encoding='utf-8', errors='replace') as handle:
+            tree = ast.parse(handle.read())
+    except (OSError, SyntaxError) as err:
+        return None, f'{os.path.basename(path)}: could not parse ({err})'
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == '__artifacts_v2__' for t in node.targets):
+            try:
+                value = ast.literal_eval(node.value)
+            except ValueError:
+                return None, f'{os.path.basename(path)}: __artifacts_v2__ is not a literal'
+            return (value if isinstance(value, dict) else {}), None
+    return {}, None
+
+
+def _normal(text):
+    return ' '.join(str(text).split()).lower()
+
+
+def check_module(path):
+    """(violations, problem) for one module. Each violation is (module, key, reason)."""
+    blocks, problem = artifact_blocks(path)
+    if blocks is None:
+        return [], problem
+    module = os.path.basename(path)
+    violations = []
+    seen = {}
+    for key, info in blocks.items():
+        if not isinstance(info, dict):
+            continue
+        description = info.get('description')
+        if not isinstance(description, str):
+            violations.append((module, key, 'description is missing or not a string'))
+            continue
+        if not description.strip():
+            violations.append((module, key, 'description is empty'))
+            continue
+        if '\n' in description:
+            violations.append((module, key, 'description runs to more than one line'))
+        name = info.get('name')
+        if isinstance(name, str) and _normal(name) == _normal(description):
+            violations.append((module, key, 'description only repeats the name'))
+        normal = _normal(description)
+        if normal in seen:
+            violations.append((module, key,
+                               f'description duplicates {seen[normal]!r} in the same module'))
+        else:
+            seen[normal] = key
+    return violations, None
+
+
+def concession_sentences(notes):
+    """The sentences of a notes field that concede a limit, for the review listing."""
+    if not isinstance(notes, str):
+        return []
+    sentences = [s.strip() for s in re.split(r'(?<=[.])\s+', notes) if s.strip()]
+    return [s for s in sentences if CONCESSION.search(s)]
+
+
+def review(paths):
+    """Print each description beside the limits its own notes concede. Never fails."""
+    for path in paths:
+        blocks, problem = artifact_blocks(path)
+        print(f'\n{"=" * 78}\n{os.path.basename(path)}')
+        if blocks is None:
+            print(f'  {problem}')
+            continue
+        for key, info in blocks.items():
+            if not isinstance(info, dict):
+                continue
+            print(f'\n  {key}')
+            print(f'     description: {info.get("description")!r}')
+            limits = concession_sentences(info.get('notes'))
+            for sentence in limits[:8]:
+                print(f'     notes limit: {sentence[:160]}')
+            if not limits:
+                print('     notes limit: (none conceded)')
+    print('\nJudge each description against the limits beside it: it must not claim past them.')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--root', default=None, help='repository root')
+    parser.add_argument('--review', nargs='+', metavar='MODULE',
+                        help='print each description beside its notes\' conceded limits '
+                             'for the named artifact modules, and exit 0')
+    args = parser.parse_args()
+
+    root = args.root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    artifacts = os.path.join(root, 'scripts', 'artifacts')
+    if not os.path.isdir(artifacts):
+        print(f'No scripts/artifacts under {root}', file=sys.stderr)
+        return 2
+
+    if args.review:
+        paths = []
+        for name in args.review:
+            base = name if name.endswith('.py') else name + '.py'
+            candidate = base if os.path.isabs(base) else os.path.join(artifacts, os.path.basename(base))
+            if not os.path.isfile(candidate):
+                print(f'No such artifact module: {name}', file=sys.stderr)
+                return 2
+            paths.append(candidate)
+        review(paths)
+        return 0
+
+    violations, unreadable, modules = [], [], 0
+    for name in sorted(os.listdir(artifacts)):
+        if not name.endswith('.py'):
+            continue
+        modules += 1
+        found, problem = check_module(os.path.join(artifacts, name))
+        violations.extend(found)
+        if problem:
+            unreadable.append(problem)
+
+    if violations:
+        print(f'Artifact descriptions that say nothing ({len(violations)}):')
+        for module, key, reason in violations:
+            print(f'  {module}::{key}  {reason}')
+        print()
+        print(STANDARD_NOTE)
+        return 1
+
+    summary = f'Checked {modules} artifact module(s): every description is present, one line, and its own.'
+    if unreadable:
+        summary += f' {len(unreadable)} module(s) NOT checked.'
+    print(summary)
+    for problem in unreadable:
+        print(f'  {problem}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -173,8 +173,6 @@ ALLOWLIST = {
 
     # The match is inside verbatim ZSYNDICATIONSTATE enum labels quoted from the
     # schema (e.g. "2-SyndPs-Manually-Saved_SWY_Synd_Asset-2"), not prose.
-    ('Ph026SyndicationPLAssets.py', 'Ph026_1SyndicationIDAssetsPhDaPsql', 'description', 'manually'),
-    ('Ph026SyndicationPLAssets.py', 'Ph026_2SyndicationPLAssetsSyndPL', 'description', 'manually'),
 
     # "visited places" restates the name of the Location.Visit stream being
     # parsed, and the description goes on to caution against relying on its

--- a/admin/test/scripts/test_check_artifact_descriptions.py
+++ b/admin/test/scripts/test_check_artifact_descriptions.py
@@ -1,0 +1,141 @@
+"""Prove the description checker fails on each shape it exists to catch and passes
+the shapes it must leave alone.
+
+The mechanical defects are exact: a description that is missing, empty, more than one
+line, identical to the artifact's name, or identical to a sibling's in the same module.
+Each gets a fixture that fails and a neighbouring fixture that passes, because a gate
+that has only ever been seen green has not been shown to gate anything.
+
+Two negative cases matter as much as the positives. Identical descriptions in two
+different modules are not flagged, since the rule is scoped to one module, where a
+duplicate is a copy left unfinished. And the review listing is not a gate: its helper
+returns the conceding sentences and nothing here asserts on them as failures.
+
+Expected values are written out as literals rather than derived from the module under
+test, so a fixture cannot move with a bug in the code it checks.
+"""
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_artifact_descriptions.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_artifact_descriptions', _MODULE_PATH)
+cad = importlib.util.module_from_spec(_spec)
+sys.modules['check_artifact_descriptions'] = cad
+_spec.loader.exec_module(cad)
+
+
+def violations_for(source, filename='sample.py'):
+    with tempfile.TemporaryDirectory() as folder:
+        path = pathlib.Path(folder) / filename
+        path.write_text(textwrap.dedent(source), encoding='utf-8')
+        found, problem = cad.check_module(str(path))
+    if problem:
+        raise AssertionError(problem)
+    return [(key, reason) for _module, key, reason in found]
+
+
+def block(entries):
+    """An __artifacts_v2__ module source from {key: {field: value}}."""
+    lines = ['__artifacts_v2__ = {']
+    for key, fields in entries.items():
+        lines.append(f'    {key!r}: {{')
+        for field, value in fields.items():
+            lines.append(f'        {field!r}: {value!r},')
+        lines.append('    },')
+    lines.append('}')
+    return '\n'.join(lines) + '\n'
+
+
+class MechanicalDefects(unittest.TestCase):
+    def test_missing_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing'}}))
+        self.assertEqual(found, [('a', 'description is missing or not a string')])
+
+    def test_non_string_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing', 'description': 7}}))
+        self.assertEqual(found, [('a', 'description is missing or not a string')])
+
+    def test_empty_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing', 'description': '   '}}))
+        self.assertEqual(found, [('a', 'description is empty')])
+
+    def test_multiline_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing',
+                                             'description': 'Rows from x.\nMore.'}}))
+        self.assertEqual(found, [('a', 'description runs to more than one line')])
+
+    def test_description_equal_to_name_fails(self):
+        found = violations_for(block({'a': {'name': 'Samsung Notes',
+                                             'description': 'Samsung Notes'}}))
+        self.assertEqual(found, [('a', 'description only repeats the name')])
+
+    def test_name_match_ignores_case_and_spacing(self):
+        found = violations_for(block({'a': {'name': 'Samsung  Notes',
+                                             'description': 'samsung notes '}}))
+        self.assertEqual(found, [('a', 'description only repeats the name')])
+
+    def test_duplicate_within_module_fails_on_the_second(self):
+        found = violations_for(block({
+            'contacts': {'name': 'Romeo Contacts', 'description': 'Parses Romeo contacts'},
+            'accounts': {'name': 'Romeo Accounts', 'description': 'Parses Romeo contacts'},
+        }))
+        self.assertEqual(found, [('accounts',
+                                  "description duplicates 'contacts' in the same module")])
+
+    def test_duplicate_match_ignores_case(self):
+        found = violations_for(block({
+            'a': {'name': 'A', 'description': 'Kik notifications from FCM'},
+            'b': {'name': 'B', 'description': 'kik Notifications from fcm'},
+        }))
+        self.assertEqual([k for k, _ in found], ['b'])
+
+
+class ShapesLeftAlone(unittest.TestCase):
+    def test_distinct_one_line_descriptions_pass(self):
+        found = violations_for(block({
+            'a': {'name': 'JusTalk - Calls', 'description': 'Calls from the JusTalk store'},
+            'b': {'name': 'JusTalk Kids - Calls',
+                  'description': 'Calls from the JusTalk Kids store'},
+        }))
+        self.assertEqual(found, [])
+
+    def test_description_that_extends_the_name_passes(self):
+        found = violations_for(block({'a': {'name': 'Samsung Notes',
+                                             'description': 'Notes from Samsung Notes, with media'}}))
+        self.assertEqual(found, [])
+
+    def test_same_description_in_two_modules_is_not_flagged(self):
+        source = block({'a': {'name': 'A', 'description': 'Chess database'}})
+        self.assertEqual(violations_for(source, 'one.py'), [])
+        self.assertEqual(violations_for(source, 'two.py'), [])
+
+    def test_unparseable_module_is_reported_not_crashed(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = pathlib.Path(folder) / 'broken.py'
+            path.write_text('__artifacts_v2__ = {\n', encoding='utf-8')
+            found, problem = cad.check_module(str(path))
+        self.assertEqual(found, [])
+        self.assertIn('could not parse', problem)
+
+
+class ReviewListing(unittest.TestCase):
+    def test_conceding_sentences_are_selected(self):
+        notes = ('One row per entry. Whether every file is recorded was not established. '
+                 'Times are UTC. A blank value is not evidence of absence.')
+        limits = cad.concession_sentences(notes)
+        self.assertEqual(limits, ['Whether every file is recorded was not established.',
+                                  'A blank value is not evidence of absence.'])
+
+    def test_non_string_notes_yield_nothing(self):
+        self.assertEqual(cad.concession_sentences(None), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/ConnectedDeviceInformation.py
+++ b/scripts/artifacts/ConnectedDeviceInformation.py
@@ -9,7 +9,9 @@ __artifacts_v2__ = {
     "connected_device_info_device_history": {
         "name": "Connected Device Information - Connected Device and \
 OS History",
-        "description": "Connected Devices",
+        "description": "Apple devices that wrote to the Health store, from data_provenances "
+                       "joined to objects in healthdb_secure.sqlite, with the first and last "
+                       "sample time for each product type, model, OS build and source id.",
         "author": "@SQLMcGee",
         'creation_date': '2025-01-30',
         'last_update_date': '2025-09-29',
@@ -41,7 +43,9 @@ Apple product identification, common name, OS, and timeframe of use",
     "connected_device_info_consolidated_connected_device_history": {
         "name": "Connected Device Information - Consolidated Connected Device \
 History",
-        "description": "Connected Devices",
+        "description": "The Health store's data_provenances grouped by product type and device "
+                       "model, with the first and last time each device wrote a sample to "
+                       "healthdb_secure.sqlite.",
         "author": "@SQLMcGee",
         'creation_date': '2025-01-30',
         'last_update_date': '2025-09-29',
@@ -72,7 +76,8 @@ Apple product grouped for starting and ending timeframe of use",
     },
     "connected_device_information_current_device_info": {
         "name": "Connected Device Information - Current Device Information",
-        "description": "Connected Devices",
+        "description": "The device recorded in the device_context table of healthdb.sqlite, with "
+                       "its product type, model, OS version and the row's modified time.",
         "author": "@SQLMcGee",
         'creation_date': '2025-01-30',
         'last_update_date': '2025-09-29',

--- a/scripts/artifacts/Ph026SyndicationPLAssets.py
+++ b/scripts/artifacts/Ph026SyndicationPLAssets.py
@@ -1,19 +1,9 @@
 __artifacts_v2__ = {
 'Ph026_1SyndicationIDAssetsPhDaPsql': {
 'name': 'Ph026.1-Syndication ID Assets-PhDaPsql',
-'description': 'Parses Syndication ID and Syndication Photos Library assets which includes'
-' Shared with You Conversation assets from PhotoData-Photos.sqlite and'
-' Syndication.photoslibrary-database-Photos.sqlite'
-' and supports iOS 15-18. Parses assets that have a ZADDITIONALASSETATTRIBUTES'
-' ZSYNDICATIONIDENTIFIER value. ZASSET ZSAVEDASSETTYPE and ZASSET ZSYNDICATIONSTATE fields'
-' can be used to filter those results: ZASSET ZSYNDICATIONSTATE:'
-' 0-PhDaPs-NA_or_SyndPs-Received-SWY_Synd_Asset-0 1-SyndPs-Sent-SWY_Synd_Asset-1'
-' 2-SyndPs-Manually-Saved_SWY_Synd_Asset-2'
-' 8-SyndPs-Linked_Asset_was_Visible_On-Device_User_Deleted_Link-8'
-' 9-SyndPs-STILLTESTING_Sent_SWY-9'
-' 10-SyndPs-Manually-Saved_SWY_Synd_Asset_User_Deleted_From_LPL-10'
-' ZASSET ZSAVEDASSETTYPE: 12-SyndPs-SWY-Asset_Auto-Display_In_CameraRoll-12'
-' https://theforensicscooter.com/2024/05/18/ileapp-parsers-photos-sqlite-queries/',
+'description': "Assets carrying a Syndication Identifier in PhotoData/Photos.sqlite (Shared with "
+               "You conversation assets, iOS 15 to 18), with their conversation album dates, "
+               "import session, file names, syndication state and saved asset type.",
 'author': 'Scott Koenig',
 'creation_date': '2026-05-28',
 'version': '6.0',
@@ -45,19 +35,10 @@ __artifacts_v2__ = {
 },
 'Ph026_2SyndicationPLAssetsSyndPL': {
 'name': 'Ph026.2-Syndication PL Assets-SyndPL',
-'description': 'Parses Syndication ID and Syndication Photos Library assets which includes'
-' Shared with You Conversation assets from PhotoData-Photos.sqlite and'
-' Syndication.photoslibrary-database-Photos.sqlite'
-' and supports iOS 15-18. Parses assets that have a ZADDITIONALASSETATTRIBUTES'
-' ZSYNDICATIONIDENTIFIER value. ZASSET ZSAVEDASSETTYPE and ZASSET ZSYNDICATIONSTATE fields'
-' can be used to filter those results: ZASSET ZSYNDICATIONSTATE:'
-' 0-PhDaPs-NA_or_SyndPs-Received-SWY_Synd_Asset-0 1-SyndPs-Sent-SWY_Synd_Asset-1'
-' 2-SyndPs-Manually-Saved_SWY_Synd_Asset-2'
-' 8-SyndPs-Linked_Asset_was_Visible_On-Device_User_Deleted_Link-8'
-' 9-SyndPs-STILLTESTING_Sent_SWY-9'
-' 10-SyndPs-Manually-Saved_SWY_Synd_Asset_User_Deleted_From_LPL-10'
-' ZASSET ZSAVEDASSETTYPE: 12-SyndPs-SWY-Asset_Auto-Display_In_CameraRoll-12'
-' https://theforensicscooter.com/2024/05/18/ileapp-parsers-photos-sqlite-queries/',
+'description': "Assets carrying a Syndication Identifier in the Syndication.photoslibrary "
+               "Photos.sqlite (Shared with You conversation assets, iOS 15 to 18), with their "
+               "conversation album dates, import session, file names, syndication state and saved "
+               "asset type.",
 'author': 'Scott Koenig',
 'creation_date': '2026-05-28',
 'version': '6.0',

--- a/scripts/artifacts/WithingsHealthMate.py
+++ b/scripts/artifacts/WithingsHealthMate.py
@@ -8,7 +8,9 @@
 __artifacts_v2__ = {
     "get_healthmate_accounts": {
         "name": "Health Mate - Accounts",
-        "description": "Existing account in Health Mate App from Withings.\nThis decoding is based on the blog post https://bebinary4n6.blogspot.com/2024/09/withings-healthmate-on-ios.html",
+        "description": "The account recorded in the Health Mate app's Application Support/account "
+                       "file, with user id, names, birthdate and email and its creation and "
+                       "modification times.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-09-22",
         "last_update_date": "2025-11-12",
@@ -21,7 +23,9 @@ __artifacts_v2__ = {
     },
     "get_healthmate_sleep_tracking": {
         "name": "Health Mate - Sleep Tracking",
-        "description": "Tracked sleep by Withings devices/app.\n This decoding is based on the blog post https://bebinary4n6.blogspot.com/2024/09/withings-healthmate-on-ios.html",
+        "description": "Sleep sessions from the Health Mate app's Core Data track store, with "
+                       "start and end, sleep stage durations, time to sleep and to get up, "
+                       "wake-up count and the device id.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-09-23",
         "last_update_date": "2025-11-12",
@@ -34,7 +38,9 @@ __artifacts_v2__ = {
     },
     "get_healthmate_daily_summary": {
         "name": "Health Mate - Daily Summary",
-        "description": "Daily Summary of activities.\n This decoding is based on the blog post https://bebinary4n6.blogspot.com/2024/09/withings-healthmate-on-ios.html",
+        "description": "Daily activity summaries from the Health Mate app's Core Data track "
+                       "store, with the day's inactive, soft, moderate and intense durations, "
+                       "steps and distance.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-09-24",
         "last_update_date": "2025-11-12",
@@ -47,7 +53,9 @@ __artifacts_v2__ = {
     },
     "get_healthmate_tracked_activities": {
         "name": "Health Mate - Tracked Activities",
-        "description": "Tracked activities.\n This decoding is based on the blog post https://bebinary4n6.blogspot.com/2024/09/withings-healthmate-on-ios.html",
+        "description": "Activities tracked in the Health Mate app's Core Data track store, with "
+                       "start and end, type, durations, heart rate, step, distance, speed and "
+                       "temperature values and start, end and region coordinates.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-09-24",
         "last_update_date": "2025-11-12",

--- a/scripts/artifacts/ZangiMessenger.py
+++ b/scripts/artifacts/ZangiMessenger.py
@@ -6,7 +6,9 @@ __artifacts_v2__ = {
     
     "zangi_messages": {
         "name": "Zangi Messenger - Messages",
-        "description": "Zangi Messenger - Messages",
+        "description": "Messages from the Zangi Messenger database (ZZANGIMESSAGE joined to its "
+                       "conversation, group and contact tables), with direction, sender, chat "
+                       "name, text, message type and the attachment file where the app kept one.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creatin_date": "2026-03-03",
         "creation_date": "2026-03-03",
@@ -42,7 +44,9 @@ __artifacts_v2__ = {
     },
     "zangi_contacts": {
         "name": "Zangi Messenger - Contacts",
-        "description": "Zangi Messenger - Contacts",
+        "description": "Contacts from the Zangi Messenger database (ZCONTACT with its numbers), "
+                       "with names, number, email, registration type, blocked and favourite flags "
+                       "and modification and activity times.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creatin_date": "2026-03-01",
         "creation_date": "2026-03-01",
@@ -59,7 +63,9 @@ __artifacts_v2__ = {
     },
     "zangi_accounts": {
         "name": "Zangi Messenger - Accounts",
-        "description": "Zangi Messenger - Accounts",
+        "description": "Account rows from the ZUSER table of the Zangi Messenger database, with "
+                       "account id, names, email, status, registration status, country and the "
+                       "passcode, password and PIN fields as stored.",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creatin_date": "2026-03-01",
         "creation_date": "2026-03-01",

--- a/scripts/artifacts/appleMapsTrips.py
+++ b/scripts/artifacts/appleMapsTrips.py
@@ -33,7 +33,11 @@ __artifacts_v2__ = {
     },
     "appleMapsSignificantLocations": {
         "name": "Apple Maps Significant Locations (routined)",
-        "description": "Location data comes from the routined (Significant Locations) cache, not the Apple Maps app. The Google Maps Link are constructed from the coordinates. They DO NOT exist in the evidence.",
+        "description": "Significant Location visits from the routined caches "
+                       "(ZRTLEARNEDLOCATIONOFINTERESTVISITMO in Local.sqlite and "
+                       "Cloud-V2.sqlite), with entry and exit times, coordinates and uncertainty; "
+                       "the Google Maps link is built from the coordinates and does not exist in "
+                       "the evidence.",
         "author": "ogmini",
         "creation_date": "2026-03-04",
         "last_update_date": "2026-08-21",
@@ -65,7 +69,11 @@ __artifacts_v2__ = {
     },
     "appleMapsSignificantLocationsVisits": {
         "name": "Apple Maps Significant Locations Visits (routined)",
-        "description": "Location data comes from the routined (Significant Locations) cache, not the Apple Maps app. The Google Maps Link are constructed from the coordinates. They DO NOT exist in the evidence.",
+        "description": "Significant Location places from the routined caches "
+                       "(ZRTLEARNEDLOCATIONOFINTERESTMO with its learned place, map item and "
+                       "address rows), with name, category, address fields and coordinates; the "
+                       "Google Maps link is built from the coordinates and does not exist in the "
+                       "evidence.",
         "author": "ogmini",
         "creation_date": "2026-03-04",
         "last_update_date": "2026-08-21",

--- a/scripts/artifacts/appleWalletCards.py
+++ b/scripts/artifacts/appleWalletCards.py
@@ -1,7 +1,9 @@
 __artifacts_v2__ = {
     "applewalletcards": {
         "name": "Apple Wallet Cards",
-        "description": "Apple Wallet Cards",
+        "description": "Card number, expiry and card type strings pattern-matched from cached "
+                       "Passbook API responses in the Wallet app's Cache.db, with the cache entry "
+                       "time; heuristic matches that need verification.",
         "author": "@any333",
         "creation_date": "2021-02-05",
         "last_update_date": "2026-07-31",

--- a/scripts/artifacts/appleWalletTransactions.py
+++ b/scripts/artifacts/appleWalletTransactions.py
@@ -1,7 +1,9 @@
 __artifacts_v2__ = {
     'appleWalletTransactions': {
         'name': 'Apple Wallet Transactions',
-        'description': 'Apple Wallet Transactions',
+        'description': "Wallet transactions from passes23.sqlite, with date, merchant, locality, "
+                       "amount and currency, location fields, peer payment handle, memo, status "
+                       "and type.",
         'author': '@any333',
         'creation_date': '2021-02-05',
         'last_update_date': '2026-07-31',

--- a/scripts/artifacts/callHistoryGroupCall.py
+++ b/scripts/artifacts/callHistoryGroupCall.py
@@ -1,7 +1,9 @@
 __artifacts_v2__ = {
     "callHistoryGroupCall": {
         "name": "Call History - Group Call",
-        "description": "Extract Call History",
+        "description": "Calls from the CallHistory store (ZCALLRECORD with its remote participant "
+                       "handles), with start and end, service, type, direction, participant "
+                       "numbers, duration, FaceTime data, disconnect cause, country and location.",
         "author": "@SQLMcGee",
         "creation_date": "2025-02-05",
         "last_update_date": "2026-07-31",
@@ -31,7 +33,9 @@ __artifacts_v2__ = {
     },
     "callHistoryInteractionC": {
         "name": "interactionC Call History - Group Call",
-        "description": "Extract Call History",
+        "description": "Call interactions from CoreDuet's interactionC.db (ZINTERACTIONS with "
+                       "their recipients), with start and end, app bundle id, direction, display "
+                       "name, number and duration.",
         "author": "@SQLMcGee",
         "creation_date": "2025-02-05",
         "last_update_date": "2026-07-31",

--- a/scripts/artifacts/facebookMessenger.py
+++ b/scripts/artifacts/facebookMessenger.py
@@ -21,7 +21,9 @@ __artifacts_v2__ = {
     },
     "facebookMessengerChats": {
         "name": "Facebook Messenger - Chats",
-        "description": "Extract messages from Facebook Messenger.",
+        "description": "Messages from the thread_messages table of the Facebook Messenger "
+                       "lightspeed user database, with direction, sender, text, attachment name "
+                       "and size and the thread id.",
         "author": "@stark4n6",
         "creation_date": "2021-03-03",
         "last_update_date": "2025-08-27",
@@ -51,7 +53,9 @@ __artifacts_v2__ = {
     },
     "facebook_messenger_client_chats": {
         "name": "Facebook Messenger - Client Messages",
-        "description": "Extract messages from Facebook Messenger.",
+        "description": "Messages from the client_messages table of the Facebook Messenger "
+                       "lightspeed user database, with direction, sender, text and the attachment "
+                       "image where its persisted file is present in the media bank.",
         "author": "Sukochev",
         "creation_date": "2026-06-24",
         "last_update_date": "2026-06-24",

--- a/scripts/artifacts/health.py
+++ b/scripts/artifacts/health.py
@@ -221,7 +221,8 @@ __artifacts_v2__ = {
     },
     "health_steps": {
         "name": "Health - Steps",
-        "description": "Health - Steps",
+        "description": "Step count samples from the samples table of healthdb_secure.sqlite, with "
+                       "start and end, steps, duration and the writing device's id and model.",
         "author": "@KevinPagano3",
         "creation_date": "2023-10-06",
         "last_update_date": "2025-10-13",

--- a/scripts/artifacts/spotlightIndex.py
+++ b/scripts/artifacts/spotlightIndex.py
@@ -1,7 +1,8 @@
 __artifacts_v2__ = {
     "get_spotlightIndexCache": {
         "name": "Spotlight Index Cache V2",
-        "description": "Spotlight Index Cache V2",
+        "description": "Text content of the CoreSpotlight index.spotlightV2 cache text files, "
+                       "with each file's modified time, cache folder and file name.",
         "author": "@snoop168",
         "creation_date": "2025-10-09",
         "last_update_date": "2025-10-09",

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -61,7 +61,9 @@ __artifacts_v2__ = {
     },
     "teleguardChannels": {
         "name": "Teleguard Channels",
-        "description": "TeleGuard channels",
+        "description": "Channels from the channels table of the TeleGuard database, with alias, "
+                       "description, category, subscriber and post counts, admin, deleted flag, "
+                       "language and type.",
         "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-06-24", "requirements": "none",
         "category": "Teleguard", "notes": "",
         "paths": ('*/Shared/AppGroup/*/Library/teleguard_database.db*',),


### PR DESCRIPTION
Adds the description gate ALEAPP carries: a description that is missing, runs to more than one line, only repeats the artifact name, or duplicates a sibling's in the same module fails the lint job. Its --review mode prints each description beside the notes sentences that concede a limit.

The 18 live cases are rewritten so the gate lands at zero: Zangi Messenger, Apple Wallet cards and transactions, Health steps, Spotlight index cache and TeleGuard channels repeated their names; Withings Health Mate ran to two lines; the Connected Device, Syndication, Apple Maps routined, call history and Facebook Messenger pairs shared one description. Each new line names the source table or file and the fields the rows carry. Two allowlist entries the Syndication rewrite made stale are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)