### PR TITLE
Read the Biome tombstone skip from the evidence path, not the staged path

### DIFF
--- a/scripts/artifacts/biomeAirpMode.py
+++ b/scripts/artifacts/biomeAirpMode.py
@@ -88,7 +88,7 @@ def get_biomeAirpMode(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeAppActivity.py
+++ b/scripts/artifacts/biomeAppActivity.py
@@ -86,7 +86,7 @@ def get_biomeAppActivity(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeAppInstallation.py
+++ b/scripts/artifacts/biomeAppInstallation.py
@@ -90,7 +90,7 @@ def get_biomeAppInstallation(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeAppIntentsTranscript.py
+++ b/scripts/artifacts/biomeAppIntentsTranscript.py
@@ -109,7 +109,7 @@ def get_biomeAppIntentsTranscript(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeAppLocationActivity.py
+++ b/scripts/artifacts/biomeAppLocationActivity.py
@@ -83,7 +83,7 @@ def get_biomeAppLocationActivity(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeAppRelevantShortcuts.py
+++ b/scripts/artifacts/biomeAppRelevantShortcuts.py
@@ -90,7 +90,7 @@ def get_biomeAppRelevantShortcuts(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeAppWebUsage.py
+++ b/scripts/artifacts/biomeAppWebUsage.py
@@ -71,7 +71,7 @@ def get_biomeAppWebUsage(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
             else:
                 report_file = os.path.dirname(file_found)

--- a/scripts/artifacts/biomeAppinstall.py
+++ b/scripts/artifacts/biomeAppinstall.py
@@ -127,7 +127,7 @@ def get_biomeAppinstall(context):
         if not os.path.isfile(file_found):
             continue
 
-        if 'tombstone' in file_found:
+        if 'tombstone' in context.get_relative_path(file_found):
             continue
 
         parent = os.path.dirname(file_found)

--- a/scripts/artifacts/biomeAppleIntelligence.py
+++ b/scripts/artifacts/biomeAppleIntelligence.py
@@ -171,7 +171,7 @@ def _stream_files(context):
     for file_found in sorted(map(str, context.get_files_found())):
         if os.path.basename(file_found).startswith('.'):
             continue
-        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         yield file_found
 

--- a/scripts/artifacts/biomeAudioMediaRoutes.py
+++ b/scripts/artifacts/biomeAudioMediaRoutes.py
@@ -86,7 +86,7 @@ def _stream_files(context):
     for file_found in sorted(map(str, context.get_files_found())):
         if os.path.basename(file_found).startswith('.'):
             continue
-        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         yield file_found
 

--- a/scripts/artifacts/biomeAutonamingMessageIds.py
+++ b/scripts/artifacts/biomeAutonamingMessageIds.py
@@ -78,7 +78,7 @@ def get_biomeAutonamingMessageIds(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeBacklight.py
+++ b/scripts/artifacts/biomeBacklight.py
@@ -47,7 +47,7 @@ def get_biomeBacklight(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeBattperc.py
+++ b/scripts/artifacts/biomeBattperc.py
@@ -85,7 +85,7 @@ def get_biomeBattperc(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeBluetooth.py
+++ b/scripts/artifacts/biomeBluetooth.py
@@ -69,7 +69,7 @@ def get_biomeBluetooth(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeBootSession.py
+++ b/scripts/artifacts/biomeBootSession.py
@@ -73,7 +73,7 @@ def get_biomeBootSession(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeCameraAutoFocusROI.py
+++ b/scripts/artifacts/biomeCameraAutoFocusROI.py
@@ -81,7 +81,7 @@ def get_biomeCameraAutoFocusROI(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeCarplayisconnected.py
+++ b/scripts/artifacts/biomeCarplayisconnected.py
@@ -84,7 +84,7 @@ def get_biomeCarplayisconnected(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeClockAlarm.py
+++ b/scripts/artifacts/biomeClockAlarm.py
@@ -68,7 +68,7 @@ def get_biomeClockAlarm(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDKEventStreams.py
+++ b/scripts/artifacts/biomeDKEventStreams.py
@@ -290,7 +290,7 @@ def _parse(context, label, value_map):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDKInfocus.py
+++ b/scripts/artifacts/biomeDKInfocus.py
@@ -74,7 +74,7 @@ def get_biomeDKInfocus(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDKKeybag.py
+++ b/scripts/artifacts/biomeDKKeybag.py
@@ -87,7 +87,7 @@ def get_biomeDKKeybag(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDevTimeZone.py
+++ b/scripts/artifacts/biomeDevTimeZone.py
@@ -38,7 +38,7 @@ def get_biomeDevTimeZone(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDevWifi.py
+++ b/scripts/artifacts/biomeDevWifi.py
@@ -49,7 +49,7 @@ def get_biomeDevWifi(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDeviceMetadata.py
+++ b/scripts/artifacts/biomeDeviceMetadata.py
@@ -65,7 +65,7 @@ def get_biomeDeviceMetadata(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDeviceStateStreams.py
+++ b/scripts/artifacts/biomeDeviceStateStreams.py
@@ -327,7 +327,7 @@ def _stream_files(context):
     for file_found in sorted(map(str, context.get_files_found())):
         if os.path.basename(file_found).startswith('.'):
             continue
-        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         yield file_found
 

--- a/scripts/artifacts/biomeDevplugin.py
+++ b/scripts/artifacts/biomeDevplugin.py
@@ -111,7 +111,7 @@ def get_biomeDevplugin(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeDiscoverabilitySignals.py
+++ b/scripts/artifacts/biomeDiscoverabilitySignals.py
@@ -73,7 +73,7 @@ def get_biomeDiscoverabilitySignals(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeEmergencyVoiceCall.py
+++ b/scripts/artifacts/biomeEmergencyVoiceCall.py
@@ -72,7 +72,7 @@ def get_biomeEmergencyVoiceCall(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeEmojiEngagement.py
+++ b/scripts/artifacts/biomeEmojiEngagement.py
@@ -82,7 +82,7 @@ def get_biomeEmojiEngagement(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeFrontBoardDisplayElement.py
+++ b/scripts/artifacts/biomeFrontBoardDisplayElement.py
@@ -82,7 +82,7 @@ def get_biomeFrontBoardDisplayElement(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeHardware.py
+++ b/scripts/artifacts/biomeHardware.py
@@ -51,7 +51,7 @@ def get_biomeHardware(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeInfocus.py
+++ b/scripts/artifacts/biomeInfocus.py
@@ -67,7 +67,7 @@ def get_biomeInfocus(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeIntents.py
+++ b/scripts/artifacts/biomeIntents.py
@@ -269,7 +269,7 @@ def get_biomeIntents(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeLocationVisit.py
+++ b/scripts/artifacts/biomeLocationVisit.py
@@ -102,7 +102,7 @@ def get_biomeLocationVisit(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeLocationactivity.py
+++ b/scripts/artifacts/biomeLocationactivity.py
@@ -124,7 +124,7 @@ def get_biomeLocationactivity(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeNetworkingEdgeSelection.py
+++ b/scripts/artifacts/biomeNetworkingEdgeSelection.py
@@ -71,7 +71,7 @@ def get_biomeNetworkingEdgeSelection(context):
         filename = os.path.basename(file_found)
         if filename.startswith('.') or not os.path.isfile(file_found):
             continue
-        if 'tombstone' in file_found:  # deletion bookkeeping, not edge observations
+        if 'tombstone' in context.get_relative_path(file_found):  # deletion bookkeeping, not edge observations
             continue
 
         source_dirs.add(os.path.dirname(file_found))

--- a/scripts/artifacts/biomeNotes.py
+++ b/scripts/artifacts/biomeNotes.py
@@ -55,7 +55,7 @@ def get_biomeNotes(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeNotificationUsage.py
+++ b/scripts/artifacts/biomeNotificationUsage.py
@@ -51,7 +51,7 @@ def get_biomeNotificationUsage(context):
         filename = os.path.basename(file_found)
         if filename.startswith('.'):
             continue
-        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         report_file = os.path.dirname(file_found)
 

--- a/scripts/artifacts/biomeNotificationsPub.py
+++ b/scripts/artifacts/biomeNotificationsPub.py
@@ -54,7 +54,7 @@ def get_biomeNotificationsPub(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeNowplaying.py
+++ b/scripts/artifacts/biomeNowplaying.py
@@ -91,7 +91,7 @@ def get_biomeNowplaying(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomePhotosSearchInsights.py
+++ b/scripts/artifacts/biomePhotosSearchInsights.py
@@ -67,7 +67,7 @@ def get_biomePhotosSearchInsights(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSafari.py
+++ b/scripts/artifacts/biomeSafari.py
@@ -119,7 +119,7 @@ def get_biomeSafari(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSafariNavigations.py
+++ b/scripts/artifacts/biomeSafariNavigations.py
@@ -82,7 +82,7 @@ def get_biomeSafariNavigations(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSafariWebPagePerformance.py
+++ b/scripts/artifacts/biomeSafariWebPagePerformance.py
@@ -71,7 +71,7 @@ def get_biomeSafariWebPagePerformance(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeShareSheetConversation.py
+++ b/scripts/artifacts/biomeShareSheetConversation.py
@@ -78,7 +78,7 @@ def get_biomeShareSheetConversation(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeShareSheetFeedback.py
+++ b/scripts/artifacts/biomeShareSheetFeedback.py
@@ -71,7 +71,7 @@ def get_biomeShareSheetFeedback(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSiriRemembersAssistantSuggestions.py
+++ b/scripts/artifacts/biomeSiriRemembersAssistantSuggestions.py
@@ -111,7 +111,7 @@ def get_biomeSiriRemembersAssistantSuggestions(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSiriRemembersAudioHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersAudioHistory.py
@@ -125,7 +125,7 @@ def get_biomeSiriRemembersAudioHistory(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSiriRemembersCallHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersCallHistory.py
@@ -121,7 +121,7 @@ def get_biomeSiriRemembersCallHistory(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersInteractionHistory.py
@@ -118,7 +118,7 @@ def get_biomeSiriRemembersInteractionHistory(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSiriRemembersMessageHistory.py
+++ b/scripts/artifacts/biomeSiriRemembersMessageHistory.py
@@ -122,7 +122,7 @@ def get_biomeSiriRemembersMessageHistory(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeSiriUI.py
+++ b/scripts/artifacts/biomeSiriUI.py
@@ -70,7 +70,7 @@ def get_biomeSiriUI(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeStreams.py
+++ b/scripts/artifacts/biomeStreams.py
@@ -176,7 +176,7 @@ def _stream_files(context):
     for file_found in map(str, context.get_files_found()):
         if os.path.basename(file_found).startswith('.'):
             continue
-        if not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         yield file_found
 

--- a/scripts/artifacts/biomeSystemSettingsSearchTerms.py
+++ b/scripts/artifacts/biomeSystemSettingsSearchTerms.py
@@ -57,7 +57,7 @@ def get_biomeSystemSettingsSearchTerms(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeUseractmeta.py
+++ b/scripts/artifacts/biomeUseractmeta.py
@@ -53,7 +53,7 @@ def get_biomeUseractmeta(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeWalletTransaction.py
+++ b/scripts/artifacts/biomeWalletTransaction.py
@@ -68,7 +68,7 @@ def get_biomeWalletTransaction(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/biomeWifi.py
+++ b/scripts/artifacts/biomeWifi.py
@@ -90,7 +90,7 @@ def get_biomeWifi(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/cnaAutocompleteFeedback.py
+++ b/scripts/artifacts/cnaAutocompleteFeedback.py
@@ -72,7 +72,7 @@ def get_cnaAutocompleteFeedback(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
         else:
             continue

--- a/scripts/artifacts/draftmessage.py
+++ b/scripts/artifacts/draftmessage.py
@@ -32,7 +32,7 @@ def get_draftmessage(context):
         if filename.startswith('.'):
             continue
         if os.path.isfile(file_found):
-            if 'tombstone' in file_found:
+            if 'tombstone' in context.get_relative_path(file_found):
                 continue
             else:
                 pass

--- a/scripts/artifacts/duetLocations.py
+++ b/scripts/artifacts/duetLocations.py
@@ -49,7 +49,7 @@ def duetlocations(context):
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
-        if filename.startswith('.') or not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if filename.startswith('.') or not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         with open(file_found, 'rb') as f:
             data = f.read()

--- a/scripts/artifacts/notificationsDuet.py
+++ b/scripts/artifacts/notificationsDuet.py
@@ -74,7 +74,7 @@ def get_notificationsDuet(context):
     for file_found in context.get_files_found():
         file_found = str(file_found)
         filename = os.path.basename(file_found)
-        if filename.startswith('.') or not os.path.isfile(file_found) or 'tombstone' in file_found:
+        if filename.startswith('.') or not os.path.isfile(file_found) or 'tombstone' in context.get_relative_path(file_found):
             continue
         rel = context.get_relative_path(file_found)
         if rel not in sources:

--- a/scripts/artifacts/privacyAccounting.py
+++ b/scripts/artifacts/privacyAccounting.py
@@ -133,7 +133,7 @@ def _stream_files(context, tombstones):
             continue
         if not os.path.isfile(file_found):
             continue
-        is_tombstone = 'tombstone' in file_found.replace('\\', '/').split('/')
+        is_tombstone = 'tombstone' in context.get_relative_path(file_found).replace('\\', '/').split('/')
         if is_tombstone == tombstones:
             yield file_found
 


### PR DESCRIPTION
Biome artifacts decide whether to skip a tombstone file by testing the absolute staged path, which contains the folder the examiner chose for the report. Saving a report into a folder named "tombstone" therefore emptied them: on hc_ios26 the run fell from 66 artifacts and 6,492 rows to 1 artifact and 10 rows.

All 62 sites now read the evidence-relative path, so the report folder cannot reach the decision. privacyAccounting is included; its segment form was narrower but read the same staged path.

Row counts on real data are unchanged: hc_ios26 6,492 rows across 66 artifacts, iphone12_ios18 23,412 across 57, identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
