### PR TITLE
Use plain Latitude and Longitude headers in two location artifacts

### DIFF
--- a/scripts/artifacts/personalizationPortrait.py
+++ b/scripts/artifacts/personalizationPortrait.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Locations aggregated for Apple's personalization features",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Locations",
         "notes": (
@@ -36,7 +36,7 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 def personalizationPortraitLocations(context):
     data_headers = (
         ("Source Time", "datetime"), "Location ID", "Bundle ID", "Group ID",
-        ("Latitude", "latitude"), ("Longitude", "longitude"), "Name", "Road", "Street Number",
+        "Latitude", "Longitude", "Name", "Road", "Street Number",
         "City", "Sub-locality", "Administrative Area", "Sub-administrative Area", "Postal Code",
         "Country Code", "Country", "iOS Build", "Category", "Algorithm", "Initial Score",
         "Sync Eligible",

--- a/scripts/artifacts/personalizationPortrait.py
+++ b/scripts/artifacts/personalizationPortrait.py
@@ -1,16 +1,25 @@
 __artifacts_v2__ = {
     "personalizationPortraitLocations": {
         "name": "Personalization Portrait - Locations",
-        "description": "Locations aggregated for Apple's personalization features",
+        "description": (
+            "Location records from PPSQLDatabase.db, with the bundle ID and, where recorded, the "
+            "group ID of the source each record references"
+        ),
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-28",
         "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Locations",
         "notes": (
-            "Aggregated locations are not proof that the device visited a place; the source "
-            "bundle and group provide essential attribution context. Based on research by "
-            "Sarah Edwards: https://www.mac4n6.com/blog/2020/6/2/guest-post-by-bizzybarney-"
+            "A location record is not proof that the device was at that place. The cited "
+            "research describes this database as aggregating data from many sources and says "
+            "attribution must be done carefully. Bundle ID, Group ID and Source Time are read "
+            "from the sources row that each record's source_id references; Source Time is that "
+            "row's seconds_from_1970 value, read as Unix epoch seconds, and what it marks is not "
+            "established here. Latitude and Longitude can be blank, and a record missing either "
+            "is left out of the KML output. Reference: @bizzybarney, 'A Peek Inside the "
+            "PPSQLDatabase.db Personalization Portrait Database', guest post on mac4n6.com, "
+            "https://www.mac4n6.com/blog/2020/6/2/guest-post-by-bizzybarney-"
             "a-peek-inside-the-ppsqldatabasedb-personalization-portrait-database"
         ),
         "paths": (
@@ -19,7 +28,7 @@ __artifacts_v2__ = {
         "output_types": ["html", "tsv", "lava", "timeline", "kml"],
         "artifact_icon": "map",
         "sample_data": {
-            "hickman_ios15": "iOS 15 | 169 rows",
+            "hickman_ios15": "iOS 15.3.1 | 169 rows",
             "jess_ios15": "iOS 15.0.2 | 16 rows",
             "magnet_ios16": "iOS 16.1.1 | 20 rows",
             "felix_ios17": "iOS 17.6.1 | 76 rows",

--- a/scripts/artifacts/wifiAnalytics.py
+++ b/scripts/artifacts/wifiAnalytics.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Geotagged Wi-Fi networks recorded by wifianalyticsd",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Wi-Fi",
         "notes": "Dates use the Apple Cocoa epoch. Locations should be corroborated.",
@@ -32,7 +32,7 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 def wifiAnalyticsGeotags(context):
     data_headers = (
         ("Date", "datetime"), ("Last Seen", "datetime"), "Geotag ID", "Entity ID",
-        ("Latitude", "latitude"), ("Longitude", "longitude"), "BSSID", "SSID",
+        "Latitude", "Longitude", "BSSID", "SSID",
     )
     data_list = []
     source_path = next(

--- a/scripts/artifacts/wifiAnalytics.py
+++ b/scripts/artifacts/wifiAnalytics.py
@@ -1,7 +1,10 @@
 __artifacts_v2__ = {
     "wifiAnalyticsGeotags": {
         "name": "Wi-Fi Analytics - Geotags",
-        "description": "Geotagged Wi-Fi networks recorded by wifianalyticsd",
+        "description": (
+            "Wi-Fi geotags from DeviceAnalyticsModel.sqlite in the com.apple.wifianalyticsd "
+            "directory, with the linked BSSID and SSID"
+        ),
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-28",
         "last_update_date": "2026-09-12",
@@ -15,7 +18,7 @@ __artifacts_v2__ = {
         "output_types": ["html", "tsv", "lava", "timeline", "kml"],
         "artifact_icon": "map-pin",
         "sample_data": {
-            "hickman_ios15": "iOS 15 | 9 rows",
+            "hickman_ios15": "iOS 15.3.1 | 9 rows",
             "jess_ios15": "iOS 15.0.2 | 17 rows",
             "magnet_ios16": "iOS 16.1.1 | 14 rows",
             "felix_ios17": "iOS 17.6.1 | 15 rows",


### PR DESCRIPTION
Uses plain Latitude and Longitude headers in two location artifacts.

- wifiAnalyticsGeotags and personalizationPortraitLocations typed these columns 'latitude' and 'longitude'. Nothing in lavafuncs, ilapfuncs or LAVA handles those types, so the only effect was an object_columns entry for each in the LAVA manifest.
- personalizationPortraitLocations notes credit the cited guest post to @bizzybarney, and the description no longer states a purpose the post leaves open.
- wifiAnalyticsGeotags description describes rows as geotags rather than networks.

Row counts, KML and TSV output are unchanged. hickman_ios15 is recorded as iOS 15.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
