### PR TITLE
Report "could not check" separately from "has drifted" in check_vendored

### DIFF
--- a/admin/scripts/check_vendored.py
+++ b/admin/scripts/check_vendored.py
@@ -11,6 +11,12 @@ script reads that banner, fetches the upstream file at that exact commit, and
 fails when anything below the banner differs from it. Only the banner is
 ignored; the rest has to match byte for byte.
 
+"Could not check" is reported separately from "has drifted", and they are not the
+same result. A failed fetch says nothing about this copy, so printing it as drift
+asserts a finding nothing measured. Both still exit non-zero: an unreachable
+upstream must not read as a pass, or a broken network silently stops guarding the
+file. Drift exits 1, an unreadable upstream exits 2.
+
     python3 admin/scripts/check_vendored.py                    # CI: fetch and compare
     python3 admin/scripts/check_vendored.py --upstream ../mmkv-parser
                                                                 # offline: compare against a
@@ -28,6 +34,7 @@ line (``# ----``). Inside it the script looks for ``github.com/<owner>/<repo>``,
 from __future__ import annotations
 
 import argparse
+import collections
 import difflib
 import os
 import re
@@ -48,6 +55,12 @@ _RULE = re.compile(rb'^# -{20,}\s*$')
 _REPO = re.compile(r'github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)')
 _COMMIT = re.compile(r'upstream commit ([0-9a-f]{40})\b')
 _FILE = re.compile(r'upstream file (\S+?)[.,]?(?:\s|$)')
+
+
+DRIFT = 'drift'      # compared against the upstream, and it differs
+BLOCKED = 'blocked'  # the upstream could not be read, so nothing was compared
+
+Problem = collections.namedtuple('Problem', 'kind text')
 
 
 class BannerError(Exception):
@@ -98,7 +111,7 @@ def read_local_upstream(info, upstream_dir):
 
 
 def compare(rel_path, body, upstream):
-    """Return a list of problem strings; empty when body matches upstream."""
+    """Return a list of DRIFT problems; empty when body matches upstream."""
     if body == upstream:
         return []
     diff = difflib.unified_diff(
@@ -106,24 +119,30 @@ def compare(rel_path, body, upstream):
         body.decode('utf-8', errors='replace').splitlines(keepends=True),
         fromfile='upstream', tofile=rel_path, n=1)
     excerpt = ''.join(list(diff)[:40])
-    return [f'{rel_path}: does not match the upstream file at the pinned commit\n'
-            f'    Either it was edited here, which is not the place to fix it, or it was\n'
-            f'    re-vendored without updating the banner\'s upstream commit line.\n'
-            + ''.join('    ' + line for line in excerpt.splitlines(keepends=True))]
+    return [Problem(DRIFT,
+                    f'{rel_path}: does not match the upstream file at the pinned commit\n'
+                    f'    Either it was edited here, which is not the place to fix it, or it was\n'
+                    f'    re-vendored without updating the banner\'s upstream commit line.\n'
+                    + ''.join('    ' + line for line in excerpt.splitlines(keepends=True)))]
 
 
 def check_file(rel_path, upstream_dir=None):
-    """Return a list of problems for one vendored file; empty means it matches."""
+    """Return a list of Problems for one vendored file; empty means it matches.
+
+    A missing file or an unreadable banner is a DRIFT problem: both are statements
+    about this repository's copy. An upstream that cannot be read is BLOCKED, because
+    no comparison happened and nothing was learned about the copy either way.
+    """
     path = os.path.join(REPO, rel_path)
     if not os.path.isfile(path):
-        return [f'{rel_path}: listed in VENDORED but not on disk']
+        return [Problem(DRIFT, f'{rel_path}: listed in VENDORED but not on disk')]
     with open(path, 'rb') as handle:
         data = handle.read()
     try:
         banner, body = split_banner(data)
         info = parse_banner(banner)
     except BannerError as exc:
-        return [f'{rel_path}: {exc}']
+        return [Problem(DRIFT, f'{rel_path}: {exc}')]
     try:
         if upstream_dir:
             upstream = read_local_upstream(info, upstream_dir)
@@ -132,8 +151,9 @@ def check_file(rel_path, upstream_dir=None):
             upstream = fetch_upstream(info)
             source = f"{info['owner']}/{info['repo']}@{info['commit'][:7]}:{info['file']}"
     except (OSError, urllib.error.URLError) as exc:
-        return [f'{rel_path}: could not read the upstream file ({exc}); '
-                f'pass --upstream <checkout> to compare offline']
+        return [Problem(BLOCKED,
+                        f'{rel_path}: could not read the upstream file ({exc}); '
+                        f'pass --upstream <checkout> to compare offline')]
     problems = compare(rel_path, body, upstream)
     if not problems:
         print(f'  {rel_path}  matches {source}')
@@ -152,11 +172,24 @@ def main(argv=None):
     for rel_path in VENDORED:
         problems.extend(check_file(rel_path, args.upstream))
 
-    if problems:
+    drifted = [p.text for p in problems if p.kind == DRIFT]
+    blocked = [p.text for p in problems if p.kind == BLOCKED]
+
+    if drifted:
         print('\nVendored files have drifted:\n')
-        for problem in problems:
-            print(f'  {problem}\n')
+        for text in drifted:
+            print(f'  {text}\n')
+    if blocked:
+        print('\nVendored files could not be checked. The upstream could not be read, so\n'
+              'nothing was compared and this is not evidence either way about the copies\n'
+              'in this repository:\n')
+        for text in blocked:
+            print(f'  {text}\n')
+
+    if drifted:
         return 1
+    if blocked:
+        return 2
     print(f'\n{len(VENDORED)} vendored file(s), all matching the pinned upstream commit.')
     return 0
 

--- a/admin/test/scripts/test_check_vendored.py
+++ b/admin/test/scripts/test_check_vendored.py
@@ -5,12 +5,20 @@ removed, so a one-byte change anywhere below the banner has to fail, a banner-on
 change has to pass, and a banner the script cannot read has to fail rather than
 be skipped. Everything here runs against a local upstream directory, never the
 network, so it holds on every CI runner.
+
+It also pins the split between the two outcomes. "The upstream could not be read"
+is not evidence that this copy drifted, so it is reported under its own headline
+and its own exit code, and it still has to be non-zero: an unreachable upstream
+must never read as a pass.
 """
 import importlib.util
+import io
 import pathlib
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from unittest import mock
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 SCRIPT = REPO_ROOT / 'admin' / 'scripts' / 'check_vendored.py'
@@ -61,7 +69,8 @@ class CheckVendoredTest(unittest.TestCase):
         self.vendored.write_bytes(BANNER + BODY.replace(b'VALUE = 1', b'VALUE = 2'))
         problems = self._check()
         self.assertEqual(len(problems), 1)
-        self.assertIn('does not match the upstream file', problems[0])
+        self.assertEqual(problems[0].kind, check_vendored.DRIFT)
+        self.assertIn('does not match the upstream file', problems[0].text)
 
     def test_trailing_newline_counts(self):
         self.vendored.write_bytes(BANNER + BODY.rstrip(b'\n'))
@@ -72,13 +81,84 @@ class CheckVendoredTest(unittest.TestCase):
         self.vendored.write_bytes(broken + BODY)
         problems = self._check()
         self.assertEqual(len(problems), 1)
-        self.assertIn('upstream commit <sha>', problems[0])
+        self.assertEqual(problems[0].kind, check_vendored.DRIFT)
+        self.assertIn('upstream commit <sha>', problems[0].text)
 
     def test_file_without_a_banner_fails(self):
         self.vendored.write_bytes(BODY)
         problems = self._check()
         self.assertEqual(len(problems), 1)
-        self.assertIn('rule line', problems[0])
+        self.assertEqual(problems[0].kind, check_vendored.DRIFT)
+        self.assertIn('rule line', problems[0].text)
+
+    # ---- "could not check" is not "has drifted" -------------------------------
+
+    def _run_main(self, argv):
+        """Run main() with VENDORED narrowed to the temp file; return (rc, output)."""
+        buf = io.StringIO()
+        with mock.patch.object(check_vendored, 'VENDORED', ['scripts/module.py']):
+            with redirect_stdout(buf):
+                rc = check_vendored.main(argv)
+        return rc, buf.getvalue()
+
+    def test_unreadable_upstream_is_blocked_not_drift(self):
+        """The upstream being unreachable says nothing about this copy."""
+        self.vendored.write_bytes(BANNER + BODY)
+        problems = check_vendored.check_file('scripts/module.py',
+                                             str(self.root / 'no-such-checkout'))
+        self.assertEqual(len(problems), 1)
+        self.assertEqual(problems[0].kind, check_vendored.BLOCKED)
+        self.assertIn('could not read the upstream file', problems[0].text)
+
+    def test_fetch_failure_is_blocked_not_drift(self):
+        """A verify failure or an outage is the reported bug: it read as drift."""
+        self.vendored.write_bytes(BANNER + BODY)
+        boom = check_vendored.urllib.error.URLError('[SSL: CERTIFICATE_VERIFY_FAILED]')
+        with mock.patch.object(check_vendored.urllib.request, 'urlopen', side_effect=boom):
+            problems = check_vendored.check_file('scripts/module.py')
+        self.assertEqual(len(problems), 1)
+        self.assertEqual(problems[0].kind, check_vendored.BLOCKED)
+
+    def test_blocked_run_does_not_print_the_drift_headline(self):
+        self.vendored.write_bytes(BANNER + BODY)
+        rc, out = self._run_main(['--upstream', str(self.root / 'no-such-checkout')])
+        self.assertNotIn('have drifted', out)
+        self.assertIn('could not be checked', out)
+        self.assertEqual(rc, 2)
+
+    def test_blocked_run_is_never_a_pass(self):
+        """Exit 0 here would let a broken network silently stop guarding the file."""
+        self.vendored.write_bytes(BANNER + BODY)
+        rc, _ = self._run_main(['--upstream', str(self.root / 'no-such-checkout')])
+        self.assertNotEqual(rc, 0)
+
+    def test_drift_still_exits_1_under_its_own_headline(self):
+        self.vendored.write_bytes(BANNER + BODY.replace(b'VALUE = 1', b'VALUE = 2'))
+        rc, out = self._run_main(['--upstream', str(self.root / 'upstream')])
+        self.assertIn('have drifted', out)
+        self.assertNotIn('could not be checked', out)
+        self.assertEqual(rc, 1)
+
+    def test_matching_run_exits_0(self):
+        self.vendored.write_bytes(BANNER + BODY)
+        rc, out = self._run_main(['--upstream', str(self.root / 'upstream')])
+        self.assertIn('all matching the pinned upstream commit', out)
+        self.assertEqual(rc, 0)
+
+    def test_drift_outranks_blocked_when_both_happen(self):
+        """Two guarded files, one drifted and one unreachable: report both, exit 1."""
+        (self.root / 'scripts' / 'other.py').write_bytes(
+            BANNER.replace(b'pkg/module.py', b'pkg/missing.py') + BODY)
+        self.vendored.write_bytes(BANNER + BODY.replace(b'VALUE = 1', b'VALUE = 2'))
+        buf = io.StringIO()
+        with mock.patch.object(check_vendored, 'VENDORED',
+                               ['scripts/module.py', 'scripts/other.py']):
+            with redirect_stdout(buf):
+                rc = check_vendored.main(['--upstream', str(self.root / 'upstream')])
+        out = buf.getvalue()
+        self.assertIn('have drifted', out)
+        self.assertIn('could not be checked', out)
+        self.assertEqual(rc, 1)
 
     def test_banner_fields_are_read_as_written(self):
         info = check_vendored.parse_banner(BANNER)


### PR DESCRIPTION
A failed fetch of the upstream file was printed under the "Vendored files have drifted:" headline. Nothing had been compared, so the run was not evidence about the vendored copy either way. On a machine with an empty Python trust store this read as a drift finding while the copy was byte-identical to its pinned commit.

- A content mismatch, a missing file and an unreadable banner keep the drift headline and exit 1.
- An upstream that could not be read gets its own headline and exit 2. Still non-zero on purpose: an unreachable upstream must not read as a pass, or a broken network silently stops guarding the file.
- Tests cover both outcomes, including a mocked verify failure and that a blocked run never prints the drift headline. Seven fail against the previous version.

CI behaviour is unchanged: both outcomes still fail the lint workflow. ALEAPP carries a byte-identical copy of the script and its test, so the two move together. Matching changes in ALEAPP #1359 and, for its separate hash-manifest implementation, VLEAPP #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)