### PR TITLE
Stop KeepSafe spinning on directory entries in files_found

### DIFF
--- a/scripts/artifacts/KeepSafe.py
+++ b/scripts/artifacts/KeepSafe.py
@@ -14,12 +14,17 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "KeepSafe",
         "notes": (
-            "RocksDB *.sst tables are not read (see module docstring); only what is "
-            "still in the write-ahead log(s) is reported, so a count here is a floor, "
-            "not a ceiling, on what the vault has ever held. 'breakin_alert' and 'fake' "
-            "were empty directories with no live records in the validation image, so "
-            "their field mapping is unexercised - see module docstring for the tier of "
-            "each claim."
+            "RocksDB *.sst tables are not read (see module docstring); only what is still in the "
+            "write-ahead log(s) is reported, so a count here is a floor, not a ceiling, on what "
+            "the vault has ever held. 'breakin_alert' and 'fake' were empty directories with no "
+            "live records in the validation image, so their field mapping is unexercised - see "
+            "module docstring for the tier of each claim. Newer builds shard each table into "
+            "two-letter folders (primary/<xx>/<item-id>_100 on the iOS 17.3 image); the folder "
+            "entries the file search returns beside the files, and the rdb_backups/<timestamp> "
+            "folder itself, are skipped. The KeepSafe version recorded in sample_data is the "
+            "app's own initialVersionInstalled preference, the version first installed rather "
+            "than the one running at acquisition. On the iOS 17.5.1 image the container held the "
+            "rdb stores and no table directory, so no item is reported there."
         ),
         "paths": (
             "*/mobile/Containers/Data/Application/*/Documents/rdb/*",
@@ -35,6 +40,15 @@ __artifacts_v2__ = {
             "hickman_ios14": (
                 "iOS 14.3 | KeepSafe 10.2.4 | 5 rows, all from the 'primary' table; "
                 "'breakin_alert' and 'fake' present as empty directories, 0 rows"
+            ),
+            "hickman_ios15": "iOS 15.0.2 | KeepSafe 11.7.3 (initial install version) | 7 rows, all from the 'primary' table",
+            "iphone11_ios17": (
+                "iOS 17.3 | KeepSafe 11.10.1 (initial install version) | 9 rows, all from the 'primary' table, "
+                "sharded into two-letter folders"
+            ),
+            "cookbook_ios1751": (
+                "iOS 17.5.1 | KeepSafe 11.13.1 (initial install version) | 0 rows: the container holds the rdb "
+                "stores and no table directory"
             ),
         },
     },
@@ -57,6 +71,9 @@ __artifacts_v2__ = {
         "artifact_icon": "folder",
         "sample_data": {
             "hickman_ios14": "iOS 14.3 | KeepSafe 10.2.4 | 5 rows: Main Album, Videos, Cards & ID, Significant Other, My Private Album",
+            "hickman_ios15": "iOS 15.0.2 | KeepSafe 11.7.3 (initial install version) | 5 rows",
+            "iphone11_ios17": "iOS 17.3 | KeepSafe 11.10.1 (initial install version) | 5 rows",
+            "cookbook_ios1751": "iOS 17.5.1 | KeepSafe 11.13.1 (initial install version) | 1 row",
         },
     },
     "keepsafe_account_security": {
@@ -86,6 +103,9 @@ __artifacts_v2__ = {
         "artifact_icon": "shield-lock",
         "sample_data": {
             "hickman_ios14": "iOS 14.3 | KeepSafe 10.2.4 | 1 row",
+            "hickman_ios15": "iOS 15.0.2 | KeepSafe 11.7.3 (initial install version) | 1 row",
+            "iphone11_ios17": "iOS 17.3 | KeepSafe 11.10.1 (initial install version) | 1 row",
+            "cookbook_ios1751": "iOS 17.5.1 | KeepSafe 11.13.1 (initial install version) | 1 row",
         },
     },
 }
@@ -203,6 +223,11 @@ def _rdb_store_dirs(files_found):
     live_dirs = set()
     backup_dirs = {}
     for path in files_found:
+        if os.path.isdir(path):
+            # the seekers hand back a matched directory (rdb_backups/<ts> itself) as well as
+            # its files; a directory entry has no store to contribute and, walked upward,
+            # never meets its own name
+            continue
         norm = str(path).replace("\\", "/")
         parent = os.path.dirname(norm)
         if "/Documents/rdb_backups/" in norm:
@@ -210,8 +235,13 @@ def _rdb_store_dirs(files_found):
             after = norm.split(marker, 1)[1]
             ts_name = after.split("/", 1)[0]
             store_dir = parent
-            while os.path.basename(store_dir) != ts_name and store_dir:
-                store_dir = os.path.dirname(store_dir)
+            while store_dir and os.path.basename(store_dir) != ts_name:
+                up = os.path.dirname(store_dir)
+                if up == store_dir:
+                    # reached the filesystem root without meeting the backup name
+                    store_dir = ""
+                    break
+                store_dir = up
             if store_dir:
                 try:
                     ts_val = int(ts_name)
@@ -350,6 +380,10 @@ def _item_files(files_found):
     """Yields (table, item_id, encrypted_file_path) for each on-disk vault content
     file (excludes .thumb/.preview/.md sidecars)."""
     for path in files_found:
+        if os.path.isdir(path):
+            # newer builds shard a table into two-letter folders (primary/5z/5zxGR_100) and the
+            # seekers return those folders too; a folder is not an item
+            continue
         norm = str(path).replace("\\", "/")
         for table in _VAULT_TABLES:
             marker = f"/Documents/{table}/"


### PR DESCRIPTION
The seekers hand an artifact a matched directory as well as its files, and two loops in KeepSafe.py treated those entries as files.

- The store-directory walk for a rdb_backups/<timestamp> folder climbed toward the root looking for a name it could never meet, and dirname('/') is '/', so keepsafe_vault_items never returned. Two of 26 corpora in a full run sat on it for over an hour each, on 20 KB and 160 KB of input.
- The item loop reported each two-letter shard folder of the newer layout (primary/5z/<item>_100) as an item with every derived field blank.

Both loops skip directory entries now and the walk stops at the root. hickman_ios14 is unchanged at 5, 5 and 1 rows and its committed test case passes; hickman_ios15 gives 7, 5, 1; iphone11_ios17 9, 5, 1 (was 18 with the nine folder rows); cookbook_ios1751 0, 1, 1 where the run never finished before. sample_data and notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
