### PR TITLE
Remove the emulatedSmeta clause from the raw image input doc

### DIFF
--- a/admin/docs/raw_image_input.md
+++ b/admin/docs/raw_image_input.md
@@ -97,9 +97,9 @@ none of them a file the seeker got wrong:
 - First-match order. A few artifacts read one file out of several equivalent
   copies and take the first the seeker returns. The zip, tar and raw seekers each
   list a directory in their own order, so which copy wins can differ. On Android
-  `emulatedSmeta` reads one user's `external.db`, `installedappsGass` labels its
-  source by the view it read, and `walstrings` numbers its rows by arrival. This
-  is a property of those artifacts and shows between the zip and tar routes too.
+  `installedappsGass` labels its source by the view it read, and `walstrings`
+  numbers its rows by arrival. This is a property of those artifacts and shows
+  between the zip and tar routes too.
 - Companion files beside the zip. Some artifacts read a file a tool exported next
   to the acquisition rather than inside it. iOS keychain artifacts read a
   `<udid>_keychain.plist` sitting beside the zip on disk, found only when the


### PR DESCRIPTION
Removes the emulatedSmeta clause from the First-match order bullet in admin/docs/raw_image_input.md. Since abrignoni/ALEAPP#1394, each emulatedSmeta artifact reads every distinct external.db for its provider instead of the first one the seeker returns. The rest of the bullet's wording is unchanged, and the same edit is made to the copy in each of the five LEAPP cores so the files stay byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
