### PR TITLE
Name KML placemarks by timestamp in two location artifacts

### DIFF
--- a/scripts/artifacts/personalizationPortrait.py
+++ b/scripts/artifacts/personalizationPortrait.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
 
 
 @artifact_processor
@@ -60,7 +60,7 @@ def personalizationPortraitLocations(context):
         return data_headers, data_list, ""
 
     query = """
-        SELECT datetime(sources.seconds_from_1970, 'unixepoch'),
+        SELECT sources.seconds_from_1970,
                loc_records.id, sources.bundle_id, sources.group_id,
                loc_records.cll_latitude_degrees, loc_records.cll_longitude_degrees,
                loc_records.clp_name, loc_records.clp_thoroughfare,
@@ -75,5 +75,7 @@ def personalizationPortraitLocations(context):
         LEFT JOIN sources ON loc_records.source_id = sources.id
         ORDER BY sources.seconds_from_1970
     """
-    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    for row in get_sqlite_db_records(source_path, query):
+        values = tuple(row)
+        data_list.append((convert_unix_ts_to_utc(values[0]),) + values[1:])
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/wifiAnalytics.py
+++ b/scripts/artifacts/wifiAnalytics.py
@@ -28,13 +28,17 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+from scripts.ilapfuncs import (
+    artifact_processor,
+    convert_cocoa_core_data_ts_to_utc,
+    get_sqlite_db_records,
+)
 
 
 @artifact_processor
 def wifiAnalyticsGeotags(context):
     data_headers = (
-        ("Date", "datetime"), ("Last Seen", "datetime"), "Geotag ID", "Entity ID",
+        ("Date", "datetime"), ("Last Seen", "datetime"), "Geotag ID",
         "Latitude", "Longitude", "BSSID", "SSID",
     )
     data_list = []
@@ -47,14 +51,17 @@ def wifiAnalyticsGeotags(context):
         return data_headers, data_list, ""
 
     query = """
-        SELECT datetime(ZGEOTAG.ZDATE + 978307200, 'unixepoch'),
-               datetime(ZBSS.ZLASTSEEN + 978307200, 'unixepoch'),
-               ZGEOTAG.Z_PK, ZGEOTAG.Z_ENT,
+        SELECT ZGEOTAG.ZDATE, ZBSS.ZLASTSEEN, ZGEOTAG.Z_PK,
                ZGEOTAG.ZLATITUDE, ZGEOTAG.ZLONGITUDE, ZBSS.ZBSSID, ZNETWORK.ZSSID
         FROM ZGEOTAG
         LEFT JOIN ZBSS ON ZBSS.Z_PK = ZGEOTAG.ZBSS
         LEFT JOIN ZNETWORK ON ZNETWORK.Z_PK = ZBSS.ZNETWORK
         ORDER BY ZGEOTAG.ZDATE
     """
-    data_list.extend(tuple(row) for row in get_sqlite_db_records(source_path, query))
+    for row in get_sqlite_db_records(source_path, query):
+        values = tuple(row)
+        data_list.append((
+            convert_cocoa_core_data_ts_to_utc(values[0]),
+            convert_cocoa_core_data_ts_to_utc(values[1]),
+        ) + values[2:])
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Names KML placemarks by timestamp in two location artifacts.

- wifiAnalyticsGeotags and personalizationPortraitLocations returned SQL datetime() strings, so kmlgen found no datetime value and named every placemark N/A. The timestamps now come from convert_cocoa_core_data_ts_to_utc and convert_unix_ts_to_utc.
- wifiAnalyticsGeotags drops Entity ID (ZGEOTAG.Z_ENT), which held one value on every tested store.

Row counts and LAVA epochs are unchanged. Timestamp text in the HTML, TSV and timeline now ends in +00:00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
