### PR TITLE
Bring five descriptions back inside the limits their notes state

### DIFF
--- a/scripts/artifacts/KeepSafe.py
+++ b/scripts/artifacts/KeepSafe.py
@@ -2,10 +2,11 @@ __artifacts_v2__ = {
     "keepsafe_vault_items": {
         "name": "KeepSafe - Vault Items",
         "description": (
-            "Media items recorded in KeepSafe's RocksDB store (Documents/rdb), matched "
-            "to the encrypted file each item's id names under Documents/<table>/. "
-            "Reports the item's name, timestamps, album, GPS, and SHA-1/dimensions as "
-            "KeepSafe itself recorded them for the original file, before encryption."
+            "Media items recorded in the write-ahead logs of KeepSafe's RocksDB store "
+            "(Documents/rdb), matched to the encrypted file each item's id names under "
+            "Documents/<table>/, with the item's name, timestamps, album, GPS and "
+            "SHA-1/dimensions as KeepSafe recorded them for the original file before encryption; "
+            "items held only in the .sst tables are not read."
         ),
         "author": "@Gear-I, Claude",
         "creation_date": "2026-08-23",

--- a/scripts/artifacts/appStoreSearches.py
+++ b/scripts/artifacts/appStoreSearches.py
@@ -1,7 +1,9 @@
 __artifacts_v2__ = {
     'appStoreSearches': {
         'name': 'App Store - Searches',
-        'description': 'Search terms submitted in the App Store, recovered from the cached search API requests',
+        'description': "Search terms the App Store app sent to its search API, recovered from the "
+                       "cached search and suggestion requests; a cached request does not "
+                       "establish that the term was submitted by the user",
         'author': '@AlexisBrignoni',
         'creation_date': '2026-07-25',
         'last_update_date': '2026-07-31',

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -1,9 +1,10 @@
 __artifacts_v2__ = {
     "get_cashApp": {
         "name": "Cash App",
-        "description": "Parses Cash App customer and payment records from the CCEntitySync SQLite stores, "
-                       "decoding the ZSYNCCUSTOMER and ZSYNCPAYMENT protobuf blobs and the JSON payloads "
-                       "they carry.",
+        "description": "Parses Cash App payment records joined to their customer records from the "
+                       "CCEntitySync SQLite stores, decoding the ZSYNCPAYMENT and ZSYNCCUSTOMER "
+                       "protobuf blobs and the JSON payloads they carry; a customer with no "
+                       "payment is not reported.",
         "author": "@gforce4n6, @AlexisBrignoni, @charpy4n6, Claude",
         "creation_date": "2021-10-06",
         "last_update_date": "2026-08-25",

--- a/scripts/artifacts/onionBrowser.py
+++ b/scripts/artifacts/onionBrowser.py
@@ -1,8 +1,9 @@
 __artifacts_v2__ = {
     "onion_browser_bookmarks": {
         "name": "Onion Browser - Bookmarks",
-        "description": "Bookmarks saved in Onion Browser, with the page name, the URL and the "
-                       "stored site icon",
+        "description": "Bookmarks held in Onion Browser's bookmark store, including the defaults "
+                       "the app seeds on first run, with the page name, the URL and the stored "
+                       "site icon",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-15",
         "last_update_date": "2026-08-21",

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -1,7 +1,8 @@
 __artifacts_v2__ = {
     "teleguardMessages": {
         "name": "Teleguard Messages",
-        "description": "TeleGuard chat messages and shared media",
+        "description": "TeleGuard chat messages, with the shared media file where the extraction "
+                       "holds it",
         "author": "@abrignoni", "creation_date": "2026-06-23", "last_update_date": "2026-08-21", "requirements": "none",
         "category": "Teleguard",
         "notes": "Timestamps are UTC (epoch milliseconds). Is Edited? held 0 on every message row of "


### PR DESCRIPTION
Read each iLEAPP description beside the sentences of its own notes that concede a limit. Five claimed past it and are reworded:

- appStoreSearches: terms the app sent to its search API, not terms the user submitted.
- cashApp: payment records joined to their customers; a customer with no payment is not reported.
- onionBrowser bookmarks: the store includes the defaults the app seeds.
- KeepSafe vault items: only the RocksDB write-ahead logs are read.
- teleguard messages: shared media only where the extraction holds the file.

Description strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
