### PR TITLE
Updates for Sysdiagnose

### DIFF
--- a/scripts/artifacts/mobileActivationLogs.py
+++ b/scripts/artifacts/mobileActivationLogs.py
@@ -51,11 +51,20 @@ def mobileActivationLogs(context):
     source_files = []
 
     for file_obj, source in get_sysdiagnose_files(context.get_files_found(), _LOG_MATCH_RE):
-        if source not in source_files:
-            source_files.append(source)
+        # 1. Separate base path and member name to correctly apply relative paths
+        if ' >> ' in source:
+            base_source, member = source.split(' >> ', 1)
+            rel_source = f"{context.get_relative_path(base_source)} >> {member}"
+            log_name = member
+        else:
+            rel_source = context.get_relative_path(source)
+            log_name = Path(source).name
             
-        log_name = source.split(' >> ')[-1] if ' >> ' in source else Path(source).name
+        # 2. Deduplicate on the full string (Relative Archive >> Member)
+        if rel_source not in source_files:
+            source_files.append(rel_source)
         
+        # 3. Process the file
         for linecount, line in enumerate(file_obj, 1):
             match = _DATE_RE.match(line)
             if not match:
@@ -74,5 +83,6 @@ def mobileActivationLogs(context):
             if _STARTUP in values:
                 data_list.append((dtime_obj, f'Mobile Activation Startup at line: {linecount}', log_name))
 
-    source_path = ', '.join(context.get_relative_path(s.split(' >> ')[0]) for s in source_files)
+    # 4. Join the fully prepared, deduplicated strings
+    source_path = ', '.join(source_files)
     return data_headers, data_list, source_path

--- a/scripts/artifacts/mobileActivationLogs.py
+++ b/scripts/artifacts/mobileActivationLogs.py
@@ -5,11 +5,11 @@ __artifacts_v2__ = {
                        "(including logs found inside sysdiagnose archives)",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-06-23",
-        "last_update_date": "2026-06-24",
+        "last_update_date": "2026-09-10",
         "requirements": "none",
         "category": "Mobile Activation Logs",
         "notes": "",
-        "paths": ('**/mobileactivationd.log*', '**/sysdiagnose_*.tar.gz'),
+        "paths": ('*/mobileactivationd.log*', '*/sysdiagnose_*.tar.gz'),
         "output_types": "standard",
         "artifact_icon": "settings",
         "sample_data": {
@@ -30,50 +30,19 @@ __artifacts_v2__ = {
     }
 }
 
-import io
 import re
-import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, get_sysdiagnose_files
 
 _DATE_RE = re.compile(r'(([A-Za-z]+[\s]+([a-zA-Z]+[\s]+[0-9]+)[\s]+([0-9]+\:[0-9]+\:[0-9]+)[\s]+'
                       r'([0-9]{4}))([\s]+[\[\d\]]+[\s]+[\<a-z\>]+[\s]+[\(\w\)]+[\s]+[A-Z]{2}\:[\s]+)'
                       r'([main\:\s]*.*)$)')
 _UPGRADE_RE = re.compile(r'((.*)(Upgrade\s+from\s+[\w]+\s+to\s+[\w]+\s+detected\.$))')
-_TAR_MEMBER_RE = re.compile(r"logs/MobileActivation/mobileactivationd\.log(\.\d+)?$")
 _STARTUP = '____________________ Mobile Activation Startup _____________________'
 
-
-def _iter_logs(files_found):
-    """Yield (log_name, lines, source_full_path) for mobileactivationd.log files and those in sysdiagnose tars."""
-    for filename in files_found:
-        filename = str(filename)
-        if 'mobileactivationd.log' in filename:
-            path = filename[4:] if filename.startswith('\\\\?\\') else filename
-            try:
-                with open(path, 'r', encoding='utf8', errors='ignore') as fp:
-                    lines = fp.readlines()
-            except OSError:
-                continue
-            yield Path(path).name, lines, filename
-        elif 'sysdiagnose_' in filename and 'IN_PROGRESS_' not in filename:
-            try:
-                tar = tarfile.open(filename)
-            except (tarfile.TarError, OSError):
-                continue
-            try:
-                for member in tar.getmembers():
-                    if not _TAR_MEMBER_RE.search(member.name):
-                        continue
-                    extracted = tar.extractfile(member)
-                    if extracted is not None:
-                        with io.TextIOWrapper(extracted, encoding='utf-8', errors='ignore') as tfp:
-                            yield member.name, tfp.readlines(), filename
-            finally:
-                tar.close()
-
+_LOG_MATCH_RE = re.compile(r"mobileactivationd\.log(\.\d+)?$")
 
 @artifact_processor
 def mobileActivationLogs(context):
@@ -81,10 +50,13 @@ def mobileActivationLogs(context):
     data_list = []
     source_files = []
 
-    for log_name, lines, source in _iter_logs(context.get_files_found()):
+    for file_obj, source in get_sysdiagnose_files(context.get_files_found(), _LOG_MATCH_RE):
         if source not in source_files:
             source_files.append(source)
-        for linecount, line in enumerate(lines, 1):
+            
+        log_name = source.split(' >> ')[-1] if ' >> ' in source else Path(source).name
+        
+        for linecount, line in enumerate(file_obj, 1):
             match = _DATE_RE.match(line)
             if not match:
                 continue
@@ -93,6 +65,7 @@ def mobileActivationLogs(context):
                                               '%b %d %Y %H:%M:%S').replace(tzinfo=timezone.utc)
             except ValueError:
                 continue
+                
             values = match.group(7)
             if 'perform_data_migration' in values:
                 upgrade_match = _UPGRADE_RE.search(values)
@@ -101,5 +74,5 @@ def mobileActivationLogs(context):
             if _STARTUP in values:
                 data_list.append((dtime_obj, f'Mobile Activation Startup at line: {linecount}', log_name))
 
-    source_path = ', '.join(context.get_relative_path(s) for s in source_files)
+    source_path = ', '.join(context.get_relative_path(s.split(' >> ')[0]) for s in source_files)
     return data_headers, data_list, source_path

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -318,13 +318,16 @@ def _events_and_source(context):
     files_sorted = sorted(str(f) for f in context.get_files_found())
     
     for file_obj, source in get_sysdiagnose_files(files_sorted, _LOG_MATCH_RE):
-        # The helper may append ' >> member.name' for tar archives; 
-        # split it so get_relative_path still operates on the base archive name
-        base_source = source.split(' >> ')[0]
-        rel = context.get_relative_path(base_source)
-        
-        if rel not in sources:
-            sources.append(rel)
+        # 1. Separate base path and member name to correctly apply relative paths
+        if ' >> ' in source:
+            base_source, member = source.split(' >> ', 1)
+            rel_source = f"{context.get_relative_path(base_source)} >> {member}"
+        else:
+            rel_source = context.get_relative_path(source)
+            
+        # 2. Deduplicate on the full string (Relative Archive >> Member)
+        if rel_source not in sources:
+            sources.append(rel_source)
             
         # Pass the file_obj directly; _parse_events iterates over lines natively
         events.extend(_parse_events(file_obj))

--- a/scripts/artifacts/mobileInstall.py
+++ b/scripts/artifacts/mobileInstall.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
                  "that an app was never installed. The Source Event column names the line that "
                  "set the state. The install kind (Placeholder, Customer, System or Developer) "
                  "is reported as written; the meaning of those values is not sourced.",
-        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "paths": ('*/mobile_installation.log.*', '*/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "download",
         "sample_data": {
@@ -65,7 +65,7 @@ __artifacts_v2__ = {
                  "that an app was never installed. The Source Event column names the line that "
                  "set the state. The install kind (Placeholder, Customer, System or Developer) "
                  "is reported as written; the meaning of those values is not sourced.",
-        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "paths": ('*/mobile_installation.log.*', '*/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "trash",
         "sample_data": {
@@ -96,7 +96,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Mobile Installation Logs",
         "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time. Patch-update lines record an attempt, not a completed update. Install kinds, container personas and version strings are reported as written. Version and Short Version carry the target of a patch attempt or the version of an installable bundle; From Version carries the source of a patch attempt.",
-        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "paths": ('*/mobile_installation.log.*', '*/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "list",
         "sample_data": {
@@ -127,7 +127,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Mobile Installation Logs",
         "notes": "Timestamps are reported as written in the log, which carries no timezone marker; in tested corpora the values were consistent with device-local time.",
-        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "paths": ('*/mobile_installation.log.*', '*/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "refresh",
         "sample_data": {
@@ -171,7 +171,7 @@ __artifacts_v2__ = {
                  "the log records, and a prefix match does not establish that the two are an "
                  "extension and its host app. The Source Event column names the most recent line "
                  "that mentioned the bundle.",
-        "paths": ('**/mobile_installation.log.*', '**/sysdiagnose_*.tar.gz'),
+        "paths": ('*/mobile_installation.log.*', '*/sysdiagnose_*.tar.gz'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "box",
         "sample_data": {
@@ -195,14 +195,13 @@ __artifacts_v2__ = {
     }
 }
 
-import io
 import re
-import tarfile
-
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, get_sysdiagnose_files
 
 _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-_TAR_MEMBER_RE = re.compile(r"logs/MobileInstallation/mobile_installation\.log(\.\d+)?$")
+
+# Replaces _TAR_MEMBER_RE to work universally with the helper function
+_LOG_MATCH_RE = re.compile(r"mobile_installation\.log(\.\d+)?$")
 
 # Only an installer-reported outcome sets a bundle's state. Container bookkeeping is
 # written during installs, updates and cleanup alike, so it stays history only.
@@ -310,44 +309,26 @@ def _parse_events(lines):
                            match.group('version'), match.group('short'), '', ''))
     return events
 
-
-def _iter_log_lines(files_found):
-    """Yield (lines, source_full_path) for mobile_installation.log files and those inside sysdiagnose tars."""
-    for filename in files_found:
-        filename = str(filename)
-        if 'mobile_installation' in filename:
-            try:
-                with open(filename, 'r', encoding='utf8', errors='ignore') as fp:
-                    yield fp.readlines(), filename
-            except OSError:
-                continue
-        elif 'sysdiagnose_' in filename and 'IN_PROGRESS_' not in filename:
-            try:
-                tar = tarfile.open(filename)
-            except (tarfile.TarError, OSError):
-                continue
-            try:
-                for member in tar.getmembers():
-                    if not _TAR_MEMBER_RE.search(member.name):
-                        continue
-                    extracted = tar.extractfile(member)
-                    if extracted is not None:
-                        with io.TextIOWrapper(extracted, encoding='utf-8', errors='ignore') as tfp:
-                            yield tfp.readlines(), filename
-            finally:
-                tar.close()
-
-
 def _events_and_source(context):
     events = []
     sources = []
+    
     # Sorting the log files fixes the order events are read in, which is what breaks
     # ties between two state-setting events written in the same second.
-    for lines, source in _iter_log_lines(sorted(str(f) for f in context.get_files_found())):
-        rel = context.get_relative_path(source)
+    files_sorted = sorted(str(f) for f in context.get_files_found())
+    
+    for file_obj, source in get_sysdiagnose_files(files_sorted, _LOG_MATCH_RE):
+        # The helper may append ' >> member.name' for tar archives; 
+        # split it so get_relative_path still operates on the base archive name
+        base_source = source.split(' >> ')[0]
+        rel = context.get_relative_path(base_source)
+        
         if rel not in sources:
             sources.append(rel)
-        events.extend(_parse_events(lines))
+            
+        # Pass the file_obj directly; _parse_events iterates over lines natively
+        events.extend(_parse_events(file_obj))
+        
     return events, ', '.join(sources)
 
 

--- a/scripts/artifacts/systemVersionPlist.py
+++ b/scripts/artifacts/systemVersionPlist.py
@@ -3,12 +3,12 @@
 __artifacts_v2__ = {
     "system_version_plist": {
         "name": "System Version plist",
-        "description": "Parses basic data from */System/Library/CoreServices/SystemVersion.plist "
+        "description": "Parses basic data from SystemVersion.plist "
                        "which is a plist in GK Logical Plus extractions and sysdiagnose archives "
                        "that will contain the iOS version. Previously named Ph99SystemVersionPlist.py",
         "author": "Scott Koenig",
         "creation_date": "2025-06-02",
-        "last_update_date": "2025-10-14",
+        "last_update_date": "2026-09-10",
         "requirements": "Acquisition that contains SystemVersion.plist",
         "category": "IOS Build",
         "notes": "Added parsing of SystemVersion.plist in a sysdiagnose archive by C_Peter",
@@ -36,54 +36,54 @@ __artifacts_v2__ = {
     }
 }
 
-import tarfile
 from scripts.ilapfuncs import artifact_processor, get_plist_file_content, logfunc, \
-    device_info, iOS
-
+    device_info, iOS, get_sysdiagnose_files
 
 @artifact_processor
 def system_version_plist(context):
     """ See artifact description """
     data_list = []
-    data_source = ""
-    pl = None
+    data_sources = []  # Changed to a list to aggregate multiple sources
 
-    plist_file = context.get_source_file_path("SystemVersion.plist")
-    sysdiagnose_archive = context.get_source_file_path("sysdiagnose_*.tar.gz")
+    # Process ALL matching standalone files and tar archives found
+    for file_obj, source_path in get_sysdiagnose_files(context.get_files_found(), "SystemVersion.plist", text_mode=False):
+        source_name = context.get_relative_path(source_path)
+        # Exclude Rapid Security Response (Splat) plists to prevent duplicate/conflicting version reports
+        if "/Splat/" in source_path or "logs/Splat" in source_path:
+            continue
+        
+        # Because we updated get_plist_file_content in ilapfuncs, 
+        # it will natively handle the ExFileObject stream without throwing a TypeError.
+        pl = get_plist_file_content(file_obj)
+        
+        # If the plist is valid/populated, process and append its data
+        if pl:
+            if source_path not in data_sources:
+                data_sources.append(source_path)
+                
+            for key, val in pl.items():
+                data_list.append((key, val, source_name))
+                
+                if key == "Product Build Version":
+                    device_info("Device Information", "Product Build Version", val, source_name)
 
-    if plist_file:
-        data_source = plist_file
-        pl = get_plist_file_content(data_source)
-    elif sysdiagnose_archive and 'sysdiagnose_' in sysdiagnose_archive and "IN_PROGRESS_" not in sysdiagnose_archive:
-        tar = tarfile.open(sysdiagnose_archive)
-        root = tar.getmembers()[0].name.split('/')[0]
-        try:
-            data_source = tar.extractfile(f"{root}/logs/SystemVersion/SystemVersion.plist")
-            pl = get_plist_file_content(data_source)
-        except KeyError:
-            pl = None
+                if key == "ProductVersion":
+                    iOS.set_version(val)
+                    context.set_installed_os_version(val)
+                    device_info("Device Information", "iOS Version", val, source_name)
 
-    if pl is not None:
-        for key, val in pl.items():
-            data_list.append((key, val))
-            if key == "Product Build Version":
-                device_info("Device Information", "Product Build Version", val, data_source)
+                if key == "ProductName":
+                    device_info("Device Information", "Product Name", val, source_name)
 
-            if key == "ProductVersion":
-                iOS.set_version(val)
-                context.set_installed_os_version(val)
-                logfunc(f"iOS Version: {val}")
-                device_info("Device Information", "iOS Version", val, data_source)
+                if key == "BuildID":
+                    device_info("Device Information", "Build ID", val, source_name)
 
-            if key == "ProductName":
-                device_info("Device Information", "Product Name", val, data_source)
+                if key == "SystemImageID":
+                    device_info("Device Information", "System Image ID", val, source_name)
 
-            if key == "BuildID":
-                device_info("Device Information", "Build ID", val, data_source)
+    data_headers = ('Property', 'Property Value', 'Source File')
 
-            if key == "SystemImageID":
-                device_info("Device Information", "System Image ID", val, data_source)
+    # Join the sources list into a single string for the final artifact return
+    data_source_str = ", ".join(data_sources)
 
-    data_headers = ('Property', 'Property Value')
-
-    return data_headers, data_list, data_source
+    return data_headers, data_list, data_source_str

--- a/scripts/artifacts/systemVersionPlist.py
+++ b/scripts/artifacts/systemVersionPlist.py
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_plist_file_content, logfunc, \
+from scripts.ilapfuncs import artifact_processor, get_plist_file_content, \
     device_info, iOS, get_sysdiagnose_files
 
 @artifact_processor

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -897,7 +897,7 @@ def get_plist_file_content(file_path):
             
             # Reassign file_path to the temp file string for the rest of the function
             file_path = temp_path
-        except Exception as e:
+        except Exception as e: # pylint: disable=broad-exception-caught
             logfunc(f"Error creating temp file for stream: {str(e)}")
             return {}
 
@@ -981,7 +981,7 @@ def get_sysdiagnose_files(files_found, target, text_mode=True, encoding='utf-8')
         if match_standalone and not ("sysdiagnose_" in filename and ".tar" in filename):
             try:
                 mode = 'r' if text_mode else 'rb'
-                kwargs = {'encoding': encoding, 'errors': 'ignore'} if text_mode else {}
+                kwargs = {'encoding': encoding, 'errors': 'replace'} if text_mode else {}
                 with open(file_path, mode, **kwargs) as f:
                     yield f, file_path
             except OSError as e:
@@ -1003,7 +1003,7 @@ def get_sysdiagnose_files(files_found, target, text_mode=True, encoding='utf-8')
                             if extracted is None:
                                 continue
                             
-                            stream = io.TextIOWrapper(extracted, encoding=encoding, errors='ignore') if text_mode else extracted
+                            stream = io.TextIOWrapper(extracted, encoding=encoding, errors='replace') if text_mode else extracted
                             try:
                                 yield stream, f"{file_path} >> {member.name}"
                             finally:

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -16,6 +16,7 @@ import shutil
 import sqlite3
 import sys
 import tarfile
+import tempfile
 import xml
 
 from datetime import datetime, timezone, timedelta
@@ -878,6 +879,28 @@ def _read_binary_plist_tolerantly(file_path):
 
 
 def get_plist_file_content(file_path):
+    is_stream = hasattr(file_path, 'read')
+    temp_path = None
+    
+    # If the input is a stream (like an ExFileObject from a tar archive),
+    # write it to a temporary file so the path-based open() and fallback 
+    # functions can handle it natively without throwing TypeErrors.
+    if is_stream:
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".plist") as temp_file:
+                content = file_path.read()
+                # Ensure we are writing bytes
+                if isinstance(content, str):
+                    content = content.encode('utf-8')
+                temp_file.write(content)
+                temp_path = temp_file.name
+            
+            # Reassign file_path to the temp file string for the rest of the function
+            file_path = temp_path
+        except Exception as e:
+            logfunc(f"Error creating temp file for stream: {str(e)}")
+            return {}
+
     try:
         with open(file_path, 'rb') as file:
             plist_content = plistlib.load(file)
@@ -905,6 +928,14 @@ def get_plist_file_content(file_path):
         logfunc(f"Error: {file_path} is not a valid NSKeyedArchive plist file")
     except Exception as e:  # pylint: disable=broad-exception-caught
         logfunc(f"Unexpected error reading plist file {file_path}: {str(e)}")
+    finally:
+        # Always clean up the temporary file if one was generated
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
+                
     return {}
 
 def get_sqlite_db_path(path):
@@ -932,43 +963,52 @@ def get_sqlite_db_path(path):
     else:
         return quote(str(path), safe='/')
         
-def get_sysdiagnose_files(files_found, target_file, text_mode=True, encoding='utf-8'):
+def get_sysdiagnose_files(files_found, target, text_mode=True, encoding='utf-8'):
     """
-    Yields (file_object, source_path) for target_file across standalone matches
-    and active sysdiagnose archives (.tar.gz / .tar).
+    Yields (file_object, source_path) for target (string or compiled regex)
+    across standalone matches and active sysdiagnose archives.
     """
+    is_regex = isinstance(target, re.Pattern)
+
     for file_found in files_found:
         file_path = str(file_found)
         filename = os.path.basename(file_path)
 
         # 1. Direct standalone file match
-        if filename == target_file:
+        match_standalone = target.search(filename) if is_regex else (target == filename)
+        
+        # Ensure it's not a tar file being falsely processed as standalone
+        if match_standalone and not ("sysdiagnose_" in filename and ".tar" in filename):
             try:
                 mode = 'r' if text_mode else 'rb'
-                kwargs = {'encoding': encoding, 'errors': 'replace'} if text_mode else {}
+                kwargs = {'encoding': encoding, 'errors': 'ignore'} if text_mode else {}
                 with open(file_path, mode, **kwargs) as f:
                     yield f, file_path
-            except (OSError, IOError) as e:
+            except OSError as e:
                 print(f"Error reading standalone file {file_path}: {e}")
 
-        # 2. Sysdiagnose archive match (ignoring incomplete/in-progress dumps)
+        # 2. Sysdiagnose archive match
         elif "sysdiagnose_" in filename and "IN_PROGRESS_" not in filename and (".tar" in filename):
             try:
                 with tarfile.open(file_path, 'r:*') as tar:
                     for member in tar.getmembers():
-                        # Match exact filename or target subpath regardless of root folder name
-                        if member.isreg() and (member.name.endswith(f"/{target_file}") or member.name == target_file):
+                        if not member.isreg():
+                            continue
+                        
+                        # Match regex or exact string
+                        match_tar = target.search(member.name) if is_regex else (member.name.endswith(f"/{target}") or member.name == target)
+                        
+                        if match_tar:
                             extracted = tar.extractfile(member)
                             if extracted is None:
                                 continue
                             
-                            # Wrap in TextIOWrapper if text mode is requested (e.g., json.load, regex, csv)
-                            stream = io.TextIOWrapper(extracted, encoding=encoding, errors='replace') if text_mode else extracted
+                            stream = io.TextIOWrapper(extracted, encoding=encoding, errors='ignore') if text_mode else extracted
                             try:
                                 yield stream, f"{file_path} >> {member.name}"
                             finally:
                                 if text_mode:
-                                    stream.detach() # Detach wrapper so tarfile manages underlying stream
+                                    stream.detach()
             except (tarfile.TarError, EOFError, OSError) as e:
                 print(f"Error processing archive {file_path}: {e}")
 


### PR DESCRIPTION
## What this changes

- Updates 3 parsers to support the new Sysdiagnose file extraction helper
- Updates get_sysdiagnose_files to handle file names now including regex
- Updates get_plist_file_content to support path and raw byte streams

## For a new or changed artifact

<!-- Delete this section if the PR does not touch scripts/artifacts. -->

- [x] Ran the tool against a real extraction and confirmed the row counts, not just that it imports.
- [x] Ran `python admin/scripts/check_artifact_output.py <report folder>` on that report and **fixed or documented every finding**. An empty or constant column is often a real result (no group chats, coarse location denied); the fix for those is to say so in the artifact's `notes`, which is also what stops the checker reporting them.
- [x] Checked it against a second app data directory where the platform provides one (a second user, account, or container). `--compare <multi-container report>` reads the scaling for you: it should be exactly double.
- [ ] `notes`, `description` and `sample_data` say only what the data shows, and the numbers were re-derived from the finished run.

## Anything reviewers should know

Core code does change on 2 helper functions so please run against corpus for any surprises
