### PR TITLE
Correct notes counts that no longer matched the swept data in 9 modules

### DIFF
--- a/scripts/artifacts/appleWalletCards.py
+++ b/scripts/artifacts/appleWalletCards.py
@@ -9,7 +9,14 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "Apple Wallet",
-        "notes": "Card values are pattern-matched from cached API responses and the type heuristic uses only the first digit; values require verification. Cache timestamps reflect response caching, not card enrollment. In tested images only iOS 13.3.1 yields a card row: the Passbook Cache.db is present but yields no card entries on the 13 other recorded corpus images (iOS 12-18) and on all 21 extractions in Mattia Epifani's 2026-08 comparison across 21 extractions (iOS 16.1.1-26.5.2). Wallet passes on current images are parsed by the Apple Wallet - Nano Passes and Apple Wallet Transactions artifacts.",
+        "notes": "Card values are pattern-matched from cached API responses and the type "
+                 "heuristic uses only the first digit; values require verification. Cache "
+                 "timestamps reflect response caching, not card enrollment. In tested images only "
+                 "iOS 13.3.1 yields a card row: the Passbook Cache.db is present but yields no "
+                 "card entries on the 20 other tested images that carry it (iOS 12-26) and on all "
+                 "21 extractions in Mattia Epifani's 2026-08 comparison across 21 extractions "
+                 "(iOS 16.1.1-26.5.2). Wallet passes on current images are parsed by the Apple "
+                 "Wallet - Nano Passes and Apple Wallet Transactions artifacts.",
         "paths": ('*/mobile/Containers/Data/Application/*/Library/Caches/com.apple.Passbook/Cache.db*'),
         "output_types": "standard",
         "artifact_icon": "credit-card",

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -17,21 +17,21 @@ __artifacts_v2__ = {
         "notes": "Value follows the UIInterfaceOrientation enumeration (UIKit, defined in "
                  "UIApplication.h); the raw value is reported alongside the label. Read the "
                  "landscape labels carefully: Apple crosses the two landscape cases against "
-                 "UIDeviceOrientation, so under UIInterfaceOrientation 3 is Landscape Right "
-                 "and 4 is Landscape Left, the opposite of the values in the "
+                 "UIDeviceOrientation, so under UIInterfaceOrientation 3 is Landscape Right and 4 "
+                 "is Landscape Left, the opposite of the values in the "
                  "_DKEvent.Display.Orientation stream parsed by Biome - Display Orientation "
                  "DKEvent. Header text: UIInterfaceOrientationLandscapeLeft = "
                  "UIDeviceOrientationLandscapeRight and UIInterfaceOrientationLandscapeRight = "
-                 "UIDeviceOrientationLandscapeLeft. Only values 0, 1 and 2 have been observed "
-                 "in sample data so far, and those three are identical in both enumerations, so "
-                 "the choice of enumeration is not yet confirmed by data: the stream name says "
+                 "UIDeviceOrientationLandscapeLeft. Only values 0, 1 and 2 have been observed on "
+                 "the written records of the tested images (records in the deleted SEGB state "
+                 "carry no value), and those three are identical in both enumerations, so the "
+                 "choice of enumeration is not yet confirmed by data: the stream name says "
                  "interface orientation while the System Events plist describes it as capturing "
-                 "device orientation. A value of 5 or 6 appearing here would indicate the "
-                 "device enumeration instead, since UIInterfaceOrientation has no Face Up or "
-                 "Face Down case. Enumeration source: Apple UIKit headers UIApplication.h and "
-                 "UIDevice.h, mirrored at "
-                 "https://github.com/silent0123/OSXDev/blob/c943c2158bcd3a6caa3023e396e653cbe3832ae1/"
-                 "uSav-Mac/usavMac/UIKit.framework/Headers/UIApplication.h "
+                 "device orientation. A value of 5 or 6 appearing here would indicate the device "
+                 "enumeration instead, since UIInterfaceOrientation has no Face Up or Face Down "
+                 "case. Enumeration source: Apple UIKit headers UIApplication.h and UIDevice.h, "
+                 "mirrored at "
+                 "https://github.com/silent0123/OSXDev/blob/c943c2158bcd3a6caa3023e396e653cbe3832ae1/uSav-Mac/usavMac/UIKit.framework/Headers/UIApplication.h "
                  "Stream reference: Mattia Epifani, '84 Streams Later, Part 2: Inside Apple "
                  "Biome', "
                  "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",
@@ -126,9 +126,10 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
-        "notes": "The raw value is temperature in hundredths of a degree Celsius (observed "
-                 "range 1900-3700, i.e. 19.00-37.00 C); both the converted and raw values are "
-                 "reported. Field 2 is reported raw as its meaning is not confirmed.",
+        "notes": "The raw value is temperature in hundredths of a degree Celsius (observed range "
+                 "600-4300 across the four tested images, i.e. 6.00-43.00 C); both the converted "
+                 "and raw values are reported. Field 2 is reported raw as its meaning is not "
+                 "confirmed.",
         "paths": ('*/streams/*/Device.Thermals.BatteryTemperature/local/*',),
         "output_types": "standard",
         "artifact_icon": "thermometer",
@@ -210,10 +211,11 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-20",
         "requirements": "none",
         "category": "Biome",
-        "notes": "Field 3 is populated only while plugged in and is reported raw as its "
-                 "meaning is not confirmed. A record is written whenever the device is "
-                 "charging, which includes wireless charging as well as a physical cable "
-                 "connection (observation by Ian Whiffin). Modern counterpart of the "
+        "notes": "Field 3 is populated on every record that carries a power state, plugged in or "
+                 "not, and absent on the records that carry none; it is reported raw as its "
+                 "meaning is not confirmed. A record is written whenever the device is charging, "
+                 "which includes wireless charging as well as a physical cable connection "
+                 "(observation by Ian Whiffin). Modern counterpart of the "
                  "_DKEvent.Device.IsPluggedIn stream parsed by Biome - Device Plugged In. "
                  "Reference: Mattia Epifani, '84 Streams Later, Part 2: Inside Apple Biome', "
                  "https://blog.digital-forensics.it/2026/07/84-streams-later-part-2-inside-apple.html",

--- a/scripts/artifacts/biomeEmojiEngagement.py
+++ b/scripts/artifacts/biomeEmojiEngagement.py
@@ -11,10 +11,11 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Biome",
         "notes": "The context field decodes to a four character ASCII string that resembles a "
-                 "trailing locale fragment (values seen: n_US and n-US, consistent with en_US "
-                 "and en-US); it is reported both raw and decoded because that reading is not "
-                 "confirmed. Field 2 was 1 on every record observed and field 4 varied from 1 "
-                 "to 4; both are reported raw.",
+                 "trailing locale fragment (values seen: n_US and n-US, consistent with en_US and "
+                 "en-US); it is reported both raw and decoded because that reading is not "
+                 "confirmed. Field 2 was 1 on every written record of the tested images and field "
+                 "4 varied from 1 to 4; records in the deleted SEGB state carry neither, and both "
+                 "are reported raw.",
         "paths": ('*/streams/*/Emoji.Engagement/local/*',),
         "output_types": "standard",
         "artifact_icon": "smile",

--- a/scripts/artifacts/iCloudWifi.py
+++ b/scripts/artifacts/iCloudWifi.py
@@ -7,19 +7,22 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Wifi Connections",
-        "notes": "The synced-data plist lives at Library/SyncedPreferences/com.apple.wifid.plist "
-                 "and, in the only local test image carrying it (iOS 12.4), holds an empty values "
-                 "dictionary. The earlier glob matched any com.apple.wifid.plist and so reported "
-                 "the unrelated /System/Library/LaunchDaemons daemon configuration as the found "
-                 "file on most images; the narrower path stops that. "
-                 "Reference: cheeky4n6monkey (based on research by M. Epifani, H. Mahalik), "
-                 "'iOS_sysdiagnose_forensic_scripts', "
+        "notes": "The synced-data plist lives at Library/SyncedPreferences/com.apple.wifid.plist; "
+                 "on the tested images it is present only on the iOS 12.4, 13.3.1 and 14.3 "
+                 "images, holding an empty values dictionary on the first and two and three "
+                 "networks on the other two, and it is absent from every iOS 15 to 26 image. The "
+                 "earlier glob matched any com.apple.wifid.plist and so reported the unrelated "
+                 "/System/Library/LaunchDaemons daemon configuration as the found file on most "
+                 "images; the narrower path stops that. Reference: cheeky4n6monkey (based on "
+                 "research by M. Epifani, H. Mahalik), 'iOS_sysdiagnose_forensic_scripts', "
                  "https://github.com/cheeky4n6monkey/iOS_sysdiagnose_forensic_scripts",
         "paths": ('*/SyncedPreferences/com.apple.wifid.plist',),
         "output_types": "standard",
         "artifact_icon": "wifi",
         "sample_data": {
             "ctf2020_ios12": "iOS 12.4 | 0 rows (plist present, values dictionary empty)",
+            "hickman_ios13": "iOS 13.3.1 | 2 rows",
+            "hickman_ios14": "iOS 14.3 | 3 rows",
             "iphone11_ios17": "iOS 17.3 | 0 rows (file not present)",
             "hc_ios18_7": "iOS 18.7.8 | 0 rows (file not present)",
             "hc_ios26": "iOS 26.5.2 | 0 rows (file not present)",

--- a/scripts/artifacts/iosDiagnosticReports.py
+++ b/scripts/artifacts/iosDiagnosticReports.py
@@ -243,8 +243,8 @@ __artifacts_v2__ = {
         "notes": "Read from the .ips reports whose metadata bug_type is 298 (JetsamEvent) or 288 "
                  "(stackshot, named stacks or stacks+<app> on the tested images). Both bodies are "
                  "JSON; Kind says which, and OS Build is the report's build value, one value per "
-                 "device. The jetsam report is documented by Apple in 'Identifying high-memory "
-                 "use with jetsam event reports' "
+                 "device on the tested images except one that carries two. The jetsam report is "
+                 "documented by Apple in 'Identifying high-memory use with jetsam event reports' "
                  "(https://developer.apple.com/documentation/xcode/identifying-high-memory-use-with-jetsam-event-reports): "
                  "largestProcess names the process using the most memory pages, only the "
                  "jettisoned process carries a reason, and the documented reasons are "
@@ -307,11 +307,12 @@ __artifacts_v2__ = {
                  "leaving 11,691 rows, 551 of them frontmost). States are joined as stored; "
                  "Frontmost is True when they include frontmost. Resident Pages and Lifetime Max "
                  "Pages are rpages and lifetimeMax in memory pages of the Page Size the parent "
-                 "report states. Jetsam Reason is set on the one jettisoned process of each "
-                 "report and blank on the rest. Age is the entry's age value as stored, with no "
-                 "unit stated. Snapshot Time is the report's date, rendered in UTC. A row records "
-                 "that the process existed at Snapshot Time in the state shown; suspended and "
-                 "idle processes were resident but not necessarily in use.",
+                 "report states. Jetsam Reason is set on the jettisoned process of a report and "
+                 "blank on the rest; one report on the tested images marks eleven processes. Age "
+                 "is the entry's age value as stored, with no unit stated. Snapshot Time is the "
+                 "report's date, rendered in UTC. A row records that the process existed at "
+                 "Snapshot Time in the state shown; suspended and idle processes were resident "
+                 "but not necessarily in use.",
         "paths": ('*/Library/Logs/CrashReporter/*.ips',),
         "output_types": "standard",
         "artifact_icon": "layers",

--- a/scripts/artifacts/knowledgeC.py
+++ b/scripts/artifacts/knowledgeC.py
@@ -96,7 +96,11 @@ __artifacts_v2__ = {
         "last_update_date": "2024-02-24",
         "requirements": "none",
         "category": "KnowledgeC",
-        "notes": "Based on research by Geraldine Blay and Dan Ogden. In tested data rows are recorded only on the iOS 13.3.1 and 14.3 images; the iOS 12.4 and 15.0.2 images and every iOS 16.1.1-26.5.2 image checked (recorded corpora plus Mattia Epifani's 2026-08 comparison across 21 extractions (iOS 16.1.1-26.5.2)) yield no rows, so an empty result on current extractions is expected.",
+        "notes": "Based on research by Geraldine Blay and Dan Ogden. In tested data rows are "
+                 "recorded only on the iOS 13.3.1, 14.3 and 15.0.2 images; the iOS 12.4 image and "
+                 "every iOS 16.1.1-26.5.2 image checked (recorded corpora plus Mattia Epifani's "
+                 "2026-08 comparison across 21 extractions (iOS 16.1.1-26.5.2)) yield no rows, so "
+                 "an empty result on current extractions is expected.",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
         "output_types": "standard",
         "artifact_icon": "moon",

--- a/scripts/artifacts/mediaLibrary.py
+++ b/scripts/artifacts/mediaLibrary.py
@@ -9,13 +9,13 @@ __artifacts_v2__ = {
         "category": "Media Library",
         "notes": (
             "Media-kind value mapping observed in testing; not documented by a published source; "
-            "unrecognized values are reported as stored. "
-            "An item that carries more than one artwork_token row is reported once per token, so the "
-            "row count can exceed the number of media items: on one tested iOS 18.3.2 image 1099 items "
-            "produced 1339 rows, 240 of them having two tokens each. "
-            "Date Purchased is left blank when item_store.date_purchased is 0, which is how the "
-            "column reads for items with no stored purchase date; it was 0 on 3529 of 3533 rows "
-            "across the seven tested images that hold media items."),
+            "unrecognized values are reported as stored. An item that carries more than one "
+            "artwork_token row is reported once per token, so the row count can exceed the number "
+            "of media items: on one tested iOS 18.3.2 image 1099 items produced 1339 rows, 240 of "
+            "them having two tokens each. Date Purchased is left blank when "
+            "item_store.date_purchased is 0, which is how the column reads for items with no "
+            "stored purchase date; it was 0 on 3822 of 3826 rows across the seven tested images "
+            "that hold media items."),
         "paths": ('**/[Mm]edia[Ll]ibrary.sqlitedb*',),
         "output_types": "standard",
         "artifact_icon": "music",
@@ -51,9 +51,9 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Media Library",
         "notes": (
-            "Every key/value row in the table is reported as stored; the meaning of the individual "
-            "keys is not documented by a published source. In 20 tested images the table held "
-            "between 8 and 37 keys each, 42 distinct keys across all of them."),
+            "Every key/value row in the table is reported as stored; the meaning of the "
+            "individual keys is not documented by a published source. In 23 tested images the "
+            "table held between 8 and 37 keys each, 42 distinct keys across all of them."),
         "paths": ('**/[Mm]edia[Ll]ibrary.sqlitedb*',),
         "output_types": "standard",
         "artifact_icon": "info-circle",

--- a/scripts/artifacts/messageRetention.py
+++ b/scripts/artifacts/messageRetention.py
@@ -10,7 +10,20 @@ __artifacts_v2__ = {
         "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Identifiers",
-        "notes": "iOS <=16 / iOS 17+ key naming per tested corpora. This directory can hold com.apple.MobileSMS.plist and com.apple.mobileSMS.plist as two different files; 6 of 20 tested images carry both, iOS 14.3 through 26.5.2. Every found file is read and each row's Setting names the source spelling it was read from. Where the report folder is on a case-insensitive volume, the file seeker preserves the second copy under a name tagged ~case- and the row's path points at the copy holding the bytes it reports; the run log records which source each tagged copy came from. On all 6 of those images the lowercase-spelled file held the same three IMDCKBackupController* keys and no retention key, so it is reported as 'No value'. Row counts are from runs on macOS. A directory input sitting on a case-insensitive volume holds only the single file that extraction kept, so both spellings can only arrive from archive or case-sensitive inputs. Reference: Apple Support, 'Delete messages and attachments', https://support.apple.com/guide/iphone/delete-messages-and-attachments-iph2c9c4bfcb/ios",
+        "notes": "iOS <=16 / iOS 17+ key naming per tested corpora. This directory can hold "
+                 "com.apple.MobileSMS.plist and com.apple.mobileSMS.plist as two different files; "
+                 "6 of 23 tested images carry both, iOS 14.3 through 26.5.2. Every found file is "
+                 "read and each row's Setting names the source spelling it was read from. Where "
+                 "the report folder is on a case-insensitive volume, the file seeker preserves "
+                 "the second copy under a name tagged ~case- and the row's path points at the "
+                 "copy holding the bytes it reports; the run log records which source each tagged "
+                 "copy came from. On all 6 of those images the lowercase-spelled file held the "
+                 "same three IMDCKBackupController* keys and no retention key, so it is reported "
+                 "as 'No value'. Row counts are from runs on macOS. A directory input sitting on "
+                 "a case-insensitive volume holds only the single file that extraction kept, so "
+                 "both spellings can only arrive from archive or case-sensitive inputs. "
+                 "Reference: Apple Support, 'Delete messages and attachments', "
+                 "https://support.apple.com/guide/iphone/delete-messages-and-attachments-iph2c9c4bfcb/ios",
         "paths": ('*/mobile/Library/Preferences/com.apple.[Mm]obileSMS.plist',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "message-circle",

--- a/scripts/artifacts/powerlog.py
+++ b/scripts/artifacts/powerlog.py
@@ -297,12 +297,11 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "PowerLog",
         "notes": (
-            "BundleId and Level are reported as stored; Level was 0 in every "
-            "test-image row (iOS 12.4-26), so other values are unobserved. Rows are "
-            "sparse: the test images held at most a few entries each. Timestamps are "
-            "adjusted using PowerLog's time-offset table and the applied offset is "
-            "reported per row; see the PowerLog - Application Runtime notes for the "
-            "mechanism."
+            "BundleId and Level are reported as stored; Level was 0 on 114 of the 120 tested rows "
+            "(iOS 12.4-26) and 1 on 6 rows of two images. Rows are sparse: the test images held "
+            "at most a few entries each. Timestamps are adjusted using PowerLog's time-offset "
+            "table and the applied offset is reported per row; see the PowerLog - Application "
+            "Runtime notes for the mechanism."
         ),
         "paths": (
             "*/BatteryLife/*.PLSQL*",


### PR DESCRIPTION
Corrects notes sentences whose counts were written against a smaller test set and no longer match a full run of the registered iOS corpora.

- knowledgeC Do Not Disturb: rows on the iOS 15.0.2 image as well as 13.3.1 and 14.3.
- iCloudWifi: the plist is present on the iOS 12.4, 13.3.1 and 14.3 images and holds networks on the last two; sample_data gains those rows.
- powerlog torch: Level is 1 on six rows of two images, not 0 everywhere.
- Biome battery temperature range, plugged-in field 3, orientation and emoji values restated for written versus deleted records.
- iOS diagnostic reports: one image carries two OS builds; one jetsam report marks eleven processes.
- mediaLibrary, messageRetention and appleWalletCards counts restated.

Notes and sample_data strings only. No code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
