### PR TITLE
Emit Core Accessories columns in a fixed order

### DIFF
--- a/scripts/artifacts/coreAccessoriesAcc.py
+++ b/scripts/artifacts/coreAccessoriesAcc.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
                        "database.",
         "author": "John Hyla",
         "creation_date": "2023-08-01",
-        "last_update_date": "2025-11-21",
+        "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Core Accessories",
         "notes": "",
@@ -63,7 +63,7 @@ def get_coreAccessories(context):
         all_keys.update(pl.keys())
 
     all_keys.remove(event_time_key)
-    all_keys_list = [event_time_key] + list(all_keys)
+    all_keys_list = [event_time_key] + sorted(all_keys)
     data_list = []
     for row in temp_data:
         row_values = []

--- a/scripts/artifacts/coreAccessoriesUserEvent.py
+++ b/scripts/artifacts/coreAccessoriesUserEvent.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
             database found in CoreAccessories",
         "author": "John Hyla",
         "creation_date": "2023-08-01",
-        "last_update_date": "2026-07-31",
+        "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Core Accessories",
         "notes": "Lightning accessory ID labels are drawn from published reverse-engineering research; unmapped IDs are reported as stored. Reference: nyansatan, 'Lightning connector reverse engineering', https://nyansatan.github.io/lightning/",
@@ -64,7 +64,7 @@ def get_coreAccessoriesUserEvent(context):
         all_keys.update(pl.keys())
 
     all_keys.remove(event_time_key)
-    all_keys_list = [event_time_key] + list(all_keys)
+    all_keys_list = [event_time_key] + sorted(all_keys)
     data_list = []
     for row in temp_data:
         row_values = []


### PR DESCRIPTION
The two Core Accessories artifacts (AccessoryD and UserEventAgent) now emit their columns in a fixed order. Both built their headers from a Python set, so the columns after the event time changed between runs with the interpreter's hash seed. The keys are now sorted after the event time column, which keeps its datetime type. Rows and row counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
