### PR TITLE
Name the Hickman iOS 15 image by its own version, 15.3.1

### DIFF
--- a/scripts/artifacts/KeepSafe.py
+++ b/scripts/artifacts/KeepSafe.py
@@ -41,7 +41,7 @@ __artifacts_v2__ = {
                 "iOS 14.3 | KeepSafe 10.2.4 | 5 rows, all from the 'primary' table; "
                 "'breakin_alert' and 'fake' present as empty directories, 0 rows"
             ),
-            "hickman_ios15": "iOS 15.0.2 | KeepSafe 11.7.3 (initial install version) | 7 rows, all from the 'primary' table",
+            "hickman_ios15": "iOS 15.3.1 | KeepSafe 11.7.3 (initial install version) | 7 rows, all from the 'primary' table",
             "iphone11_ios17": (
                 "iOS 17.3 | KeepSafe 11.10.1 (initial install version) | 9 rows, all from the 'primary' table, "
                 "sharded into two-letter folders"
@@ -71,7 +71,7 @@ __artifacts_v2__ = {
         "artifact_icon": "folder",
         "sample_data": {
             "hickman_ios14": "iOS 14.3 | KeepSafe 10.2.4 | 5 rows: Main Album, Videos, Cards & ID, Significant Other, My Private Album",
-            "hickman_ios15": "iOS 15.0.2 | KeepSafe 11.7.3 (initial install version) | 5 rows",
+            "hickman_ios15": "iOS 15.3.1 | KeepSafe 11.7.3 (initial install version) | 5 rows",
             "iphone11_ios17": "iOS 17.3 | KeepSafe 11.10.1 (initial install version) | 5 rows",
             "cookbook_ios1751": "iOS 17.5.1 | KeepSafe 11.13.1 (initial install version) | 1 row",
         },
@@ -103,7 +103,7 @@ __artifacts_v2__ = {
         "artifact_icon": "shield-lock",
         "sample_data": {
             "hickman_ios14": "iOS 14.3 | KeepSafe 10.2.4 | 1 row",
-            "hickman_ios15": "iOS 15.0.2 | KeepSafe 11.7.3 (initial install version) | 1 row",
+            "hickman_ios15": "iOS 15.3.1 | KeepSafe 11.7.3 (initial install version) | 1 row",
             "iphone11_ios17": "iOS 17.3 | KeepSafe 11.10.1 (initial install version) | 1 row",
             "cookbook_ios1751": "iOS 17.5.1 | KeepSafe 11.13.1 (initial install version) | 1 row",
         },

--- a/scripts/artifacts/knowledgeC.py
+++ b/scripts/artifacts/knowledgeC.py
@@ -97,10 +97,10 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "KnowledgeC",
         "notes": "Based on research by Geraldine Blay and Dan Ogden. In tested data rows are "
-                 "recorded only on the iOS 13.3.1, 14.3 and 15.0.2 images; the iOS 12.4 image and "
-                 "every iOS 16.1.1-26.5.2 image checked (recorded corpora plus Mattia Epifani's "
-                 "2026-08 comparison across 21 extractions (iOS 16.1.1-26.5.2)) yield no rows, so "
-                 "an empty result on current extractions is expected.",
+                 "recorded only on the iOS 13.3.1, 14.3 and 15.3.1 images; the iOS 12.4 and "
+                 "15.0.2 images and every iOS 16.1.1-26.5.2 image checked (recorded corpora plus "
+                 "Mattia Epifani's 2026-08 comparison across 21 extractions (iOS 16.1.1-26.5.2)) "
+                 "yield no rows, so an empty result on current extractions is expected.",
         "paths": ('*/mobile/Library/CoreDuet/Knowledge/knowledgeC.db*',),
         "output_types": "standard",
         "artifact_icon": "moon",

--- a/scripts/artifacts/sessionIOS.py
+++ b/scripts/artifacts/sessionIOS.py
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
         "artifact_icon": "message-circle",
         "sample_data": {
             "iphone11_ios17": "iOS 17.3 | 51 rows",
-            "hickman_ios15": "iOS 15.0.2 | 24 rows",
+            "hickman_ios15": "iOS 15.3.1 | 24 rows",
             "dexter_ios18": "iOS 18.3.2 | 10 rows",
             "felix_ios17": "iOS 17.6.1 | 0 rows",
             "felix23_ios16": "iOS 16.5 | 0 rows",
@@ -84,7 +84,7 @@ __artifacts_v2__ = {
             "iphone11_ios17": "iOS 17.3 | 3 rows",
             "dexter_ios18": "iOS 18.3.2 | 2 rows",
             "felix_ios17": "iOS 17.6.1 | 1 row",
-            "hickman_ios15": "iOS 15.0.2 | 0 rows",
+            "hickman_ios15": "iOS 15.3.1 | 0 rows",
             "felix23_ios16": "iOS 16.5 | 0 rows",
             "iphone14plus_ios18": "iOS 18.0 | 0 rows (no keychain in the extraction)",
             "hc_ios18_7": "iOS 18.7.8 | 0 rows (no keychain in the extraction)",


### PR DESCRIPTION
Two strings added today called the hickman_ios15 image iOS 15.0.2. The image's own SystemVersion.plist and LastBuildInfo say 15.3.1; 15.0.2 is the Jess CTF image.

- knowledgeC Do Not Disturb: 15.3.1 joins the images with rows, 15.0.2 stays among those without.
- KeepSafe: the three sample_data entries for that image read 15.3.1.
- sessionIOS: the two pre-existing entries for the same image read 15.3.1.

Strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)