### PR TITLE
Read older Fitbit and IMO HD stores instead of failing on missing columns

### DIFF
--- a/scripts/artifacts/fitbitIOS.py
+++ b/scripts/artifacts/fitbitIOS.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "with the coordinates, altitude, speed and accuracy of each.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-20",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-06",
         "requirements": "none",
         "category": "Fitbit",
         "notes": "One row per recorded point. These points belong to exercise sessions the "
@@ -17,13 +17,19 @@ __artifacts_v2__ = {
                  "stating: it is not a plain numeric column. That reading is corroborated "
                  "independently, because the heart rate table in the same database stores "
                  "its own times as ISO text written by a different code path and its dates "
-                 "coincide with the span these points cover. All 9,419 points on the tested "
-                 "device decoded to one five day window. Interpolated marks a point the app "
+                 "coincide with the span these points cover. All 9,419 points on the iOS 17.3 "
+                 "image (iphone11_ios17) decoded to one five day window. Interpolated marks a point the app "
                  "flagged as filled in rather than measured, and is reported as stored so a "
                  "derived position is not read as an observed one. Horizontal and vertical "
                  "accuracy are the values the record carries. Field mapping was done against "
                  "a private sample provided by Mattia; no sample data is recorded for it. Every copy of the database in the extraction is read rather than the first one found, so a device holding more than one app data container reports all of them.",
         "paths": ('*/Documents/fitbit.sqlite*',),
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 9,419 rows",
+            "hickman_ios15": "iOS 15.3.1 | 2,938 rows",
+            "hickman_ios14": "iOS 14.3 | 2,642 rows",
+            "hickman_ios13": "iOS 13.3.1 | 0 rows",
+        },
         "output_types": ["html", "tsv", "timeline", "lava", "kml"],
         "artifact_icon": "map-pin"
     },
@@ -33,7 +39,7 @@ __artifacts_v2__ = {
                        "start time, duration, distance and the tracker that recorded them.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-20",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-06",
         "requirements": "none",
         "category": "Fitbit",
         "notes": "One row per logged session. Start Time uses the same eight byte big endian "
@@ -48,8 +54,17 @@ __artifacts_v2__ = {
                  "plausible range is treated as the app's own absent marker and left empty "
                  "rather than rendered as a first century date. Field mapping was done "
                  "against a private sample provided by Mattia; no sample data is recorded "
-                 "for it.",
+                 "for it. Source Name is a column older stores lack: the iOS 13.3.1, 14.3 and "
+                 "15.3.1 images carry Source Type and Source ID but no ZSOURCENAME, so the "
+                 "column is blank there and the query reads it as NULL rather than failing. "
+                 "On the iOS 17.3 image 12 of 27 sessions have no Source Name stored either.",
         "paths": ('*/Documents/fitbit.sqlite*',),
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 27 rows",
+            "hickman_ios15": "iOS 15.3.1 | 21 rows",
+            "hickman_ios14": "iOS 14.3 | 22 rows",
+            "hickman_ios13": "iOS 13.3.1 | 5 rows",
+        },
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "activity"
     },
@@ -59,7 +74,7 @@ __artifacts_v2__ = {
                        "time and value of each.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-20",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-06",
         "requirements": "none",
         "category": "Fitbit",
         "notes": "One row per sample. Unlike the location and session times in the same "
@@ -67,11 +82,21 @@ __artifacts_v2__ = {
                  "state; the text carries no zone, so no conversion is applied. Resolution "
                  "is the value the record carries and is reported as stored. A sample places "
                  "the tracker on a wearer at that moment rather than placing the phone, and "
-                 "the two are not the same device. On the tested device the samples were "
-                 "dense, 56,282 of them, so the artifact is large by nature. Field mapping "
-                 "was done against a private sample provided by Mattia; no sample data is "
-                 "recorded for it.",
+                 "the two are not the same device. On the iOS 17.3 image (iphone11_ios17) the "
+                 "samples were dense, 56,282 of them, so the artifact is large by nature. Field "
+                 "mapping was done against a private sample provided by Mattia; no sample data "
+                 "is recorded for it. Older stores have no ZMANAGEDHEARTRATE table: the iOS "
+                 "13.3.1 and 14.3 images keep per day heart rate rows in ZFBHEARTRATESTAT and "
+                 "the 15.3.1 image in ZHEARTRATESTAT, with intraday points archived in keyed "
+                 "archive blobs, and this artifact reads none of those, so it reports no rows "
+                 "on such stores and logs the skip.",
         "paths": ('*/Documents/fitbit.sqlite*',),
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 56,282 rows",
+            "hickman_ios15": "iOS 15.3.1 | 0 rows",
+            "hickman_ios14": "iOS 14.3 | 0 rows",
+            "hickman_ios13": "iOS 13.3.1 | 0 rows",
+        },
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "heart"
     },
@@ -81,7 +106,7 @@ __artifacts_v2__ = {
                        "including steps, distance, floors and active minutes.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-20",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-09-06",
         "requirements": "none",
         "category": "Fitbit",
         "notes": "One row per stored day. These are totals the service computed for the day "
@@ -91,6 +116,12 @@ __artifacts_v2__ = {
                  "the extraction maps to a unit. Field mapping was done against a private "
                  "sample provided by Mattia; no sample data is recorded for it.",
         "paths": ('*/Documents/fitbit.sqlite*',),
+        "sample_data": {
+            "iphone11_ios17": "iOS 17.3 | 68 rows",
+            "hickman_ios15": "iOS 15.3.1 | 45 rows",
+            "hickman_ios14": "iOS 14.3 | 54 rows",
+            "hickman_ios13": "iOS 13.3.1 | 62 rows",
+        },
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "bar-chart-2"
     },
@@ -101,7 +132,8 @@ import re
 import struct
 from datetime import datetime, timedelta, timezone
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+from scripts.ilapfuncs import (artifact_processor, does_table_exist_in_db, get_sqlite_db_records,
+                               logfunc, null_absent_columns)
 
 _COCOA = datetime(2001, 1, 1, tzinfo=timezone.utc)
 _FRACTION = re.compile(r'^(.*\.)(\d+)(.*)$')
@@ -182,9 +214,13 @@ def _databases(files_found):
 
 
 def _rows(path, statement):
-    '''The rows a statement returns, or nothing when the table is absent.'''
+    '''The rows a statement returns, or nothing when the table is absent.
+
+    Columns the store lacks are read as NULL, because older releases of the app wrote
+    fewer columns and a query naming one of them would otherwise return nothing at all.
+    '''
     try:
-        return list(get_sqlite_db_records(path, statement))
+        return list(get_sqlite_db_records(path, null_absent_columns(path, statement)))
     except Exception as error:                   # pylint: disable=broad-except
         logfunc(f'Fitbit: could not read from fitbit.sqlite: {error}')
         return []
@@ -234,7 +270,7 @@ def fitbit_ios_locations(context):
         'Cumulative Distance (as stored)', 'Cumulative Duration (as stored)',
         'Cumulative Calories (as stored)', 'Location Group',
     )
-    return data_headers, data_list, '; '.join(sources)
+    return data_headers, data_list, '\n'.join(sources)
 
 
 @artifact_processor
@@ -272,7 +308,7 @@ def fitbit_ios_activities(context):
         'In Progress (as stored)', 'Source Name', 'Source Type (as stored)', 'Source ID',
         'Log Type (as stored)', ('Last Modified', 'datetime'), 'Log ID',
     )
-    return data_headers, data_list, '; '.join(sources)
+    return data_headers, data_list, '\n'.join(sources)
 
 
 @artifact_processor
@@ -283,6 +319,10 @@ def fitbit_ios_heart_rate(context):
         return (), [], ''
 
     for source_path in sources:
+        if not does_table_exist_in_db(source_path, 'ZMANAGEDHEARTRATE'):
+            logfunc('Fitbit: no ZMANAGEDHEARTRATE table in fitbit.sqlite; older stores keep heart '
+                    'rate in per day stat tables, which this artifact does not read')
+            continue
         for stamp, value, resolution, identifier in _rows(
                 source_path,
                 'SELECT ZDATETIME, ZVALUE, ZRESOLUTION, ZID FROM ZMANAGEDHEARTRATE'):
@@ -294,7 +334,7 @@ def fitbit_ios_heart_rate(context):
     data_headers = (
         ('Timestamp', 'datetime'), 'Heart Rate', 'Resolution (as stored)', 'Record ID',
     )
-    return data_headers, data_list, '; '.join(sources)
+    return data_headers, data_list, '\n'.join(sources)
 
 
 @artifact_processor
@@ -321,4 +361,4 @@ def fitbit_ios_daily_stats(context):
         ('Day', 'datetime'), 'Steps', 'Distance (as stored)', 'Floors', 'Calories',
         'Minutes Very Active', 'Minutes Fairly Active', 'Deflated (as stored)',
     )
-    return data_headers, data_list, '; '.join(sources)
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/imoHD_Chat.py
+++ b/scripts/artifacts/imoHD_Chat.py
@@ -2,8 +2,13 @@ __artifacts_v2__ = {
     "imoHDChatMessages": {
         "name": "IMO HD Chat - Messages",
         "description": "IMO HD chat messages and attachments",
-        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-07-31", "requirements": "none",
-        "category": "IMO HD Chat", "notes": "URLs are constructed by the parser from object IDs using an observed IMO CDN pattern; they are not stored in the data.",
+        "author": "@stark4n6", "creation_date": "2026-06-23", "last_update_date": "2026-09-06", "requirements": "none",
+        "category": "IMO HD Chat",
+        "notes": "URLs are constructed by the parser from object IDs using an observed IMO CDN pattern; "
+                 "they are not stored in the data. Older stores have no ZCONTACT_ALIAS column on the "
+                 "message table (the iOS 13.3.1 and 14.3 images), so on those the chat and sender names "
+                 "fall back from the contact table's display name straight to the alias stored on the "
+                 "message.",
         "paths": ('*/IMODb2.sqlite*',
                   '*/mobile/Containers/Data/Application/*/Library/Caches/videos/*.webp'),
         "output_types": "standard", "artifact_icon": "message-circle",
@@ -21,6 +26,7 @@ __artifacts_v2__ = {
         },
         "sample_data": {
             "iphone11_ios17": "iOS 17.3 | imo video calls and chat HD 7.2.23 | 38 rows",
+            "hickman_ios15": "iOS 15.3.1 | 16 rows",
             "hickman_ios13": "iOS 13.3.1 | imo video calls and chat HD 7.1.88, group.co.babypenguin | 5 rows",
             "hickman_ios14": "iOS 14.3 | imo video calls and chat HD 7.2.8, group.co.babypenguin | 9 rows",
         }
@@ -34,6 +40,7 @@ __artifacts_v2__ = {
         "output_types": "standard", "artifact_icon": "users",
         "sample_data": {
             "iphone11_ios17": "iOS 17.3 | imo video calls and chat HD 7.2.23 | 5 rows",
+            "hickman_ios15": "iOS 15.3.1 | 4 rows",
             "hickman_ios13": "iOS 13.3.1 | group.co.babypenguin | 2 rows",
             "hickman_ios14": "iOS 14.3 | group.co.babypenguin | 3 rows",
         }
@@ -47,6 +54,9 @@ __artifacts_v2__ = {
         "output_types": "standard", "artifact_icon": "key",
         "sample_data": {
             "iphone11_ios17": "iOS 17.3 | imo video calls and chat HD 7.2.23 | 6 rows",
+            "hickman_ios15": "iOS 15.3.1 | 7 rows",
+            "hickman_ios14": "iOS 14.3 | 7 rows",
+            "hickman_ios13": "iOS 13.3.1 | 7 rows",
         }
     }
 }
@@ -56,7 +66,8 @@ import plistlib
 
 import nska_deserialize as nd
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, check_in_media, logfunc
+from scripts.ilapfuncs import (artifact_processor, does_column_exist_in_db, get_sqlite_db_records,
+                               check_in_media, logfunc)
 
 _PLIST_ERRORS = (nd.DeserializeError, nd.biplist.NotBinaryPlistException,
                  nd.biplist.InvalidPlistException, nd.plistlib.InvalidFileException,
@@ -162,13 +173,17 @@ def imoHDChatMessages(context):
     local_user_name = _get_key_value(key_values, 'imo_account_alias') or 'Local User'
     local_user_id = _get_key_value(key_values, 'imo_account_uid')
 
-    query = '''
+    # Older releases (the iOS 13 and 14 stores) have no ZCONTACT_ALIAS column, so the
+    # name falls back straight to the message's own alias on those.
+    contact_alias = ('ZIMOCHATMSG.ZCONTACT_ALIAS, '
+                     if does_column_exist_in_db(db_path, 'ZIMOCHATMSG', 'ZCONTACT_ALIAS') else '')
+    query = f'''
     SELECT
         CASE ZIMOCHATMSG.ZTS WHEN 0 THEN '' ELSE datetime(ZTS/1000000000, 'unixepoch') END,
         ZIMOCHATMSG.ZBUID,
-        COALESCE(chat_contact.ZDISPLAY, ZIMOCHATMSG.ZCONTACT_ALIAS, ZIMOCHATMSG.ZALIAS),
+        COALESCE(chat_contact.ZDISPLAY, {contact_alias}ZIMOCHATMSG.ZALIAS),
         ZIMOCHATMSG.ZA_UID,
-        COALESCE(sender_contact.ZDISPLAY, ZIMOCHATMSG.ZCONTACT_ALIAS, ZIMOCHATMSG.ZALIAS),
+        COALESCE(sender_contact.ZDISPLAY, {contact_alias}ZIMOCHATMSG.ZALIAS),
         ZIMOCHATMSG.ZALIAS,
         sender_contact.ZDIGIT_PHONE,
         ZIMOCHATMSG.ZTEXT,


### PR DESCRIPTION
Fixes two iOS modules that returned nothing on older app stores because their queries named columns or tables those stores do not have.

- Fitbit: Exercise Sessions reads columns the store lacks as NULL, so the iOS 13, 14 and 15 stores (no ZSOURCENAME) return their rows. Heart Rate skips a store with no ZMANAGEDHEARTRATE table and logs why. Every copy of the database read is cited in the source path.
- IMO HD Chat: the messages query names ZCONTACT_ALIAS only when the store has it, so the iOS 13 and 14 stores return their 5 and 9 messages again.

Validated with module-only runs on the Hickman iOS 13.3.1, 14.3, 15.3.1 and 17.3 images; the iOS 17.3 counts are unchanged. Notes name the older layouts and sample_data records the four images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
